### PR TITLE
Expose code scanning collection in PR Quality

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -10,6 +10,7 @@ permissions:
   pull-requests: write
   checks: read
   actions: read
+  security-events: read
 concurrency:
   group: pr-quality-comment-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -109,6 +110,44 @@ jobs:
             --sentinel-control-room build/sdetkit/sentinel/control-room.json \
             --merged-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
             --out-dir build/pr-quality/security-review
+
+      - name: Collect code scanning alert evidence
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        run: |
+          mkdir -p build/pr-quality/code-scanning
+
+          collection_status="collected"
+          collection_reason=""
+          if ! gh api             -H "Accept: application/vnd.github+json"             "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME/code-scanning/alerts?state=open&pr=$PR_NUMBER&per_page=100"             > build/pr-quality/code-scanning/alerts-raw.json; then
+            collection_status="unavailable"
+            collection_reason="GitHub code-scanning alerts API was unavailable or not permitted."
+            printf '[]\n' > build/pr-quality/code-scanning/alerts-raw.json
+          fi
+
+          COLLECTION_STATUS="$collection_status" COLLECTION_REASON="$collection_reason" python - <<'PYCODE'
+          import json
+          import os
+          from pathlib import Path
+
+          raw_path = Path("build/pr-quality/code-scanning/alerts-raw.json")
+          raw = json.loads(raw_path.read_text(encoding="utf-8"))
+          alerts = raw if isinstance(raw, list) else []
+
+          payload = {
+              "collection_status": os.environ["COLLECTION_STATUS"],
+              "collection_reason": os.environ["COLLECTION_REASON"],
+              "alerts": alerts,
+          }
+          Path("build/pr-quality/code-scanning/alerts.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PYCODE
 
       - name: Build PR check intelligence action report
         if: always()
@@ -231,6 +270,8 @@ jobs:
             --checks-json build/pr-quality/checks/check-runs.json \
             --logs-dir build/pr-quality/check-logs/failed-check-logs \
             --review-threads-json build/pr-quality/security-review/review-threads.json \
+            --code-scanning-alerts-json build/pr-quality/code-scanning/alerts.json \
+            --current-head-sha "$HEAD_SHA" \
             --out-dir build/pr-quality/check-intelligence
 
 
@@ -372,6 +413,8 @@ jobs:
             build/pr-quality/checks/
             build/pr-quality/check-logs/
             build/pr-quality/check-intelligence/
+            build/pr-quality/security-review/
+            build/pr-quality/code-scanning/
             build/pr-quality/safe-formatting-autopilot/
             build/pr-quality/trajectory/
             build/pr-quality/pr-evidence-narrative.md

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -918,25 +918,68 @@ def _open_code_scanning_alerts(payload: Any) -> list[JsonObject]:
     ]
 
 
+def _empty_code_scanning_review(
+    *,
+    collected: bool,
+    collection_status: str,
+    source: str,
+    collection_reason: str,
+    current_head_sha: str,
+) -> JsonObject:
+    return {
+        "collected": collected,
+        "collection_status": collection_status,
+        "collection_reason": collection_reason,
+        "source": source,
+        "open_alerts": 0,
+        "current_alerts": 0,
+        "stale_alerts": 0,
+        "unknown_freshness_alerts": 0,
+        "current_head_sha": current_head_sha,
+        "rule_counts": {},
+        "findings": [],
+    }
+
+
 def _code_scanning_review_summary(
     alerts_json: Path | None,
     *,
     current_head_sha: str = "",
 ) -> JsonObject:
-    if alerts_json is None or not alerts_json.exists():
-        return {
-            "collected": False,
-            "source": alerts_json.as_posix() if alerts_json else "",
-            "open_alerts": 0,
-            "current_alerts": 0,
-            "stale_alerts": 0,
-            "unknown_freshness_alerts": 0,
-            "current_head_sha": current_head_sha,
-            "rule_counts": {},
-            "findings": [],
-        }
+    if alerts_json is None:
+        return _empty_code_scanning_review(
+            collected=False,
+            collection_status="not_requested",
+            collection_reason="No code-scanning alert collection artifact was provided.",
+            source="",
+            current_head_sha=current_head_sha,
+        )
+
+    if not alerts_json.exists():
+        return _empty_code_scanning_review(
+            collected=False,
+            collection_status="unavailable",
+            collection_reason="The code-scanning alert collection artifact was not found.",
+            source=alerts_json.as_posix(),
+            current_head_sha=current_head_sha,
+        )
 
     payload = json.loads(alerts_json.read_text(encoding="utf-8"))
