### PR TITLE
Add trajectory pattern insights

### DIFF
--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -189,8 +189,21 @@ def build_alignment_components() -> list[AlignmentComponent]:
             status="aligned",
             stages=("history", "reporting"),
             existing_artifacts=("trajectory history JSON/Markdown reports",),
-            integration_points=("trajectory_store",),
-            recommended_next_action="feed future pattern insights and RepoMemory",
+            integration_points=("trajectory_store", "trajectory_pattern_insights"),
+            recommended_next_action="feed trajectory pattern insights and later RepoMemory",
+        ),
+        _component(
+            module="trajectory_pattern_insights",
+            role="detect recurring review-first and safe-fix patterns from trajectory history",
+            status="aligned",
+            stages=("history", "decision", "reporting"),
+            existing_artifacts=("trajectory pattern insights JSON/Markdown reports",),
+            integration_points=(
+                "trajectory_history_report",
+                "PatchScorer",
+                "RepoMemory",
+            ),
+            recommended_next_action="feed a local PatchScorer prototype without expanding automation",
         ),
         _component(
             module="current_head_failure_bundle",
@@ -305,7 +318,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/trajectory-pattern-insights",
+        "next_recommended_pr": "feature/patch-scorer-prototype",
     }
 
 

--- a/src/sdetkit/trajectory_pattern_insights.py
+++ b/src/sdetkit/trajectory_pattern_insights.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.trajectory_history_report import (
+    build_history_summary,
+    load_trajectory_records,
+)
+
+SCHEMA_VERSION = "sdetkit.trajectory_pattern_insights.v1"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _decision(record: Mapping[str, Any]) -> JsonObject:
+    return _as_dict(record.get("decision"))
+
+
+def _diagnosis(record: Mapping[str, Any]) -> JsonObject:
+    return _as_dict(record.get("diagnosis"))
+
+
+def _risk_surface(record: Mapping[str, Any]) -> str:
+    diagnosis = _diagnosis(record)
+    return _string(diagnosis.get("risk_surface") or record.get("risk_surface") or "unknown")
+
+
+def _failure_class(record: Mapping[str, Any]) -> str:
+    diagnosis = _diagnosis(record)
+    return _string(diagnosis.get("failure_class") or record.get("failure_class") or "unknown")
+
+
+def _action(record: Mapping[str, Any]) -> str:
+    return _string(record.get("action") or "unknown")
+
+
+def _counter_rows(counter: Counter[str], *, minimum_count: int = 1) -> list[JsonObject]:
+    return [
+        {"value": value, "count": count}
+        for value, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))
+        if count >= minimum_count
+    ]
+
+
+def _dominant(counter: Counter[str], *, total: int) -> JsonObject:
+    if not counter:
+        return {"value": "none", "count": 0, "share": 0.0, "repeated": False}
+
+    value, count = sorted(counter.items(), key=lambda item: (-item[1], item[0]))[0]
+    return {
+        "value": value,
+        "count": count,
+        "share": round(count / total, 4) if total else 0.0,
+        "repeated": count >= 2,
+    }
+
+
+def _safe_fix_patterns(
+    rows: list[JsonObject],
+    *,
+    minimum_repeat: int,
+) -> list[JsonObject]:
+    counter: Counter[tuple[str, str]] = Counter(
+        (_failure_class(row), _action(row))
+        for row in rows
+        if _bool(_decision(row).get("auto_fix_allowed"))
+    )
+    return [
+        {
+            "failure_class": failure_class,
+            "action": action,
+            "count": count,
+        }
+        for (failure_class, action), count in sorted(
+            counter.items(),
+            key=lambda item: (-item[1], item[0][0], item[0][1]),
+        )
+        if count >= minimum_repeat
+    ]
+
+
+def _operator_focus(
+    *,
+    record_count: int,
+    recurring_review_surfaces: list[JsonObject],
+    review_first_count: int,
+    recurring_safe_fixes: list[JsonObject],
+    auto_fix_allowed_count: int,
+) -> JsonObject:
+    if recurring_review_surfaces:
+        surface = _string(recurring_review_surfaces[0].get("value"))
+        return {
+            "priority": "review_first_recurrence",
+            "surface": surface,
+            "reason": f"Repeated review-first decisions were recorded on {surface}.",
+            "recommended_next_action": (
+                "Inspect repeated review-first evidence before expanding automation."
+            ),
+        }
+
+    if review_first_count:
+        return {
+            "priority": "review_first_observed",
+            "surface": "mixed",
+            "reason": "Review-first decisions exist but no repeated surface is proven yet.",
+            "recommended_next_action": "Collect more trajectory history before automation changes.",
+        }
+
+    if recurring_safe_fixes:
+        failure_class = _string(recurring_safe_fixes[0].get("failure_class"))
+        return {
+            "priority": "safe_fix_recurrence",
+            "surface": "quality",
+            "reason": f"Repeated safe-fix decisions were recorded for {failure_class}.",
+            "recommended_next_action": (
+                "Use this proven pattern as an input for the future PatchScorer prototype."
+            ),
+        }
+
+    if auto_fix_allowed_count:
+        return {
+            "priority": "safe_fix_observed",
+            "surface": "quality",
+            "reason": "A safe-fix decision exists but repetition is not proven yet.",
+            "recommended_next_action": "Collect more trajectory history before scoring patterns.",
+        }
+
+    if record_count:
+        return {
+            "priority": "observe_more_history",
+            "surface": "unknown",
+            "reason": "Trajectory records exist without a repeated operator pattern.",
+            "recommended_next_action": "Continue collecting deterministic trajectory records.",
+        }
+
+    return {
+        "priority": "no_history",
+        "surface": "none",
+        "reason": "No trajectory records were supplied.",
+        "recommended_next_action": "Generate trajectory records before evaluating patterns.",
+    }
+
+
+def build_pattern_insights(
+    records: list[Mapping[str, Any]],
+    *,
+    minimum_repeat: int = 2,
+    recent_limit: int = 5,
+) -> JsonObject:
+    if minimum_repeat < 1:
+        msg = "minimum_repeat must be at least 1"
+        raise ValueError(msg)
+
+    rows = [_as_dict(record) for record in records if _as_dict(record)]
+    review_first_rows = [row for row in rows if _bool(_decision(row).get("review_first"))]
+    auto_fix_rows = [row for row in rows if _bool(_decision(row).get("auto_fix_allowed"))]
+
+    surfaces = Counter(_risk_surface(row) for row in rows)
+    failure_classes = Counter(_failure_class(row) for row in rows)
+    actions = Counter(_action(row) for row in rows)
+    review_surfaces = Counter(_risk_surface(row) for row in review_first_rows)
+
+    recurring_review_surfaces = _counter_rows(
+        review_surfaces,
+        minimum_count=minimum_repeat,
+    )
+    recurring_safe_fixes = _safe_fix_patterns(
+        auto_fix_rows,
+        minimum_repeat=minimum_repeat,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "record_count": len(rows),
+        "minimum_repeat": minimum_repeat,
+        "history_summary": build_history_summary(rows, recent_limit=recent_limit),
+        "dominant_risk_surface": _dominant(surfaces, total=len(rows)),
+        "dominant_failure_class": _dominant(failure_classes, total=len(rows)),
+        "dominant_action": _dominant(actions, total=len(rows)),
+        "recurring_review_first_surfaces": recurring_review_surfaces,
+        "recurring_safe_fix_patterns": recurring_safe_fixes,
+        "operator_focus": _operator_focus(
+            record_count=len(rows),
+            recurring_review_surfaces=recurring_review_surfaces,
+            review_first_count=len(review_first_rows),
+            recurring_safe_fixes=recurring_safe_fixes,
+            auto_fix_allowed_count=len(auto_fix_rows),
+        ),
+    }
+
+
+def render_pattern_markdown(insights: Mapping[str, Any]) -> str:
+    history = _as_dict(insights.get("history_summary"))
+    focus = _as_dict(insights.get("operator_focus"))
+
+    lines = [
+        "# Trajectory pattern insights",
+        "",
+        f"- Schema: `{_string(insights.get('schema_version'))}`",
+        f"- Records analyzed: `{int(insights.get('record_count', 0) or 0)}`",
+        f"- Minimum repeat threshold: `{int(insights.get('minimum_repeat', 0) or 0)}`",
+        f"- Review-first decisions: `{int(history.get('review_first_count', 0) or 0)}`",
+        f"- Auto-fix allowed decisions: `{int(history.get('auto_fix_allowed_count', 0) or 0)}`",
+        "",
+        "## Dominant patterns",
+        "",
+    ]
+
+    for title, key in (
+        ("Risk surface", "dominant_risk_surface"),
+        ("Failure class", "dominant_failure_class"),
+        ("Action", "dominant_action"),
+    ):
+        item = _as_dict(insights.get(key))
+        lines.append(
+            f"- {title}: `{_string(item.get('value'))}` "
+            f"(count=`{int(item.get('count', 0) or 0)}`, "
+            f"share=`{float(item.get('share', 0.0) or 0.0):.4f}`)"
+        )
+
+    lines.extend(["", "## Recurring review-first surfaces", ""])
+    review_surfaces = insights.get("recurring_review_first_surfaces")
+    if isinstance(review_surfaces, list) and review_surfaces:
+        for item in review_surfaces:
+            row = _as_dict(item)
+            lines.append(f"- `{_string(row.get('value'))}`: `{int(row.get('count', 0) or 0)}`")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Recurring safe-fix patterns", ""])
+    safe_patterns = insights.get("recurring_safe_fix_patterns")
+    if isinstance(safe_patterns, list) and safe_patterns:
+        for item in safe_patterns:
+            row = _as_dict(item)
+            lines.append(
+                f"- class=`{_string(row.get('failure_class'))}`, "
+                f"action=`{_string(row.get('action'))}`, "
+                f"count=`{int(row.get('count', 0) or 0)}`"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Operator focus",
+            "",
+            f"- Priority: `{_string(focus.get('priority'))}`",
+            f"- Surface: `{_string(focus.get('surface'))}`",
+            f"- Reason: {_string(focus.get('reason'))}",
+            f"- Next action: {_string(focus.get('recommended_next_action'))}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_pattern_insights(
+    *,
+    records: list[Mapping[str, Any]],
+    json_out: Path | None = None,
+    markdown_out: Path | None = None,
+    minimum_repeat: int = 2,
+    recent_limit: int = 5,
+) -> JsonObject:
+    insights = build_pattern_insights(
+        records,
+        minimum_repeat=minimum_repeat,
+        recent_limit=recent_limit,
+    )
+
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(
+            json.dumps(insights, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if markdown_out is not None:
+        markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        markdown_out.write_text(render_pattern_markdown(insights), encoding="utf-8")
+
+    return insights
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.trajectory_pattern_insights")
+    parser.add_argument(
+        "--trajectory-jsonl",
+        type=Path,
+        action="append",
+        required=True,
+        help="TrajectoryStore JSONL file. May be provided more than once.",
+    )
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    parser.add_argument("--minimum-repeat", type=int, default=2)
+    parser.add_argument("--recent-limit", type=int, default=5)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        records = load_trajectory_records(args.trajectory_jsonl)
+        insights = write_pattern_insights(
+            records=records,
+            json_out=args.json_out,
+            markdown_out=args.markdown_out,
+            minimum_repeat=args.minimum_repeat,
+            recent_limit=args.recent_limit,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(json.dumps({"insights": insights}, indent=2, sort_keys=True))
+    else:
+        print(render_pattern_markdown(insights))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -22,6 +22,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "check_intelligence" in modules
     assert "trajectory_store" in modules
     assert "trajectory_history_report" in modules
+    assert "trajectory_pattern_insights" in modules
     assert "maintenance_autopilot" in modules
     assert "PatchScorer" in modules
     assert "ProtectedVerifier" in modules
@@ -36,7 +37,7 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     assert status_counts["aligned"] >= 8
     assert status_counts["partially_aligned"] >= 4
     assert status_counts["planned"] >= 4
-    assert report["next_recommended_pr"] == "feature/trajectory-pattern-insights"
+    assert report["next_recommended_pr"] == "feature/patch-scorer-prototype"
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -68,6 +69,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "## Components" in markdown
     assert "`check_intelligence`: `aligned`" in markdown
     assert "`maintenance_autopilot`: `partially_aligned`" in markdown
+    assert "`trajectory_pattern_insights`: `aligned`" in markdown
     assert "`PatchScorer`: `planned`" in markdown
 
 
@@ -92,7 +94,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/trajectory-pattern-insights"
+    assert saved["next_recommended_pr"] == "feature/patch-scorer-prototype"
     assert "Reliability spine alignment audit" in markdown
 
 

--- a/tests/test_trajectory_pattern_insights.py
+++ b/tests/test_trajectory_pattern_insights.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.trajectory_pattern_insights import (
+    build_pattern_insights,
+    main,
+    render_pattern_markdown,
+)
+
+
+def _records() -> list[dict]:
+    return [
+        {
+            "trajectory_id": "t1",
+            "diagnostic_id": "evidence-review-1",
+            "action": "review",
+            "diagnosis": {
+                "failure_class": "evidence_review_signal",
+                "risk_surface": "pr_quality",
+            },
+            "decision": {"review_first": True, "auto_fix_allowed": False},
+            "final_result": "evidence_review_required",
+        },
+        {
+            "trajectory_id": "t2",
+            "diagnostic_id": "evidence-review-2",
+            "action": "review",
+            "diagnosis": {
+                "failure_class": "evidence_review_signal",
+                "risk_surface": "pr_quality",
+            },
+            "decision": {"review_first": True, "auto_fix_allowed": False},
+            "final_result": "evidence_review_required",
+        },
+        {
+            "trajectory_id": "t3",
+            "diagnostic_id": "release-review",
+            "action": "review_release_failure",
+            "diagnosis": {
+                "failure_class": "release_artifact_invalid",
+                "risk_surface": "release",
+            },
+            "decision": {"review_first": True, "auto_fix_allowed": False},
+            "final_result": "review_required",
+        },
+        {
+            "trajectory_id": "t4",
+            "diagnostic_id": "format-fix-1",
+            "action": "run_pre_commit",
+            "diagnosis": {
+                "failure_class": "pre_commit_format_drift",
+                "risk_surface": "quality",
+            },
+            "decision": {"review_first": False, "auto_fix_allowed": True},
+            "final_result": "safe_fix_candidate",
+        },
+        {
+            "trajectory_id": "t5",
+            "diagnostic_id": "format-fix-2",
+            "action": "run_pre_commit",
+            "diagnosis": {
+                "failure_class": "pre_commit_format_drift",
+                "risk_surface": "quality",
+            },
+            "decision": {"review_first": False, "auto_fix_allowed": True},
+            "final_result": "safe_fix_candidate",
+        },
+    ]
+
+
+def test_pattern_insights_find_repeated_review_and_safe_fix_signals() -> None:
+    insights = build_pattern_insights(_records(), minimum_repeat=2)
+
+    assert insights["schema_version"] == "sdetkit.trajectory_pattern_insights.v1"
+    assert insights["record_count"] == 5
+    assert insights["history_summary"]["review_first_count"] == 3
+    assert insights["history_summary"]["auto_fix_allowed_count"] == 2
+    assert insights["dominant_risk_surface"]["value"] == "pr_quality"
+    assert insights["dominant_risk_surface"]["count"] == 2
+    assert insights["dominant_action"]["value"] == "review"
+    assert insights["recurring_review_first_surfaces"] == [{"value": "pr_quality", "count": 2}]
+    assert insights["recurring_safe_fix_patterns"] == [
+        {
+            "failure_class": "pre_commit_format_drift",
+            "action": "run_pre_commit",
+            "count": 2,
+        }
+    ]
+    assert insights["operator_focus"]["priority"] == "review_first_recurrence"
+    assert insights["operator_focus"]["surface"] == "pr_quality"
+
+
+def test_pattern_insights_does_not_claim_recurrence_from_one_record() -> None:
+    insights = build_pattern_insights(_records()[:1], minimum_repeat=2)
+
+    assert insights["recurring_review_first_surfaces"] == []
+    assert insights["recurring_safe_fix_patterns"] == []
+    assert insights["operator_focus"]["priority"] == "review_first_observed"
+
+
+def test_pattern_insights_rejects_invalid_repeat_threshold() -> None:
+    try:
+        build_pattern_insights(_records(), minimum_repeat=0)
+    except ValueError as exc:
+        assert "minimum_repeat must be at least 1" in str(exc)
+    else:
+        raise AssertionError("expected invalid repeat threshold to raise")
+
+
+def test_pattern_markdown_renders_operator_focus() -> None:
+    markdown = render_pattern_markdown(build_pattern_insights(_records()))
+
+    assert "# Trajectory pattern insights" in markdown
+    assert "Records analyzed: `5`" in markdown
+    assert "## Recurring review-first surfaces" in markdown
+    assert "`pr_quality`: `2`" in markdown
+    assert "class=`pre_commit_format_drift`, action=`run_pre_commit`, count=`2`" in markdown
+    assert "Priority: `review_first_recurrence`" in markdown
+
+
+def test_pattern_insights_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
+    trajectory_path = tmp_path / "trajectory.jsonl"
+    json_out = tmp_path / "insights.json"
+    markdown_out = tmp_path / "insights.md"
+    trajectory_path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in _records()) + "\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--trajectory-jsonl",
+            str(trajectory_path),
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+            "--minimum-repeat",
+            "2",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert printed["insights"]["record_count"] == 5
+    assert saved["operator_focus"]["priority"] == "review_first_recurrence"
+    assert "Trajectory pattern insights" in markdown
+
+
+def test_pattern_insights_cli_accepts_multiple_trajectory_files(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    first = tmp_path / "first.jsonl"
+    second = tmp_path / "second.jsonl"
+    first.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in _records()[:3]) + "\n",
+        encoding="utf-8",
+    )
+    second.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in _records()[3:]) + "\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--trajectory-jsonl",
+            str(first),
+            "--trajectory-jsonl",
+            str(second),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["insights"]["record_count"] == 5
+    assert printed["insights"]["recurring_review_first_surfaces"][0]["value"] == "pr_quality"


### PR DESCRIPTION
## Summary
- Adds a local read-only trajectory pattern insights reporter.
- Detects recurring review-first surfaces and repeated safe-fix patterns from trajectory JSONL history.
- Reports dominant risk surface, failure class, action, and operator focus.
- Supports JSON and Markdown output with multiple trajectory input files.
- Updates the reliability spine alignment audit to mark `trajectory_pattern_insights` as aligned and advance the next recommended PR to `feature/patch-scorer-prototype`.

## Why
- TrajectoryStore and trajectory history reporting are now merged and green.
- Operators need useful pattern-level insight before the repo introduces PatchScorer, ProtectedVerifier, or RepoMemory.
- This keeps existing capabilities connected to the reliability spine rather than adding isolated modules.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_trajectory_pattern_insights.py tests/test_trajectory_history_report.py tests/test_reliability_spine_alignment.py tests/test_trajectory_store.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low.
- Read-only local reporting and architecture-map refresh only.
- No workflow behavior change.
- No auto-remediation expansion.
- No external service dependency.
- Rollback: revert this PR.