### PR TITLE
Add local RepoMemory profiles

### DIFF
--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -204,9 +204,9 @@ def build_alignment_components() -> list[AlignmentComponent]:
             integration_points=(
                 "trajectory_history_report",
                 "patch_scorer",
-                "RepoMemory",
+                "repo_memory",
             ),
-            recommended_next_action="feed read-only PatchScorer evidence without expanding automation",
+            recommended_next_action="feed candidate patterns into patch_scorer and repo_memory without expanding automation",
         ),
         _component(
             module="current_head_failure_bundle",
@@ -300,21 +300,33 @@ def build_alignment_components() -> list[AlignmentComponent]:
             integration_points=(
                 "patch_scorer",
                 "protected_verifier",
-                "RepoMemory",
+                "repo_memory",
             ),
             gaps=(
                 "current fixtures replay structural evidence without isolated command execution",
                 "anti-cheat runtime checks and fresh-workspace execution remain future work",
             ),
-            recommended_next_action="feed proven scenario outcomes into RepoMemory before automation wiring",
+            recommended_next_action="feed proven scenario outcomes into repo_memory and add isolated proof next",
         ),
         _component(
-            module="RepoMemory",
-            role="persist repeated failure patterns and proven decisions",
-            status="planned",
-            stages=("history", "decision"),
-            gaps=("not implemented yet", "should remain local-first initially"),
-            recommended_next_action="build after trajectory pattern insights are proven",
+            module="repo_memory",
+            role="produce local repo-specific memory profiles from trajectory and benchmark evidence",
+            status="partially_aligned",
+            stages=("history", "decision", "reporting"),
+            existing_artifacts=(
+                "repo-memory-profile.json",
+                "repo-memory-profile.md",
+            ),
+            integration_points=(
+                "trajectory_pattern_insights",
+                "replayable_benchmark_harness",
+                "protected_verifier",
+            ),
+            gaps=(
+                "read-only profiles do not execute proof commands",
+                "flaky-test registry ingestion and persistent profile updates are not implemented",
+            ),
+            recommended_next_action="add isolated proof-command execution before any automation wiring",
         ),
     ]
 