+    metadata = _as_dict(payload)
+    collection_status = _string(metadata.get("collection_status") or "collected").lower()
+    collection_reason = _string(metadata.get("collection_reason"))
+
+    if collection_status != "collected":
+        return _empty_code_scanning_review(
+            collected=False,
+            collection_status=collection_status or "unavailable",
+            collection_reason=(
+                collection_reason or "Code-scanning alert collection did not complete successfully."
+            ),
+            source=alerts_json.as_posix(),
+            current_head_sha=current_head_sha,
+        )
+
     findings: list[JsonObject] = []
     rule_counts: dict[str, int] = {}
 
@@ -983,6 +1026,8 @@ def _code_scanning_review_summary(
 
     return {
         "collected": True,
+        "collection_status": "collected",
+        "collection_reason": "",
         "source": alerts_json.as_posix(),
         "open_alerts": len(findings),
         "current_alerts": len([item for item in findings if item["freshness"] == "current"]),

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -235,7 +235,16 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
 
     if code_scanning:
         collected = "true" if bool(code_scanning.get("collected", False)) else "false"
+        collection_status = _string(
+            code_scanning.get("collection_status")
+            or ("collected" if collected == "true" else "unavailable")
+        )
+        collection_reason = _string(code_scanning.get("collection_reason"))
+
         lines.append(f"- Code scanning review collected: `{collected}`")
+        lines.append(f"- Code scanning collection status: `{collection_status}`")
+        if collection_reason:
+            lines.append(f"- Code scanning collection reason: {collection_reason}")
         lines.append(f"- Open code scanning alerts: `{_int(code_scanning.get('open_alerts'))}`")
         lines.append(
             f"- Current code scanning alerts: `{_int(code_scanning.get('current_alerts'))}`"
@@ -244,6 +253,24 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
         unknown_count = _int(code_scanning.get("unknown_freshness_alerts"))
         if unknown_count:
             lines.append(f"- Unknown-freshness code scanning alerts: `{unknown_count}`")
+
+        findings = [
+            _as_dict(item)
+            for item in _as_list(code_scanning.get("findings"))
+            if isinstance(item, dict)
+        ]
+        for finding in findings[:5]:
+            freshness = _string(finding.get("freshness") or "unknown")
+            path = _string(finding.get("path") or "unknown")
+            line = _string(finding.get("line"))
+            location = f"{path}:{line}" if line else path
+            rule_id = _string(finding.get("rule_id") or "unknown")
+            severity = _string(finding.get("severity") or "unknown")
+            action = _string(finding.get("recommended_action") or "review_alert_freshness")
+            lines.append(
+                f"- Code scanning {freshness} finding: `{location}` "
+                f"(`{rule_id}`, severity=`{severity}`), action=`{action}`"
+            )
 
     return lines
 

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -562,3 +562,33 @@ def test_check_intelligence_preserves_unresolved_security_review_findings(
     assert report["primary_blocker"]["path"] == "src/sdetkit/protected_verifier.py"
     assert report["primary_blocker"]["code"] == "_".join(("SECURITY", "REVIEW", "FINDING"))
     assert report["automation"]["allowed"] is False
+
+
+def test_check_intelligence_reports_unavailable_code_scanning_collection(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {"check_runs": [{"name": "CI", "status": "completed", "conclusion": "success"}]},
+    )
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        {
+            "collection_status": "unavailable",
+            "collection_reason": "GitHub code-scanning alerts API was unavailable or not permitted.",
+            "alerts": [],
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        code_scanning_alerts_json=alerts,
+        current_head_sha="abc123",
+    )
+
+    review = intelligence["code_scanning_review"]
+    assert review["collected"] is False
+    assert review["collection_status"] == "unavailable"
+    assert "unavailable or not permitted" in review["collection_reason"]
+    assert review["current_alerts"] == 0
+    assert review["findings"] == []

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1443,3 +1443,92 @@ def test_comment_does_not_clear_unresolved_security_review_evidence() -> None:
     assert "Unresolved security findings: `1`" in body
     assert "- File: `src/sdetkit/protected_verifier.py:141`" in body
     assert "Security review cleared for changed code" not in body
+
+
+def test_action_report_renders_current_code_scanning_alert_location() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+        "code_scanning_review": {
+            "collected": True,
+            "collection_status": "collected",
+            "collection_reason": "",
+            "open_alerts": 2,
+            "current_alerts": 1,
+            "stale_alerts": 1,
+            "unknown_freshness_alerts": 0,
+            "findings": [
+                {
+                    "freshness": "current",
+                    "path": "src/sdetkit/current.py",
+                    "line": "14",
+                    "rule_id": "py/example",
+                    "severity": "warning",
+                    "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                },
+                {
+                    "freshness": "stale",
+                    "path": "src/sdetkit/old.py",
+                    "line": "20",
+                    "rule_id": "py/example",
+                    "severity": "warning",
+                    "recommended_action": "wait_for_code_scanning_refresh",
+                },
+            ],
+        },
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "Code scanning review collected: `true`" in body
+    assert "Code scanning collection status: `collected`" in body
+    assert "Current code scanning alerts: `1`" in body
+    assert "Stale code scanning alerts: `1`" in body
+    assert "Code scanning current finding: `src/sdetkit/current.py:14`" in body
+    assert "action=`fix_current_alert_or_dismiss_reviewed_false_positive`" in body
+    assert "Code scanning stale finding: `src/sdetkit/old.py:20`" in body
+
+
+def test_action_report_renders_unavailable_code_scanning_collection() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+        "code_scanning_review": {
+            "collected": False,
+            "collection_status": "unavailable",
+            "collection_reason": "GitHub code-scanning alerts API was unavailable or not permitted.",
+            "open_alerts": 0,
+            "current_alerts": 0,
+            "stale_alerts": 0,
+            "unknown_freshness_alerts": 0,
+            "findings": [],
+        },
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "Code scanning review collected: `false`" in body
+    assert "Code scanning collection status: `unavailable`" in body
+    assert "GitHub code-scanning alerts API was unavailable or not permitted." in body

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -29,6 +29,7 @@ def test_pr_quality_comment_workflow_has_comment_permissions() -> None:
     assert "pull-requests: write" in permissions
     assert "checks: read" in permissions
     assert "actions: read" in permissions
+    assert "security-events: read" in permissions
 
 
 def test_pr_quality_comment_workflow_writes_comment_status_before_posting() -> None:
@@ -268,3 +269,19 @@ def test_pr_quality_comment_workflow_exposes_trajectory_comment_metadata() -> No
     assert 'print(f"trajectory_record_count={trajectory_record_count}")' in text
     assert 'print(f"trajectory_review_first_count={trajectory_review_first_count}")' in text
     assert 'print(f"trajectory_auto_fix_allowed_count={trajectory_auto_fix_allowed_count}")' in text
+
+
+def test_pr_quality_comment_workflow_collects_code_scanning_alert_visibility() -> None:
+    text = _workflow_text()
+
+    collection = text.index("Collect code scanning alert evidence")
+    intelligence = text.index("Build PR check intelligence action report")
+
+    assert collection < intelligence
+    assert "security-events: read" in text.split("jobs:", 1)[0]
+    assert "code-scanning/alerts?state=open&pr=$PR_NUMBER&per_page=100" in text
+    assert '"collection_status": os.environ["COLLECTION_STATUS"]' in text
+    assert "build/pr-quality/code-scanning/alerts.json" in text
+    assert "--code-scanning-alerts-json build/pr-quality/code-scanning/alerts.json" in text
+    assert '--current-head-sha "$HEAD_SHA"' in text
+    assert "build/pr-quality/code-scanning/" in text


### PR DESCRIPTION
## Summary
- Wires PR Quality to collect PR-scoped GitHub code-scanning alert evidence.
- Adds `security-events: read` permission for code-scanning alert visibility.
- Passes code-scanning evidence and current PR head SHA into `check_intelligence`.
- Distinguishes `collected`, `unavailable`, and `not_requested` code-scanning collection states.
- Renders current and stale code-scanning finding locations in the PR Quality comment.
- Uploads code-scanning evidence artifacts for operator inspection.

## Why
- PR #1400 exposed that security review threads were visible after repair, but code-scanning collection still always appeared as unavailable because the workflow never supplied alert evidence.
- Existing code-scanning freshness logic was already present; this PR connects it to live PR Quality evidence collection.
- The change closes a reporting blind spot without expanding remediation or merge policy.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_security_review_workflow.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium-low.
- Changes PR Quality workflow permissions and evidence collection only.
- No auto-remediation expansion.
- No new merge-blocking policy for code-scanning alerts in this PR.
- If code-scanning collection is unavailable, the comment now reports that explicitly instead of silently implying no evidence.
- Rollback: revert this PR.