### PR TITLE
Record PR Quality evidence signals in trajectories

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -282,26 +282,6 @@ jobs:
             --pr-quality-safe-bridge-only \
             --out-dir build/pr-quality/safe-formatting-autopilot
 
-      - name: Build PR trajectory artifact
-        if: always()
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          mkdir -p build/pr-quality/trajectory
-          PYTHONPATH=src python -m sdetkit.trajectory_store \
-            --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
-            --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
-            --out build/pr-quality/trajectory/trajectory.jsonl \
-            --repo "$REPOSITORY" \
-            --branch "$HEAD_REF" \
-            --commit-sha "$HEAD_SHA" \
-            --pr-number "$PR_NUMBER" \
-            --format json \
-            > build/pr-quality/trajectory/trajectory-metadata.json
-
       - name: Build PR comment body
         run: |
           mkdir -p build/pr-quality
@@ -319,6 +299,19 @@ jobs:
             --changed-files build/pr-quality/changed-files.txt \
             --out build/pr-quality/pr-evidence-narrative.md \
             --json-out build/pr-quality/pr-evidence-narrative.json
+
+          mkdir -p build/pr-quality/trajectory
+          PYTHONPATH=src python -m sdetkit.trajectory_store \
+            --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
+            --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
+            --evidence-narrative build/pr-quality/pr-evidence-narrative.json \
+            --out build/pr-quality/trajectory/trajectory.jsonl \
+            --repo "${{ github.repository }}" \
+            --branch "${{ github.event.pull_request.head.ref }}" \
+            --commit-sha "${{ github.event.pull_request.head.sha }}" \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --format json \
+            > build/pr-quality/trajectory/trajectory-metadata.json
 
           PYTHONPATH=src python -m sdetkit.pr_quality_action_report \
             --action-report build/pr-quality/check-intelligence/action-report.json \

--- a/src/sdetkit/trajectory_store.py
+++ b/src/sdetkit/trajectory_store.py
@@ -32,6 +32,13 @@ def _bool(value: Any) -> bool:
     return str(value).lower() in {"1", "true", "yes"}
 
 
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _string_list(value: Any) -> list[str]:
     return sorted({_string(item) for item in _as_list(value) if _string(item)})
 
@@ -178,17 +185,70 @@ def _pr_quality_primary_as_check(action_report: Mapping[str, Any]) -> JsonObject
     }
 
 
+def _evidence_narrative_as_check(evidence_narrative: Mapping[str, Any]) -> JsonObject:
+    primary = _as_dict(evidence_narrative.get("primary_signal"))
+    graph = _as_dict(evidence_narrative.get("graph"))
+    top_blocker = _as_dict(graph.get("top_blocker"))
+
+    kind = _string(primary.get("kind"))
+    title = _string(primary.get("title") or top_blocker.get("title"))
+    surface = _string(primary.get("surface") or top_blocker.get("surface") or "unknown")
+    action = _string(top_blocker.get("action") or primary.get("action"))
+    top_title = _string(top_blocker.get("title"))
+    top_surface = _string(top_blocker.get("surface"))
+
+    has_narrative_signal = kind in {"review_signal", "integration_proof"}
+    has_top_blocker = bool(top_title) and top_title != "none" and top_surface != "none"
+    if not has_narrative_signal and not has_top_blocker:
+        return {}
+
+    review_required = (
+        _int(graph.get("review_first_count")) > 0
+        or _int(graph.get("critical_count")) > 0
+        or action == "review"
+        or _bool(top_blocker.get("review_first"))
+    )
+    signal_kind = "review" if review_required else "proof"
+    code = "EVIDENCE_REVIEW_SIGNAL" if review_required else "EVIDENCE_PROOF_SIGNAL"
+    action = action or ("review" if review_required else "rerun_proof")
+
+    return {
+        "name": "PR Quality evidence signal",
+        "surface": surface,
+        "code": code,
+        "title": title or "PR Quality evidence signal",
+        "safe_to_auto_fix": False,
+        "review_first": review_required,
+        "evidence_signal": True,
+        "evidence_signal_kind": signal_kind,
+        "operator_action": action,
+        "diagnosis": {
+            "code": code,
+            "title": title or "PR Quality evidence signal",
+            "risk_surface": surface,
+            "diagnosis": title or "PR Quality evidence signal",
+            "proof_commands": _string_list(evidence_narrative.get("next_proof")),
+            "confidence": "high" if review_required else "medium",
+        },
+    }
+
+
 def _pr_quality_checks(
     *,
     action_report: Mapping[str, Any],
     check_intelligence: Mapping[str, Any],
+    evidence_narrative: Mapping[str, Any] | None = None,
 ) -> list[JsonObject]:
     failed_checks = [_as_dict(item) for item in _as_list(check_intelligence.get("failed_checks"))]
     if failed_checks:
         return failed_checks
 
     primary = _pr_quality_primary_as_check(action_report)
