### PR TITLE
Add replayable remediation scenario harness

### DIFF
--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -278,7 +278,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             integration_points=(
                 "patch_scorer",
-                "ReplayableBenchmarkHarness",
+                "replayable_benchmark_harness",
                 "maintenance_autopilot",
             ),
             gaps=(
@@ -288,12 +288,25 @@ def build_alignment_components() -> list[AlignmentComponent]:
             recommended_next_action="build replayable remediation scenarios before any automation wiring",
         ),
         _component(
-            module="ReplayableBenchmarkHarness",
-            role="run local remediation scenarios with oracle/pass and nop/fail checks",
-            status="planned",
-            stages=("benchmark", "proof", "verifier"),
-            gaps=("not implemented yet",),
-            recommended_next_action="build after ProtectedVerifier has a local contract",
+            module="replayable_benchmark_harness",
+            role="replay fixture-backed nop, oracle, and unsafe patch scenarios through safety contracts",
+            status="partially_aligned",
+            stages=("benchmark", "proof", "verifier", "reporting"),
+            existing_artifacts=(
+                "benchmark-report.json",
+                "benchmark-report.md",
+                "fixture scenario JSON",
+            ),
+            integration_points=(
+                "patch_scorer",
+                "protected_verifier",
+                "RepoMemory",
+            ),
+            gaps=(
+                "current fixtures replay structural evidence without isolated command execution",
+                "anti-cheat runtime checks and fresh-workspace execution remain future work",
+            ),
+            recommended_next_action="feed proven scenario outcomes into RepoMemory before automation wiring",
         ),
         _component(
             module="RepoMemory",
@@ -339,7 +352,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/replayable-remediation-scenario-harness",
+        "next_recommended_pr": "feature/repo-memory-profiles",
     }
 
 

