### PR TITLE
Add read-only patch safety scorer

### DIFF
--- a/src/sdetkit/patch_scorer.py
+++ b/src/sdetkit/patch_scorer.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.remediation_plan_engine import (
+    ALLOWED_STRATEGY,
+    BLOCKED_REASON,
+    CLASSIFICATION,
+    EXACT_FIX_SCOPE,
+    EXECUTABLE_STRATEGIES,
+    RISK_LEVEL,
+    SAFE_TO_AUTO_FIX,
+)
+
+SCHEMA_VERSION = "sdetkit.patch_score.v1"
+DEFAULT_OUT_DIR = Path("build") / "patch-scorer"
+PATCH_SCORE_JSON = "patch-score.json"
+PATCH_SCORE_MD = "patch-score.md"
+DEFAULT_MINIMUM_SCORE = 80
+
+JsonObject = dict[str, Any]
+
+PROTECTED_EXACT_PATHS = {
+    ".pre-commit-config.yaml",
+    "ci.sh",
+    "constraints-ci.txt",
+    "pyproject.toml",
+    "quality.sh",
+    "sdetkit.policy.toml",
+}
+PROTECTED_PREFIXES = (
+    ".github/",
+    "tests/",
+)
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _string_list(value: Any) -> list[str]:
+    return sorted({_string(item) for item in _as_list(value) if _string(item)})
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"expected JSON object in {path}"
+        raise ValueError(msg)
+    return payload
+
+
+def _protected_path(path: str) -> bool:
+    return path in PROTECTED_EXACT_PATHS or path.startswith(PROTECTED_PREFIXES)
+
+
+def _select_plan(remediation_plan: Mapping[str, Any], diagnosis_id: str) -> JsonObject:
+    plans = [_as_dict(item) for item in _as_list(remediation_plan.get("plans"))]
+    if diagnosis_id:
+        for plan in plans:
+            if _string(plan.get("diagnosis_id")) == diagnosis_id:
+                return plan
+        return {}
+    return plans[0] if plans else {}
+
+
+def _history_safe_pattern_match(
+    *,
+    pattern_insights: Mapping[str, Any],
+    classification: str,
+    strategy: str,
+) -> bool:
+    for item in _as_list(pattern_insights.get("recurring_safe_fix_patterns")):
+        pattern = _as_dict(item)
+        if (
+            _string(pattern.get("failure_class")) == classification
+            and _string(pattern.get("action")) == strategy
+        ):
+            return True
+    return False
+
+
+def _history_review_surface_match(
+    *,
+    pattern_insights: Mapping[str, Any],
+    surface: str,
+) -> bool:
+    for item in _as_list(pattern_insights.get("recurring_review_first_surfaces")):
+        pattern = _as_dict(item)
+        if _string(pattern.get("value")) == surface:
+            return True
+    return False
+
+
+def _risk_flag(
+    code: str,
+    message: str,
+    *,
+    blocking: bool,
+    penalty: int,
+    files: list[str] | None = None,
+) -> JsonObject:
+    return {
+        "code": code,
+        "message": message,
+        "blocking": blocking,
+        "penalty": penalty,
+        "files": files or [],
+    }
+
+
+def _decision_reason(*, blocked: bool, candidate: bool) -> str:
+    if blocked:
+        return "Blocking safety signals require review-first handling."
+    if candidate:
+        return (
+            "The patch stays inside an approved formatting-only scope; "
+            "it is a candidate for future protected verification only."
+        )
+    return "The patch is not blocked, but its score is below the verification threshold."
+
+
+def score_patch(
+    *,
+    remediation_plan: Mapping[str, Any],
+    proposed_patch: Mapping[str, Any],
+    pattern_insights: Mapping[str, Any] | None = None,
+    diagnosis_id: str = "",
+    minimum_score: int = DEFAULT_MINIMUM_SCORE,
+) -> JsonObject:
+    if minimum_score < 0 or minimum_score > 100:
+        msg = "minimum_score must be between 0 and 100"
+        raise ValueError(msg)
+
+    insights = _as_dict(pattern_insights)
+    plan = _select_plan(remediation_plan, diagnosis_id)
+    patch_id = _string(proposed_patch.get("patch_id")) or "proposed-patch"
+    changed_files = _string_list(proposed_patch.get("changed_files"))
+    flags: list[JsonObject] = []
+
+    if not plan:
+        flags.append(
+            _risk_flag(
+                "PLAN_NOT_FOUND",
+                "No remediation plan matched the proposed patch.",
+                blocking=True,
+                penalty=100,
+            )
+        )
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "patch_id": patch_id,
+            "diagnosis_id": diagnosis_id or "unknown",
+            "changed_files": changed_files,
+            "score": 0,
+            "minimum_score": minimum_score,
+            "risk_flags": flags,
+            "decision": {
+                "status": "blocked_review_first",
+                "candidate_for_protected_verification": False,
+                "automation_allowed": False,
+                "reason": _decision_reason(blocked=True, candidate=False),
+            },
+            "proof_requirements": [],
+            "history_evidence": {
+                "safe_fix_pattern_match": False,
+                "review_first_surface_match": False,
+            },
+        }
+
+    selected_diagnosis_id = _string(plan.get("diagnosis_id")) or diagnosis_id or "unknown"
+    surface = _string(plan.get("failure_surface")) or "unknown"
+    classification = _string(plan.get(CLASSIFICATION)) or "unknown"
+    strategy = _string(plan.get(ALLOWED_STRATEGY)) or "unknown"
+    exact_scope = _as_dict(plan.get(EXACT_FIX_SCOPE))
+    allowed_files = _string_list(exact_scope.get("allowed_files")) or _string_list(
+        plan.get("affected_files")
+    )
+    proof_commands = _string_list(plan.get("proof_commands"))
+
+    if not _bool(plan.get(SAFE_TO_AUTO_FIX)):
+        flags.append(
+            _risk_flag(
+                "PLAN_REVIEW_FIRST",
+                _string(plan.get(BLOCKED_REASON))
+                or "The remediation plan is not approved for automatic mutation.",
+                blocking=True,
+                penalty=100,
+            )
+        )
+
+    if surface != "formatting":
+        flags.append(
+            _risk_flag(
+                "NON_FORMATTING_SURFACE",
+                f"Only formatting surface patches are eligible in this prototype; got {surface}.",
+                blocking=True,
+                penalty=100,
+            )
+        )
+
+    if strategy not in EXECUTABLE_STRATEGIES:
+        flags.append(
+            _risk_flag(
+                "STRATEGY_NOT_APPROVED",
+                f"Strategy {strategy} is not an approved mechanical remediation strategy.",
+                blocking=True,
+                penalty=100,
+            )
+        )
+
+    if not changed_files:
+        flags.append(
+            _risk_flag(
+                "NO_CHANGED_FILES",
+                "A patch cannot be scored as safe without explicit changed files.",
+                blocking=True,
+                penalty=100,
+            )
+        )
+
+    outside_scope = sorted(set(changed_files) - set(allowed_files))
+    if outside_scope:
+        flags.append(
+            _risk_flag(
+                "OUTSIDE_EXACT_FIX_SCOPE",
+                "The proposed patch changes files outside the remediation plan scope.",
+                blocking=True,
+                penalty=100,
+                files=outside_scope,
+            )
+        )
+
+    protected_files = [path for path in changed_files if _protected_path(path)]
+    if protected_files:
+        flags.append(
+            _risk_flag(
+                "PROTECTED_PATH_CHANGED",
+                (
+                    "Tests, workflow files, or gate/configuration files require "
+                    "ProtectedVerifier before trust."
+                ),
+                blocking=True,
+                penalty=100,
+                files=protected_files,
+            )
+        )
+
+    if not proof_commands:
+        flags.append(
+            _risk_flag(
+                "PROOF_COMMANDS_MISSING",
+                "The remediation plan does not provide required proof commands.",
+                blocking=True,
+                penalty=100,
+            )
+        )
+
+    safe_pattern_match = _history_safe_pattern_match(
+        pattern_insights=insights,
+        classification=classification,
+        strategy=strategy,
+    )
+    review_surface_match = _history_review_surface_match(
+        pattern_insights=insights,
+        surface=surface,
+    )
+
+    if review_surface_match:
+        flags.append(
+            _risk_flag(
+                "RECURRING_REVIEW_FIRST_SURFACE",
+                (
+                    "Trajectory history records repeated review-first handling "
+                    f"for the {surface} surface."
+                ),
+                blocking=True,
+                penalty=100,
+            )
+        )
+    elif not safe_pattern_match:
+        flags.append(
+            _risk_flag(
+                "SAFE_PATTERN_NOT_REPEATED",
+                "No repeated matching safe-fix pattern is proven in trajectory history yet.",
+                blocking=False,
+                penalty=10,
+            )
+        )
+
+    score = max(0, 100 - sum(int(flag["penalty"]) for flag in flags))
+    blocked = any(_bool(flag.get("blocking")) for flag in flags)
+    candidate = not blocked and score >= minimum_score
+    status = (
+        "blocked_review_first"
+        if blocked
+        else ("candidate_for_protected_verification" if candidate else "needs_review")
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "patch_id": patch_id,
+        "diagnosis_id": selected_diagnosis_id,
+        "failure_surface": surface,
+        "classification": classification,
+        "risk_level": _string(plan.get(RISK_LEVEL)) or "unknown",
+        "strategy": strategy,
+        "changed_files": changed_files,
+        "allowed_files": allowed_files,
+        "score": score,
+        "minimum_score": minimum_score,
+        "risk_flags": flags,
+        "decision": {
+            "status": status,
+            "candidate_for_protected_verification": candidate,
+            "automation_allowed": False,
+            "reason": _decision_reason(blocked=blocked, candidate=candidate),
+        },
+        "proof_requirements": proof_commands,
+        "history_evidence": {
+            "safe_fix_pattern_match": safe_pattern_match,
+            "review_first_surface_match": review_surface_match,
+        },
+    }
+
+
+def render_markdown(payload: Mapping[str, Any]) -> str:
+    decision = _as_dict(payload.get("decision"))
+    history = _as_dict(payload.get("history_evidence"))
+    flags = [_as_dict(item) for item in _as_list(payload.get("risk_flags"))]
+
+    lines = [
+        "# Patch safety score",
+        "",
+        f"- Patch: `{_string(payload.get('patch_id'))}`",
+        f"- Diagnosis: `{_string(payload.get('diagnosis_id'))}`",
+        f"- Surface: `{_string(payload.get('failure_surface'))}`",
+        f"- Classification: `{_string(payload.get('classification'))}`",
+        f"- Strategy: `{_string(payload.get('strategy'))}`",
+        f"- Score: `{int(payload.get('score', 0) or 0)}`",
+        f"- Minimum score: `{int(payload.get('minimum_score', 0) or 0)}`",
+        f"- Decision: `{_string(decision.get('status'))}`",
+        "- Automation allowed: `false`",
+        "",
+        "## History evidence",
+        "",
+        f"- Matching repeated safe-fix pattern: `{str(_bool(history.get('safe_fix_pattern_match'))).lower()}`",
+        f"- Matching recurring review-first surface: `{str(_bool(history.get('review_first_surface_match'))).lower()}`",
+        "",
+        "## Risk flags",
+        "",
+    ]
+
+    if flags:
+        for flag in flags:
+            files = ", ".join(_string(item) for item in _as_list(flag.get("files")))
+            suffix = f" files=`{files}`" if files else ""
+            lines.append(
+                f"- `{_string(flag.get('code'))}`: "
+                f"blocking=`{str(_bool(flag.get('blocking'))).lower()}` "
+                f"{_string(flag.get('message'))}{suffix}"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Required proof", ""])
+    proof = _string_list(payload.get("proof_requirements"))
+    if proof:
+        lines.extend(f"- `{command}`" for command in proof)
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "- This score is read-only.",
+            "- A candidate result does not authorize mutation or merge.",
+            "- ProtectedVerifier must exist and pass before broader automation is trusted.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_patch_score(
+    payload: Mapping[str, Any],
+    *,
+    out_dir: Path,
+) -> dict[str, str]:
+    json_path = out_dir / PATCH_SCORE_JSON
+    markdown_path = out_dir / PATCH_SCORE_MD
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(payload), encoding="utf-8")
+    return {
+        "patch_score_json": json_path.as_posix(),
+        "patch_score_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.patch_scorer")
+    parser.add_argument("--remediation-plan", type=Path, required=True)
+    parser.add_argument("--proposed-patch", type=Path, required=True)
+    parser.add_argument("--pattern-insights", type=Path)
+    parser.add_argument("--diagnosis-id", default="")
+    parser.add_argument("--minimum-score", type=int, default=DEFAULT_MINIMUM_SCORE)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        payload = score_patch(
+            remediation_plan=_read_json(args.remediation_plan),
+            proposed_patch=_read_json(args.proposed_patch),
+            pattern_insights=_read_json(args.pattern_insights),
+            diagnosis_id=args.diagnosis_id,
+            minimum_score=args.minimum_score,
+        )
+        artifacts = write_patch_score(payload, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "artifacts": artifacts,
+                    "decision": payload["decision"],
+                    "score": payload["score"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -116,12 +116,9 @@ def build_alignment_components() -> list[AlignmentComponent]:
             status="partially_aligned",
             stages=("decision", "remediation_eligibility", "proof"),
             existing_artifacts=("remediation plans",),
-            integration_points=("diagnostic_vector_engine", "trajectory_store"),
-            gaps=(
-                "needs stronger feedback from trajectory history",
-                "needs PatchScorer before broader mutation use",
-            ),
-            recommended_next_action="connect plan decisions to PatchScorer and protected proof",
+            integration_points=("diagnostic_vector_engine", "trajectory_store", "patch_scorer"),
+            gaps=("needs ProtectedVerifier feedback before broader mutation use",),
+            recommended_next_action="feed plans through PatchScorer before protected proof",
         ),
         _component(
             module="safe_remediation_eligibility",
@@ -136,12 +133,16 @@ def build_alignment_components() -> list[AlignmentComponent]:
             role="bridge approved safe formatting fixes into PR branches",
             status="partially_aligned",
             stages=("remediation_eligibility", "proof"),
-            integration_points=("check_intelligence", "safe_remediation_eligibility"),
+            integration_points=(
+                "check_intelligence",
+                "safe_remediation_eligibility",
+                "patch_scorer",
+            ),
             gaps=(
-                "should remain formatting-only until PatchScorer exists",
+                "PatchScorer exists but is not wired into automation yet",
                 "needs ProtectedVerifier before broader automation",
             ),
-            recommended_next_action="do not expand beyond approved safe formatting fixes yet",
+            recommended_next_action="keep formatting-only until PatchScorer and ProtectedVerifier are wired",
         ),
         _component(
             module="pr_quality_evidence_narrative",
@@ -200,10 +201,10 @@ def build_alignment_components() -> list[AlignmentComponent]:
             existing_artifacts=("trajectory pattern insights JSON/Markdown reports",),
             integration_points=(
                 "trajectory_history_report",
-                "PatchScorer",
+                "patch_scorer",
                 "RepoMemory",
             ),
-            recommended_next_action="feed a local PatchScorer prototype without expanding automation",
+            recommended_next_action="feed read-only PatchScorer evidence without expanding automation",
         ),
         _component(
             module="current_head_failure_bundle",
@@ -248,15 +249,21 @@ def build_alignment_components() -> list[AlignmentComponent]:
             recommended_next_action="harden unknown-failure classification without broad automation",
         ),
         _component(
-            module="PatchScorer",
-            role="score proposed patches for safety before trusting them",
-            status="planned",
-            stages=("decision", "proof", "verifier"),
-            gaps=(
-                "not implemented yet",
-                "needed before expanding safe remediation beyond formatting",
+            module="patch_scorer",
+            role="score proposed patch safety before any future automation consumes it",
+            status="partially_aligned",
+            stages=("decision", "remediation_eligibility", "proof"),
+            existing_artifacts=("patch-score.json", "patch-score.md"),
+            integration_points=(
+                "remediation_plan_engine",
+                "trajectory_pattern_insights",
+                "ProtectedVerifier",
             ),
-            recommended_next_action="build local prototype after pattern insights",
+            gaps=(
+                "read-only prototype is not wired into maintenance_autopilot",
+                "requires ProtectedVerifier before eligible scores may influence automation",
+            ),
+            recommended_next_action="build ProtectedVerifier prototype and keep automation unchanged",
         ),
         _component(
             module="ProtectedVerifier",
@@ -318,7 +325,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/patch-scorer-prototype",
+        "next_recommended_pr": "feature/protected-verifier-prototype",
     }
 
 

--- a/tests/test_patch_scorer.py
+++ b/tests/test_patch_scorer.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.patch_scorer import main, score_patch
+
+
+def _safe_plan() -> dict:
+    return {
+        "plans": [
+            {
+                "diagnosis_id": "formatting-autopilot",
+                "failure_surface": "formatting",
+                "classification": "formatting_only",
+                "safe_to_auto_fix": True,
+                "allowed_strategy": "run_pre_commit",
+                "blocked_reason": "",
+                "risk_level": "low",
+                "affected_files": ["src/sdetkit/example.py"],
+                "exact_fix_scope": {
+                    "allowed_files": ["src/sdetkit/example.py"],
+                    "allowed_strategy": "run_pre_commit",
+                    "scope": "deterministic formatting or whitespace only",
+                },
+                "proof_commands": ["python -m pre_commit run -a"],
+            }
+        ]
+    }
+
+
+def _review_first_plan() -> dict:
+    return {
+        "plans": [
+            {
+                "diagnosis_id": "release-case",
+                "failure_surface": "release",
+                "classification": "release_artifact",
+                "safe_to_auto_fix": False,
+                "allowed_strategy": "review_first_release_validation",
+                "blocked_reason": "release artifacts require clean build and metadata validation",
+                "risk_level": "high",
+                "affected_files": ["pyproject.toml"],
+                "exact_fix_scope": {"allowed_files": []},
+                "proof_commands": [
+                    "python -m build",
+                    "python -m twine check dist/*",
+                ],
+            }
+        ]
+    }
+
+
+def _matching_safe_insights() -> dict:
+    return {
+        "recurring_review_first_surfaces": [],
+        "recurring_safe_fix_patterns": [
+            {
+                "failure_class": "formatting_only",
+                "action": "run_pre_commit",
+                "count": 2,
+            }
+        ],
+    }
+
+
+def test_patch_scorer_marks_exact_formatting_patch_as_verification_candidate_only() -> None:
+    payload = score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "format-patch",
+            "changed_files": ["src/sdetkit/example.py"],
+        },
+        pattern_insights=_matching_safe_insights(),
+    )
+
+    assert payload["score"] == 100
+    assert payload["risk_flags"] == []
+    assert payload["decision"]["status"] == "candidate_for_protected_verification"
+    assert payload["decision"]["candidate_for_protected_verification"] is True
+    assert payload["decision"]["automation_allowed"] is False
+    assert payload["proof_requirements"] == ["python -m pre_commit run -a"]
+    assert payload["history_evidence"]["safe_fix_pattern_match"] is True
+
+
+def test_patch_scorer_blocks_out_of_scope_and_protected_test_changes() -> None:
+    payload = score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "broad-patch",
+            "changed_files": [
+                "src/sdetkit/example.py",
+                "tests/test_example.py",
+            ],
+        },
+        pattern_insights=_matching_safe_insights(),
+    )
+
+    codes = {flag["code"] for flag in payload["risk_flags"]}
+    assert payload["score"] == 0
+    assert "OUTSIDE_EXACT_FIX_SCOPE" in codes
+    assert "PROTECTED_PATH_CHANGED" in codes
+    assert payload["decision"]["status"] == "blocked_review_first"
+    assert payload["decision"]["candidate_for_protected_verification"] is False
+    assert payload["decision"]["automation_allowed"] is False
+
+
+def test_patch_scorer_blocks_review_first_release_plan() -> None:
+    payload = score_patch(
+        remediation_plan=_review_first_plan(),
+        proposed_patch={
+            "patch_id": "release-patch",
+            "changed_files": ["pyproject.toml"],
+        },
+        pattern_insights={},
+    )
+
+    codes = {flag["code"] for flag in payload["risk_flags"]}
+    assert payload["score"] == 0
+    assert "PLAN_REVIEW_FIRST" in codes
+    assert "NON_FORMATTING_SURFACE" in codes
+    assert "PROTECTED_PATH_CHANGED" in codes
+    assert payload["decision"]["status"] == "blocked_review_first"
+
+
+def test_patch_scorer_keeps_unproven_safe_pattern_read_only() -> None:
+    payload = score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "first-observed-format-patch",
+            "changed_files": ["src/sdetkit/example.py"],
+        },
+        pattern_insights={},
+    )
+
+    assert payload["score"] == 90
+    assert payload["risk_flags"][0]["code"] == "SAFE_PATTERN_NOT_REPEATED"
+    assert payload["risk_flags"][0]["blocking"] is False
+    assert payload["decision"]["status"] == "candidate_for_protected_verification"
+    assert payload["decision"]["automation_allowed"] is False
+
+
+def test_patch_scorer_blocks_matching_review_first_surface_history() -> None:
+    payload = score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "format-review-history",
+            "changed_files": ["src/sdetkit/example.py"],
+        },
+        pattern_insights={
+            "recurring_review_first_surfaces": [{"value": "formatting", "count": 2}],
+            "recurring_safe_fix_patterns": [],
+        },
+    )
+
+    assert payload["score"] == 0
+    assert payload["risk_flags"][0]["code"] == "RECURRING_REVIEW_FIRST_SURFACE"
+    assert payload["decision"]["status"] == "blocked_review_first"
+
+
+def test_patch_scorer_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
+    remediation_path = tmp_path / "remediation-plan.json"
+    proposed_path = tmp_path / "proposed-patch.json"
+    insights_path = tmp_path / "pattern-insights.json"
+    out_dir = tmp_path / "patch-score"
+
+    remediation_path.write_text(json.dumps(_safe_plan()), encoding="utf-8")
+    proposed_path.write_text(
+        json.dumps(
+            {
+                "patch_id": "format-patch",
+                "changed_files": ["src/sdetkit/example.py"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    insights_path.write_text(json.dumps(_matching_safe_insights()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--remediation-plan",
+            str(remediation_path),
+            "--proposed-patch",
+            str(proposed_path),
+            "--pattern-insights",
+            str(insights_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    score = json.loads((out_dir / "patch-score.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "patch-score.md").read_text(encoding="utf-8")
+
+    assert printed["score"] == 100
+    assert score["decision"]["status"] == "candidate_for_protected_verification"
+    assert score["decision"]["automation_allowed"] is False
+    assert "# Patch safety score" in markdown
+    assert "ProtectedVerifier must exist and pass" in markdown

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -24,7 +24,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "trajectory_history_report" in modules
     assert "trajectory_pattern_insights" in modules
     assert "maintenance_autopilot" in modules
-    assert "PatchScorer" in modules
+    assert "patch_scorer" in modules
     assert "ProtectedVerifier" in modules
     assert "ReplayableBenchmarkHarness" in modules
     assert "RepoMemory" in modules
@@ -35,9 +35,9 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 8
-    assert status_counts["partially_aligned"] >= 4
-    assert status_counts["planned"] >= 4
-    assert report["next_recommended_pr"] == "feature/patch-scorer-prototype"
+    assert status_counts["partially_aligned"] >= 5
+    assert status_counts["planned"] >= 3
+    assert report["next_recommended_pr"] == "feature/protected-verifier-prototype"
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -54,10 +54,10 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     gaps_by_module = {item["module"]: item["gaps"] for item in report["gaps"]}
 
     assert "maintenance_autopilot" in gaps_by_module
-    assert "PatchScorer" in gaps_by_module
+    assert "patch_scorer" in gaps_by_module
     assert "ProtectedVerifier" in gaps_by_module
-    assert any("PatchScorer" in gap for gap in gaps_by_module["maintenance_autopilot"])
-    assert any("not implemented yet" in gap for gap in gaps_by_module["PatchScorer"])
+    assert any("PatchScorer exists" in gap for gap in gaps_by_module["maintenance_autopilot"])
+    assert any("ProtectedVerifier" in gap for gap in gaps_by_module["patch_scorer"])
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -70,7 +70,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`check_intelligence`: `aligned`" in markdown
     assert "`maintenance_autopilot`: `partially_aligned`" in markdown
     assert "`trajectory_pattern_insights`: `aligned`" in markdown
-    assert "`PatchScorer`: `planned`" in markdown
+    assert "`patch_scorer`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -94,7 +94,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/patch-scorer-prototype"
+    assert saved["next_recommended_pr"] == "feature/protected-verifier-prototype"
     assert "Reliability spine alignment audit" in markdown
 
 
@@ -136,6 +136,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         "reliability_spine_alignment",
         "trajectory_history_report",
         "pr_quality_action_report",
+        "patch_scorer",
     }
 
     assert "maintenance_autopilot" not in report_modules


### PR DESCRIPTION
## Summary
- Adds a local read-only `patch_scorer` prototype.
- Scores proposed patch files against remediation-plan scope, strategy, proof requirements, and trajectory pattern insights.
- Blocks review-first plans, non-formatting surfaces, unapproved strategies, protected files, missing proof commands, and files outside exact fix scope.
- Allows only formatting-scope patches to become candidates for future protected verification.
- Keeps `automation_allowed=false` for every outcome.
- Updates the reliability spine alignment audit to classify `patch_scorer` as partially aligned and advance the next recommended PR to `feature/protected-verifier-prototype`.

## Why
- The repo now records trajectory history and detects recurring decision patterns.
- Before any future automation expansion, proposed fixes need a deterministic safety scoring layer.
- This prototype establishes that boundary without applying changes or authorizing merges.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_patch_scorer.py tests/test_remediation_plan_engine.py tests/test_trajectory_pattern_insights.py tests/test_reliability_spine_alignment.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-to-medium.
- New read-only scoring module plus architecture-map refresh.
- No workflow behavior change.
- No auto-remediation expansion.
- No external service dependency.
- No protected-verifier enforcement yet.
- Rollback: revert this PR.