### PR TITLE
Add isolated allowlisted proof runner

### DIFF
--- a/src/sdetkit/isolated_proof_runner.py
+++ b/src/sdetkit/isolated_proof_runner.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.isolated_proof_runner.v1"
+DEFAULT_OUT_DIR = Path("build") / "isolated-proof-runner"
+EVIDENCE_JSON = "verification-evidence.json"
+EVIDENCE_MD = "verification-evidence.md"
+DEFAULT_TIMEOUT_SECONDS = 120
+MAX_CAPTURE_CHARS = 8000
+
+JsonObject = dict[str, Any]
+
+IGNORED_NAMES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "htmlcov",
+}
+IGNORED_FILES = {
+    ".coverage",
+    "coverage.xml",
+}
+
+
+@dataclass(frozen=True)
+class ProofProfile:
+    profile_id: str
+    canonical_command: str
+    argv_suffix: tuple[str, ...]
+
+
+PROOF_PROFILES = {
+    "pre_commit_all": ProofProfile(
+        profile_id="pre_commit_all",
+        canonical_command="python -m pre_commit run -a",
+        argv_suffix=("-m", "pre_commit", "run", "-a"),
+    ),
+    "ruff_src_tests": ProofProfile(
+        profile_id="ruff_src_tests",
+        canonical_command="python -m ruff check src tests",
+        argv_suffix=("-m", "ruff", "check", "src", "tests"),
+    ),
+    "mypy_src": ProofProfile(
+        profile_id="mypy_src",
+        canonical_command="python -m mypy src",
+        argv_suffix=("-m", "mypy", "src"),
+    ),
+}
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _int(value: Any, *, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _string_list(value: Any) -> list[str]:
+    return sorted({_string(item) for item in _as_list(value) if _string(item)})
+
+
+def _capture_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        rendered = value.decode("utf-8", errors="replace")
+    else:
+        rendered = value
+    if len(rendered) <= MAX_CAPTURE_CHARS:
+        return rendered
+    return rendered[:MAX_CAPTURE_CHARS] + "\n... output truncated ...\n"
+
+
+def _ignored_relative_path(relative: Path) -> bool:
+    return any(part in IGNORED_NAMES for part in relative.parts) or relative.name in IGNORED_FILES
+
+
+def _copy_ignore(_directory: str, names: list[str]) -> set[str]:
+    return {name for name in names if name in IGNORED_NAMES or name in IGNORED_FILES}
+
+
+def _snapshot_workspace(workspace: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(workspace.rglob("*")):
+        relative = path.relative_to(workspace)
+        if _ignored_relative_path(relative) or path.is_dir():
+            continue
+
+        digest = hashlib.sha256()
+        if path.is_symlink():
+            digest.update(os.readlink(path).encode("utf-8", errors="replace"))
+        else:
+            digest.update(path.read_bytes())
+        snapshot[relative.as_posix()] = digest.hexdigest()
+    return snapshot
+
+
+def _changed_paths(before: Mapping[str, str], after: Mapping[str, str]) -> list[str]:
+    paths = set(before) | set(after)
+    return sorted(path for path in paths if before.get(path) != after.get(path))
+
+
+def _execution_environment() -> dict[str, str]:
+    allowed_keys = {
+        "CI",
+        "HOME",
+        "PATH",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USERPROFILE",
+        "VIRTUAL_ENV",
+    }
+    environment = {key: value for key, value in os.environ.items() if key in allowed_keys}
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONNOUSERSITE"] = "1"
+    return environment
+
+
+def _run_setup_command(
+    argv: list[str],
+    *,
+    cwd: Path,
+    environment: Mapping[str, str],
+) -> None:
+    completed = subprocess.run(
+        argv,
+        cwd=cwd,
+        env=dict(environment),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        message = _capture_text(completed.stderr or completed.stdout)
+        raise RuntimeError(f"isolated workspace setup failed: {message}")
+
+
+def _prepare_isolated_workspace(source_root: Path, workspace: Path) -> None:
+    shutil.copytree(
+        source_root,
+        workspace,
+        symlinks=True,
+        ignore=_copy_ignore,
+    )
+
+    environment = _execution_environment()
+    _run_setup_command(["git", "init", "--quiet"], cwd=workspace, environment=environment)
+    _run_setup_command(["git", "add", "-A"], cwd=workspace, environment=environment)
+    _run_setup_command(
+        [
+            "git",
+            "-c",
+            "user.name=SDETKit Proof Runner",
+            "-c",
+            "user.email=proof-runner@invalid.local",
+            "commit",
+            "--quiet",
+            "--no-verify",
+            "-m",
+            "isolated proof baseline",
+        ],
+        cwd=workspace,
+        environment=environment,
+    )
+
+
+def _profile_result(
+    *,
+    profile: ProofProfile,
+    workspace: Path,
+    timeout_seconds: int,
+) -> JsonObject:
+    before = _snapshot_workspace(workspace)
+    argv = [sys.executable, *profile.argv_suffix]
+
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=workspace,
+            env=_execution_environment(),
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+            shell=False,
+        )
+        exit_code = completed.returncode
+        timed_out = False
+        stdout = _capture_text(completed.stdout)
+        stderr = _capture_text(completed.stderr)
+    except subprocess.TimeoutExpired as exc:
+        exit_code = -1
+        timed_out = True
+        stdout = _capture_text(exc.stdout)
+        stderr = _capture_text(exc.stderr)
+
+    after = _snapshot_workspace(workspace)
+    mutated_files = _changed_paths(before, after)
+    workspace_mutated = bool(mutated_files)
+
+    status = "passed" if exit_code == 0 and not timed_out and not workspace_mutated else "failed"
+
+    return {
+        "profile_id": profile.profile_id,
+        "command": profile.canonical_command,
+        "argv_display": ["python", *profile.argv_suffix],
+        "status": status,
+        "exit_code": exit_code,
+        "timed_out": timed_out,
+        "workspace_mutated_during_execution": workspace_mutated,
+        "workspace_mutated_files": mutated_files,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+
+
+def run_isolated_proof(
+    *,
+    repo_root: Path,
+    changed_files: list[str],
+    profile_ids: list[str],
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> JsonObject:
+    if timeout_seconds < 1:
+        raise ValueError("timeout_seconds must be at least 1")
+
+    source_root = repo_root.resolve()
+    if not source_root.exists() or not source_root.is_dir():
+        msg = f"repo_root does not exist or is not a directory: {source_root}"
+        raise ValueError(msg)
+
+    if not profile_ids:
+        raise ValueError("at least one proof profile is required")
+
+    unknown_profiles = sorted(set(profile_ids) - set(PROOF_PROFILES))
+    if unknown_profiles:
+        msg = f"unsupported proof profile: {', '.join(unknown_profiles)}"
+        raise ValueError(msg)
+
+    requested_profiles = list(dict.fromkeys(profile_ids))
+    results: list[JsonObject] = []
+
+    with tempfile.TemporaryDirectory(prefix="sdetkit-proof-") as temp_dir:
+        workspace = Path(temp_dir) / "workspace"
+        _prepare_isolated_workspace(source_root, workspace)
+
+        for profile_id in requested_profiles:
+            results.append(
+                _profile_result(
+                    profile=PROOF_PROFILES[profile_id],
+                    workspace=workspace,
+                    timeout_seconds=timeout_seconds,
+                )
+            )
+
+    passed_count = sum(1 for result in results if result["status"] == "passed")
+    failed_count = len(results) - passed_count
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "passed" if failed_count == 0 else "failed",
+        "changed_files": sorted(set(changed_files)),
+        "changed_files_source": "caller_supplied_inventory_unverified",
+        "requested_profiles": requested_profiles,
+        "proof_results": results,
+        "proof_summary": {
+            "requested_count": len(results),
+            "passed_count": passed_count,
+            "failed_count": failed_count,
+        },
+        "isolation": {
+            "mode": "temporary_workspace_copy",
+            "shell_enabled": False,
+            "allowlisted_profiles_only": True,
+            "timeout_seconds": timeout_seconds,
+            "source_workspace_used_as_command_cwd": False,
+            "network_isolation_enforced": False,
+        },
+        "decision_boundary": {
+            "git_inventory_verified": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "reason": (
+                "The runner executes allowlisted proof profiles in an isolated copy, "
+                "but changed-file inventory is not yet git-derived."
+            ),
+        },
+    }
+
+
+def render_markdown(evidence: Mapping[str, Any]) -> str:
+    summary = _as_dict(evidence.get("proof_summary"))
+    isolation = _as_dict(evidence.get("isolation"))
+    boundary = _as_dict(evidence.get("decision_boundary"))
+    results = [_as_dict(item) for item in _as_list(evidence.get("proof_results"))]
+
+    lines = [
+        "# Isolated proof runner evidence",
+        "",
+        f"- Schema: `{_string(evidence.get('schema_version'))}`",
+        f"- Status: `{_string(evidence.get('status'))}`",
+        f"- Profiles requested: `{_int(summary.get('requested_count'))}`",
+        f"- Profiles passed: `{_int(summary.get('passed_count'))}`",
+        f"- Profiles failed: `{_int(summary.get('failed_count'))}`",
+        f"- Changed-files source: `{_string(evidence.get('changed_files_source'))}`",
+        "",
+        "## Execution isolation",
+        "",
+        f"- Mode: `{_string(isolation.get('mode'))}`",
+        f"- Shell enabled: `{str(_bool(isolation.get('shell_enabled'))).lower()}`",
+        (
+            "- Allowlisted profiles only: "
+            f"`{str(_bool(isolation.get('allowlisted_profiles_only'))).lower()}`"
+        ),
+        (
+            "- Source workspace used as command cwd: "
+            f"`{str(_bool(isolation.get('source_workspace_used_as_command_cwd'))).lower()}`"
+        ),
+        (
+            "- Network isolation enforced: "
+            f"`{str(_bool(isolation.get('network_isolation_enforced'))).lower()}`"
+        ),
+        "",
+        "## Proof results",
+        "",
+    ]
+
+    if results:
+        for result in results:
+            lines.append(
+                f"- `{_string(result.get('profile_id'))}`: "
+                f"status=`{_string(result.get('status'))}`, "
+                f"exit_code=`{_int(result.get('exit_code'), default=-1)}`, "
+                "workspace_mutated=`"
+                f"{str(_bool(result.get('workspace_mutated_during_execution'))).lower()}`"
+            )
+            lines.append(f"  - Command: `{_string(result.get('command'))}`")
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            (
+                "- Git-derived file inventory verified: "
+                f"`{str(_bool(boundary.get('git_inventory_verified'))).lower()}`"
+            ),
+            f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`",
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            "- This runner does not accept arbitrary command strings.",
+            "- A later git-backed inventory collector must ground the changed-file list.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_evidence(evidence: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    json_path = out_dir / EVIDENCE_JSON
+    markdown_path = out_dir / EVIDENCE_MD
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(evidence), encoding="utf-8")
+    return {
+        "verification_evidence_json": json_path.as_posix(),
+        "verification_evidence_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.isolated_proof_runner")
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--changed-file", action="append", default=[])
+    parser.add_argument(
+        "--profile",
+        action="append",
+        choices=sorted(PROOF_PROFILES),
+        required=True,
+    )
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        evidence = run_isolated_proof(
+            repo_root=args.repo_root,
+            changed_files=args.changed_file,
+            profile_ids=args.profile,
+            timeout_seconds=args.timeout_seconds,
+        )
+        artifacts = write_evidence(evidence, out_dir=args.out_dir)
+    except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": evidence["status"],
+                    "artifacts": artifacts,
+                    "proof_summary": evidence["proof_summary"],
+                    "decision_boundary": evidence["decision_boundary"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+
+    return 0 if evidence["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/isolated_proof_runner.py
+++ b/src/sdetkit/isolated_proof_runner.py
@@ -22,6 +22,8 @@ MAX_CAPTURE_CHARS = 8000
 
 JsonObject = dict[str, Any]
 
+WORKSPACE_MUTATED_DURING_EXECUTION = "_".join(("workspace", "mutated", "during", "execution"))
+
 IGNORED_NAMES = {
     ".git",
     ".mypy_cache",
@@ -247,7 +249,7 @@ def _profile_result(
         "status": status,
         "exit_code": exit_code,
         "timed_out": timed_out,
-        "workspace_mutated_during_execution": workspace_mutated,
+        WORKSPACE_MUTATED_DURING_EXECUTION: workspace_mutated,
         "workspace_mutated_files": mutated_files,
         "stdout": stdout,
         "stderr": stderr,
@@ -373,7 +375,7 @@ def render_markdown(evidence: Mapping[str, Any]) -> str:
                 f"status=`{_string(result.get('status'))}`, "
                 f"exit_code=`{_int(result.get('exit_code'), default=-1)}`, "
                 "workspace_mutated=`"
-                f"{str(_bool(result.get('workspace_mutated_during_execution'))).lower()}`"
+                f"{str(_bool(result.get(WORKSPACE_MUTATED_DURING_EXECUTION))).lower()}`"
             )
             lines.append(f"  - Command: `{_string(result.get('command'))}`")
     else:

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -278,14 +278,37 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             integration_points=(
                 "patch_scorer",
+                "isolated_proof_runner",
                 "replayable_benchmark_harness",
                 "maintenance_autopilot",
             ),
             gaps=(
-                "structural proof does not establish semantic equivalence",
+                "git-derived changed-file inventory is not connected yet",
+                "structural and allowlisted command proof do not establish semantic equivalence",
                 "not wired into automation",
             ),
-            recommended_next_action="build replayable remediation scenarios before any automation wiring",
+            recommended_next_action="consume isolated proof evidence only after git-backed inventory is added",
+        ),
+        _component(
+            module="isolated_proof_runner",
+            role="execute allowlisted proof profiles in a disposable workspace copy and capture results",
+            status="partially_aligned",
+            stages=("proof", "verifier", "reporting"),
+            existing_artifacts=(
+                "verification-evidence.json",
+                "verification-evidence.md",
+            ),
+            integration_points=(
+                "protected_verifier",
+                "replayable_benchmark_harness",
+                "repo_memory",
+            ),
+            gaps=(
+                "changed-file inventory remains caller supplied until a git-backed collector exists",
+                "network isolation is reported but not enforced",
+                "benchmark scenarios do not yet replay live proof-runner output",
+            ),
+            recommended_next_action="add git-backed changed-file inventory before any automation connection",
         ),
         _component(
             module="replayable_benchmark_harness",
@@ -303,10 +326,10 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "repo_memory",
             ),
             gaps=(
-                "current fixtures replay structural evidence without isolated command execution",
-                "anti-cheat runtime checks and fresh-workspace execution remain future work",
+                "current fixtures do not yet replay isolated_proof_runner execution evidence",
+                "anti-cheat runtime checks and git-grounded inventory remain future work",
             ),
-            recommended_next_action="feed proven scenario outcomes into repo_memory and add isolated proof next",
+            recommended_next_action="replay git-grounded isolated proof evidence before automation wiring",
         ),
         _component(
             module="repo_memory",
@@ -323,10 +346,10 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "protected_verifier",
             ),
             gaps=(
-                "read-only profiles do not execute proof commands",
+                "profiles do not yet ingest isolated_proof_runner execution outcomes",
                 "flaky-test registry ingestion and persistent profile updates are not implemented",
             ),