-    return [primary] if primary else []
+    if primary:
+        return [primary]
+
+    evidence = _evidence_narrative_as_check(_as_dict(evidence_narrative))
+    return [evidence] if evidence else []
 
 
 def _pr_quality_action(
@@ -206,6 +266,7 @@ def build_pr_quality_trajectory_records(
     *,
     action_report: Mapping[str, Any],
     check_intelligence: Mapping[str, Any],
+    evidence_narrative: Mapping[str, Any] | None = None,
     safe_fix_outcome: Mapping[str, Any] | None = None,
     repo: str = "",
     branch: str = "",
@@ -222,6 +283,7 @@ def build_pr_quality_trajectory_records(
         _pr_quality_checks(
             action_report=action_report,
             check_intelligence=check_intelligence,
+            evidence_narrative=evidence_narrative,
         ),
         start=1,
     ):
@@ -239,7 +301,10 @@ def build_pr_quality_trajectory_records(
             or automation.get("allowed")
             or check.get("safe_to_auto_fix")
         )
-        review_first = _bool(check.get("review_first")) or not auto_fix_allowed
+        evidence_signal = _bool(check.get("evidence_signal"))
+        review_first = _bool(check.get("review_first")) or (
+            not auto_fix_allowed and not evidence_signal
+        )
         proof_commands = _string_list(diagnosis.get("proof_commands")) or default_proof_commands
         owner_files = (
             _string_list(check.get("owner_files"))
@@ -248,7 +313,7 @@ def build_pr_quality_trajectory_records(
             or _string_list(check.get("formatter_changed_files"))
         )
         patch_files = _string_list(check.get("formatter_changed_files")) if auto_fix_allowed else []
-        action = _pr_quality_action(
+        action = _string(check.get("operator_action")) or _pr_quality_action(
             surface=surface,
             safe_remediation=safe_remediation,
             auto_fix_allowed=auto_fix_allowed,
@@ -278,9 +343,15 @@ def build_pr_quality_trajectory_records(
                     "source": "pr_quality",
                 },
                 "response": {
-                    "response_type": "safe_fix_candidate"
-                    if auto_fix_allowed
-                    else f"{surface or 'unknown'}_review_required",
+                    "response_type": (
+                        "safe_fix_candidate"
+                        if auto_fix_allowed
+                        else (
+                            "evidence_proof_signal"
+                            if evidence_signal and not review_first
+                            else f"{surface or 'unknown'}_review_required"
+                        )
+                    ),
                     "exit_code": "unknown",
                     "first_failing_line": _first_failure_line(check),
                 },
@@ -315,9 +386,17 @@ def build_pr_quality_trajectory_records(
                     "quality_proof": "not_run",
                     "verifier_result": "not_run",
                 },
-                "final_result": _final_result(
-                    {"safe_to_auto_fix": auto_fix_allowed},
-                    outcome,
+                "final_result": (
+                    "evidence_review_required"
+                    if evidence_signal and review_first
+                    else (
+                        "proof_signal"
+                        if evidence_signal
+                        else _final_result(
+                            {"safe_to_auto_fix": auto_fix_allowed},
+                            outcome,
+                        )
+                    )
                 ),
                 "learned_pattern": "pr_quality_check_intelligence",
             }
@@ -453,6 +532,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--remediation-plan", default="")
     parser.add_argument("--pr-quality-action-report", default="")
     parser.add_argument("--check-intelligence", default="")
+    parser.add_argument("--evidence-narrative", default="")
     parser.add_argument("--safe-fix-outcome", default="")
     parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--repo", default="")
@@ -476,6 +556,7 @@ def main(argv: list[str] | None = None) -> int:
             records = build_pr_quality_trajectory_records(
                 action_report=_read_json(_optional_path(args.pr_quality_action_report)),
                 check_intelligence=_read_json(_optional_path(args.check_intelligence)),
+                evidence_narrative=_read_json(_optional_path(args.evidence_narrative)),
                 safe_fix_outcome=_read_json(_optional_path(args.safe_fix_outcome)),
                 repo=args.repo,
                 branch=args.branch,

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -185,8 +185,11 @@ def test_pr_quality_comment_workflow_passes_evidence_narrative_into_final_commen
     narrative_step = text.index("python -m sdetkit.pr_quality_evidence_narrative")
     narrative_json = text.index("--json-out build/pr-quality/pr-evidence-narrative.json")
     action_report_step = text.index("python -m sdetkit.pr_quality_action_report")
-    evidence_arg = text.index("--evidence-narrative build/pr-quality/pr-evidence-narrative.json")
-    comment_out = text.index("--out build/pr-quality/pr-comment-body.md")
+    evidence_arg = text.index(
+        "--evidence-narrative build/pr-quality/pr-evidence-narrative.json",
+        action_report_step,
+    )
+    comment_out = text.index("--out build/pr-quality/pr-comment-body.md", action_report_step)
 
     assert narrative_step < narrative_json < action_report_step
     assert action_report_step < evidence_arg < comment_out
@@ -232,17 +235,18 @@ def test_pr_quality_comment_workflow_builds_and_passes_trajectory_artifact() -> 
     text = _workflow_text()
 
     check_intelligence = text.index("python -m sdetkit.check_intelligence")
-    trajectory = text.index("Build PR trajectory artifact")
+    evidence_narrative = text.index("python -m sdetkit.pr_quality_evidence_narrative")
+    trajectory = text.index("python -m sdetkit.trajectory_store")
     comment_body = text.index("python -m sdetkit.pr_quality_action_report")
 
-    assert check_intelligence < trajectory < comment_body
-    assert "python -m sdetkit.trajectory_store" in text
+    assert check_intelligence < evidence_narrative < trajectory < comment_body
     assert (
         "--pr-quality-action-report build/pr-quality/check-intelligence/action-report.json" in text
     )
     assert (
         "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in text
     )
+    assert "--evidence-narrative build/pr-quality/pr-evidence-narrative.json" in text
     assert "--out build/pr-quality/trajectory/trajectory.jsonl" in text
     assert "> build/pr-quality/trajectory/trajectory-metadata.json" in text
     assert "--trajectory-jsonl build/pr-quality/trajectory/trajectory.jsonl" in text

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -282,3 +282,200 @@ def test_pr_quality_trajectory_cli_writes_artifact(tmp_path: Path, capsys) -> No
     assert printed["summary"]["auto_fix_allowed_count"] == 1
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["action"] == "run_pre_commit"
+
+
+def _green_pr_quality_action_report() -> dict:
+    return {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "no remediation needed",
+        },
+        "recommended_actions": [],
+        "proof_commands": [],
+    }
+
+
+def _green_pr_quality_check_intelligence() -> dict:
+    return {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+    }
+
+
+def _evidence_review_narrative() -> dict:
+    return {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "pr_quality",
+            "title": "PR Quality evidence changed",
+        },
+        "graph": {
+            "node_count": 2,
+            "review_first_count": 1,
+            "critical_count": 0,
+            "top_blocker": {
+                "title": "PR Quality evidence changed",
+                "surface": "pr_quality",
+                "action": "review",
+                "review_first": True,
+            },
+        },
+        "next_proof": [
+            "python -m pytest -q tests/test_pr_quality_evidence_narrative.py -o addopts=",
+            "python -m pre_commit run -a",
+        ],
+    }
+
+
+def _evidence_proof_narrative() -> dict:
+    return {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "pr_quality",
+            "title": "PR Quality proof changed",
+        },
+        "graph": {
+            "node_count": 2,
+            "review_first_count": 0,
+            "critical_count": 0,
+            "top_blocker": {
+                "title": "PR Quality proof changed",
+                "surface": "pr_quality",
+                "action": "rerun_proof",
+                "review_first": False,
+            },
+        },
+        "next_proof": ["python -m pre_commit run -a"],
+    }
+
+
+def test_pr_quality_trajectory_records_capture_green_evidence_review_signal() -> None:
+    from sdetkit.trajectory_store import build_pr_quality_trajectory_records
+
+    records = build_pr_quality_trajectory_records(
+        action_report=_green_pr_quality_action_report(),
+        check_intelligence=_green_pr_quality_check_intelligence(),
+        evidence_narrative=_evidence_review_narrative(),
+        repo="sherif69-sa/DevS69-sdetkit",
+        branch="feature/trajectory-evidence-review-records",
+        commit_sha="abc123",
+        pr_number=1389,
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["environment"]["source"] == "pr_quality"
+    assert record["diagnosis"]["failure_class"] == "evidence_review_signal"
+    assert record["diagnosis"]["risk_surface"] == "pr_quality"
+    assert record["decision"]["review_first"] is True
+    assert record["decision"]["auto_fix_allowed"] is False
+    assert record["action"] == "review"
+    assert record["final_result"] == "evidence_review_required"
+
+
+def test_pr_quality_trajectory_records_capture_green_evidence_proof_signal() -> None:
+    from sdetkit.trajectory_store import build_pr_quality_trajectory_records
+
+    records = build_pr_quality_trajectory_records(
+        action_report=_green_pr_quality_action_report(),
+        check_intelligence=_green_pr_quality_check_intelligence(),
+        evidence_narrative=_evidence_proof_narrative(),
+        repo="sherif69-sa/DevS69-sdetkit",
+        branch="feature/trajectory-evidence-review-records",
+        commit_sha="abc123",
+        pr_number=1389,
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["diagnosis"]["failure_class"] == "evidence_proof_signal"
+    assert record["decision"]["review_first"] is False
+    assert record["decision"]["auto_fix_allowed"] is False
+    assert record["action"] == "rerun_proof"
+    assert record["response"]["response_type"] == "evidence_proof_signal"
+    assert record["final_result"] == "proof_signal"
+
+
+def test_pr_quality_trajectory_cli_writes_green_evidence_review_record(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    action_path = tmp_path / "action-report.json"
+    intelligence_path = tmp_path / "check-intelligence.json"
+    narrative_path = tmp_path / "pr-evidence-narrative.json"
+    out = tmp_path / "trajectory.jsonl"
+
+    action_path.write_text(json.dumps(_green_pr_quality_action_report()), encoding="utf-8")
+    intelligence_path.write_text(
+        json.dumps(_green_pr_quality_check_intelligence()),
+        encoding="utf-8",
+    )
+    narrative_path.write_text(json.dumps(_evidence_review_narrative()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pr-quality-action-report",
+            str(action_path),
+            "--check-intelligence",
+            str(intelligence_path),
+            "--evidence-narrative",
+            str(narrative_path),
+            "--out",
+            str(out),
+            "--repo",
+            "sherif69-sa/DevS69-sdetkit",
+            "--branch",
+            "feature/trajectory-evidence-review-records",
+            "--commit-sha",
+            "abc123",
+            "--pr-number",
+            "1389",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["summary"]["record_count"] == 1
+    assert printed["summary"]["review_first_count"] == 1
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["action"] == "review"
+    assert payload["final_result"] == "evidence_review_required"
+
+
+def test_pr_quality_comment_can_show_green_evidence_review_trajectory_summary() -> None:
+    from sdetkit import pr_quality_action_report as report
+    from sdetkit.trajectory_store import build_pr_quality_trajectory_records
+
+    records = build_pr_quality_trajectory_records(
+        action_report=_green_pr_quality_action_report(),
+        check_intelligence=_green_pr_quality_check_intelligence(),
+        evidence_narrative=_evidence_review_narrative(),
+        repo="sherif69-sa/DevS69-sdetkit",
+        branch="feature/trajectory-evidence-review-records",
+        commit_sha="abc123",
+        pr_number=1389,
+    )
+
+    body = report.render_comment_body(
+        action_report=_green_pr_quality_action_report(),
+        check_intelligence=_green_pr_quality_check_intelligence(),
+        evidence_narrative=_evidence_review_narrative(),
+        trajectory_records=records,
+    )
+
+    assert "SDETKit Review Result: Green with evidence review" in body
+    assert "## Evidence review signal" in body
+    assert "## Trajectory summary" in body
+    assert "Records: `1`" in body
+    assert "Review-first decisions: `1`" in body
+    assert "`evidence_review_required`=1" in body
+    assert "`pr-quality-evidence-signal-evidence-review-signal`: action=`review`" in body


### PR DESCRIPTION
## Summary
- Records PR Quality evidence-review and proof-signal states as TrajectoryStore records.
- Moves PR Quality trajectory artifact generation after evidence narrative creation.
- Passes the evidence narrative into `sdetkit.trajectory_store`.
- Proves green-with-evidence-review comments can now include a Trajectory summary.

## Why
- PR Quality could generate trajectory artifacts for failed checks and primary blockers, but green PRs with review/proof evidence signals produced no trajectory records.
- This closes the gap from evidence review → durable trajectory memory.

## Verification
- `python -m pytest -q tests/test_trajectory_store.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-to-medium.
- Workflow ordering change plus trajectory-record generation logic.
- No auto-remediation expansion.
- No cloud queue.
- No verifier behavior change.
- Rollback: revert this PR.