@@ -352,7 +364,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/repo-memory-profiles",
+        "next_recommended_pr": "feature/protected-verifier-isolated-proof-runner",
     }
 
 

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.repo_memory.v1"
+DEFAULT_OUT_DIR = Path("build") / "repo-memory"
+PROFILE_JSON = "repo-memory-profile.json"
+PROFILE_MD = "repo-memory-profile.md"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _int(value: Any, *, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"expected JSON object in {path}"
+        raise ValueError(msg)
+    return payload
+
+
+def _decision_status(payload: Mapping[str, Any]) -> str:
+    return _string(_as_dict(payload.get("decision")).get("status"))
+
+
+def _benchmark_contract_proven(benchmark_report: Mapping[str, Any]) -> bool:
+    required = _as_dict(benchmark_report.get("required_contract"))
+    boundary = _as_dict(benchmark_report.get("safety_boundary"))
+    return (
+        _string(benchmark_report.get("status")) == "passed"
+        and _bool(required.get("all_required_present"))
+        and _bool(required.get("all_required_passed"))
+        and _bool(boundary.get("preserved"))
+        and _int(boundary.get("automation_allowed_count")) == 0
+        and _int(boundary.get("merge_authorized_count")) == 0
+        and _int(boundary.get("semantic_equivalence_claimed_count")) == 0
+    )
+
+
+def _proof_commands(benchmark_report: Mapping[str, Any]) -> list[str]:
+    commands: set[str] = set()
+    for scenario in _as_list(benchmark_report.get("scenarios")):
+        patch_score = _as_dict(_as_dict(scenario).get("patch_score"))
+        for command in _as_list(patch_score.get("proof_requirements")):
+            rendered = _string(command)
+            if rendered:
+                commands.add(rendered)
+    return sorted(commands)
+
+
+def _oracle_supports_pattern(
+    *,
+    benchmark_report: Mapping[str, Any],
+    failure_class: str,
+    action: str,
+) -> bool:
+    if not _benchmark_contract_proven(benchmark_report):
+        return False
+
+    for scenario in _as_list(benchmark_report.get("scenarios")):
+        row = _as_dict(scenario)
+        if _string(row.get("scenario_type")) != "oracle_pass" or not _bool(row.get("passed")):
+            continue
+
+        patch_score = _as_dict(row.get("patch_score"))
+        verifier = _as_dict(row.get("protected_verifier_result"))
+        if (
+            _string(patch_score.get("classification")) == failure_class
+            and _string(patch_score.get("strategy")) == action
+            and _decision_status(patch_score) == "candidate_for_protected_verification"
+            and _decision_status(verifier) == "structurally_verified_candidate"
+        ):
+            return True
+
+    return False
+
+
+def _safe_fix_history(
+    *,
+    pattern_insights: Mapping[str, Any],
+    benchmark_report: Mapping[str, Any],
+) -> list[JsonObject]:
+    records: list[JsonObject] = []
+    for item in _as_list(pattern_insights.get("recurring_safe_fix_patterns")):
+        pattern = _as_dict(item)
+        failure_class = _string(pattern.get("failure_class") or "unknown")
+        action = _string(pattern.get("action") or "unknown")
+        supported = _oracle_supports_pattern(
+            benchmark_report=benchmark_report,
+            failure_class=failure_class,
+            action=action,
+        )
+        records.append(
+            {
+                "failure_class": failure_class,
+                "action": action,
+                "trajectory_count": _int(pattern.get("count")),
+                "benchmark_supported": supported,
+                "proof_state": (
+                    "benchmark_supported_candidate" if supported else "trajectory_observed_only"
+                ),
+                "automation_allowed": False,
+                "reason": (
+                    "A repeated trajectory pattern has matching passing oracle evidence, "
+                    "but automation remains disabled."
+                    if supported
+                    else "Trajectory repetition exists without matching benchmark proof."
+                ),
+            }
+        )
+    return records
+
+
+def _review_first_patterns(pattern_insights: Mapping[str, Any]) -> list[JsonObject]:
+    records: list[JsonObject] = []
+    for item in _as_list(pattern_insights.get("recurring_review_first_surfaces")):
+        pattern = _as_dict(item)
+        records.append(
+            {
+                "pattern_kind": "review_first_surface",
+                "surface": _string(pattern.get("value") or "unknown"),
+                "trajectory_count": _int(pattern.get("count")),
+                "decision": "review_first",
+                "automation_allowed": False,
+            }
+        )
+    return records
+
+
+def _benchmark_rejections(benchmark_report: Mapping[str, Any]) -> list[JsonObject]:
+    records: list[JsonObject] = []
+    for item in _as_list(benchmark_report.get("scenarios")):
+        scenario = _as_dict(item)
+        scenario_type = _string(scenario.get("scenario_type"))
+        if scenario_type not in {"nop_fail", "unsafe_patch_fail"}:
+            continue
+        if not _bool(scenario.get("passed")):
+            continue
+
+        records.append(
+            {
+                "pattern_kind": "benchmark_rejection",
+                "scenario_id": _string(scenario.get("scenario_id")),
+                "scenario_type": scenario_type,
+                "patch_score_status": _decision_status(_as_dict(scenario.get("patch_score"))),
+                "verifier_status": _decision_status(
+                    _as_dict(scenario.get("protected_verifier_result"))
+                ),
+                "decision": "blocked_review_first",
+                "automation_allowed": False,
+            }
+        )
+    return records
+
+
+def _escalation_rules() -> list[JsonObject]:
+    return [
+        {
+            "rule_id": "current_security_evidence_review_first",
+            "when": "a current security review or code-scanning finding exists",
+            "decision": "review_first",
+            "automation_allowed": False,
+        },
+        {
+            "rule_id": "unsupported_safe_pattern_advisory_only",
+            "when": "a repeated safe-fix pattern lacks passing oracle benchmark evidence",
+            "decision": "keep_advisory",
+            "automation_allowed": False,
+        },
+        {
+            "rule_id": "structural_proof_not_semantic_equivalence",
+            "when": "protected structural verification passes without isolated runtime proof",
+            "decision": "do_not_authorize_automation",
+            "automation_allowed": False,
+        },
+    ]
+
+
+def build_repo_memory_profile(
+    *,
+    pattern_insights: Mapping[str, Any],
+    benchmark_report: Mapping[str, Any],
+) -> JsonObject:
+    benchmark_proven = _benchmark_contract_proven(benchmark_report)
+    safe_fix_history = _safe_fix_history(
+        pattern_insights=pattern_insights,
+        benchmark_report=benchmark_report,
+    )
+    review_first = _review_first_patterns(pattern_insights)
+    benchmark_rejections = _benchmark_rejections(benchmark_report)
+    supported_candidates = [
+        item for item in safe_fix_history if _bool(item.get("benchmark_supported"))
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "profile_status": (
+            "benchmark_supported_memory" if benchmark_proven else "observation_only"
+        ),
+        "memory_mode": "read_only_profile",
+        "inputs": {
+            "trajectory_pattern_schema": _string(pattern_insights.get("schema_version")),
+            "trajectory_record_count": _int(pattern_insights.get("record_count")),
+            "benchmark_schema": _string(benchmark_report.get("schema_version")),
+            "benchmark_status": _string(benchmark_report.get("status")),
+            "benchmark_contract_proven": benchmark_proven,
+        },
+        "command_profile": {
+            "source": "replayable_benchmark_harness",
+            "observed_proof_commands": _proof_commands(benchmark_report),
+            "commands_executed_by_repo_memory": False,
+            "note": (
+                "Commands are stored from benchmark evidence only; "
+                "RepoMemory does not execute proof commands."
+            ),
+        },
+        "failure_patterns": {
+            "review_first": review_first,
+            "benchmark_rejections": benchmark_rejections,
+        },
+        "safe_fix_history": safe_fix_history,
+        "known_safe_candidate_count": len(supported_candidates),
+        "flaky_test_registry": {
+            "collection_status": "not_collected",
+            "entries": [],
+            "note": "No flaky-test evidence source is connected to RepoMemory yet.",
+        },
+        "escalation_rules": _escalation_rules(),
+        "unproven_boundaries": [
+            "semantic equivalence",
+            "isolated proof-command execution",
+            "anti-cheat runtime validation",
+            "broader remediation classes beyond formatting-only candidates",
+        ],
+        "decision_boundary": {
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "reason": (
+                "RepoMemory records observed and benchmark-supported patterns; "
+                "it does not authorize remediation."
+            ),
+        },
+        "recommended_next_action": (
+            "Add isolated proof-command execution and anti-cheat checks "
+            "before any automation wiring."
+        ),
+    }
+
+
+def render_markdown(profile: Mapping[str, Any]) -> str:
+    inputs = _as_dict(profile.get("inputs"))
+    commands = _as_dict(profile.get("command_profile"))
+    failure_patterns = _as_dict(profile.get("failure_patterns"))
+    flaky = _as_dict(profile.get("flaky_test_registry"))
+    boundary = _as_dict(profile.get("decision_boundary"))
+
+    lines = [
+        "# RepoMemory profile",
+        "",
+        f"- Schema: `{_string(profile.get('schema_version'))}`",
+        f"- Status: `{_string(profile.get('profile_status'))}`",
+        f"- Mode: `{_string(profile.get('memory_mode'))}`",
+        f"- Trajectory records observed: `{_int(inputs.get('trajectory_record_count'))}`",
+        (
+            "- Benchmark contract proven: "
+            f"`{str(_bool(inputs.get('benchmark_contract_proven'))).lower()}`"
+        ),
+        f"- Known safe candidates: `{_int(profile.get('known_safe_candidate_count'))}`",
+        "",
+        "## Command profile",
+        "",
+    ]
+
+    proof_commands = [_string(item) for item in _as_list(commands.get("observed_proof_commands"))]
+    if proof_commands:
+        lines.extend(f"- `{command}`" for command in proof_commands)
+    else:
+        lines.append("- none observed")
+    lines.append("- RepoMemory executes commands: `false`")
+
+    lines.extend(["", "## Safe-fix history", ""])
+    safe_history = [_as_dict(item) for item in _as_list(profile.get("safe_fix_history"))]
+    if safe_history:
+        for item in safe_history:
+            lines.append(
+                f"- class=`{_string(item.get('failure_class'))}`, "
+                f"action=`{_string(item.get('action'))}`, "
+                f"trajectory_count=`{_int(item.get('trajectory_count'))}`, "
+                f"proof_state=`{_string(item.get('proof_state'))}`, "
+                "automation_allowed=`false`"
+            )
+    else:
+        lines.append("- none observed")
+
+    lines.extend(["", "## Review-first failure patterns", ""])
+    review_first = [_as_dict(item) for item in _as_list(failure_patterns.get("review_first"))]
+    rejections = [_as_dict(item) for item in _as_list(failure_patterns.get("benchmark_rejections"))]
+    if review_first:
+        for item in review_first:
+            lines.append(
+                f"- recurring surface=`{_string(item.get('surface'))}`, "
+                f"trajectory_count=`{_int(item.get('trajectory_count'))}`"
+            )
+    if rejections:
+        for item in rejections:
+            lines.append(
+                f"- benchmark scenario=`{_string(item.get('scenario_id'))}`, "
+                f"type=`{_string(item.get('scenario_type'))}`, "
+                "decision=`blocked_review_first`"
+            )
+    if not review_first and not rejections:
+        lines.append("- none observed")
+
+    lines.extend(
+        [
+            "",
+            "## Flaky test registry",
+            "",
+            f"- Collection status: `{_string(flaky.get('collection_status'))}`",
+            f"- Entries: `{len(_as_list(flaky.get('entries')))}`",
+            "",
+            "## Escalation rules",
+            "",
+        ]
+    )
+    for rule in _as_list(profile.get("escalation_rules")):
+        item = _as_dict(rule)
+        lines.append(
+            f"- `{_string(item.get('rule_id'))}`: "
+            f"decision=`{_string(item.get('decision'))}`, automation_allowed=`false`"
+        )
+
+    lines.extend(["", "## Unproven boundaries", ""])
+    for item in _as_list(profile.get("unproven_boundaries")):
+        lines.append(f"- {_string(item)}")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`",
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            f"- Next: {_string(profile.get('recommended_next_action'))}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_profile(profile: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    json_path = out_dir / PROFILE_JSON
+    markdown_path = out_dir / PROFILE_MD
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(profile), encoding="utf-8")
+    return {
+        "repo_memory_profile_json": json_path.as_posix(),
+        "repo_memory_profile_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.repo_memory")
+    parser.add_argument("--pattern-insights", type=Path, required=True)
+    parser.add_argument("--benchmark-report", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        profile = build_repo_memory_profile(
+            pattern_insights=_read_json(args.pattern_insights),
+            benchmark_report=_read_json(args.benchmark_report),
+        )
+        artifacts = write_profile(profile, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "profile_status": profile["profile_status"],
+                    "artifacts": artifacts,
+                    "known_safe_candidate_count": profile["known_safe_candidate_count"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -27,7 +27,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "patch_scorer" in modules
     assert "protected_verifier" in modules
     assert "replayable_benchmark_harness" in modules
-    assert "RepoMemory" in modules
+    assert "repo_memory" in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -35,9 +35,9 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 8
-    assert status_counts["partially_aligned"] >= 7
-    assert status_counts["planned"] >= 1
-    assert report["next_recommended_pr"] == "feature/repo-memory-profiles"
+    assert status_counts["partially_aligned"] >= 8
+    assert status_counts.get("planned", 0) == 0
+    assert report["next_recommended_pr"] == "feature/protected-verifier-isolated-proof-runner"
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -57,6 +57,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "patch_scorer" in gaps_by_module
     assert "protected_verifier" in gaps_by_module
     assert "replayable_benchmark_harness" in gaps_by_module
+    assert "repo_memory" in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
@@ -64,6 +65,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
         "isolated command execution" in gap
         for gap in gaps_by_module["replayable_benchmark_harness"]
     )
+    assert any("proof commands" in gap for gap in gaps_by_module["repo_memory"])
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -79,6 +81,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`patch_scorer`: `partially_aligned`" in markdown
     assert "`protected_verifier`: `partially_aligned`" in markdown
     assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
+    assert "`repo_memory`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -102,7 +105,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/repo-memory-profiles"
+    assert saved["next_recommended_pr"] == "feature/protected-verifier-isolated-proof-runner"
     assert "Reliability spine alignment audit" in markdown
 
 
@@ -147,6 +150,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         "patch_scorer",
         "protected_verifier",
         "replayable_benchmark_harness",
+        "repo_memory",
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from sdetkit.replayable_benchmark_harness import (
+    build_benchmark_report,
+    load_scenarios,
+)
+from sdetkit.repo_memory import (
+    build_repo_memory_profile,
+    main,
+    render_markdown,
+)
+
+FIXTURES = Path("tests/fixtures/remediation_benchmark")
+SCENARIOS = [
+    FIXTURES / "nop_formatting_patch.json",
+    FIXTURES / "oracle_formatting_patch.json",
+    FIXTURES / "unsafe_protected_path_patch.json",
+]
+
+
+def _benchmark_report() -> dict:
+    return build_benchmark_report(load_scenarios(SCENARIOS))
+
+
+def _pattern_insights() -> dict:
+    return {
+        "schema_version": "sdetkit.trajectory_pattern_insights.v1",
+        "record_count": 5,
+        "recurring_safe_fix_patterns": [
+            {
+                "failure_class": "formatting_only",
+                "action": "run_pre_commit",
+                "count": 2,
+            }
+        ],
+        "recurring_review_first_surfaces": [
+            {
+                "value": "security",
+                "count": 2,
+            }
+        ],
+    }
+
+
+def test_repo_memory_records_benchmark_supported_candidate_without_automation() -> None:
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=_benchmark_report(),
+    )
+
+    assert profile["schema_version"] == "sdetkit.repo_memory.v1"
+    assert profile["profile_status"] == "benchmark_supported_memory"
+    assert profile["memory_mode"] == "read_only_profile"
+    assert profile["inputs"]["benchmark_contract_proven"] is True
+    assert profile["known_safe_candidate_count"] == 1
+
+    history = profile["safe_fix_history"][0]
+    assert history["failure_class"] == "formatting_only"
+    assert history["action"] == "run_pre_commit"
+    assert history["proof_state"] == "benchmark_supported_candidate"
+    assert history["benchmark_supported"] is True
+    assert history["automation_allowed"] is False
+
+    boundary = profile["decision_boundary"]
+    assert boundary["automation_allowed"] is False
+    assert boundary["merge_authorized"] is False
+    assert boundary["semantic_equivalence_proven"] is False
+
+
+def test_repo_memory_records_proof_commands_and_benchmark_rejections() -> None:
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=_benchmark_report(),
+    )
+
+    assert profile["command_profile"]["observed_proof_commands"] == ["python -m pre_commit run -a"]
+    assert profile["command_profile"]["commands_executed_by_repo_memory"] is False
+
+    rejections = profile["failure_patterns"]["benchmark_rejections"]
+    types = {item["scenario_type"] for item in rejections}
+    assert types == {"nop_fail", "unsafe_patch_fail"}
+    assert all(item["decision"] == "blocked_review_first" for item in rejections)
+    assert all(item["automation_allowed"] is False for item in rejections)
+
+
+def test_repo_memory_records_review_first_and_flaky_registry_boundaries() -> None:
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=_benchmark_report(),
+    )
+
+    review_first = profile["failure_patterns"]["review_first"]
+    assert review_first == [
+        {
+            "pattern_kind": "review_first_surface",
+            "surface": "security",
+            "trajectory_count": 2,
+            "decision": "review_first",
+            "automation_allowed": False,
+        }
+    ]
+
+    flaky = profile["flaky_test_registry"]
+    assert flaky["collection_status"] == "not_collected"
+    assert flaky["entries"] == []
+    assert "semantic equivalence" in profile["unproven_boundaries"]
+
+
+def test_repo_memory_does_not_promote_pattern_when_benchmark_contract_fails() -> None:
+    benchmark = copy.deepcopy(_benchmark_report())
+    benchmark["status"] = "failed"
+    benchmark["required_contract"]["all_required_passed"] = False
+
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=benchmark,
+    )
+
+    assert profile["profile_status"] == "observation_only"
+    assert profile["known_safe_candidate_count"] == 0
+    history = profile["safe_fix_history"][0]
+    assert history["proof_state"] == "trajectory_observed_only"
+    assert history["benchmark_supported"] is False
+    assert history["automation_allowed"] is False
+
+
+def test_repo_memory_markdown_renders_memory_and_safety_boundary() -> None:
+    markdown = render_markdown(
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+        )
+    )
+
+    assert "# RepoMemory profile" in markdown
+    assert "Status: `benchmark_supported_memory`" in markdown
+    assert "Known safe candidates: `1`" in markdown
+    assert "proof_state=`benchmark_supported_candidate`" in markdown
+    assert "benchmark scenario=`nop-formatting-patch`" in markdown
+    assert "Collection status: `not_collected`" in markdown
+    assert "Automation allowed: `false`" in markdown
+    assert "Semantic equivalence proven: `false`" in markdown
+
+
+def test_repo_memory_cli_writes_profile_artifacts(tmp_path: Path, capsys) -> None:
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    out_dir = tmp_path / "repo-memory"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "repo-memory-profile.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "repo-memory-profile.md").read_text(encoding="utf-8")
+
+    assert printed["profile_status"] == "benchmark_supported_memory"
+    assert printed["known_safe_candidate_count"] == 1
+    assert saved["decision_boundary"]["automation_allowed"] is False
+    assert "# RepoMemory profile" in markdown


### PR DESCRIPTION
## Summary
- Adds a local read-only `repo_memory` profile generator.
- Builds deterministic memory profiles from trajectory pattern insights and replayable benchmark reports.
- Records benchmark-supported safe candidates, recurring review-first patterns, benchmark-rejected no-op and protected-path attempts, observed proof commands, escalation rules, and unproven boundaries.
- Explicitly records that RepoMemory does not execute proof commands, authorize automation, authorize merge, or prove semantic equivalence.
- Updates the reliability spine alignment audit to classify `repo_memory` as partially aligned and advance the next recommended PR to `feature/protected-verifier-isolated-proof-runner`.

## Why
- The repo now has trajectory history, pattern insights, PatchScorer, ProtectedVerifier, and replayable benchmark outcomes.
- Those proven outcomes need a deterministic repo-owned memory artifact before any further remediation or automation integration.
- This PR establishes that memory layer without introducing hidden model state, external storage, or new authority.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_repo_memory.py tests/test_replayable_benchmark_harness.py tests/test_trajectory_pattern_insights.py tests/test_reliability_spine_alignment.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-to-medium.
- New read-only local reporting module plus architecture-map refresh.
- No workflow behavior change.
- No database, cloud service, or model dependency.
- No patch application or proof-command execution.
- No auto-remediation expansion.
- Rollback: revert this PR.