### PR TITLE
Restore PR Quality runtime proof integrity

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
@@ -40,6 +42,7 @@ jobs:
         env:
           COV_FAIL_UNDER: "95"
         run: |
+          set -o pipefail
           bash quality.sh cov 2>&1 | tee quality.log
 
       - name: Build adaptive failure intelligence bundle
@@ -340,6 +343,7 @@ jobs:
             fi
           done
 
+          runtime_proof_rc=0
           PYTHONPATH=src python -m sdetkit.isolated_proof_runner \
             --repo-root . \
             --inventory-mode base_head \
@@ -349,13 +353,17 @@ jobs:
             --profile ruff_src_tests \
             --out-dir build/pr-quality/runtime-proof/isolated-proof \
             --format json \
-            > build/pr-quality/runtime-proof/isolated-proof-cli.json || true
+            > build/pr-quality/runtime-proof/isolated-proof-cli.json \
+            || runtime_proof_rc=$?
+
 
           PYTHONPATH=src python -m sdetkit.pr_quality_runtime_proof_artifacts \
             --isolated-proof build/pr-quality/runtime-proof/isolated-proof/verification-evidence.json \
             --out-dir build/pr-quality/runtime-proof/summary \
             --format json \
             > build/pr-quality/runtime-proof/summary-metadata.json
+
+          printf '%s\n' "$runtime_proof_rc" > build/pr-quality/runtime-proof/isolated-proof-exit-code.txt
 
           PYTHONPATH=src python -m sdetkit.pr_quality_evidence_narrative \
             --quality-log quality.log \
@@ -610,5 +618,15 @@ jobs:
               raise SystemExit(
                   "PR Quality comment signal metadata invalid: "
                   f"evidence_signal_kind={evidence_signal_kind}"
+              )
+
+          if not runtime_proof_artifacts_present:
+              raise SystemExit(
+                  "PR Quality runtime proof artifacts missing from rendered comment metadata"
+              )
+          if runtime_proof_collection_status != "collected":
+              raise SystemExit(
+                  "PR Quality runtime proof collection failed after diagnostic comment publication: "
+                  f"status={runtime_proof_collection_status}"
               )
           PY

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -360,7 +360,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.evidence_narrative",
         "module_path": "src/sdetkit/evidence_narrative.py",
