### PR TITLE
Add Git-derived proof inventory collection

### DIFF
--- a/src/sdetkit/git_inventory_collector.py
+++ b/src/sdetkit/git_inventory_collector.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.git_inventory_collector.v1"
+DEFAULT_OUT_DIR = Path("build") / "git-inventory"
+INVENTORY_JSON = "git-inventory.json"
+INVENTORY_MD = "git-inventory.md"
+COMMAND_TIMEOUT_SECONDS = 30
+GIT_DIFF_FILE_FILTER = "--diff-filter=" + "".join(("ACDM", "RTUXB"))
+
+BASE_HEAD = "_".join(("base", "head"))
+STAGED_WORKTREE = "_".join(("staged", "worktree"))
+SUPPORTED_MODES = (BASE_HEAD, STAGED_WORKTREE)
+GIT_DERIVED_BASE_HEAD = "_".join(("git", "derived", "base", "head"))
+GIT_DERIVED_STAGED_WORKTREE = "_".join(("git", "derived", "staged", "worktree"))
+
+_SHA_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _git_environment() -> dict[str, str]:
+    allowed_keys = {
+        "CI",
+        "HOME",
+        "PATH",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USERPROFILE",
+    }
+    environment = {key: value for key, value in os.environ.items() if key in allowed_keys}
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    return environment
+
+
+def _run_git(repo_root: Path, args: list[str]) -> bytes:
+    completed = subprocess.run(
+        ["git", "-c", "core.quotepath=false", *args],
+        cwd=repo_root,
+        env=_git_environment(),
+        capture_output=True,
+        text=False,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.decode("utf-8", errors="replace").strip()
+        stdout = completed.stdout.decode("utf-8", errors="replace").strip()
+        message = stderr or stdout or "git command returned non-zero status"
+        raise RuntimeError(f"git inventory command failed: {message}")
+    return completed.stdout
+
+
+def _verify_repository(repo_root: Path) -> None:
+    output = _run_git(repo_root, ["rev-parse", "--is-inside-work-tree"])
+    if output.decode("utf-8", errors="replace").strip().lower() != "true":
+        raise ValueError(f"repo_root is not a Git working tree: {repo_root}")
+
+
+def _resolve_commit(repo_root: Path, ref: str) -> str:
+    rendered_ref = _string(ref)
+    if not rendered_ref:
+        raise ValueError("Git ref must not be empty")
+
+    output = _run_git(
+        repo_root,
+        ["rev-parse", "--verify", "--end-of-options", f"{rendered_ref}^{{commit}}"],
+    )
+    sha = output.decode("utf-8", errors="replace").strip().lower()
+    if not _SHA_PATTERN.fullmatch(sha):
+        raise RuntimeError(f"Git returned an invalid commit SHA for ref: {rendered_ref}")
+    return sha
+
+
+def _paths_from_null_output(output: bytes) -> list[str]:
+    paths = {item.decode("utf-8", errors="replace") for item in output.split(b"\0") if item}
+    return sorted(path for path in paths if path)
+
+
+def collect_git_inventory(
+    *,
+    repo_root: Path,
+    mode: str,
+    base_ref: str = "",
+    head_ref: str = "HEAD",
+) -> JsonObject:
+    source_root = repo_root.resolve()
+    if not source_root.exists() or not source_root.is_dir():
+        raise ValueError(f"repo_root does not exist or is not a directory: {source_root}")
+    if mode not in SUPPORTED_MODES:
+        raise ValueError(f"unsupported inventory mode: {mode}")
+
+    _verify_repository(source_root)
+
+    if mode == BASE_HEAD:
+        if not _string(base_ref):
+            raise ValueError("base_ref is required for base_head inventory")
+        base_sha = _resolve_commit(source_root, base_ref)
+        head_sha = _resolve_commit(source_root, head_ref)
+        changed_files = _paths_from_null_output(
+            _run_git(
+                source_root,
+                [
+                    "diff",
+                    "--name-only",
+                    "-z",
+                    "--no-ext-diff",
+                    GIT_DIFF_FILE_FILTER,
+                    f"{base_sha}...{head_sha}",
+                    "--",
+                ],
+            )
+        )
+        source = GIT_DERIVED_BASE_HEAD
+        collections = {
+            "base_head_diff": changed_files,
+        }
+    else:
+        if _string(base_ref):
+            raise ValueError("base_ref is not valid for staged_worktree inventory")
+        base_sha = ""
+        head_sha = _resolve_commit(source_root, "HEAD")
+        staged = _paths_from_null_output(
+            _run_git(
+                source_root,
+                [
+                    "diff",
+                    "--cached",
+                    "--name-only",
+                    "-z",
+                    "--no-ext-diff",
+                    GIT_DIFF_FILE_FILTER,
+                    "--",
+                ],
+            )
+        )
+        worktree = _paths_from_null_output(
+            _run_git(
+                source_root,
+                [
+                    "diff",
+                    "--name-only",
+                    "-z",
+                    "--no-ext-diff",
+                    GIT_DIFF_FILE_FILTER,
+                    "--",
+                ],
+            )
+        )
+        untracked = _paths_from_null_output(
+            _run_git(source_root, ["ls-files", "-z", "--others", "--exclude-standard", "--"])
+        )
+        changed_files = sorted(set(staged) | set(worktree) | set(untracked))
+        source = GIT_DERIVED_STAGED_WORKTREE
+        collections = {
+            "staged": staged,
+            "worktree": worktree,
+            "untracked": untracked,
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "collected",
+        "mode": mode,
+        "repo_root": source_root.as_posix(),
+        "base_ref": _string(base_ref),
+        "head_ref": _string(head_ref if mode == BASE_HEAD else "HEAD"),
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "changed_files": changed_files,
+        "changed_files_source": source,
+        "collections": collections,
+        "git_inventory_verified": True,
+        "boundary": {
+            "read_only": True,
+            "shell_enabled": False,
+            "fixed_git_argv_only": True,
+            "network_action": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+        },
+    }
+
+
+def render_markdown(inventory: Mapping[str, Any]) -> str:
+    boundary = _as_dict(inventory.get("boundary"))
+    changed_files = [_string(item) for item in _as_list(inventory.get("changed_files"))]
+
+    lines = [
+        "# Git inventory report",
+        "",
+        f"- Schema: `{_string(inventory.get('schema_version'))}`",
+        f"- Status: `{_string(inventory.get('status'))}`",
+        f"- Mode: `{_string(inventory.get('mode'))}`",
+        f"- Changed-files source: `{_string(inventory.get('changed_files_source'))}`",
+        f"- Changed files: `{len(changed_files)}`",
+        f"- Head SHA: `{_string(inventory.get('head_sha'))}`",
+        "",
+        "## Changed files",
+        "",
+    ]
+
+    if changed_files:
+        lines.extend(f"- `{path}`" for path in changed_files)
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            f"- Read-only: `{str(_bool(boundary.get('read_only'))).lower()}`",
+            f"- Shell enabled: `{str(_bool(boundary.get('shell_enabled'))).lower()}`",
+            (f"- Fixed Git argv only: `{str(_bool(boundary.get('fixed_git_argv_only'))).lower()}`"),
+            f"- Network action: `{str(_bool(boundary.get('network_action'))).lower()}`",
+            f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_inventory(inventory: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    json_path = out_dir / INVENTORY_JSON
+    markdown_path = out_dir / INVENTORY_MD
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(inventory, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(inventory), encoding="utf-8")
+    return {
+        "git_inventory_json": json_path.as_posix(),
+        "git_inventory_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.git_inventory_collector")
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--mode", choices=list(SUPPORTED_MODES), required=True)
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--head-ref", default="HEAD")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        inventory = collect_git_inventory(
+            repo_root=args.repo_root,
+            mode=args.mode,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+        )
+        artifacts = write_inventory(inventory, out_dir=args.out_dir)
+    except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": inventory["status"],
+                    "mode": inventory["mode"],
+                    "changed_files": inventory["changed_files"],
+                    "artifacts": artifacts,
+                    "boundary": inventory["boundary"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/isolated_proof_runner.py
+++ b/src/sdetkit/isolated_proof_runner.py
@@ -13,7 +13,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = "sdetkit.isolated_proof_runner.v1"
+from sdetkit.git_inventory_collector import (
+    BASE_HEAD,
+    STAGED_WORKTREE,
+    collect_git_inventory,
+)
+
+SCHEMA_VERSION = "sdetkit.isolated_proof_runner.v2"
 DEFAULT_OUT_DIR = Path("build") / "isolated-proof-runner"
 EVIDENCE_JSON = "verification-evidence.json"
 EVIDENCE_MD = "verification-evidence.md"
@@ -23,6 +29,8 @@ MAX_CAPTURE_CHARS = 8000
 JsonObject = dict[str, Any]
 
 WORKSPACE_MUTATED_DURING_EXECUTION = "_".join(("workspace", "mutated", "during", "execution"))
+CLAIMED_CHANGED_FILES = "_".join(("claimed", "changed", "files"))
+INVENTORY_CLAIM_MATCH = "_".join(("inventory", "claim", "match"))
 
 IGNORED_NAMES = {
     ".git",
@@ -262,6 +270,9 @@ def run_isolated_proof(
     changed_files: list[str],
     profile_ids: list[str],
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    inventory_mode: str | None = None,
+    base_ref: str = "",
+    head_ref: str = "HEAD",
 ) -> JsonObject:
     if timeout_seconds < 1:
         raise ValueError("timeout_seconds must be at least 1")
@@ -278,6 +289,29 @@ def run_isolated_proof(
     if unknown_profiles:
         msg = f"unsupported proof profile: {', '.join(unknown_profiles)}"
         raise ValueError(msg)
+
+    claimed_changed_files = sorted(set(changed_files))
+    inventory: JsonObject = {}
+    effective_changed_files = claimed_changed_files
+    changed_files_source = "caller_supplied_inventory_unverified"
+    inventory_claim_match: bool | None = None
+    git_inventory_verified = False
+
+    if inventory_mode:
+        inventory = collect_git_inventory(
+            repo_root=source_root,
+            mode=inventory_mode,
+            base_ref=base_ref,
+            head_ref=head_ref,
+        )
+        effective_changed_files = _string_list(inventory.get("changed_files"))
+        changed_files_source = _string(inventory.get("changed_files_source"))
+        inventory_claim_match = (
+            not claimed_changed_files or claimed_changed_files == effective_changed_files
+        )
+        git_inventory_verified = (
+            _bool(inventory.get("git_inventory_verified")) and inventory_claim_match
+        )
 
     requested_profiles = list(dict.fromkeys(profile_ids))
     results: list[JsonObject] = []
@@ -297,12 +331,33 @@ def run_isolated_proof(
 
     passed_count = sum(1 for result in results if result["status"] == "passed")
     failed_count = len(results) - passed_count
+    inventory_failed = inventory_claim_match is False
+    status = "passed" if failed_count == 0 and not inventory_failed else "failed"
+
+    if not inventory_mode:
+        boundary_reason = (
+            "The runner executes allowlisted proof profiles in an isolated copy, "
+            "but changed-file inventory is not yet git-derived."
+        )
+    elif inventory_failed:
+        boundary_reason = (
+            "Git-derived inventory disagrees with the caller-declared changed-file claim; "
+            "verification evidence is blocked."
+        )
+    else:
+        boundary_reason = (
+            "The runner executes allowlisted proof profiles in an isolated copy "
+            "with Git-derived changed-file inventory; automation remains disabled."
+        )
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "status": "passed" if failed_count == 0 else "failed",
-        "changed_files": sorted(set(changed_files)),
-        "changed_files_source": "caller_supplied_inventory_unverified",
+        "status": status,
+        "changed_files": effective_changed_files,
+        CLAIMED_CHANGED_FILES: claimed_changed_files,
+        "changed_files_source": changed_files_source,
+        INVENTORY_CLAIM_MATCH: inventory_claim_match,
+        "git_inventory": inventory,
         "requested_profiles": requested_profiles,
         "proof_results": results,
         "proof_summary": {
@@ -319,14 +374,11 @@ def run_isolated_proof(
             "network_isolation_enforced": False,
         },
         "decision_boundary": {
-            "git_inventory_verified": False,
+            "git_inventory_verified": git_inventory_verified,
             "automation_allowed": False,
             "merge_authorized": False,
             "semantic_equivalence_proven": False,
-            "reason": (
-                "The runner executes allowlisted proof profiles in an isolated copy, "
-                "but changed-file inventory is not yet git-derived."
-            ),
+            "reason": boundary_reason,
         },
     }
 
@@ -335,7 +387,10 @@ def render_markdown(evidence: Mapping[str, Any]) -> str:
     summary = _as_dict(evidence.get("proof_summary"))
     isolation = _as_dict(evidence.get("isolation"))
     boundary = _as_dict(evidence.get("decision_boundary"))
+    inventory = _as_dict(evidence.get("git_inventory"))
     results = [_as_dict(item) for item in _as_list(evidence.get("proof_results"))]
+    claim_value = evidence.get(INVENTORY_CLAIM_MATCH)
+    claim_status = "not_checked" if claim_value is None else str(_bool(claim_value)).lower()
 
     lines = [
         "# Isolated proof runner evidence",
@@ -346,6 +401,8 @@ def render_markdown(evidence: Mapping[str, Any]) -> str:
         f"- Profiles passed: `{_int(summary.get('passed_count'))}`",
         f"- Profiles failed: `{_int(summary.get('failed_count'))}`",
         f"- Changed-files source: `{_string(evidence.get('changed_files_source'))}`",
+        f"- Inventory claim matches: `{claim_status}`",
+        f"- Git inventory mode: `{_string(inventory.get('mode') or 'not_used')}`",
         "",
         "## Execution isolation",
         "",
@@ -397,7 +454,7 @@ def render_markdown(evidence: Mapping[str, Any]) -> str:
                 f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
             ),
             "- This runner does not accept arbitrary command strings.",
-            "- A later git-backed inventory collector must ground the changed-file list.",
+            "- Git-derived inventory is used only when explicitly requested and collected in-process.",
             "",
         ]
     )
@@ -423,6 +480,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.isolated_proof_runner")
     parser.add_argument("--repo-root", type=Path, required=True)
     parser.add_argument("--changed-file", action="append", default=[])
+    parser.add_argument("--inventory-mode", choices=[BASE_HEAD, STAGED_WORKTREE])
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--head-ref", default="HEAD")
     parser.add_argument(
         "--profile",
         action="append",
@@ -444,6 +504,9 @@ def main(argv: list[str] | None = None) -> int:
             changed_files=args.changed_file,
             profile_ids=args.profile,
             timeout_seconds=args.timeout_seconds,
+            inventory_mode=args.inventory_mode,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
         )
         artifacts = write_evidence(evidence, out_dir=args.out_dir)
     except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -278,16 +278,37 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             integration_points=(
                 "patch_scorer",
+                "git_inventory_collector",
                 "isolated_proof_runner",
                 "replayable_benchmark_harness",
                 "maintenance_autopilot",
             ),
             gaps=(
-                "git-derived changed-file inventory is not connected yet",
+                "git-derived inventory and allowlisted command proof are not yet replayed in benchmark scenarios",
                 "structural and allowlisted command proof do not establish semantic equivalence",
                 "not wired into automation",
             ),
-            recommended_next_action="consume isolated proof evidence only after git-backed inventory is added",
+            recommended_next_action="replay git-grounded isolated proof evidence in benchmark scenarios",
+        ),
+        _component(
+            module="git_inventory_collector",
+            role="derive changed-file inventories from fixed read-only Git queries",
+            status="partially_aligned",
+            stages=("evidence", "proof", "verifier"),
+            existing_artifacts=(
+                "git-inventory.json",
+                "git-inventory.md",
+            ),
+            integration_points=(
+                "isolated_proof_runner",
+                "protected_verifier",
+                "replayable_benchmark_harness",
+            ),
+            gaps=(
+                "not wired into workflow evidence collection",
+                "benchmark scenarios do not yet replay Git-derived inventory",
+            ),
+            recommended_next_action="feed Git-derived proof evidence through replayable benchmark scenarios",
         ),
         _component(
             module="isolated_proof_runner",
@@ -299,16 +320,16 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "verification-evidence.md",
             ),
             integration_points=(
+                "git_inventory_collector",
                 "protected_verifier",
                 "replayable_benchmark_harness",
                 "repo_memory",
             ),
             gaps=(
-                "changed-file inventory remains caller supplied until a git-backed collector exists",
                 "network isolation is reported but not enforced",
-                "benchmark scenarios do not yet replay live proof-runner output",
+                "benchmark scenarios do not yet replay Git-derived live proof-runner output",
             ),
-            recommended_next_action="add git-backed changed-file inventory before any automation connection",
+            recommended_next_action="replay Git-derived isolated proof evidence before any automation connection",
         ),
         _component(
             module="replayable_benchmark_harness",
@@ -326,10 +347,10 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "repo_memory",
             ),
             gaps=(
-                "current fixtures do not yet replay isolated_proof_runner execution evidence",
-                "anti-cheat runtime checks and git-grounded inventory remain future work",
+                "current fixtures do not yet replay git_inventory_collector and isolated_proof_runner evidence",
+                "anti-cheat runtime checks remain future work",
             ),
-            recommended_next_action="replay git-grounded isolated proof evidence before automation wiring",
+            recommended_next_action="replay Git-derived isolated proof evidence before automation wiring",
         ),
         _component(
             module="repo_memory",
@@ -387,7 +408,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/protected-verifier-git-inventory-collector",
+        "next_recommended_pr": "feature/replayable-benchmark-isolated-proof-evidence",
     }
 
 

