### PR TITLE
Require review for current code scanning alerts

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -16,6 +16,7 @@ ACTION_REPORT_SCHEMA_VERSION = "sdetkit.pr_quality.action_report.v1"
 JsonObject = dict[str, Any]
 
 DEPENDENCY_AUDIT_VULNERABILITY = "DEPENDENCY_AUDIT_VULNERABILITY"
+CODE_SCANNING_CURRENT_ALERT = "_".join(("CODE", "SCANNING", "CURRENT", "ALERT"))
 DEPENDENCY_AUDIT_OWNER_FILES = [
     "requirements-test.txt",
     "requirements-docs.txt",
@@ -1010,6 +1011,7 @@ def _code_scanning_review_summary(
         findings.append(
             {
                 "number": alert.get("number", ""),
+                "url": _string(alert.get("html_url") or alert.get("url")),
                 "rule_id": rule_id,
                 "severity": _string(
                     rule.get("security_severity_level") or rule.get("severity") or "unknown"
@@ -1300,6 +1302,82 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 ),
                 "security_review": security_review,
                 "code_scanning_review": intelligence.get("code_scanning_review", {}),
+            },
+        }
+
+    code_scanning_review = _as_dict(intelligence.get("code_scanning_review"))
+    current_code_scanning_findings = [
+        _as_dict(item)
+        for item in _as_list(code_scanning_review.get("findings"))
+        if isinstance(item, dict) and _string(_as_dict(item).get("freshness")).lower() == "current"
+    ]
+    if current_code_scanning_findings and not failed:
+        finding = current_code_scanning_findings[0]
+        path = _string(finding.get("path"))
+        line = _string(finding.get("line"))
+        location = f"{path}:{line}" if path and line else path
+        rule_id = _string(finding.get("rule_id") or "unknown")
+        severity = _string(finding.get("severity") or "unknown")
+        title = (
+            f"Current code scanning alert requires action in {location}"
+            if location
+            else "Current code scanning alert requires action"
+        )
+        message = _string(finding.get("message"))
+        impact = (
+            message
+            or "A current PR-owned code scanning alert must be fixed or dismissed with a review reason."
+        )
+        return {
+            "schema_version": ACTION_REPORT_SCHEMA_VERSION,
+            "status": "review_required",
+            "primary_blocker": {
+                "check": "GitHub code scanning",
+                "title": title,
+                "surface": "security",
+                "impact": impact,
+                "code": CODE_SCANNING_CURRENT_ALERT,
+                "url": _string(finding.get("url")),
+                "path": path,
+                "line": line,
+                "rule_id": rule_id,
+                "severity": severity,
+            },
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": (
+                    "current code-scanning alerts are review-first and cannot be auto-dismissed"
+                ),
+            },
+            "recommended_actions": [
+                "Review the current GitHub code scanning alert on the PR.",
+                "Fix the flagged surface or dismiss the reviewed false positive with a reason.",
+            ],
+            "proof_commands": [
+                "python -m sdetkit security check --root . --format json",
+                "python -m pre_commit run -a",
+            ],
+            "evidence": {
+                "failed_check_count": 0,
+                "queued_check_count": len(queued),
+                "required_queued_check_count": len(
+                    [
+                        _as_dict(item)
+                        for item in queued
+                        if bool(_as_dict(item).get("required", False))
+                    ]
+                ),
+                "startup_failure_count": len(startup),
+                "required_startup_failure_count": len(
+                    [
+                        _as_dict(item)
+                        for item in startup
+                        if bool(_as_dict(item).get("required", False))
+                    ]
+                ),
+                "security_review": security_review,
+                "code_scanning_review": code_scanning_review,
             },
         }
 

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -493,7 +493,12 @@ def test_check_intelligence_reports_code_scanning_freshness_counts(
     assert review["findings"][1]["recommended_action"] == "wait_for_code_scanning_refresh"
 
     action = check_intelligence.build_action_report(intelligence)
-    assert action["status"] == "green"
+    assert action["status"] == "review_required"
+    assert action["primary_blocker"]["surface"] == "security"
+    assert action["primary_blocker"]["code"] == check_intelligence.CODE_SCANNING_CURRENT_ALERT
+    assert action["primary_blocker"]["path"] == "src/sdetkit/example.py"
+    assert action["primary_blocker"]["line"] == "12"
+    assert action["automation"]["allowed"] is False
     assert action["evidence"]["code_scanning_review"]["current_alerts"] == 1
 
 
@@ -592,3 +597,44 @@ def test_check_intelligence_reports_unavailable_code_scanning_collection(
     assert "unavailable or not permitted" in review["collection_reason"]
     assert review["current_alerts"] == 0
     assert review["findings"] == []
+
+
+def test_check_intelligence_keeps_stale_code_scanning_alert_visible_non_blocking(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {"check_runs": [{"name": "CI", "status": "completed", "conclusion": "success"}]},
+    )
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        {
+            "collection_status": "collected",
+            "alerts": [
+                {
+                    "number": 18,
+                    "state": "open",
+                    "html_url": "https://example.test/code-scanning/18",
+                    "rule": {"id": "py/stale-example", "severity": "warning"},
+                    "most_recent_instance": {
+                        "commit_sha": "previous-sha",
+                        "message": {"text": "Stale alert"},
+                        "location": {"path": "src/sdetkit/old.py", "start_line": 20},
+                    },
+                }
+            ],
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        code_scanning_alerts_json=alerts,
+        current_head_sha="current-sha",
+    )
+    action = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["code_scanning_review"]["collected"] is True
+    assert intelligence["code_scanning_review"]["current_alerts"] == 0
+    assert intelligence["code_scanning_review"]["stale_alerts"] == 1
+    assert action["status"] == "green"
+    assert action["primary_blocker"] == {}

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1532,3 +1532,47 @@ def test_action_report_renders_unavailable_code_scanning_collection() -> None:
     assert "Code scanning review collected: `false`" in body
     assert "Code scanning collection status: `unavailable`" in body
     assert "GitHub code-scanning alerts API was unavailable or not permitted." in body
+
+
+def test_action_report_promotes_current_code_scanning_alert_to_security_blocker() -> None:
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+        "code_scanning_review": {
+            "collected": True,
+            "collection_status": "collected",
+            "collection_reason": "",
+            "open_alerts": 1,
+            "current_alerts": 1,
+            "stale_alerts": 0,
+            "unknown_freshness_alerts": 0,
+            "findings": [
+                {
+                    "freshness": "current",
+                    "url": "https://example.test/code-scanning/44",
+                    "path": "src/sdetkit/current.py",
+                    "line": "14",
+                    "rule_id": "py/example",
+                    "severity": "warning",
+                    "message": "Current code-scanning alert on changed code.",
+                    "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                }
+            ],
+        },
+    }
+
+    action = check_intelligence.build_action_report(intelligence)
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert action["status"] == "review_required"
+    assert action["primary_blocker"]["surface"] == "security"
+    assert action["primary_blocker"]["code"] == check_intelligence.CODE_SCANNING_CURRENT_ALERT
+    assert action["automation"]["allowed"] is False
+    assert "SDETKit Review Result: Action required" in body
+    assert "Current code scanning alert requires action" in body
+    assert "src/sdetkit/current.py:14" in body
+    assert "Current code scanning alerts: `1`" in body
+    assert "Code scanning current finding: `src/sdetkit/current.py:14`" in body


### PR DESCRIPTION
## Summary
- Promotes current PR-head code-scanning alerts into `review_required` action reports.
- Reports the current alert as a security primary blocker with exact file, line, rule, severity, and alert URL.
- Keeps auto-dismissal and auto-remediation disabled for code-scanning findings.
- Preserves stale code-scanning alerts as visible but non-blocking evidence.
- Preserves unavailable collection as an explicit visibility state without inventing a blocker.

## Why
- PR #1401 made code-scanning evidence visible in PR Quality.
- A current PR-owned code-scanning alert could still appear beside a green action report.
- This PR connects current code-scanning evidence to the existing review-first security decision boundary.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_security_review_workflow.py tests/test_security_review_evidence.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium-low.
- Decision-layer change only; evidence collection was already added in #1401.
- Current code-scanning alerts now require human review before merge.
- Stale alerts and collection failures remain non-blocking evidence.
- No auto-remediation expansion.
- No automatic security dismissal.
- Rollback: revert this PR.