-        "tests_referencing_module": 12
+        "tests_referencing_module": 13
       },
       {
         "contract_script_paths": [
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 91
+        "tests_referencing_module": 113
       },
       {
         "contract_script_paths": [
@@ -792,7 +792,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.reliability",
         "module_path": "src/sdetkit/reliability.py",
-        "tests_referencing_module": 28
+        "tests_referencing_module": 29
       },
       {
         "contract_script_paths": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
 ]
 test = [
   "hypothesis==6.152.9",
+  "pre-commit==4.6.0",
   "PyYAML",
   "pytest",
   "pytest-asyncio",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,6 +8,7 @@ PyYAML==6.0.3
 httpx==0.28.1
 ruff==0.15.13
 mypy==2.1.0
+pre-commit==4.6.0
 mutmut==3.5.0
 
 # Security scanner transitive dependency floors

--- a/src/sdetkit/test_bootstrap.py
+++ b/src/sdetkit/test_bootstrap.py
@@ -5,7 +5,7 @@ import platform
 import sys
 from collections.abc import Sequence
 
-REQUIRED_TEST_MODULES: tuple[str, ...] = ("httpx", "yaml", "hypothesis")
+REQUIRED_TEST_MODULES: tuple[str, ...] = ("httpx", "yaml", "hypothesis", "pre_commit")
 MIN_TEST_PYTHON: tuple[int, int] = (3, 10)
 TEST_BOOTSTRAP_REMEDIATION = "python -m pip install -r requirements-test.txt"
 

--- a/src/sdetkit/test_bootstrap_contract.py
+++ b/src/sdetkit/test_bootstrap_contract.py
@@ -11,6 +11,7 @@ from .test_bootstrap import REQUIRED_TEST_MODULES
 MODULE_TO_PACKAGE = {
     "httpx": "httpx",
     "hypothesis": "hypothesis",
+    "pre_commit": "pre-commit",
     "yaml": "PyYAML",
 }
 
@@ -26,8 +27,8 @@ def extract_requirement_name(line: str) -> str:
     raw = line.strip()
     if not raw or raw.startswith("#"):
         return ""
-    token = _SPEC_SEP.split(raw, maxsplit=1)[0].strip()
-    return normalize_package_name(token)
+    requirement_name = _SPEC_SEP.split(raw, maxsplit=1)[0].strip()
+    return normalize_package_name(requirement_name)
 
 
 def load_requirements_packages(path: Path) -> set[str]:

--- a/tests/test_check_test_bootstrap_contract.py
+++ b/tests/test_check_test_bootstrap_contract.py
@@ -21,7 +21,9 @@ def test_build_report_flags_missing(tmp_path):
 
     assert report["ok"] is False
     assert "pyyaml" in report["missing_from_requirements_test"]
+    assert "pre-commit" in report["missing_from_requirements_test"]
     assert "httpx" in report["missing_from_pyproject_test_visible_deps"]
+    assert "pre-commit" in report["missing_from_pyproject_test_visible_deps"]
 
 
 def test_main_json_success(monkeypatch, capsys):
@@ -35,7 +37,7 @@ def test_main_json_success(monkeypatch, capsys):
         "build_report",
         lambda repo_root: {
             "ok": True,
-            "expected_packages": ["httpx", "hypothesis", "pyyaml"],
+            "expected_packages": ["httpx", "hypothesis", "pre-commit", "pyyaml"],
             "missing_from_requirements_test": [],
             "missing_from_pyproject_test_visible_deps": [],
             "paths": {"requirements_test": "requirements-test.txt", "pyproject": "pyproject.toml"},
@@ -61,7 +63,7 @@ def test_main_writes_output_file(monkeypatch, tmp_path):
         "build_report",
         lambda repo_root: {
             "ok": True,
-            "expected_packages": ["httpx", "hypothesis", "pyyaml"],
+            "expected_packages": ["httpx", "hypothesis", "pre-commit", "pyyaml"],
             "missing_from_requirements_test": [],
             "missing_from_pyproject_test_visible_deps": [],
             "paths": {"requirements_test": "requirements-test.txt", "pyproject": "pyproject.toml"},
@@ -96,7 +98,7 @@ def test_parse_args_and_render_text_branches(monkeypatch):
     text_out = contract.render_text(
         {
             "ok": False,
-            "expected_packages": ["httpx", "hypothesis", "pyyaml"],
+            "expected_packages": ["httpx", "hypothesis", "pre-commit", "pyyaml"],
             "missing_from_requirements_test": ["pyyaml"],
             "missing_from_pyproject_test_visible_deps": ["httpx"],
         }

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -331,3 +331,57 @@ def test_pr_quality_comment_workflow_exposes_runtime_proof_metadata() -> None:
     )
     assert 'print(f"runtime_proof_collection_status={runtime_proof_collection_status}")' in text
     assert 'print(f"runtime_guard_violation_count={runtime_guard_violation_count}")' in text
+
+
+def test_pr_quality_comment_workflow_does_not_mask_quality_gate_failure_with_tee() -> None:
+    text = _workflow_text()
+
+    quality_step = text[
+        text.index("- name: Run quality gate") : text.index(
+            "- name: Build adaptive failure intelligence bundle"
+        )
+    ]
+
+    assert "set -o pipefail" in quality_step
+    assert "bash quality.sh cov 2>&1 | tee quality.log" in quality_step
+
+
+def test_pr_quality_comment_workflow_checks_out_history_for_runtime_proof_merge_base() -> None:
+    text = _workflow_text()
+
+    checkout = text[
+        text.index("- uses: actions/checkout@") : text.index("- uses: actions/setup-python@")
+    ]
+
+    assert "fetch-depth: 0" in checkout
+    assert "--inventory-mode base_head" in text
+    assert '--base-ref "origin/${{ github.event.pull_request.base.ref }}"' in text
+
+
+def test_pr_quality_comment_workflow_posts_runtime_diagnostic_before_failing_missing_collection() -> (
+    None
+):
+    text = _workflow_text()
+
+    build_comment = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build verified operator evidence loop"
+        )
+    ]
+    verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
+
+    assert "runtime_proof_rc=0" in build_comment
+    assert "|| runtime_proof_rc=$?" in build_comment
+    assert "isolated-proof-exit-code.txt" in build_comment
+    assert (
+        "test -s build/pr-quality/runtime-proof/isolated-proof/verification-evidence.json"
+        not in build_comment
+    )
+    assert (
+        "runtime proof artifact collection failed: isolated proof not collected"
+        not in build_comment
+    )
+
+    assert "if not runtime_proof_artifacts_present:" in verify_visibility
+    assert 'if runtime_proof_collection_status != "collected":' in verify_visibility
+    assert "after diagnostic comment publication" in verify_visibility


### PR DESCRIPTION
## Summary
- Repairs a false-green failure mode in the PR Quality workflow discovered after the runtime-proof visibility PR merged.
- Enables `pipefail` for the quality-log pipeline so `bash quality.sh cov` failures cannot be masked by `tee`.
- Fetches full Git history in PR Quality so Git-derived `base_head` runtime-proof inventory can calculate a real merge base.
- Preserves diagnostic PR comment publication when runtime-proof collection fails, then fails the final visibility-verification step instead of silently reporting success.
- Declares `pre-commit==4.6.0` as a real test dependency because live isolated-proof tests execute the `pre_commit_all` proof profile.
- Extends the bootstrap dependency contract so missing `pre_commit` fails deterministically in fresh CI environments.
- Retains the generated roadmap manifest refresh produced by the new test-reference surface.

## Why
PR #1411 introduced runtime-proof visibility, but its live GitHub Actions evidence exposed two integrity failures:

1. Runtime-proof collection reported `not_collected` because the shallow Actions checkout did not provide a merge base for Git-derived PR inventory.
2. The PR Quality job printed real test failures and `merge/release recommendation: do-not-merge`, but the shell pipeline still passed because `tee` masked the failing `quality.sh cov` exit status.

A fresh Python 3.12 reproduction also showed that the live proof tests relied on `pre-commit` without declaring it in the test dependency contract. The existing local Python 3.10 environment only passed because that tool happened to be installed already.

This PR repairs the reporting integrity and the dependency declaration before any further runtime-proof evidence expansion.

## Root cause
- Missing `set -o pipefail` allowed a failed quality command to appear successful after piping through `tee`.
- Shallow PR workflow history prevented `origin/main...HEAD` merge-base inventory collection.
- Runtime-proof runner failure was allowed to fall through to a successful `not_collected` comment state.
- `pre-commit` was pinned in CI constraints and available in development dependencies, but absent from declared test dependencies even though live proof tests execute it.

## Verification
- Confirmed `docs/roadmap/manifest.json` is a deterministic generated reference-count refresh.
- `python -m pytest -q tests/test_generated_artifacts_freshness.py tests/test_roadmap_manifest_tooling.py tests/test_roadmap_manifest_edges_wave12.py -o addopts=` → `13 passed`.
- Confirmed this PR introduces no warning/error security findings in its changed files.
- Created a fresh Python 3.12 environment outside the repository and installed only the repaired declared test/docs/editable package dependencies under `constraints-ci.txt`.
- Confirmed `pre-commit 4.6.0` is installed from the repaired test dependency contract.
- `python -m sdetkit.test_bootstrap_contract --strict --format text` → contract passes and includes `pre-commit`.
- Re-ran the Python 3.12 suites that previously failed in GitHub Actions:
  - live isolated-proof evidence tests;
  - PR Quality workflow observability tests;
  - runtime-proof artifact tests;
  - action-report tests;
  - reliability-spine alignment tests;
  - bootstrap-contract tests.
- Focused Python 3.12 repair proof → `85 passed`.
- Full Python 3.12 truth lane with pipe-failure preservation:
  - `COV_FAIL_UNDER=95 bash quality.sh cov 2>&1 | tee ...`
  - `3564 passed, 1 skipped, 3 deselected`;
  - coverage `96.69%`;
  - `blocking failures: none`;
  - `merge/release recommendation: ready-for-merge-review`.
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium, but corrective and fail-safe.
- The PR Quality workflow will now fail when the underlying quality lane fails instead of publishing false-green evidence.
- Missing runtime-proof collection will remain visible in the posted diagnostic comment, then correctly fail final visibility verification.
- Full history checkout increases workflow fetch volume modestly but is required for truthful Git-derived PR inventory.
- Adding `pre-commit` to test dependencies makes the declared test environment match actual test behavior.
- No auto-remediation is enabled.
- No security finding is auto-dismissed.
- No merge authorization is added.
- No semantic-equivalence claim is added.
- Rollback: revert this PR, noting that doing so would reintroduce the false-green and missing-dependency risks.

## Boundary
- Quality pipeline failure masking: fixed.
- Runtime-proof merge-base collection: enabled through full Git history.
- Missing runtime-proof evidence: diagnostic comment remains visible, then workflow blocks.
- Fresh Python 3.12 live-proof dependency contract: fixed.
- Automated patching: false.
- Automation authorization: false.
- Merge authorization: false.
- Semantic equivalence proven: false.