--- a/tests/test_git_inventory_collector.py
+++ b/tests/test_git_inventory_collector.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from sdetkit.git_inventory_collector import (
+    BASE_HEAD,
+    GIT_DERIVED_BASE_HEAD,
+    GIT_DERIVED_STAGED_WORKTREE,
+    STAGED_WORKTREE,
+    collect_git_inventory,
+    main,
+    render_markdown,
+)
+
+
+def _git(root: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    target = root / "src" / "sdetkit"
+    target.mkdir(parents=True)
+    _git(root, "init", "--quiet")
+    _git(root, "config", "user.name", "Inventory Test")
+    _git(root, "config", "user.email", "inventory-test@invalid.local")
+    (target / "example.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "--quiet", "-m", "baseline")
+    return root
+
+
+def test_git_inventory_collects_staged_worktree_and_untracked_paths(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    tracked = root / "src" / "sdetkit" / "example.py"
+    staged = root / "src" / "sdetkit" / "staged.py"
+    untracked = root / "src" / "sdetkit" / "untracked.py"
+
+    tracked.write_text("VALUE = 2\n", encoding="utf-8")
+    staged.write_text("STAGED = True\n", encoding="utf-8")
+    _git(root, "add", "src/sdetkit/staged.py")
+    untracked.write_text("UNTRACKED = True\n", encoding="utf-8")
+
+    inventory = collect_git_inventory(repo_root=root, mode=STAGED_WORKTREE)
+
+    assert inventory["status"] == "collected"
+    assert inventory["mode"] == STAGED_WORKTREE
+    assert inventory["changed_files_source"] == GIT_DERIVED_STAGED_WORKTREE
+    assert inventory["changed_files"] == [
+        "src/sdetkit/example.py",
+        "src/sdetkit/staged.py",
+        "src/sdetkit/untracked.py",
+    ]
+    assert inventory["collections"]["staged"] == ["src/sdetkit/staged.py"]
+    assert inventory["collections"]["worktree"] == ["src/sdetkit/example.py"]
+    assert inventory["collections"]["untracked"] == ["src/sdetkit/untracked.py"]
+    assert inventory["git_inventory_verified"] is True
+    assert inventory["boundary"]["shell_enabled"] is False
+    assert inventory["boundary"]["automation_allowed"] is False
+
+
+def test_git_inventory_collects_base_head_diff_from_resolved_commits(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    base_sha = _git(root, "rev-parse", "HEAD")
+    (root / "src" / "sdetkit" / "example.py").write_text("VALUE = 3\n", encoding="utf-8")
+    (root / "src" / "sdetkit" / "new.py").write_text("NEW = True\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "--quiet", "-m", "change")
+
+    inventory = collect_git_inventory(
+        repo_root=root,
+        mode=BASE_HEAD,
+        base_ref=base_sha,
+        head_ref="HEAD",
+    )
+
+    assert inventory["mode"] == BASE_HEAD
+    assert inventory["changed_files_source"] == GIT_DERIVED_BASE_HEAD
+    assert inventory["base_sha"] == base_sha
+    assert inventory["head_sha"] == _git(root, "rev-parse", "HEAD")
+    assert inventory["changed_files"] == [
+        "src/sdetkit/example.py",
+        "src/sdetkit/new.py",
+    ]
+
+
+def test_git_inventory_requires_base_ref_for_base_head_mode(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+
+    with pytest.raises(ValueError, match="base_ref is required"):
+        collect_git_inventory(repo_root=root, mode=BASE_HEAD)
+
+
+def test_git_inventory_markdown_renders_grounded_boundary(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    (root / "src" / "sdetkit" / "example.py").write_text("VALUE = 9\n", encoding="utf-8")
+
+    markdown = render_markdown(collect_git_inventory(repo_root=root, mode=STAGED_WORKTREE))
+
+    assert "# Git inventory report" in markdown
+    assert f"Mode: `{STAGED_WORKTREE}`" in markdown
+    assert "src/sdetkit/example.py" in markdown
+    assert "Read-only: `true`" in markdown
+    assert "Shell enabled: `false`" in markdown
+    assert "Automation allowed: `false`" in markdown
+
+
+def test_git_inventory_cli_writes_artifacts(tmp_path: Path, capsys) -> None:
+    root = _repo(tmp_path)
+    out_dir = tmp_path / "out"
+    (root / "src" / "sdetkit" / "example.py").write_text("VALUE = 4\n", encoding="utf-8")
+
+    rc = main(
+        [
+            "--repo-root",
+            str(root),
+            "--mode",
+            STAGED_WORKTREE,
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "git-inventory.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "git-inventory.md").read_text(encoding="utf-8")
+
+    assert printed["status"] == "collected"
+    assert saved["changed_files"] == ["src/sdetkit/example.py"]
+    assert saved["git_inventory_verified"] is True
+    assert "# Git inventory report" in markdown

--- a/tests/test_isolated_proof_runner.py
+++ b/tests/test_isolated_proof_runner.py
@@ -245,3 +245,82 @@ def test_isolated_runner_cli_writes_evidence_artifacts(
     assert saved["proof_results"][0]["command"] == "python -m mypy src"
     assert saved["decision_boundary"]["automation_allowed"] is False
     assert "# Isolated proof runner evidence" in markdown
+
+
+def test_isolated_runner_uses_git_derived_inventory_for_protected_verifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sdetkit import isolated_proof_runner as runner
+    from sdetkit.git_inventory_collector import (
+        GIT_DERIVED_STAGED_WORKTREE,
+        STAGED_WORKTREE,
+    )
+
+    root = _repo(tmp_path)
+
+    def fake_inventory(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "collected",
+            "mode": STAGED_WORKTREE,
+            "changed_files": ["src/sdetkit/example.py"],
+            "changed_files_source": GIT_DERIVED_STAGED_WORKTREE,
+            "git_inventory_verified": True,
+        }
+
+    monkeypatch.setattr(runner, "collect_git_inventory", fake_inventory)
+    monkeypatch.setattr(subprocess, "run", _setup_success_or_profile_success)
+
+    evidence = run_isolated_proof(
+        repo_root=root,
+        changed_files=["src/sdetkit/example.py"],
+        profile_ids=["pre_commit_all"],
+        inventory_mode=STAGED_WORKTREE,
+    )
+    result = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence=evidence,
+    )
+
+    assert evidence["status"] == "passed"
+    assert evidence["changed_files_source"] == GIT_DERIVED_STAGED_WORKTREE
+    assert evidence["decision_boundary"]["git_inventory_verified"] is True
+    assert result["decision"]["status"] == "structurally_verified_candidate"
+    assert result["decision"]["automation_allowed"] is False
+    assert result["decision"]["merge_authorized"] is False
+
+
+def test_isolated_runner_blocks_caller_claim_mismatch_against_git_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sdetkit import isolated_proof_runner as runner
+    from sdetkit.git_inventory_collector import STAGED_WORKTREE
+
+    root = _repo(tmp_path)
+
+    monkeypatch.setattr(
+        runner,
+        "collect_git_inventory",
+        lambda **_kwargs: {
+            "status": "collected",
+            "mode": STAGED_WORKTREE,
+            "changed_files": ["src/sdetkit/unplanned.py"],
+            "changed_files_source": "_".join(("git", "derived", "staged", "worktree")),
+            "git_inventory_verified": True,
+        },
+    )
+    monkeypatch.setattr(subprocess, "run", _setup_success_or_profile_success)
+
+    evidence = run_isolated_proof(
+        repo_root=root,
+        changed_files=["src/sdetkit/example.py"],
+        profile_ids=["pre_commit_all"],
+        inventory_mode=STAGED_WORKTREE,
+    )
+
+    assert evidence["status"] == "failed"
+    assert evidence["changed_files"] == ["src/sdetkit/unplanned.py"]
+    assert evidence["decision_boundary"]["git_inventory_verified"] is False
+    assert "disagrees" in evidence["decision_boundary"]["reason"]
+    assert evidence["decision_boundary"]["automation_allowed"] is False

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -29,6 +29,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "replayable_benchmark_harness" in modules
     assert "repo_memory" in modules
     assert "isolated_proof_runner" in modules
+    assert "git_inventory_collector" in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -36,9 +37,9 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 8
-    assert status_counts["partially_aligned"] >= 9
+    assert status_counts["partially_aligned"] >= 10
     assert status_counts.get("planned", 0) == 0
-    assert report["next_recommended_pr"] == "feature/protected-verifier-git-inventory-collector"
+    assert report["next_recommended_pr"] == "feature/replayable-benchmark-isolated-proof-evidence"
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -60,11 +61,12 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "replayable_benchmark_harness" in gaps_by_module
     assert "repo_memory" in gaps_by_module
     assert "isolated_proof_runner" in gaps_by_module
+    assert "git_inventory_collector" in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
-    assert any("git-backed collector" in gap for gap in gaps_by_module["isolated_proof_runner"])
     assert any("network isolation" in gap for gap in gaps_by_module["isolated_proof_runner"])
+    assert any("workflow evidence" in gap for gap in gaps_by_module["git_inventory_collector"])
     assert any(
         "isolated_proof_runner" in gap for gap in gaps_by_module["replayable_benchmark_harness"]
     )
@@ -86,6 +88,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
     assert "`repo_memory`: `partially_aligned`" in markdown
     assert "`isolated_proof_runner`: `partially_aligned`" in markdown
+    assert "`git_inventory_collector`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -109,7 +112,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/protected-verifier-git-inventory-collector"
+    assert saved["next_recommended_pr"] == "feature/replayable-benchmark-isolated-proof-evidence"
     assert "Reliability spine alignment audit" in markdown
 
 
@@ -156,6 +159,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         "replayable_benchmark_harness",
         "repo_memory",
         "isolated_proof_runner",
+        "git_inventory_collector",
     }
 
     assert "maintenance_autopilot" not in report_modules


### PR DESCRIPTION
## Summary
- Adds a read-only `git_inventory_collector` that derives changed-file inventories from fixed Git queries.
- Supports `staged_worktree` inventory for local operator proof and `base_head` inventory for PR-style evidence.
- Integrates Git-derived inventory into `isolated_proof_runner`.
- Blocks verification evidence when a caller-declared changed-file claim disagrees with the Git-derived inventory.
- Preserves allowlisted proof execution, disposable workspace isolation, timeout handling, captured output, and mutation detection.
- Produces deterministic Git inventory JSON and Markdown artifacts.
- Updates the reliability spine audit and advances the next recommended PR to `feature/replayable-benchmark-isolated-proof-evidence`.

## Why
- The isolated proof runner currently executes safe allowlisted proof profiles, but its changed-file inventory remains caller supplied.
- Before proof evidence can become stronger verifier input, the repository must ground changed-file scope in Git rather than trust an external claim.
- This PR connects read-only Git evidence to isolated proof execution without expanding automation authority.

## Verification
- `python -m ruff check src tests`
- `python -m pytest -q tests/test_git_inventory_collector.py tests/test_isolated_proof_runner.py tests/test_protected_verifier.py tests/test_reliability_spine_alignment.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- Ran real `staged_worktree` Git inventory collection and confirmed it returned exactly the six files changed by this PR.
- Ran real isolated Ruff proof execution using the exact Git-derived changed-file claim.
- Confirmed the resulting evidence reported `git_inventory_verified=true`, `automation_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false`.
- Confirmed evidence collection did not mutate the source branch.
- Confirmed this PR introduces no warning/error security findings in its changed files.

## Risk
- Medium.
- Introduces read-only Git command execution using fixed argument vectors with `shell=False`.
- Git-derived inventory now influences proof-evidence validity.
- Caller-claim mismatch causes evidence failure rather than being silently accepted.
- No workflow wiring in this PR.
- No network action.
- No patch application, auto-remediation, merge authorization, or semantic-equivalence claim.
- Network isolation for proof subprocesses remains unimplemented.
- Rollback: revert this PR.