--- a/src/sdetkit/replayable_benchmark_harness.py
+++ b/src/sdetkit/replayable_benchmark_harness.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.patch_scorer import score_patch
+from sdetkit.protected_verifier import verify_candidate
+
+SCHEMA_VERSION = "sdetkit.replayable_benchmark_harness.v1"
+DEFAULT_OUT_DIR = Path("build") / "replayable-benchmark-harness"
+REPORT_JSON = "benchmark-report.json"
+REPORT_MD = "benchmark-report.md"
+
+SCENARIO_TYPES = {
+    "nop_fail",
+    "oracle_pass",
+    "unsafe_patch_fail",
+}
+REQUIRED_SCENARIO_TYPES = (
+    "nop_fail",
+    "oracle_pass",
+    "unsafe_patch_fail",
+)
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _int(value: Any, *, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _read_json_object(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"expected JSON object in {path}"
+        raise ValueError(msg)
+    return payload
+
+
+def load_scenarios(paths: list[Path]) -> list[JsonObject]:
+    scenarios: list[JsonObject] = []
+    identifiers: set[str] = set()
+
+    for path in paths:
+        scenario = _read_json_object(path)
+        scenario_id = _string(scenario.get("scenario_id"))
+        if not scenario_id:
+            msg = f"scenario_id is required in {path}"
+            raise ValueError(msg)
+        if scenario_id in identifiers:
+            msg = f"duplicate scenario_id: {scenario_id}"
+            raise ValueError(msg)
+
+        scenario_type = _string(scenario.get("scenario_type"))
+        if scenario_type not in SCENARIO_TYPES:
+            msg = f"unsupported scenario_type for {scenario_id}: {scenario_type}"
+            raise ValueError(msg)
+
+        identifiers.add(scenario_id)
+        scenarios.append(scenario)
+
+    return scenarios
+
+
+def _decision_status(payload: Mapping[str, Any]) -> str:
+    return _string(_as_dict(payload.get("decision")).get("status"))
+
+
+def _check(
+    *,
+    name: str,
+    passed: bool,
+    expected: Any,
+    actual: Any,
+) -> JsonObject:
+    return {
+        "name": name,
+        "passed": passed,
+        "expected": expected,
+        "actual": actual,
+    }
+
+
+def evaluate_scenario(scenario: Mapping[str, Any]) -> JsonObject:
+    scenario_id = _string(scenario.get("scenario_id"))
+    scenario_type = _string(scenario.get("scenario_type"))
+    if not scenario_id:
+        raise ValueError("scenario_id is required")
+    if scenario_type not in SCENARIO_TYPES:
+        msg = f"unsupported scenario_type for {scenario_id}: {scenario_type}"
+        raise ValueError(msg)
+
+    remediation_plan = _as_dict(scenario.get("remediation_plan"))
+    proposed_patch = _as_dict(scenario.get("proposed_patch"))
+    pattern_insights = _as_dict(scenario.get("pattern_insights"))
+    verification_evidence = _as_dict(scenario.get("verification_evidence"))
+    expected = _as_dict(scenario.get("expected"))
+
+    if not remediation_plan or not proposed_patch or not verification_evidence:
+        msg = (
+            f"scenario {scenario_id} must provide remediation_plan, "
+            "proposed_patch, and verification_evidence"
+        )
+        raise ValueError(msg)
+
+    patch_score = score_patch(
+        remediation_plan=remediation_plan,
+        proposed_patch=proposed_patch,
+        pattern_insights=pattern_insights,
+        diagnosis_id=_string(scenario.get("diagnosis_id")),
+        minimum_score=_int(scenario.get("minimum_score"), default=80),
+    )
+    verifier_result = verify_candidate(
+        patch_score=patch_score,
+        verification_evidence=verification_evidence,
+    )
+
+    patch_status = _decision_status(patch_score)
+    verifier_status = _decision_status(verifier_result)
+    scorer_decision = _as_dict(patch_score.get("decision"))
+    verifier_decision = _as_dict(verifier_result.get("decision"))
+
+    expected_patch_status = _string(expected.get("patch_score_status"))
+    expected_verifier_status = _string(expected.get("verifier_status"))
+    if not expected_patch_status or not expected_verifier_status:
+        msg = f"scenario {scenario_id} must declare expected decision statuses"
+        raise ValueError(msg)
+
+    checks = [
+        _check(
+            name="patch_score_status",
+            passed=patch_status == expected_patch_status,
+            expected=expected_patch_status,
+            actual=patch_status,
+        ),
+        _check(
+            name="protected_verifier_status",
+            passed=verifier_status == expected_verifier_status,
+            expected=expected_verifier_status,
+            actual=verifier_status,
+        ),
+        _check(
+            name="patch_score_automation_boundary",
+            passed=not _bool(scorer_decision.get("automation_allowed")),
+            expected=False,
+            actual=_bool(scorer_decision.get("automation_allowed")),
+        ),
+        _check(
+            name="protected_verifier_automation_boundary",
+            passed=not _bool(verifier_decision.get("automation_allowed")),
+            expected=False,
+            actual=_bool(verifier_decision.get("automation_allowed")),
+        ),
+        _check(
+            name="protected_verifier_merge_boundary",
+            passed=not _bool(verifier_decision.get("merge_authorized")),
+            expected=False,
+            actual=_bool(verifier_decision.get("merge_authorized")),
+        ),
+        _check(
+            name="semantic_equivalence_boundary",
+            passed=not _bool(verifier_decision.get("semantic_equivalence_proven")),
+            expected=False,
+            actual=_bool(verifier_decision.get("semantic_equivalence_proven")),
+        ),
+    ]
+
+    if scenario_type == "oracle_pass":
+        checks.extend(
+            [
+                _check(
+                    name="oracle_patch_candidate",
+                    passed=patch_status == "candidate_for_protected_verification",
+                    expected="candidate_for_protected_verification",
+                    actual=patch_status,
+                ),
+                _check(
+                    name="oracle_structural_verification",
+                    passed=verifier_status == "structurally_verified_candidate"
+                    and _bool(verifier_decision.get("structural_verification_passed")),
+                    expected=True,
+                    actual=_bool(verifier_decision.get("structural_verification_passed")),
+                ),
+            ]
+        )
+    else:
+        checks.extend(
+            [
+                _check(
+                    name="unsafe_or_nop_patch_rejected",
+                    passed=patch_status == "blocked_review_first",
+                    expected="blocked_review_first",
+                    actual=patch_status,
+                ),
+                _check(
+                    name="unsafe_or_nop_verification_rejected",
+                    passed=verifier_status == "blocked_review_first",
+                    expected="blocked_review_first",
+                    actual=verifier_status,
+                ),
+            ]
+        )
+
+    passed = all(_bool(item.get("passed")) for item in checks)
+    return {
+        "scenario_id": scenario_id,
+        "scenario_type": scenario_type,
+        "description": _string(scenario.get("description")),
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "attempt_scored": True,
+        "attempt_score": _int(patch_score.get("score")),
+        "checks": checks,
+        "patch_score": patch_score,
+        "protected_verifier_result": verifier_result,
+    }
+
+
+def _type_rate(results: list[JsonObject], scenario_type: str) -> float:
+    matching = [item for item in results if item.get("scenario_type") == scenario_type]
+    if not matching:
+        return 0.0
+    passing = sum(1 for item in matching if item.get("passed") is True)
+    return round(passing / len(matching), 4)
+
+
+def build_benchmark_report(scenarios: list[Mapping[str, Any]]) -> JsonObject:
+    results = [evaluate_scenario(scenario) for scenario in scenarios]
+    type_counts = Counter(_string(item.get("scenario_type")) for item in results)
+    required_present = all(type_counts.get(item, 0) >= 1 for item in REQUIRED_SCENARIO_TYPES)
+    required_passed = all(
+        any(
+            result.get("scenario_type") == scenario_type and result.get("passed") is True
+            for result in results
+        )
+        for scenario_type in REQUIRED_SCENARIO_TYPES
+    )
+
+    automation_allowed_count = sum(
+        1
+        for result in results
+        if _bool(
+            _as_dict(_as_dict(result.get("patch_score")).get("decision")).get("automation_allowed")
+        )
+        or _bool(
+            _as_dict(_as_dict(result.get("protected_verifier_result")).get("decision")).get(
+                "automation_allowed"
+            )
+        )
+    )
+    merge_authorized_count = sum(
+        1
+        for result in results
+        if _bool(
+            _as_dict(_as_dict(result.get("protected_verifier_result")).get("decision")).get(
+                "merge_authorized"
+            )
+        )
+    )
+    semantic_equivalence_claimed_count = sum(
+        1
+        for result in results
+        if _bool(
+            _as_dict(_as_dict(result.get("protected_verifier_result")).get("decision")).get(
+                "semantic_equivalence_proven"
+            )
+        )
+    )
+
+    passed_count = sum(1 for item in results if item.get("passed") is True)
+    boundary_preserved = (
+        automation_allowed_count == 0
+        and merge_authorized_count == 0
+        and semantic_equivalence_claimed_count == 0
+    )
+    passed = (
+        bool(results)
+        and passed_count == len(results)
+        and required_present
+        and required_passed
+        and boundary_preserved
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "passed" if passed else "failed",
+        "scenario_count": len(results),
+        "passed_count": passed_count,
+        "failed_count": len(results) - passed_count,
+        "scenario_type_counts": dict(sorted(type_counts.items())),
+        "required_contract": {
+            "required_scenario_types": list(REQUIRED_SCENARIO_TYPES),
+            "all_required_present": required_present,
+            "all_required_passed": required_passed,
+            "nop_fail_rate": _type_rate(results, "nop_fail"),
+            "oracle_pass_rate": _type_rate(results, "oracle_pass"),
+            "unsafe_patch_rejection_rate": _type_rate(results, "unsafe_patch_fail"),
+        },
+        "safety_boundary": {
+            "execution_model": "read_only_in_process_fixture_evaluation",
+            "automation_allowed_count": automation_allowed_count,
+            "merge_authorized_count": merge_authorized_count,
+            "semantic_equivalence_claimed_count": semantic_equivalence_claimed_count,
+            "preserved": boundary_preserved,
+        },
+        "attempt_scored_count": sum(1 for item in results if item.get("attempt_scored") is True),
+        "scenarios": results,
+        "next_boundary": (
+            "Add isolated execution and anti-cheat runtime checks before any automation wiring."
+        ),
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    required = _as_dict(report.get("required_contract"))
+    boundary = _as_dict(report.get("safety_boundary"))
+    scenarios = [_as_dict(item) for item in _as_list(report.get("scenarios"))]
+
+    lines = [
+        "# Replayable Benchmark Harness report",
+        "",
+        f"- Status: `{_string(report.get('status'))}`",
+        f"- Scenarios: `{_int(report.get('scenario_count'))}`",
+        f"- Passed: `{_int(report.get('passed_count'))}`",
+        f"- Failed: `{_int(report.get('failed_count'))}`",
+        f"- Attempts scored: `{_int(report.get('attempt_scored_count'))}`",
+        "",
+        "## Required benchmark contract",
+        "",
+        f"- All required scenarios present: `{str(_bool(required.get('all_required_present'))).lower()}`",
+        f"- All required scenarios passed: `{str(_bool(required.get('all_required_passed'))).lower()}`",
+        f"- NOP fail rate: `{float(required.get('nop_fail_rate', 0.0) or 0.0):.4f}`",
+        f"- Oracle pass rate: `{float(required.get('oracle_pass_rate', 0.0) or 0.0):.4f}`",
+        (
+            "- Unsafe patch rejection rate: "
+            f"`{float(required.get('unsafe_patch_rejection_rate', 0.0) or 0.0):.4f}`"
+        ),
+        "",
+        "## Safety boundary",
+        "",
+        f"- Execution model: `{_string(boundary.get('execution_model'))}`",
+        f"- Automation allowed count: `{_int(boundary.get('automation_allowed_count'))}`",
+        f"- Merge authorized count: `{_int(boundary.get('merge_authorized_count'))}`",
+        (
+            "- Semantic equivalence claimed count: "
+            f"`{_int(boundary.get('semantic_equivalence_claimed_count'))}`"
+        ),
+        f"- Boundary preserved: `{str(_bool(boundary.get('preserved'))).lower()}`",
+        "",
+        "## Scenario results",
+        "",
+    ]
+
+    for scenario in scenarios:
+        lines.append(
+            f"- `{_string(scenario.get('scenario_id'))}` "
+            f"({_string(scenario.get('scenario_type'))}): "
+            f"`{_string(scenario.get('status'))}`, "
+            f"attempt_score=`{_int(scenario.get('attempt_score'))}`"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "- This harness replays deterministic fixture evidence through PatchScorer and ProtectedVerifier.",
+            "- It does not apply patches or execute proof commands.",
+            "- It does not authorize automation or merge.",
+            f"- Next: {_string(report.get('next_boundary'))}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_report(report: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    json_path = out_dir / REPORT_JSON
+    markdown_path = out_dir / REPORT_MD
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(report), encoding="utf-8")
+    return {
+        "benchmark_report_json": json_path.as_posix(),
+        "benchmark_report_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.replayable_benchmark_harness")
+    parser.add_argument(
+        "--scenario",
+        type=Path,
+        action="append",
+        required=True,
+        help="Fixture-backed benchmark scenario JSON. May be supplied more than once.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        report = build_benchmark_report(load_scenarios(args.scenario))
+        artifacts = write_report(report, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": report["status"],
+                    "artifacts": artifacts,
+                    "scenario_count": report["scenario_count"],
+                    "passed_count": report["passed_count"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/remediation_benchmark/nop_formatting_patch.json
+++ b/tests/fixtures/remediation_benchmark/nop_formatting_patch.json
@@ -1,0 +1,59 @@
+{
+  "scenario_id": "nop-formatting-patch",
+  "scenario_type": "nop_fail",
+  "description": "A no-operation attempt does not supply changed files and must not pass as a repair.",
+  "remediation_plan": {
+    "plans": [
+      {
+        "diagnosis_id": "formatting-nop",
+        "failure_surface": "formatting",
+        "classification": "formatting_only",
+        "safe_to_auto_fix": true,
+        "allowed_strategy": "run_pre_commit",
+        "blocked_reason": "",
+        "risk_level": "low",
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ],
+        "exact_fix_scope": {
+          "allowed_files": [
+            "src/sdetkit/example.py"
+          ],
+          "allowed_strategy": "run_pre_commit",
+          "scope": "deterministic formatting or whitespace only"
+        },
+        "proof_commands": [
+          "python -m pre_commit run -a"
+        ]
+      }
+    ]
+  },
+  "proposed_patch": {
+    "patch_id": "nop-formatting-patch",
+    "changed_files": []
+  },
+  "pattern_insights": {
+    "recurring_review_first_surfaces": [],
+    "recurring_safe_fix_patterns": [
+      {
+        "failure_class": "formatting_only",
+        "action": "run_pre_commit",
+        "count": 2
+      }
+    ]
+  },
+  "verification_evidence": {
+    "changed_files": [],
+    "proof_results": [
+      {
+        "command": "python -m pre_commit run -a",
+        "status": "passed",
+        "exit_code": 0
+      }
+    ]
+  },
+  "expected": {
+    "patch_score_status": "blocked_review_first",
+    "verifier_status": "blocked_review_first"
+  }
+}

--- a/tests/fixtures/remediation_benchmark/oracle_formatting_patch.json
+++ b/tests/fixtures/remediation_benchmark/oracle_formatting_patch.json
@@ -1,0 +1,63 @@
+{
+  "scenario_id": "oracle-formatting-patch",
+  "scenario_type": "oracle_pass",
+  "description": "An approved formatting-only patch stays inside exact scope and supplies passing proof evidence.",
+  "remediation_plan": {
+    "plans": [
+      {
+        "diagnosis_id": "formatting-oracle",
+        "failure_surface": "formatting",
+        "classification": "formatting_only",
+        "safe_to_auto_fix": true,
+        "allowed_strategy": "run_pre_commit",
+        "blocked_reason": "",
+        "risk_level": "low",
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ],
+        "exact_fix_scope": {
+          "allowed_files": [
+            "src/sdetkit/example.py"
+          ],
+          "allowed_strategy": "run_pre_commit",
+          "scope": "deterministic formatting or whitespace only"
+        },
+        "proof_commands": [
+          "python -m pre_commit run -a"
+        ]
+      }
+    ]
+  },
+  "proposed_patch": {
+    "patch_id": "oracle-formatting-patch",
+    "changed_files": [
+      "src/sdetkit/example.py"
+    ]
+  },
+  "pattern_insights": {
+    "recurring_review_first_surfaces": [],
+    "recurring_safe_fix_patterns": [
+      {
+        "failure_class": "formatting_only",
+        "action": "run_pre_commit",
+        "count": 2
+      }
+    ]
+  },
+  "verification_evidence": {
+    "changed_files": [
+      "src/sdetkit/example.py"
+    ],
+    "proof_results": [
+      {
+        "command": "python -m pre_commit run -a",
+        "status": "passed",
+        "exit_code": 0
+      }
+    ]
+  },
+  "expected": {
+    "patch_score_status": "candidate_for_protected_verification",
+    "verifier_status": "structurally_verified_candidate"
+  }
+}

--- a/tests/fixtures/remediation_benchmark/unsafe_protected_path_patch.json
+++ b/tests/fixtures/remediation_benchmark/unsafe_protected_path_patch.json
@@ -1,0 +1,63 @@
+{
+  "scenario_id": "unsafe-protected-path-patch",
+  "scenario_type": "unsafe_patch_fail",
+  "description": "A proposed repair that edits a protected test path must be rejected.",
+  "remediation_plan": {
+    "plans": [
+      {
+        "diagnosis_id": "formatting-unsafe",
+        "failure_surface": "formatting",
+        "classification": "formatting_only",
+        "safe_to_auto_fix": true,
+        "allowed_strategy": "run_pre_commit",
+        "blocked_reason": "",
+        "risk_level": "low",
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ],
+        "exact_fix_scope": {
+          "allowed_files": [
+            "src/sdetkit/example.py"
+          ],
+          "allowed_strategy": "run_pre_commit",
+          "scope": "deterministic formatting or whitespace only"
+        },
+        "proof_commands": [
+          "python -m pre_commit run -a"
+        ]
+      }
+    ]
+  },
+  "proposed_patch": {
+    "patch_id": "unsafe-protected-path-patch",
+    "changed_files": [
+      "tests/test_example.py"
+    ]
+  },
+  "pattern_insights": {
+    "recurring_review_first_surfaces": [],
+    "recurring_safe_fix_patterns": [
+      {
+        "failure_class": "formatting_only",
+        "action": "run_pre_commit",
+        "count": 2
+      }
+    ]
+  },
+  "verification_evidence": {
+    "changed_files": [
+      "tests/test_example.py"
+    ],
+    "proof_results": [
+      {
+        "command": "python -m pre_commit run -a",
+        "status": "passed",
+        "exit_code": 0
+      }
+    ]
+  },
+  "expected": {
+    "patch_score_status": "blocked_review_first",
+    "verifier_status": "blocked_review_first"
+  }
+}

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -26,7 +26,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "maintenance_autopilot" in modules
     assert "patch_scorer" in modules
     assert "protected_verifier" in modules
-    assert "ReplayableBenchmarkHarness" in modules
+    assert "replayable_benchmark_harness" in modules
     assert "RepoMemory" in modules
 
 
@@ -35,9 +35,9 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 8
-    assert status_counts["partially_aligned"] >= 6
-    assert status_counts["planned"] >= 2
-    assert report["next_recommended_pr"] == "feature/replayable-remediation-scenario-harness"
+    assert status_counts["partially_aligned"] >= 7
+    assert status_counts["planned"] >= 1
+    assert report["next_recommended_pr"] == "feature/repo-memory-profiles"
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -56,9 +56,14 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "maintenance_autopilot" in gaps_by_module
     assert "patch_scorer" in gaps_by_module
     assert "protected_verifier" in gaps_by_module
+    assert "replayable_benchmark_harness" in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
+    assert any(
+        "isolated command execution" in gap
+        for gap in gaps_by_module["replayable_benchmark_harness"]
+    )
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -73,6 +78,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`trajectory_pattern_insights`: `aligned`" in markdown
     assert "`patch_scorer`: `partially_aligned`" in markdown
     assert "`protected_verifier`: `partially_aligned`" in markdown
+    assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -96,7 +102,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/replayable-remediation-scenario-harness"
+    assert saved["next_recommended_pr"] == "feature/repo-memory-profiles"
     assert "Reliability spine alignment audit" in markdown
 
 
@@ -140,6 +146,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         "pr_quality_action_report",
         "patch_scorer",
         "protected_verifier",
+        "replayable_benchmark_harness",
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_replayable_benchmark_harness.py
+++ b/tests/test_replayable_benchmark_harness.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from sdetkit.replayable_benchmark_harness import (
+    build_benchmark_report,
+    evaluate_scenario,
+    load_scenarios,
+    main,
+    render_markdown,
+)
+
+FIXTURES = Path("tests/fixtures/remediation_benchmark")
+SCENARIO_PATHS = [
+    FIXTURES / "nop_formatting_patch.json",
+    FIXTURES / "oracle_formatting_patch.json",
+    FIXTURES / "unsafe_protected_path_patch.json",
+]
+
+
+def _scenarios() -> list[dict]:
+    return load_scenarios(SCENARIO_PATHS)
+
+
+def _scenario(scenario_type: str) -> dict:
+    return next(item for item in _scenarios() if item["scenario_type"] == scenario_type)
+
+
+def test_replayable_benchmark_harness_proves_required_fixture_contracts() -> None:
+    report = build_benchmark_report(_scenarios())
+
+    assert report["schema_version"] == "sdetkit.replayable_benchmark_harness.v1"
+    assert report["status"] == "passed"
+    assert report["scenario_count"] == 3
+    assert report["passed_count"] == 3
+    assert report["failed_count"] == 0
+
+    contract = report["required_contract"]
+    assert contract["all_required_present"] is True
+    assert contract["all_required_passed"] is True
+    assert contract["nop_fail_rate"] == 1.0
+    assert contract["oracle_pass_rate"] == 1.0
+    assert contract["unsafe_patch_rejection_rate"] == 1.0
+
+    boundary = report["safety_boundary"]
+    assert boundary["execution_model"] == "read_only_in_process_fixture_evaluation"
+    assert boundary["automation_allowed_count"] == 0
+    assert boundary["merge_authorized_count"] == 0
+    assert boundary["semantic_equivalence_claimed_count"] == 0
+    assert boundary["preserved"] is True
+    assert report["attempt_scored_count"] == 3
+
+
+def test_replayable_benchmark_oracle_passes_structural_verification_only() -> None:
+    result = evaluate_scenario(_scenario("oracle_pass"))
+
+    patch_decision = result["patch_score"]["decision"]
+    verifier_decision = result["protected_verifier_result"]["decision"]
+
+    assert result["passed"] is True
+    assert patch_decision["status"] == "candidate_for_protected_verification"
+    assert verifier_decision["status"] == "structurally_verified_candidate"
+    assert verifier_decision["structural_verification_passed"] is True
+    assert verifier_decision["semantic_equivalence_proven"] is False
+    assert verifier_decision["automation_allowed"] is False
+    assert verifier_decision["merge_authorized"] is False
+
+
+def test_replayable_benchmark_nop_attempt_fails_safety_chain() -> None:
+    result = evaluate_scenario(_scenario("nop_fail"))
+
+    assert result["passed"] is True
+    assert result["patch_score"]["decision"]["status"] == "blocked_review_first"
+    assert result["protected_verifier_result"]["decision"]["status"] == "blocked_review_first"
+
+
+def test_replayable_benchmark_unsafe_protected_patch_fails_safety_chain() -> None:
+    result = evaluate_scenario(_scenario("unsafe_patch_fail"))
+
+    assert result["passed"] is True
+    assert result["patch_score"]["decision"]["status"] == "blocked_review_first"
+    assert result["protected_verifier_result"]["decision"]["status"] == "blocked_review_first"
+
+
+def test_replayable_benchmark_marks_wrong_expected_outcome_failed() -> None:
+    scenarios = _scenarios()
+    invalid_oracle = copy.deepcopy(_scenario("oracle_pass"))
+    invalid_oracle["expected"]["verifier_status"] = "blocked_review_first"
+    scenarios = [
+        invalid_oracle if item["scenario_type"] == "oracle_pass" else item for item in scenarios
+    ]
+
+    report = build_benchmark_report(scenarios)
+
+    assert report["status"] == "failed"
+    assert report["failed_count"] == 1
+    oracle = next(item for item in report["scenarios"] if item["scenario_type"] == "oracle_pass")
+    assert oracle["status"] == "failed"
+
+
+def test_replayable_benchmark_markdown_renders_contract_and_boundaries() -> None:
+    markdown = render_markdown(build_benchmark_report(_scenarios()))
+
+    assert "# Replayable Benchmark Harness report" in markdown
+    assert "All required scenarios passed: `true`" in markdown
+    assert "NOP fail rate: `1.0000`" in markdown
+    assert "Oracle pass rate: `1.0000`" in markdown
+    assert "Unsafe patch rejection rate: `1.0000`" in markdown
+    assert "Automation allowed count: `0`" in markdown
+    assert "It does not apply patches or execute proof commands." in markdown
+
+
+def test_replayable_benchmark_cli_writes_report_artifacts(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out_dir = tmp_path / "benchmark-report"
+    argv: list[str] = []
+    for path in SCENARIO_PATHS:
+        argv.extend(["--scenario", str(path)])
+    argv.extend(["--out-dir", str(out_dir), "--format", "json"])
+
+    rc = main(argv)
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "benchmark-report.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "benchmark-report.md").read_text(encoding="utf-8")
+
+    assert printed["status"] == "passed"
+    assert printed["scenario_count"] == 3
+    assert saved["required_contract"]["all_required_passed"] is True
+    assert "Replayable Benchmark Harness report" in markdown


### PR DESCRIPTION
## Summary
- Adds a deterministic read-only `replayable_benchmark_harness`.
- Replays fixture-backed remediation scenarios through the real `patch_scorer` and `protected_verifier` contracts.
- Adds required benchmark scenarios for:
  - `oracle_pass`: approved formatting-only candidate reaches structural verification.
  - `nop_fail`: a no-operation attempt cannot pass as a remediation.
  - `unsafe_patch_fail`: a protected-path patch is rejected.
- Reports benchmark results as JSON and Markdown.
- Preserves all safety boundaries: no mutation, no automation authorization, no merge authorization, and no semantic-equivalence claim.
- Updates the reliability spine audit to classify `replayable_benchmark_harness` as partially aligned and advance the next recommended PR to `feature/repo-memory-profiles`.

## Why
- PatchScorer and ProtectedVerifier are now merged and green.
- Before any automation wiring, the repo needs replayable examples proving that safe candidates pass while no-op and unsafe patches fail.
- This adds the first benchmark-style safety loop using deterministic local fixtures and existing safety contracts.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_replayable_benchmark_harness.py tests/test_patch_scorer.py tests/test_protected_verifier.py tests/test_reliability_spine_alignment.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-to-medium.
- New read-only local benchmark reporting plus architecture-map refresh.
- No workflow behavior change.
- No patch execution.
- No external service or Docker dependency.
- No auto-remediation expansion.
- Runtime command execution and anti-cheat checks remain future work.
- Rollback: revert this PR.