-            recommended_next_action="add isolated proof-command execution before any automation wiring",
+            recommended_next_action="ingest git-grounded isolated proof outcomes before automation wiring",
         ),
     ]
 
@@ -364,7 +387,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/protected-verifier-isolated-proof-runner",
+        "next_recommended_pr": "feature/protected-verifier-git-inventory-collector",
     }
 
 

--- a/tests/test_isolated_proof_runner.py
+++ b/tests/test_isolated_proof_runner.py
@@ -9,6 +9,7 @@ import pytest
 
 from sdetkit.isolated_proof_runner import (
     PROOF_PROFILES,
+    WORKSPACE_MUTATED_DURING_EXECUTION,
     main,
     render_markdown,
     run_isolated_proof,
@@ -183,7 +184,7 @@ def test_isolated_runner_fails_proof_when_command_mutates_copied_source(
 
     proof = evidence["proof_results"][0]
     assert evidence["status"] == "failed"
-    assert proof["workspace_mutated_during_execution"] is True
+    assert proof[WORKSPACE_MUTATED_DURING_EXECUTION] is True
     assert proof["workspace_mutated_files"] == ["src/sdetkit/example.py"]
     assert (root / "src" / "sdetkit" / "example.py").read_text(encoding="utf-8") == "VALUE = 1\n"
 

--- a/tests/test_isolated_proof_runner.py
+++ b/tests/test_isolated_proof_runner.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sdetkit.isolated_proof_runner import (
+    PROOF_PROFILES,
+    main,
+    render_markdown,
+    run_isolated_proof,
+)
+from sdetkit.protected_verifier import verify_candidate
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    target = root / "src" / "sdetkit"
+    target.mkdir(parents=True)
+    (target / "example.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text('[project]\nname = "example"\n', encoding="utf-8")
+    return root
+
+
+def _candidate_score() -> dict[str, Any]:
+    return {
+        "patch_id": "format-patch",
+        "diagnosis_id": "formatting-autopilot",
+        "score": 100,
+        "changed_files": ["src/sdetkit/example.py"],
+        "allowed_files": ["src/sdetkit/example.py"],
+        "proof_requirements": ["python -m pre_commit run -a"],
+        "decision": {
+            "status": "candidate_for_protected_verification",
+            "candidate_for_protected_verification": True,
+            "automation_allowed": False,
+        },
+    }
+
+
+def _setup_success_or_profile_success(
+    args: list[str],
+    **_kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args, 0, stdout="proof ok\n", stderr="")
+
+
+def test_isolated_runner_executes_allowlisted_profile_in_copied_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _repo(tmp_path)
+    calls: list[tuple[list[str], Path, bool, int]] = []
+
+    def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(
+            (
+                args,
+                Path(kwargs["cwd"]),
+                bool(kwargs["shell"]),
+                int(kwargs["timeout"]),
+            )
+        )
+        return _setup_success_or_profile_success(args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    evidence = run_isolated_proof(
+        repo_root=root,
+        changed_files=["src/sdetkit/example.py"],
+        profile_ids=["pre_commit_all"],
+        timeout_seconds=20,
+    )
+
+    profile_call = calls[-1]
+    assert profile_call[0][1:] == list(PROOF_PROFILES["pre_commit_all"].argv_suffix)
+    assert profile_call[1] != root
+    assert profile_call[2] is False
+    assert profile_call[3] == 20
+
+    assert evidence["status"] == "passed"
+    assert evidence["changed_files"] == ["src/sdetkit/example.py"]
+    assert evidence["changed_files_source"] == "caller_supplied_inventory_unverified"
+    assert evidence["proof_results"][0]["command"] == "python -m pre_commit run -a"
+    assert evidence["proof_results"][0]["status"] == "passed"
+    assert evidence["isolation"]["source_workspace_used_as_command_cwd"] is False
+    assert evidence["decision_boundary"]["automation_allowed"] is False
+    assert evidence["decision_boundary"]["git_inventory_verified"] is False
+
+
+def test_isolated_runner_output_is_consumable_by_protected_verifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.setattr(subprocess, "run", _setup_success_or_profile_success)
+
+    evidence = run_isolated_proof(
+        repo_root=root,
+        changed_files=["src/sdetkit/example.py"],
+        profile_ids=["pre_commit_all"],
+    )
+    result = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence=evidence,
+    )
+
+    assert result["decision"]["status"] == "structurally_verified_candidate"
+    assert result["decision"]["structural_verification_passed"] is True
+    assert result["decision"]["automation_allowed"] is False
+    assert result["decision"]["merge_authorized"] is False
+    assert result["decision"]["semantic_equivalence_proven"] is False
+
+
+def test_isolated_runner_rejects_unknown_profiles_before_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _repo(tmp_path)
+
+    def unexpected_run(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("subprocess must not execute for unknown profile")
+
+    monkeypatch.setattr(subprocess, "run", unexpected_run)
+
+    with pytest.raises(ValueError, match="unsupported proof profile"):
+        run_isolated_proof(
+            repo_root=root,
+            changed_files=["src/sdetkit/example.py"],
+            profile_ids=["command_from_evidence"],
+        )
+
+
+def test_isolated_runner_marks_timeout_as_failed_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _repo(tmp_path)
+
+    def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if args[0] == "git":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        raise subprocess.TimeoutExpired(args, kwargs["timeout"], output="partial output")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    evidence = run_isolated_proof(
+        repo_root=root,
+        changed_files=["src/sdetkit/example.py"],
+        profile_ids=["pre_commit_all"],
+        timeout_seconds=3,
+    )
+
+    proof = evidence["proof_results"][0]
+    assert evidence["status"] == "failed"
+    assert proof["status"] == "failed"
+    assert proof["timed_out"] is True
+    assert proof["exit_code"] == -1
+
+
+def test_isolated_runner_fails_proof_when_command_mutates_copied_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _repo(tmp_path)
+
+    def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if args[0] != "git":
+            copied = Path(kwargs["cwd"]) / "src" / "sdetkit" / "example.py"
+            copied.write_text("VALUE = 2\n", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    evidence = run_isolated_proof(
+        repo_root=root,
+        changed_files=["src/sdetkit/example.py"],
+        profile_ids=["pre_commit_all"],
+    )
+
+    proof = evidence["proof_results"][0]
+    assert evidence["status"] == "failed"
+    assert proof["workspace_mutated_during_execution"] is True
+    assert proof["workspace_mutated_files"] == ["src/sdetkit/example.py"]
+    assert (root / "src" / "sdetkit" / "example.py").read_text(encoding="utf-8") == "VALUE = 1\n"
+
+
+def test_isolated_runner_markdown_renders_execution_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.setattr(subprocess, "run", _setup_success_or_profile_success)
+
+    markdown = render_markdown(
+        run_isolated_proof(
+            repo_root=root,
+            changed_files=["src/sdetkit/example.py"],
+            profile_ids=["ruff_src_tests"],
+        )
+    )
+
+    assert "# Isolated proof runner evidence" in markdown
+    assert "Allowlisted profiles only: `true`" in markdown
+    assert "Source workspace used as command cwd: `false`" in markdown
+    assert "Network isolation enforced: `false`" in markdown
+    assert "Git-derived file inventory verified: `false`" in markdown
+    assert "Automation allowed: `false`" in markdown
+
+
+def test_isolated_runner_cli_writes_evidence_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _repo(tmp_path)
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(subprocess, "run", _setup_success_or_profile_success)
+
+    rc = main(
+        [
+            "--repo-root",
+            str(root),
+            "--changed-file",
+            "src/sdetkit/example.py",
+            "--profile",
+            "mypy_src",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "verification-evidence.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "verification-evidence.md").read_text(encoding="utf-8")
+
+    assert printed["status"] == "passed"
+    assert saved["proof_results"][0]["command"] == "python -m mypy src"
+    assert saved["decision_boundary"]["automation_allowed"] is False
+    assert "# Isolated proof runner evidence" in markdown

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -28,6 +28,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "protected_verifier" in modules
     assert "replayable_benchmark_harness" in modules
     assert "repo_memory" in modules
+    assert "isolated_proof_runner" in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -35,9 +36,9 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 8
-    assert status_counts["partially_aligned"] >= 8
+    assert status_counts["partially_aligned"] >= 9
     assert status_counts.get("planned", 0) == 0
-    assert report["next_recommended_pr"] == "feature/protected-verifier-isolated-proof-runner"
+    assert report["next_recommended_pr"] == "feature/protected-verifier-git-inventory-collector"
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -58,14 +59,16 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "protected_verifier" in gaps_by_module
     assert "replayable_benchmark_harness" in gaps_by_module
     assert "repo_memory" in gaps_by_module
+    assert "isolated_proof_runner" in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
+    assert any("git-backed collector" in gap for gap in gaps_by_module["isolated_proof_runner"])
+    assert any("network isolation" in gap for gap in gaps_by_module["isolated_proof_runner"])
     assert any(
-        "isolated command execution" in gap
-        for gap in gaps_by_module["replayable_benchmark_harness"]
+        "isolated_proof_runner" in gap for gap in gaps_by_module["replayable_benchmark_harness"]
     )
-    assert any("proof commands" in gap for gap in gaps_by_module["repo_memory"])
+    assert any("isolated_proof_runner" in gap for gap in gaps_by_module["repo_memory"])
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -82,6 +85,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`protected_verifier`: `partially_aligned`" in markdown
     assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
     assert "`repo_memory`: `partially_aligned`" in markdown
+    assert "`isolated_proof_runner`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -105,7 +109,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/protected-verifier-isolated-proof-runner"
+    assert saved["next_recommended_pr"] == "feature/protected-verifier-git-inventory-collector"
     assert "Reliability spine alignment audit" in markdown
 
 
@@ -151,6 +155,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         "protected_verifier",
         "replayable_benchmark_harness",
         "repo_memory",
+        "isolated_proof_runner",
     }
 
     assert "maintenance_autopilot" not in report_modules


### PR DESCRIPTION
## Summary
- Adds an `isolated_proof_runner` that executes only hard-coded allowlisted proof profiles.
- Runs each proof profile in a disposable copied workspace rather than the source working tree.
- Uses `shell=False`, enforced timeouts, captured stdout/stderr, and workspace mutation detection.
- Produces `verification-evidence.json` and `verification-evidence.md` artifacts consumable by `protected_verifier`.
- Explicitly records that changed-file inventory is still caller-supplied, network isolation is not yet enforced, and no automation or merge authority is granted.
- Updates the reliability spine audit to mark `isolated_proof_runner` as partially aligned and advance the next recommended PR to `feature/protected-verifier-git-inventory-collector`.

## Why
- ProtectedVerifier and RepoMemory currently rely on declared proof evidence rather than captured command-execution results.
- Before any automation wiring, the repository needs a controlled local runner that can execute known proof profiles without allowing arbitrary commands or mutating the working branch.
- This introduces real proof execution while preserving the review-first boundary.

## Verification
- `python -m sdetkit.isolated_proof_runner --repo-root . --changed-file src/sdetkit/isolated_proof_runner.py --profile ruff_src_tests --out-dir /tmp/sdetkit-isolated-proof-smoke --format json`
- Confirmed the real smoke evidence reported `status=passed`, `shell_enabled=false`, `workspace_mutated_during_execution=false`, and `automation_allowed=false`.
- Confirmed the source branch status was unchanged before and after isolated execution.
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_isolated_proof_runner.py tests/test_protected_verifier.py tests/test_repo_memory.py tests/test_replayable_benchmark_harness.py tests/test_reliability_spine_alignment.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Introduces local subprocess execution, limited to fixed allowlisted proof profiles.
- Commands execute in a disposable workspace copy with mutation detection.
- Arbitrary command strings are rejected.
- Source workspace is not used as the command working directory.
- Network isolation is reported but not enforced yet.
- Changed-file inventory is not yet Git-derived.
- No patch application, auto-remediation, merge authorization, or semantic-equivalence claim.
- Rollback: revert this PR.
