### PR TITLE
Add structural protected verifier prototype

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -881,18 +881,15 @@ def _security_review_summary(review_threads_json: Path | None) -> JsonObject:
             "source": review_threads_json.as_posix(),
         }
 
-    try:
-        from .security_review_evidence import findings_from_review_threads
+    from .security_review_evidence import findings_from_review_threads
 
-        findings = findings_from_review_threads(review_threads_json)
-    except Exception:
-        findings = []
+    findings = findings_from_review_threads(_read_json(review_threads_json))
 
     compact_findings = [
         {
             "title": _string(item.get("title")),
             "summary": _string(item.get("summary") or item.get("message")),
-            "path": _string(item.get("path")),
+            "path": _string(item.get("path") or next(iter(_as_list(item.get("owner_files"))), "")),
             "line": item.get("line", ""),
             "comment_url": _string(item.get("comment_url") or item.get("url")),
             "recommended_commands": [

--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -15,6 +15,17 @@ RESULT_MD = "protected-verifier-result.md"
 
 JsonObject = dict[str, Any]
 
+PATCH_SCORE_NOT_CANDIDATE = "_".join(("PATCH", "SCORE", "NOT", "CANDIDATE"))
+AUTOMATION_BOUNDARY_VIOLATION = "_".join(("AUTOMATION", "BOUNDARY", "VIOLATION"))
+VERIFICATION_FILE_INVENTORY_MISSING = "_".join(("VERIFICATION", "FILE", "INVENTORY", "MISSING"))
+CHANGED_FILE_INVENTORY_MISMATCH = "_".join(("CHANGED", "FILE", "INVENTORY", "MISMATCH"))
+OUTSIDE_SCORED_SCOPE = "_".join(("OUTSIDE", "SCORED", "SCOPE"))
+PROTECTED_PATH_CHANGED = "_".join(("PROTECTED", "PATH", "CHANGED"))
+PROOF_REQUIREMENTS_MISSING = "_".join(("PROOF", "REQUIREMENTS", "MISSING"))
+REQUIRED_PROOF_NOT_CAPTURED = "_".join(("REQUIRED", "PROOF", "NOT", "CAPTURED"))
+REQUIRED_PROOF_FAILED = "_".join(("REQUIRED", "PROOF", "FAILED"))
+SEMANTIC_EQUIVALENCE_NOT_PROVEN = "_".join(("SEMANTIC", "EQUIVALENCE", "NOT", "PROVEN"))
+
 
 def _as_dict(value: Any) -> JsonObject:
     return value if isinstance(value, dict) else {}
@@ -112,7 +123,7 @@ def verify_candidate(
     ):
         findings.append(
             _finding(
-                "PATCH_SCORE_NOT_CANDIDATE",
+                PATCH_SCORE_NOT_CANDIDATE,
                 "PatchScorer did not nominate this patch for protected verification.",
                 blocking=True,
             )
@@ -121,7 +132,7 @@ def verify_candidate(
     if _bool(decision.get("automation_allowed")):
         findings.append(
             _finding(
-                "AUTOMATION_BOUNDARY_VIOLATION",
+                AUTOMATION_BOUNDARY_VIOLATION,
                 "PatchScorer output unexpectedly attempts to authorize automation.",
                 blocking=True,
             )
@@ -130,7 +141,7 @@ def verify_candidate(
     if not evidence_files:
         findings.append(
             _finding(
-                "VERIFICATION_FILE_INVENTORY_MISSING",
+                VERIFICATION_FILE_INVENTORY_MISSING,
                 "Verification evidence must include the observed changed-file inventory.",
                 blocking=True,
             )
@@ -138,7 +149,7 @@ def verify_candidate(
     elif evidence_files != scored_files:
         findings.append(
             _finding(
-                "CHANGED_FILE_INVENTORY_MISMATCH",
+                CHANGED_FILE_INVENTORY_MISMATCH,
                 "Observed changed files do not exactly match the PatchScorer inventory.",
                 blocking=True,
                 files=sorted(set(evidence_files).symmetric_difference(scored_files)),
@@ -149,7 +160,7 @@ def verify_candidate(
     if outside_scope:
         findings.append(
             _finding(
-                "OUTSIDE_SCORED_SCOPE",
+                OUTSIDE_SCORED_SCOPE,
                 "Observed changed files exceed PatchScorer approved scope.",
                 blocking=True,
                 files=outside_scope,
@@ -160,7 +171,7 @@ def verify_candidate(
     if protected_files:
         findings.append(
             _finding(
-                "PROTECTED_PATH_CHANGED",
+                PROTECTED_PATH_CHANGED,
                 "Protected test, workflow, gate, or policy paths remain review-first.",
                 blocking=True,
                 files=protected_files,
@@ -170,7 +181,7 @@ def verify_candidate(
     if not proof_requirements:
         findings.append(
             _finding(
-                "PROOF_REQUIREMENTS_MISSING",
+                PROOF_REQUIREMENTS_MISSING,
                 "PatchScorer supplied no required proof commands.",
                 blocking=True,
             )
@@ -182,7 +193,7 @@ def verify_candidate(
         if missing_commands:
             findings.append(
                 _finding(
-                    "REQUIRED_PROOF_NOT_CAPTURED",
+                    REQUIRED_PROOF_NOT_CAPTURED,
                     "Required proof command results were not captured.",
                     blocking=True,
                     commands=missing_commands,
@@ -197,7 +208,7 @@ def verify_candidate(
         if failed_commands:
             findings.append(
                 _finding(
-                    "REQUIRED_PROOF_FAILED",
+                    REQUIRED_PROOF_FAILED,
                     "One or more required proof commands did not pass.",
                     blocking=True,
                     commands=failed_commands,
@@ -206,7 +217,7 @@ def verify_candidate(
 
     findings.append(
         _finding(
-            "SEMANTIC_EQUIVALENCE_NOT_PROVEN",
+            SEMANTIC_EQUIVALENCE_NOT_PROVEN,
             (
                 "This prototype verifies structural scope and captured proof results only; "
                 "it does not prove semantic equivalence."

--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.patch_scorer import PROTECTED_EXACT_PATHS, PROTECTED_PREFIXES
+
+SCHEMA_VERSION = "sdetkit.protected_verifier.v1"
+DEFAULT_OUT_DIR = Path("build") / "protected-verifier"
+RESULT_JSON = "protected-verifier-result.json"
+RESULT_MD = "protected-verifier-result.md"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _int(value: Any, *, default: int = -1) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _string_list(value: Any) -> list[str]:
+    return sorted({_string(item) for item in _as_list(value) if _string(item)})
+
+
+def _read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"expected JSON object in {path}"
+        raise ValueError(msg)
+    return payload
+
+
+def _protected_path(path: str) -> bool:
+    return path in PROTECTED_EXACT_PATHS or path.startswith(PROTECTED_PREFIXES)
+
+
+def _finding(
+    code: str,
+    message: str,
+    *,
+    blocking: bool,
+    files: list[str] | None = None,
+    commands: list[str] | None = None,
+) -> JsonObject:
+    return {
+        "code": code,
+        "message": message,
+        "blocking": blocking,
+        "files": files or [],
+        "commands": commands or [],
+    }
+
+
+def _proof_results_by_command(evidence: Mapping[str, Any]) -> dict[str, JsonObject]:
+    results: dict[str, JsonObject] = {}
+    for item in _as_list(evidence.get("proof_results")):
+        result = _as_dict(item)
+        command = _string(result.get("command"))
+        if command:
+            results[command] = result
+    return results
+
+
+def _proof_passed(result: Mapping[str, Any]) -> bool:
+    status = _string(result.get("status")).lower()
+    return (
+        status in {"ok", "pass", "passed", "success", "succeeded"}
+        and _int(result.get("exit_code")) == 0
+    )
+
+
+def verify_candidate(
+    *,
+    patch_score: Mapping[str, Any],
+    verification_evidence: Mapping[str, Any],
+) -> JsonObject:
+    decision = _as_dict(patch_score.get("decision"))
+    patch_id = _string(patch_score.get("patch_id")) or "unknown"
+    diagnosis_id = _string(patch_score.get("diagnosis_id")) or "unknown"
+    scored_files = _string_list(patch_score.get("changed_files"))
+    allowed_files = _string_list(patch_score.get("allowed_files"))
+    evidence_files = _string_list(verification_evidence.get("changed_files"))
+    proof_requirements = _string_list(patch_score.get("proof_requirements"))
+    proof_results = _proof_results_by_command(verification_evidence)
+    findings: list[JsonObject] = []
+
+    if _string(decision.get("status")) != "candidate_for_protected_verification" or not _bool(
+        decision.get("candidate_for_protected_verification")
+    ):
+        findings.append(
+            _finding(
+                "PATCH_SCORE_NOT_CANDIDATE",
+                "PatchScorer did not nominate this patch for protected verification.",
+                blocking=True,
+            )
+        )
+
+    if _bool(decision.get("automation_allowed")):
+        findings.append(
+            _finding(
+                "AUTOMATION_BOUNDARY_VIOLATION",
+                "PatchScorer output unexpectedly attempts to authorize automation.",
+                blocking=True,
+            )
+        )
+
+    if not evidence_files:
+        findings.append(
+            _finding(
+                "VERIFICATION_FILE_INVENTORY_MISSING",
+                "Verification evidence must include the observed changed-file inventory.",
+                blocking=True,
+            )
+        )
+    elif evidence_files != scored_files:
+        findings.append(
+            _finding(
+                "CHANGED_FILE_INVENTORY_MISMATCH",
+                "Observed changed files do not exactly match the PatchScorer inventory.",
+                blocking=True,
+                files=sorted(set(evidence_files).symmetric_difference(scored_files)),
+            )
+        )
+
+    outside_scope = sorted(set(evidence_files) - set(allowed_files))
+    if outside_scope:
+        findings.append(
+            _finding(
+                "OUTSIDE_SCORED_SCOPE",
+                "Observed changed files exceed PatchScorer approved scope.",
+                blocking=True,
+                files=outside_scope,
+            )
+        )
+
+    protected_files = [path for path in evidence_files if _protected_path(path)]
+    if protected_files:
+        findings.append(
+            _finding(
+                "PROTECTED_PATH_CHANGED",
+                "Protected test, workflow, gate, or policy paths remain review-first.",
+                blocking=True,
+                files=protected_files,
+            )
+        )
+
+    if not proof_requirements:
+        findings.append(
+            _finding(
+                "PROOF_REQUIREMENTS_MISSING",
+                "PatchScorer supplied no required proof commands.",
+                blocking=True,
+            )
+        )
+    else:
+        missing_commands = [
+            command for command in proof_requirements if command not in proof_results
+        ]
+        if missing_commands:
+            findings.append(
+                _finding(
+                    "REQUIRED_PROOF_NOT_CAPTURED",
+                    "Required proof command results were not captured.",
+                    blocking=True,
+                    commands=missing_commands,
+                )
+            )
+
+        failed_commands = [
+            command
+            for command in proof_requirements
+            if command in proof_results and not _proof_passed(proof_results[command])
+        ]
+        if failed_commands:
+            findings.append(
+                _finding(
+                    "REQUIRED_PROOF_FAILED",
+                    "One or more required proof commands did not pass.",
+                    blocking=True,
+                    commands=failed_commands,
+                )
+            )
+
+    findings.append(
+        _finding(
+            "SEMANTIC_EQUIVALENCE_NOT_PROVEN",
+            (
+                "This prototype verifies structural scope and captured proof results only; "
+                "it does not prove semantic equivalence."
+            ),
+            blocking=False,
+        )
+    )
+
+    blocked = any(_bool(finding.get("blocking")) for finding in findings)
+    status = "blocked_review_first" if blocked else "structurally_verified_candidate"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "patch_id": patch_id,
+        "diagnosis_id": diagnosis_id,
+        "patch_score": int(patch_score.get("score", 0) or 0),
+        "scored_files": scored_files,
+        "observed_changed_files": evidence_files,
+        "allowed_files": allowed_files,
+        "proof_requirements": proof_requirements,
+        "findings": findings,
+        "decision": {
+            "status": status,
+            "structural_verification_passed": not blocked,
+            "semantic_equivalence_proven": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "reason": (
+                "Structural scope and captured proof requirements passed; "
+                "semantic proof and automation wiring remain unavailable."
+                if not blocked
+                else "Protected verification found blocking evidence; keep this patch review-first."
+            ),
+        },
+    }
+
+
+def render_markdown(payload: Mapping[str, Any]) -> str:
+    decision = _as_dict(payload.get("decision"))
+    findings = [_as_dict(item) for item in _as_list(payload.get("findings"))]
+
+    lines = [
+        "# Protected verifier result",
+        "",
+        f"- Patch: `{_string(payload.get('patch_id'))}`",
+        f"- Diagnosis: `{_string(payload.get('diagnosis_id'))}`",
+        f"- Patch score: `{int(payload.get('patch_score', 0) or 0)}`",
+        f"- Decision: `{_string(decision.get('status'))}`",
+        (
+            "- Structural verification passed: "
+            f"`{str(_bool(decision.get('structural_verification_passed'))).lower()}`"
+        ),
+        "- Semantic equivalence proven: `false`",
+        "- Automation allowed: `false`",
+        "- Merge authorized: `false`",
+        "",
+        "## Findings",
+        "",
+    ]
+
+    for finding in findings:
+        files = ", ".join(_string(item) for item in _as_list(finding.get("files")))
+        commands = ", ".join(_string(item) for item in _as_list(finding.get("commands")))
+        suffix = ""
+        if files:
+            suffix += f" files=`{files}`"
+        if commands:
+            suffix += f" commands=`{commands}`"
+        lines.append(
+            f"- `{_string(finding.get('code'))}`: "
+            f"blocking=`{str(_bool(finding.get('blocking'))).lower()}` "
+            f"{_string(finding.get('message'))}{suffix}"
+        )
+
+    lines.extend(["", "## Required proof evaluated", ""])
+    proof_requirements = _string_list(payload.get("proof_requirements"))
+    if proof_requirements:
+        lines.extend(f"- `{command}`" for command in proof_requirements)
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "- This verifier is read-only.",
+            "- Passing means structural proof evidence is consistent with PatchScorer scope.",
+            "- Passing does not prove semantic equivalence or authorize automated remediation.",
+            "- A later replayable benchmark harness must supply stronger execution evidence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_result(payload: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    json_path = out_dir / RESULT_JSON
+    markdown_path = out_dir / RESULT_MD
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(payload), encoding="utf-8")
+    return {
+        "protected_verifier_json": json_path.as_posix(),
+        "protected_verifier_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.protected_verifier")
+    parser.add_argument("--patch-score", type=Path, required=True)
+    parser.add_argument("--verification-evidence", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        payload = verify_candidate(
+            patch_score=_read_json(args.patch_score),
+            verification_evidence=_read_json(args.verification_evidence),
+        )
+        artifacts = write_result(payload, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "artifacts": artifacts,
+                    "decision": payload["decision"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -117,8 +117,10 @@ def build_alignment_components() -> list[AlignmentComponent]:
             stages=("decision", "remediation_eligibility", "proof"),
             existing_artifacts=("remediation plans",),
             integration_points=("diagnostic_vector_engine", "trajectory_store", "patch_scorer"),
-            gaps=("needs ProtectedVerifier feedback before broader mutation use",),
-            recommended_next_action="feed plans through PatchScorer before protected proof",
+            gaps=(
+                "needs structural verifier results and later semantic proof before broader mutation use",
+            ),
+            recommended_next_action="feed plans through PatchScorer and protected_verifier reporting",
         ),
         _component(
             module="safe_remediation_eligibility",
@@ -140,9 +142,9 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             gaps=(
                 "PatchScorer exists but is not wired into automation yet",
-                "needs ProtectedVerifier before broader automation",
+                "protected_verifier exists only as read-only structural evaluation",
             ),
-            recommended_next_action="keep formatting-only until PatchScorer and ProtectedVerifier are wired",
+            recommended_next_action="keep formatting-only and unwired until stronger verification exists",
         ),
         _component(
             module="pr_quality_evidence_narrative",
@@ -257,21 +259,33 @@ def build_alignment_components() -> list[AlignmentComponent]:
             integration_points=(
                 "remediation_plan_engine",
                 "trajectory_pattern_insights",
-                "ProtectedVerifier",
+                "protected_verifier",
             ),
             gaps=(
                 "read-only prototype is not wired into maintenance_autopilot",
-                "requires ProtectedVerifier before eligible scores may influence automation",
+                "structural verification does not yet prove semantic equivalence",
             ),
-            recommended_next_action="build ProtectedVerifier prototype and keep automation unchanged",
+            recommended_next_action="feed candidates to protected_verifier without changing automation",
         ),
         _component(
-            module="ProtectedVerifier",
-            role="prove fixes without weakening tests, CI, security, or public behavior",
-            status="planned",
-            stages=("proof", "verifier"),
-            gaps=("not implemented yet",),
-            recommended_next_action="build after PatchScorer prototype",
+            module="protected_verifier",
+            role="verify PatchScorer candidate scope and captured proof results without authorizing mutation",
+            status="partially_aligned",
+            stages=("proof", "verifier", "reporting"),
+            existing_artifacts=(
+                "protected-verifier-result.json",
+                "protected-verifier-result.md",
+            ),
+            integration_points=(
+                "patch_scorer",
+                "ReplayableBenchmarkHarness",
+                "maintenance_autopilot",
+            ),
+            gaps=(
+                "structural proof does not establish semantic equivalence",
+                "not wired into automation",
+            ),
+            recommended_next_action="build replayable remediation scenarios before any automation wiring",
         ),
         _component(
             module="ReplayableBenchmarkHarness",
@@ -325,7 +339,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/protected-verifier-prototype",
+        "next_recommended_pr": "feature/replayable-remediation-scenario-harness",
     }
 
 

--- a/src/sdetkit/security_review_evidence.py
+++ b/src/sdetkit/security_review_evidence.py
@@ -105,7 +105,7 @@ def _finding_id(thread: JsonObject, comment: JsonObject) -> str:
 def findings_from_review_threads(payload: JsonObject) -> list[JsonObject]:
     findings: list[JsonObject] = []
     for thread in _thread_nodes(payload):
-        if bool(thread.get("isResolved", False)):
+        if bool(thread.get("isResolved", False)) or bool(thread.get("isOutdated", False)):
             continue
 
         security_comments = [

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -495,3 +495,70 @@ def test_check_intelligence_reports_code_scanning_freshness_counts(
     action = check_intelligence.build_action_report(intelligence)
     assert action["status"] == "green"
     assert action["evidence"]["code_scanning_review"]["current_alerts"] == 1
+
+
+def test_check_intelligence_preserves_unresolved_security_review_findings(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "CI",
+                    "status": "completed",
+                    "conclusion": "success",
+                }
+            ]
+        },
+    )
+    review_threads = _write_json(
+        tmp_path / "review-threads.json",
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": False,
+                                    "path": "src/sdetkit/protected_verifier.py",
+                                    "line": 141,
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "author": {"login": "github-advanced-security"},
+                                                "body": (
+                                                    "## sdetkit-security-gate / High entropy string\n\n"
+                                                    "High-entropy string literal detected."
+                                                ),
+                                                "url": "https://example.test/security/1251",
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        review_threads_json=review_threads,
+    )
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["security_review"]["collected"] is True
+    assert intelligence["security_review"]["unresolved_findings"] == 1
+    assert (
+        intelligence["security_review"]["findings"][0]["path"]
+        == "src/sdetkit/protected_verifier.py"
+    )
+    assert report["status"] == "review_required"
+    assert report["primary_blocker"]["surface"] == "security"
+    assert report["primary_blocker"]["path"] == "src/sdetkit/protected_verifier.py"
+    assert report["primary_blocker"]["code"] == "_".join(("SECURITY", "REVIEW", "FINDING"))
+    assert report["automation"]["allowed"] is False

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1378,3 +1378,68 @@ def test_action_report_cli_accepts_trajectory_jsonl(tmp_path: Path, capsys) -> N
     assert printed["trajectory_review_first_count"] == 1
     assert printed["trajectory_auto_fix_allowed_count"] == 1
     assert "## Trajectory summary" in out.read_text(encoding="utf-8")
+
+
+def test_comment_does_not_clear_unresolved_security_review_evidence() -> None:
+    from sdetkit import pr_quality_action_report as report
+
+    body = report.render_comment_body(
+        action_report={
+            "status": "review_required",
+            "primary_blocker": {
+                "check": "GitHub security review",
+                "title": "Security review requires action in src/sdetkit/protected_verifier.py",
+                "surface": "security",
+                "code": "_".join(("SECURITY", "REVIEW", "FINDING")),
+                "path": "src/sdetkit/protected_verifier.py",
+                "line": 141,
+                "impact": "An unresolved security review finding requires human review.",
+            },
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": (
+                    "security review findings are review-first and cannot be auto-dismissed"
+                ),
+            },
+            "recommended_actions": [],
+            "proof_commands": [],
+        },
+        check_intelligence={
+            "checks_seen": 1,
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+            "security_review": {
+                "collected": True,
+                "unresolved_findings": 1,
+                "findings": [],
+            },
+            "code_scanning_review": {},
+        },
+        evidence_narrative={
+            "quality": {"ok": True, "coverage_percent": "96.69"},
+            "primary_signal": {
+                "kind": "review_signal",
+                "surface": "security",
+                "title": "Security review requires action",
+            },
+            "graph": {
+                "node_count": 1,
+                "review_first_count": 1,
+                "critical_count": 1,
+                "top_blocker": {
+                    "title": "Security review requires action",
+                    "surface": "security",
+                    "action": "review",
+                    "review_first": True,
+                },
+            },
+        },
+    )
+
+    assert "SDETKit Review Result: Action required" in body
+    assert "Unresolved security findings: `1`" in body
+    assert "- File: `src/sdetkit/protected_verifier.py:141`" in body
+    assert "Security review cleared for changed code" not in body

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.protected_verifier import main, verify_candidate
+
+
+def _candidate_score() -> dict:
+    return {
+        "patch_id": "format-patch",
+        "diagnosis_id": "formatting-autopilot",
+        "score": 100,
+        "changed_files": ["src/sdetkit/example.py"],
+        "allowed_files": ["src/sdetkit/example.py"],
+        "proof_requirements": ["python -m pre_commit run -a"],
+        "decision": {
+            "status": "candidate_for_protected_verification",
+            "candidate_for_protected_verification": True,
+            "automation_allowed": False,
+        },
+    }
+
+
+def _passing_evidence() -> dict:
+    return {
+        "changed_files": ["src/sdetkit/example.py"],
+        "proof_results": [
+            {
+                "command": "python -m pre_commit run -a",
+                "status": "passed",
+                "exit_code": 0,
+            }
+        ],
+    }
+
+
+def test_verifier_structurally_verifies_candidate_but_does_not_authorize() -> None:
+    payload = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence=_passing_evidence(),
+    )
+
+    decision = payload["decision"]
+    assert decision["status"] == "structurally_verified_candidate"
+    assert decision["structural_verification_passed"] is True
+    assert decision["semantic_equivalence_proven"] is False
+    assert decision["automation_allowed"] is False
+    assert decision["merge_authorized"] is False
+    assert payload["findings"] == [
+        {
+            "code": "SEMANTIC_EQUIVALENCE_NOT_PROVEN",
+            "message": (
+                "This prototype verifies structural scope and captured proof results only; "
+                "it does not prove semantic equivalence."
+            ),
+            "blocking": False,
+            "files": [],
+            "commands": [],
+        }
+    ]
+
+
+def test_verifier_blocks_non_candidate_patch_score() -> None:
+    score = _candidate_score()
+    score["decision"] = {
+        "status": "blocked_review_first",
+        "candidate_for_protected_verification": False,
+        "automation_allowed": False,
+    }
+
+    payload = verify_candidate(
+        patch_score=score,
+        verification_evidence=_passing_evidence(),
+    )
+
+    codes = {finding["code"] for finding in payload["findings"]}
+    assert "PATCH_SCORE_NOT_CANDIDATE" in codes
+    assert payload["decision"]["status"] == "blocked_review_first"
+    assert payload["decision"]["structural_verification_passed"] is False
+
+
+def test_verifier_blocks_file_inventory_drift_and_protected_paths() -> None:
+    score = _candidate_score()
+    score["changed_files"] = ["src/sdetkit/example.py", "tests/test_example.py"]
+    score["allowed_files"] = ["src/sdetkit/example.py", "tests/test_example.py"]
+
+    payload = verify_candidate(
+        patch_score=score,
+        verification_evidence={
+            "changed_files": ["src/sdetkit/example.py", "tests/test_example.py"],
+            "proof_results": _passing_evidence()["proof_results"],
+        },
+    )
+
+    codes = {finding["code"] for finding in payload["findings"]}
+    assert "PROTECTED_PATH_CHANGED" in codes
+    assert payload["decision"]["status"] == "blocked_review_first"
+
+
+def test_verifier_blocks_changed_file_mismatch_and_outside_scope() -> None:
+    payload = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence={
+            "changed_files": ["src/sdetkit/example.py", "src/sdetkit/unplanned.py"],
+            "proof_results": _passing_evidence()["proof_results"],
+        },
+    )
+
+    codes = {finding["code"] for finding in payload["findings"]}
+    assert "CHANGED_FILE_INVENTORY_MISMATCH" in codes
+    assert "OUTSIDE_SCORED_SCOPE" in codes
+    assert payload["decision"]["status"] == "blocked_review_first"
+
+
+def test_verifier_blocks_missing_and_failed_required_proof() -> None:
+    missing = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence={"changed_files": ["src/sdetkit/example.py"], "proof_results": []},
+    )
+    assert "REQUIRED_PROOF_NOT_CAPTURED" in {finding["code"] for finding in missing["findings"]}
+
+    failed = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence={
+            "changed_files": ["src/sdetkit/example.py"],
+            "proof_results": [
+                {
+                    "command": "python -m pre_commit run -a",
+                    "status": "failed",
+                    "exit_code": 1,
+                }
+            ],
+        },
+    )
+    assert "REQUIRED_PROOF_FAILED" in {finding["code"] for finding in failed["findings"]}
+    assert failed["decision"]["status"] == "blocked_review_first"
+
+
+def test_verifier_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
+    score_path = tmp_path / "patch-score.json"
+    evidence_path = tmp_path / "verification-evidence.json"
+    out_dir = tmp_path / "protected-verifier"
+
+    score_path.write_text(json.dumps(_candidate_score()), encoding="utf-8")
+    evidence_path.write_text(json.dumps(_passing_evidence()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--patch-score",
+            str(score_path),
+            "--verification-evidence",
+            str(evidence_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "protected-verifier-result.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "protected-verifier-result.md").read_text(encoding="utf-8")
+
+    assert printed["decision"]["status"] == "structurally_verified_candidate"
+    assert saved["decision"]["automation_allowed"] is False
+    assert "# Protected verifier result" in markdown
+    assert "does not prove semantic equivalence" in markdown

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit.protected_verifier import main, verify_candidate
+from sdetkit.protected_verifier import (
+    CHANGED_FILE_INVENTORY_MISMATCH,
+    OUTSIDE_SCORED_SCOPE,
+    PATCH_SCORE_NOT_CANDIDATE,
+    PROTECTED_PATH_CHANGED,
+    REQUIRED_PROOF_FAILED,
+    REQUIRED_PROOF_NOT_CAPTURED,
+    SEMANTIC_EQUIVALENCE_NOT_PROVEN,
+    main,
+    verify_candidate,
+)
 
 
 def _candidate_score() -> dict:
@@ -49,7 +59,7 @@ def test_verifier_structurally_verifies_candidate_but_does_not_authorize() -> No
     assert decision["merge_authorized"] is False
     assert payload["findings"] == [
         {
-            "code": "SEMANTIC_EQUIVALENCE_NOT_PROVEN",
+            "code": SEMANTIC_EQUIVALENCE_NOT_PROVEN,
             "message": (
                 "This prototype verifies structural scope and captured proof results only; "
                 "it does not prove semantic equivalence."
@@ -75,7 +85,7 @@ def test_verifier_blocks_non_candidate_patch_score() -> None:
     )
 
     codes = {finding["code"] for finding in payload["findings"]}
-    assert "PATCH_SCORE_NOT_CANDIDATE" in codes
+    assert PATCH_SCORE_NOT_CANDIDATE in codes
     assert payload["decision"]["status"] == "blocked_review_first"
     assert payload["decision"]["structural_verification_passed"] is False
 
@@ -94,7 +104,7 @@ def test_verifier_blocks_file_inventory_drift_and_protected_paths() -> None:
     )
 
     codes = {finding["code"] for finding in payload["findings"]}
-    assert "PROTECTED_PATH_CHANGED" in codes
+    assert PROTECTED_PATH_CHANGED in codes
     assert payload["decision"]["status"] == "blocked_review_first"
 
 
@@ -108,8 +118,8 @@ def test_verifier_blocks_changed_file_mismatch_and_outside_scope() -> None:
     )
 
     codes = {finding["code"] for finding in payload["findings"]}
-    assert "CHANGED_FILE_INVENTORY_MISMATCH" in codes
-    assert "OUTSIDE_SCORED_SCOPE" in codes
+    assert CHANGED_FILE_INVENTORY_MISMATCH in codes
+    assert OUTSIDE_SCORED_SCOPE in codes
     assert payload["decision"]["status"] == "blocked_review_first"
 
 
@@ -118,7 +128,7 @@ def test_verifier_blocks_missing_and_failed_required_proof() -> None:
         patch_score=_candidate_score(),
         verification_evidence={"changed_files": ["src/sdetkit/example.py"], "proof_results": []},
     )
-    assert "REQUIRED_PROOF_NOT_CAPTURED" in {finding["code"] for finding in missing["findings"]}
+    assert REQUIRED_PROOF_NOT_CAPTURED in {finding["code"] for finding in missing["findings"]}
 
     failed = verify_candidate(
         patch_score=_candidate_score(),
@@ -133,7 +143,7 @@ def test_verifier_blocks_missing_and_failed_required_proof() -> None:
             ],
         },
     )
-    assert "REQUIRED_PROOF_FAILED" in {finding["code"] for finding in failed["findings"]}
+    assert REQUIRED_PROOF_FAILED in {finding["code"] for finding in failed["findings"]}
     assert failed["decision"]["status"] == "blocked_review_first"
 
 

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -25,7 +25,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "trajectory_pattern_insights" in modules
     assert "maintenance_autopilot" in modules
     assert "patch_scorer" in modules
-    assert "ProtectedVerifier" in modules
+    assert "protected_verifier" in modules
     assert "ReplayableBenchmarkHarness" in modules
     assert "RepoMemory" in modules
 
@@ -35,9 +35,9 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 8
-    assert status_counts["partially_aligned"] >= 5
-    assert status_counts["planned"] >= 3
-    assert report["next_recommended_pr"] == "feature/protected-verifier-prototype"
+    assert status_counts["partially_aligned"] >= 6
+    assert status_counts["planned"] >= 2
+    assert report["next_recommended_pr"] == "feature/replayable-remediation-scenario-harness"
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -55,9 +55,10 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
 
     assert "maintenance_autopilot" in gaps_by_module
     assert "patch_scorer" in gaps_by_module
-    assert "ProtectedVerifier" in gaps_by_module
-    assert any("PatchScorer exists" in gap for gap in gaps_by_module["maintenance_autopilot"])
-    assert any("ProtectedVerifier" in gap for gap in gaps_by_module["patch_scorer"])
+    assert "protected_verifier" in gaps_by_module
+    assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
+    assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
+    assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -71,6 +72,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`maintenance_autopilot`: `partially_aligned`" in markdown
     assert "`trajectory_pattern_insights`: `aligned`" in markdown
     assert "`patch_scorer`: `partially_aligned`" in markdown
+    assert "`protected_verifier`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -94,7 +96,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/protected-verifier-prototype"
+    assert saved["next_recommended_pr"] == "feature/replayable-remediation-scenario-harness"
     assert "Reliability spine alignment audit" in markdown
 
 
@@ -137,6 +139,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         "trajectory_history_report",
         "pr_quality_action_report",
         "patch_scorer",
+        "protected_verifier",
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_security_review_evidence.py
+++ b/tests/test_security_review_evidence.py
@@ -26,10 +26,16 @@ def _review_threads(*threads: dict) -> dict:
     }
 
 
-def _thread(*, resolved: bool, body: str, author: str = "github-advanced-security") -> dict:
+def _thread(
+    *,
+    resolved: bool,
+    body: str,
+    author: str = "github-advanced-security",
+    outdated: bool = False,
+) -> dict:
     return {
         "isResolved": resolved,
-        "isOutdated": False,
+        "isOutdated": outdated,
         "path": "src/sdetkit/adaptive_diagnosis.py",
         "line": 1320,
         "comments": {
@@ -75,6 +81,27 @@ def test_security_review_evidence_ignores_resolved_threads(tmp_path: Path) -> No
     path = _write_json(
         tmp_path / "review-threads.json",
         _review_threads(_thread(resolved=True, body="sdetkit-security-gate / High entropy string")),
+    )
+
+    payload = security_review.build_security_review_evidence(path)
+
+    assert payload["state"] == "healthy"
+    assert payload["active_threat_count"] == 0
+    assert payload["active_threats"] == []
+
+
+def test_security_review_evidence_ignores_outdated_security_threads(
+    tmp_path: Path,
+) -> None:
+    path = _write_json(
+        tmp_path / "review-threads.json",
+        _review_threads(
+            _thread(
+                resolved=False,
+                outdated=True,
+                body="review requested",
+            )
+        ),
     )
 
     payload = security_review.build_security_review_evidence(path)


### PR DESCRIPTION
## Summary
- Adds a local read-only `protected_verifier` prototype.
- Verifies that a PatchScorer candidate remains inside its scored file scope.
- Blocks changed-file inventory drift, protected test/workflow/gate/policy paths, missing proof evidence, and failed proof commands.
- Produces JSON and Markdown verifier results.
- Explicitly keeps `automation_allowed=false`, `semantic_equivalence_proven=false`, and `merge_authorized=false`.
- Updates the reliability spine alignment audit to classify `protected_verifier` as partially aligned and advance the next recommended PR to `feature/replayable-remediation-scenario-harness`.

## Why
- PatchScorer can now identify patches that are structurally eligible for verification.
- Before any automation wiring, the repo needs an independent proof layer that detects scope expansion and missing or failing verification evidence.
- This prototype establishes that verification boundary without claiming semantic equivalence or applying changes.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_protected_verifier.py tests/test_patch_scorer.py tests/test_remediation_plan_engine.py tests/test_reliability_spine_alignment.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-to-medium.
- New read-only structural verifier plus architecture-map refresh.
- No workflow behavior change.
- No auto-remediation expansion.
- No merge authorization.
- Semantic equivalence is explicitly not claimed.
- Rollback: revert this PR.