### PR TITLE
Persist trusted main RepoMemory profile history

### DIFF
--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -1,0 +1,265 @@
+name: RepoMemory Profile History
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: repo-memory-profile-history-main
+  cancel-in-progress: false
+
+jobs:
+  record:
+    name: Record trusted main RepoMemory history
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout trusted main revision
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-test.txt
+
+      - name: Install trusted-main evidence dependencies
+        run: |
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .
+
+      - name: Build trusted-main live RepoMemory profile
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p \
+            build/repo-memory-history/fixture-report \
+            build/repo-memory-history/live-report \
+            build/repo-memory-history/pattern-insights \
+            build/repo-memory-history/profile
+
+          live_root="${RUNNER_TEMP}/sdetkit-repo-memory-history-live-repositories"
+          rm -rf "$live_root"
+
+          PYTHONPATH=src python -m sdetkit.pr_quality_live_benchmark_workspace \
+            --out-dir "$live_root" \
+            --format json \
+            > build/repo-memory-history/live-workspace-cli.json
+
+          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
+            --scenario tests/fixtures/remediation_benchmark/nop_formatting_patch.json \
+            --scenario tests/fixtures/remediation_benchmark/oracle_formatting_patch.json \
+            --scenario tests/fixtures/remediation_benchmark/unsafe_protected_path_patch.json \
+            --out-dir build/repo-memory-history/fixture-report \
+            --format json \
+            > build/repo-memory-history/fixture-report-cli.json
+
+          mapfile -t live_args < <(
+            LIVE_ROOT="$live_root" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(
+              (Path(os.environ["LIVE_ROOT"]) / "workspace-manifest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          for item in manifest["scenarios"]:
+              print("--isolated-scenario")
+              print(item["fixture_path"])
+              print("--isolated-repo-root")
+              print(item["repo_root"])
+          PY
+          )
+
+          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
+            "${live_args[@]}" \
+            --out-dir build/repo-memory-history/live-report \
+            --format json \
+            > build/repo-memory-history/live-report-cli.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = {
+              "schema_version": "sdetkit.trajectory_pattern_insights.v1",
+              "record_count": 0,
+              "recurring_safe_fix_patterns": [],
+              "recurring_review_first_surfaces": [],
+              "source": "trusted_main_snapshot",
+          }
+          Path("build/repo-memory-history/pattern-insights/pattern-insights.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+          PYTHONPATH=src python -m sdetkit.repo_memory \
+            --pattern-insights build/repo-memory-history/pattern-insights/pattern-insights.json \
+            --benchmark-report build/repo-memory-history/fixture-report/benchmark-report.json \
+            --live-benchmark-report build/repo-memory-history/live-report/benchmark-report.json \
+            --out-dir build/repo-memory-history/profile \
+            --format json \
+            > build/repo-memory-history/profile-cli.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          profile = json.loads(
+              Path("build/repo-memory-history/profile/repo-memory-profile.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+
+          assert profile["profile_status"] == "live_proof_supported_memory"
+          assert profile["inputs"]["live_contract_proven"] is True
+          assert profile["proof_provenance"]["git_verified_scenario_count"] == 5
+          assert profile["proof_provenance"]["expected_failed_scenario_count"] == 5
+          assert profile["proof_provenance"]["network_boundary_blocked_scenario_count"] == 1
+          assert profile["proof_provenance"]["anti_cheat_rejection_scenario_count"] == 2
+
+          boundary = profile["decision_boundary"]
+          assert boundary["automation_allowed"] is False
+          assert boundary["merge_authorized"] is False
+          assert boundary["semantic_equivalence_proven"] is False
+
+          print("Trusted-main RepoMemory live profile passed.")
+          PY
+
+      - name: Select prior trusted main history artifact
+        id: prior
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p build/repo-memory-history/prior-download
+
+          prior_run_id=""
+          prior_head_sha=""
+
+          while IFS=$'\t' read -r candidate_run_id candidate_head_sha; do
+            if [ -z "$candidate_run_id" ] || [ "$candidate_run_id" = "${GITHUB_RUN_ID}" ]; then
+              continue
+            fi
+
+            if git merge-base --is-ancestor "$candidate_head_sha" "$GITHUB_SHA"; then
+              prior_run_id="$candidate_run_id"
+              prior_head_sha="$candidate_head_sha"
+              break
+            fi
+          done < <(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/repo-memory-history.yml/runs?branch=main&event=push&status=completed&per_page=100" \
+              --jq '.workflow_runs[] | select(.conclusion == "success") | [.id, .head_sha] | @tsv'
+          )
+
+          if [ -z "$prior_run_id" ]; then
+            echo "prior_history_jsonl=" >> "$GITHUB_OUTPUT"
+            echo "prior_run_id=" >> "$GITHUB_OUTPUT"
+            echo "prior_head_sha=" >> "$GITHUB_OUTPUT"
+            echo "No prior successful trusted-main history artifact found; starting initial history chain."
+            exit 0
+          fi
+
+          gh run download "$prior_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name repo-memory-profile-history \
+            --dir build/repo-memory-history/prior-download
+
+          prior_history_jsonl="$(
+            find build/repo-memory-history/prior-download \
+              -name repo-memory-profile-history.jsonl \
+              -print \
+              -quit
+          )"
+
+          if [ -z "$prior_history_jsonl" ] || [ ! -f "$prior_history_jsonl" ]; then
+            echo "Prior trusted-main run was selected but supplied no history JSONL artifact."
+            exit 1
+          fi
+
+          echo "prior_history_jsonl=$prior_history_jsonl" >> "$GITHUB_OUTPUT"
+          echo "prior_run_id=$prior_run_id" >> "$GITHUB_OUTPUT"
+          echo "prior_head_sha=$prior_head_sha" >> "$GITHUB_OUTPUT"
+
+          echo "Selected prior trusted-main history run: $prior_run_id"
+          echo "Selected prior trusted-main history head: $prior_head_sha"
+
+      - name: Record trusted main RepoMemory profile history
+        shell: bash
+        env:
+          PRIOR_HISTORY_JSONL: ${{ steps.prior.outputs.prior_history_jsonl }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            --profile-json build/repo-memory-history/profile/repo-memory-profile.json
+            --source-run-id "${GITHUB_RUN_ID}"
+            --source-head-sha "${GITHUB_SHA}"
+            --out-dir build/repo-memory-history/output
+            --format json
+          )
+
+          if [ -n "$PRIOR_HISTORY_JSONL" ]; then
+            args+=(--prior-history-jsonl "$PRIOR_HISTORY_JSONL")
+          fi
+
+          PYTHONPATH=src python -m sdetkit.repo_memory_profile_history \
+            "${args[@]}" \
+            > build/repo-memory-history/history-cli.json
+
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary = json.loads(
+              Path(
+                  "build/repo-memory-history/output/repo-memory-history-summary.json"
+              ).read_text(encoding="utf-8")
+          )
+
+          assert summary["status"] == "history_recorded"
+          assert summary["record_count"] >= 1
+          assert summary["live_contract_proven_record_count"] >= 1
+          assert summary["latest_record"]["source_run_id"] == os.environ["GITHUB_RUN_ID"]
+          assert summary["latest_record"]["source_head_sha"] == os.environ["GITHUB_SHA"]
+          assert summary["latest_record"]["profile_status"] == "live_proof_supported_memory"
+          assert summary["latest_record"]["live_contract_proven"] is True
+
+          boundary = summary["decision_boundary"]
+          assert boundary["automation_allowed"] is False
+          assert boundary["merge_authorized"] is False
+          assert boundary["semantic_equivalence_proven"] is False
+          assert boundary["prior_history_is_read_only_input"] is True
+
+          print("Trusted-main RepoMemory history snapshot passed.")
+          PY
+
+      - name: Upload trusted main RepoMemory history artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: repo-memory-profile-history
+          path: |
+            build/repo-memory-history/output/
+            build/repo-memory-history/profile/
+            build/repo-memory-history/live-report/
+            build/repo-memory-history/fixture-report/
+            build/repo-memory-history/pattern-insights/
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 113
+        "tests_referencing_module": 114
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -11,6 +11,13 @@ from typing import Any
 SCHEMA_VERSION = "sdetkit.reliability_spine_alignment.v1"
 PR_QUALITY_LIVE_WORKSPACE_MODULE = "_".join(("pr", "quality", "live", "benchmark", "workspace"))
 REPLAYABLE_BENCHMARK_MODULE = "_".join(("replayable", "benchmark", "harness"))
+REPO_MEMORY_PROFILE_HISTORY_MODULE = "_".join(("repo", "memory", "profile", "history"))
+NEXT_RECOMMENDED_PR = "/".join(
+    (
+        "feature",
+        "-".join(("pr", "quality", "trusted", "repo", "memory", "history", "visibility")),
+    )
+)
 
 SPINE_STAGES = (
     "evidence",
@@ -451,12 +458,29 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "replayable_benchmark_harness",
                 "protected_verifier",
                 "pr_quality_runtime_proof_artifacts",
+                REPO_MEMORY_PROFILE_HISTORY_MODULE,
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "flaky-test registry ingestion and persistent profile updates are not implemented",
+                "flaky-test registry ingestion is not implemented",
             ),
-            recommended_next_action="persist read-only historical profiles before automation wiring",
+            recommended_next_action="surface trusted-main read-only history without expanding authority",
+        ),
+        _component(
+            module=REPO_MEMORY_PROFILE_HISTORY_MODULE,
+            role="record trusted-main RepoMemory profile snapshots through an immutable artifact history chain",
+            status="aligned",
+            stages=("history", "reporting"),
+            existing_artifacts=(
+                "repo-memory-profile-history.jsonl",
+                "repo-memory-history-summary.json",
+                "repo-memory-history-summary.md",
+            ),
+            integration_points=(
+                "repo_memory",
+                "RepoMemory Profile History workflow",
+            ),
+            recommended_next_action="keep trusted-main history advisory-only and visible before automation wiring",
         ),
     ]
 
@@ -494,7 +518,7 @@ def build_alignment_report(
         "stage_counts": dict(sorted(stage_counts.items())),
         "components": [_component_payload(component) for component in rows],
         "gaps": gaps,
-        "next_recommended_pr": "feature/repo-memory-persistent-profile-history",
+        "next_recommended_pr": NEXT_RECOMMENDED_PR,
     }
 
 

--- a/src/sdetkit/repo_memory_profile_history.py
+++ b/src/sdetkit/repo_memory_profile_history.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = ".".join(("sdetkit", "repo", "memory", "profile", "history", "v1"))
+RECORD_SCHEMA_VERSION = ".".join(
+    ("sdetkit", "repo", "memory", "profile", "history", "record", "v1")
+)
+DEFAULT_OUT_DIR = Path("build") / "repo-memory-history"
+SUMMARY_JSON = "repo-memory-history-summary.json"
+SUMMARY_MD = "repo-memory-history-summary.md"
+HISTORY_JSONL = "repo-memory-profile-history.jsonl"
+
+READ_ONLY_PROFILE_MODE = "_".join(("read", "only", "profile"))
+LIVE_PROFILE_STATUS = "_".join(("live", "proof", "supported", "memory"))
+AUTOMATION_ALLOWED = "_".join(("automation", "allowed"))
+MERGE_AUTHORIZED = "_".join(("merge", "authorized"))
+SEMANTIC_EQUIVALENCE_PROVEN = "_".join(("semantic", "equivalence", "proven"))
+LIVE_CONTRACT_PROVEN = "_".join(("live", "contract", "proven"))
+GIT_VERIFIED_SCENARIO_COUNT = "_".join(("git", "verified", "scenario", "count"))
+EXPECTED_FAILED_SCENARIO_COUNT = "_".join(("expected", "failed", "scenario", "count"))
+NETWORK_BOUNDARY_BLOCKED_SCENARIO_COUNT = "_".join(
+    ("network", "boundary", "blocked", "scenario", "count")
+)
+ANTI_CHEAT_REJECTION_SCENARIO_COUNT = "_".join(("anti", "cheat", "rejection", "scenario", "count"))
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes"}
+
+
+def _read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _read_jsonl(path: Path) -> list[JsonObject]:
+    if not path.exists():
+        return []
+
+    records: list[JsonObject] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object on line {line_number} in {path}")
+        records.append(payload)
+    return records
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _assert_no_authority(boundary: Mapping[str, Any], *, source: str) -> None:
+    enabled = [
+        key
+        for key in (
+            AUTOMATION_ALLOWED,
+            MERGE_AUTHORIZED,
+            SEMANTIC_EQUIVALENCE_PROVEN,
+        )
+        if _bool(boundary.get(key))
+    ]
+    if enabled:
+        raise ValueError(
+            f"{source} expands authority and cannot enter read-only history: {', '.join(enabled)}"
+        )
+
+
+def validate_profile(profile: Mapping[str, Any]) -> None:
+    if _text(profile.get("memory_mode")) != READ_ONLY_PROFILE_MODE:
+        raise ValueError("RepoMemory profile must use read_only_profile memory mode")
+    _assert_no_authority(
+        _as_dict(profile.get("decision_boundary")),
+        source="RepoMemory profile",
+    )
+
+
+def validate_record(record: Mapping[str, Any]) -> None:
+    if _text(record.get("schema_version")) != RECORD_SCHEMA_VERSION:
+        raise ValueError("history record schema is not supported")
+    _assert_no_authority(
+        _as_dict(record.get("decision_boundary")),
+        source="RepoMemory history record",
+    )
+
+
+def build_history_record(
+    profile: Mapping[str, Any],
+    *,
+    source_run_id: str,
+    source_head_sha: str,
+    recorded_at_utc: str | None = None,
+) -> JsonObject:
+    validate_profile(profile)
+
+    run_id = _text(source_run_id)
+    head_sha = _text(source_head_sha)
+    if not run_id:
+        raise ValueError("source_run_id is required")
+    if not head_sha:
+        raise ValueError("source_head_sha is required")
+
+    provenance = _as_dict(profile.get("proof_provenance"))
+    boundary = {
+        AUTOMATION_ALLOWED: False,
+        MERGE_AUTHORIZED: False,
+        SEMANTIC_EQUIVALENCE_PROVEN: False,
+    }
+    stable = {
+        "source_run_id": run_id,
+        "source_head_sha": head_sha,
+        "profile_status": _text(profile.get("profile_status")),
+        LIVE_CONTRACT_PROVEN: _bool(provenance.get(LIVE_CONTRACT_PROVEN)),
+        "known_safe_candidate_count": _int(profile.get("known_safe_candidate_count")),
+        "live_safe_candidate_count": _int(profile.get("live_safe_candidate_count")),
+        GIT_VERIFIED_SCENARIO_COUNT: _int(provenance.get(GIT_VERIFIED_SCENARIO_COUNT)),
+        EXPECTED_FAILED_SCENARIO_COUNT: _int(provenance.get(EXPECTED_FAILED_SCENARIO_COUNT)),
+        NETWORK_BOUNDARY_BLOCKED_SCENARIO_COUNT: _int(
+            provenance.get(NETWORK_BOUNDARY_BLOCKED_SCENARIO_COUNT)
+        ),
+        ANTI_CHEAT_REJECTION_SCENARIO_COUNT: _int(
+            provenance.get(ANTI_CHEAT_REJECTION_SCENARIO_COUNT)
+        ),
+        "decision_boundary": boundary,
+    }
+
+    return {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "record_id": _stable_hash(stable),
+        "recorded_at_utc": recorded_at_utc or _utc_now(),
+        **stable,
+    }
+
+
+def merge_history_records(
+    prior_records: list[Mapping[str, Any]],
+    record: Mapping[str, Any],
+) -> tuple[list[JsonObject], bool]:
+    validate_record(record)
+    records = [dict(item) for item in prior_records]
+    for existing in records:
+        validate_record(existing)
+
+    record_id = _text(record.get("record_id"))
+    existing_ids = {_text(item.get("record_id")) for item in records}
+    appended = record_id not in existing_ids
+    if appended:
+        records.append(dict(record))
+
+    return records, appended
+
+
+def write_history_jsonl(records: list[Mapping[str, Any]], *, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    history_path = out_dir / HISTORY_JSONL
+    history_path.write_text(
+        "".join(json.dumps(dict(item), sort_keys=True) + "\n" for item in records),
+        encoding="utf-8",
+    )
+    return history_path
+
+
+def build_history_summary(
+    records: list[Mapping[str, Any]],
+    *,
+    appended: bool,
+    history_path: Path,
+    prior_history_collected: bool,
+    prior_record_count: int,
+) -> JsonObject:
+    for record in records:
+        validate_record(record)
+
+    statuses = Counter(_text(item.get("profile_status")) for item in records)
+    latest = dict(records[-1]) if records else {}
+    live_records = [item for item in records if _bool(item.get(LIVE_CONTRACT_PROVEN))]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "history_recorded",
+        "history_path": history_path.as_posix(),
+        "prior_history_collected": prior_history_collected,
+        "prior_record_count": prior_record_count,
+        "appended": appended,
+        "record_count": len(records),
+        "live_contract_proven_record_count": len(live_records),
+        "profile_status_counts": dict(sorted(statuses.items())),
+        "known_safe_candidate_total": sum(
+            _int(item.get("known_safe_candidate_count")) for item in records
+        ),
+        "live_safe_candidate_total": sum(
+            _int(item.get("live_safe_candidate_count")) for item in records
+        ),
+        ANTI_CHEAT_REJECTION_SCENARIO_COUNT: sum(
+            _int(item.get(ANTI_CHEAT_REJECTION_SCENARIO_COUNT)) for item in records
+        ),
+        "latest_record": {
+            "record_id": _text(latest.get("record_id")),
+            "source_run_id": _text(latest.get("source_run_id")),
+            "source_head_sha": _text(latest.get("source_head_sha")),
+            "profile_status": _text(latest.get("profile_status")),
+            LIVE_CONTRACT_PROVEN: _bool(latest.get(LIVE_CONTRACT_PROVEN)),
+        },
+        "decision_boundary": {
+            AUTOMATION_ALLOWED: False,
+            MERGE_AUTHORIZED: False,
+            SEMANTIC_EQUIVALENCE_PROVEN: False,
+            "prior_history_is_read_only_input": True,
+            "reason": (
+                "RepoMemory profile history records proven read-only outcomes only; "
+                "it does not authorize remediation."
+            ),
+        },
+    }
+
+
+def render_markdown(summary: Mapping[str, Any]) -> str:
+    latest = _as_dict(summary.get("latest_record"))
+    boundary = _as_dict(summary.get("decision_boundary"))
+    lines = [
+        "# RepoMemory profile history",
+        "",
+        f"- Status: `{_text(summary.get('status'))}`",
+        (
+            "- Prior history collected: "
+            f"`{str(_bool(summary.get('prior_history_collected'))).lower()}`"
+        ),
+        f"- Prior records: `{_int(summary.get('prior_record_count'))}`",
+        f"- Record appended: `{str(_bool(summary.get('appended'))).lower()}`",
+        f"- Records: `{_int(summary.get('record_count'))}`",
+        (
+            "- Live-contract-proven records: "
+            f"`{_int(summary.get('live_contract_proven_record_count'))}`"
+        ),
+        (
+            "- Anti-cheat rejection scenario total: "
+            f"`{_int(summary.get(ANTI_CHEAT_REJECTION_SCENARIO_COUNT))}`"
+        ),
+        "",
+        "## Latest record",
+        "",
+        f"- Record id: `{_text(latest.get('record_id'))}`",
+        f"- Source run id: `{_text(latest.get('source_run_id'))}`",
+        f"- Source head sha: `{_text(latest.get('source_head_sha'))}`",
+        f"- Profile status: `{_text(latest.get('profile_status'))}`",
+        (f"- Live contract proven: `{str(_bool(latest.get(LIVE_CONTRACT_PROVEN))).lower()}`"),
+        "",
+        "## Boundary",
+        "",
+        f"- Automation allowed: `{str(_bool(boundary.get(AUTOMATION_ALLOWED))).lower()}`",
+        f"- Merge authorized: `{str(_bool(boundary.get(MERGE_AUTHORIZED))).lower()}`",
+        (
+            "- Semantic equivalence proven: "
+            f"`{str(_bool(boundary.get(SEMANTIC_EQUIVALENCE_PROVEN))).lower()}`"
+        ),
+        (
+            "- Prior history is read-only input: "
+            f"`{str(_bool(boundary.get('prior_history_is_read_only_input'))).lower()}`"
+        ),
+        "- History executes proof commands: `false`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_summary(summary: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / SUMMARY_JSON
+    markdown_path = out_dir / SUMMARY_MD
+    json_path.write_text(
+        json.dumps(dict(summary), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(summary), encoding="utf-8")
+    return {
+        "history_summary_json": json_path.as_posix(),
+        "history_summary_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.repo_memory_profile_history")
+    parser.add_argument("--profile-json", type=Path, required=True)
+    parser.add_argument("--prior-history-jsonl", type=Path)
+    parser.add_argument("--source-run-id", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--recorded-at-utc")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        record = build_history_record(
+            _read_json(args.profile_json),
+            source_run_id=args.source_run_id,
+            source_head_sha=args.source_head_sha,
+            recorded_at_utc=args.recorded_at_utc,
+        )
+        prior_history_collected = args.prior_history_jsonl is not None
+        if prior_history_collected and not args.prior_history_jsonl.exists():
+            raise ValueError(f"prior history input does not exist: {args.prior_history_jsonl}")
+        prior_records = (
+            _read_jsonl(args.prior_history_jsonl) if args.prior_history_jsonl is not None else []
+        )
+        records, appended = merge_history_records(prior_records, record)
+        history_path = write_history_jsonl(records, out_dir=args.out_dir)
+        summary = build_history_summary(
+            records,
+            appended=appended,
+            history_path=history_path,
+            prior_history_collected=prior_history_collected,
+            prior_record_count=len(prior_records),
+        )
+        artifacts = write_summary(summary, out_dir=args.out_dir)
+        artifacts["history_jsonl"] = history_path.as_posix()
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": summary["status"],
+                    "record_count": summary["record_count"],
+                    "appended": summary["appended"],
+                    "artifacts": artifacts,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -4,7 +4,9 @@ import json
 from pathlib import Path
 
 from sdetkit.reliability_spine_alignment import (
+    NEXT_RECOMMENDED_PR,
     PR_QUALITY_LIVE_WORKSPACE_MODULE,
+    REPO_MEMORY_PROFILE_HISTORY_MODULE,
     SPINE_STAGES,
     build_alignment_components,
     build_alignment_report,
@@ -35,16 +37,17 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert "proof_runtime_guard" in modules
     assert "pr_quality_runtime_proof_artifacts" in modules
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE in modules
+    assert REPO_MEMORY_PROFILE_HISTORY_MODULE in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     report = build_alignment_report()
     status_counts = report["status_counts"]
 
-    assert status_counts["aligned"] >= 10
+    assert status_counts["aligned"] >= 11
     assert status_counts["partially_aligned"] >= 12
     assert status_counts.get("planned", 0) == 0
-    assert report["next_recommended_pr"] == "feature/repo-memory-persistent-profile-history"
+    assert report["next_recommended_pr"] == NEXT_RECOMMENDED_PR
 
 
 def test_alignment_stage_counts_cover_every_spine_stage() -> None:
@@ -71,6 +74,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "proof_runtime_guard" in gaps_by_module
     assert "pr_quality_runtime_proof_artifacts" not in gaps_by_module
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE not in gaps_by_module
+    assert REPO_MEMORY_PROFILE_HISTORY_MODULE not in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
@@ -82,6 +86,8 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert any("containment" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
+    assert any("flaky-test registry" in gap for gap in gaps_by_module["repo_memory"])
+    assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
     assert any("verified" in gap for gap in gaps_by_module["network_boundary"])
     assert any("external filesystem" in gap for gap in gaps_by_module["proof_runtime_guard"])
 
@@ -106,6 +112,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`proof_runtime_guard`: `partially_aligned`" in markdown
     assert "`pr_quality_runtime_proof_artifacts`: `aligned`" in markdown
     assert f"`{PR_QUALITY_LIVE_WORKSPACE_MODULE}`: `aligned`" in markdown
+    assert f"`{REPO_MEMORY_PROFILE_HISTORY_MODULE}`: `aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -129,7 +136,7 @@ def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     markdown = markdown_out.read_text(encoding="utf-8")
 
     assert printed["report"]["component_count"] == saved["component_count"]
-    assert saved["next_recommended_pr"] == "feature/repo-memory-persistent-profile-history"
+    assert saved["next_recommended_pr"] == NEXT_RECOMMENDED_PR
     assert "Reliability spine alignment audit" in markdown
 
 
@@ -181,6 +188,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         "proof_runtime_guard",
         "pr_quality_runtime_proof_artifacts",
         PR_QUALITY_LIVE_WORKSPACE_MODULE,
+        REPO_MEMORY_PROFILE_HISTORY_MODULE,
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_repo_memory_profile_history.py
+++ b/tests/test_repo_memory_profile_history.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.repo_memory_profile_history import (
+    ANTI_CHEAT_REJECTION_SCENARIO_COUNT,
+    AUTOMATION_ALLOWED,
+    HISTORY_JSONL,
+    LIVE_CONTRACT_PROVEN,
+    LIVE_PROFILE_STATUS,
+    MERGE_AUTHORIZED,
+    SEMANTIC_EQUIVALENCE_PROVEN,
+    build_history_record,
+    build_history_summary,
+    main,
+    merge_history_records,
+    render_markdown,
+    write_history_jsonl,
+)
+
+READ_ONLY_MODE = "_".join(("read", "only", "profile"))
+GIT_SCENARIOS = "_".join(("git", "verified", "scenario", "count"))
+EXPECTED_FAILURES = "_".join(("expected", "failed", "scenario", "count"))
+NETWORK_BLOCKED = "_".join(("network", "boundary", "blocked", "scenario", "count"))
+
+
+def _profile() -> dict:
+    return {
+        "schema_version": "sdetkit.repo_memory.v4",
+        "profile_status": LIVE_PROFILE_STATUS,
+        "memory_mode": READ_ONLY_MODE,
+        "known_safe_candidate_count": 1,
+        "live_safe_candidate_count": 1,
+        "proof_provenance": {
+            LIVE_CONTRACT_PROVEN: True,
+            GIT_SCENARIOS: 5,
+            EXPECTED_FAILURES: 5,
+            NETWORK_BLOCKED: 1,
+            ANTI_CHEAT_REJECTION_SCENARIO_COUNT: 2,
+        },
+        "decision_boundary": {
+            AUTOMATION_ALLOWED: False,
+            MERGE_AUTHORIZED: False,
+            SEMANTIC_EQUIVALENCE_PROVEN: False,
+        },
+    }
+
+
+def _record(run_id: str, head_sha: str) -> dict:
+    return build_history_record(
+        _profile(),
+        source_run_id=run_id,
+        source_head_sha=head_sha,
+        recorded_at_utc="2026-05-23T00:00:00Z",
+    )
+
+
+def test_history_record_captures_live_proof_without_authority() -> None:
+    record = _record("run-1", "abc123")
+
+    assert record["source_run_id"] == "run-1"
+    assert record["source_head_sha"] == "abc123"
+    assert record["profile_status"] == LIVE_PROFILE_STATUS
+    assert record[LIVE_CONTRACT_PROVEN] is True
+    assert record[ANTI_CHEAT_REJECTION_SCENARIO_COUNT] == 2
+    assert record["decision_boundary"][AUTOMATION_ALLOWED] is False
+    assert record["decision_boundary"][MERGE_AUTHORIZED] is False
+    assert record["decision_boundary"][SEMANTIC_EQUIVALENCE_PROVEN] is False
+
+
+def test_history_rejects_profile_that_expands_authority() -> None:
+    profile = _profile()
+    profile["decision_boundary"][AUTOMATION_ALLOWED] = True
+
+    with pytest.raises(ValueError, match="expands authority"):
+        build_history_record(
+            profile,
+            source_run_id="run-1",
+            source_head_sha="abc123",
+        )
+
+
+def test_history_merge_is_idempotent_per_run_and_head() -> None:
+    record = _record("run-1", "abc123")
+
+    records, appended = merge_history_records([], record)
+    second_records, second_appended = merge_history_records(records, record)
+
+    assert appended is True
+    assert second_appended is False
+    assert len(records) == 1
+    assert len(second_records) == 1
+
+
+def test_history_summary_aggregates_imported_and_current_proven_runs(
+    tmp_path: Path,
+) -> None:
+    records, appended = merge_history_records(
+        [_record("run-1", "abc123")],
+        _record("run-2", "def456"),
+    )
+    history_path = write_history_jsonl(records, out_dir=tmp_path)
+    summary = build_history_summary(
+        records,
+        appended=appended,
+        history_path=history_path,
+        prior_history_collected=True,
+        prior_record_count=1,
+    )
+
+    assert summary["prior_history_collected"] is True
+    assert summary["prior_record_count"] == 1
+    assert summary["record_count"] == 2
+    assert summary["live_contract_proven_record_count"] == 2
+    assert summary[ANTI_CHEAT_REJECTION_SCENARIO_COUNT] == 4
+    assert summary["latest_record"]["source_run_id"] == "run-2"
+    assert summary["decision_boundary"]["prior_history_is_read_only_input"] is True
+    assert summary["decision_boundary"][AUTOMATION_ALLOWED] is False
+    assert summary["decision_boundary"][MERGE_AUTHORIZED] is False
+    assert summary["decision_boundary"][SEMANTIC_EQUIVALENCE_PROVEN] is False
+
+    markdown = render_markdown(summary)
+    assert "Prior history collected: `true`" in markdown
+    assert "Prior records: `1`" in markdown
+    assert "Live-contract-proven records: `2`" in markdown
+    assert "Anti-cheat rejection scenario total: `4`" in markdown
+    assert "Prior history is read-only input: `true`" in markdown
+
+
+def test_history_rejects_imported_record_with_authority_enabled() -> None:
+    existing = _record("run-1", "abc123")
+    existing["decision_boundary"][MERGE_AUTHORIZED] = True
+
+    with pytest.raises(ValueError, match="expands authority"):
+        merge_history_records([existing], _record("run-2", "def456"))
+
+
+def test_history_cli_writes_new_snapshot_without_mutating_prior_input(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    profile_path = tmp_path / "repo-memory-profile.json"
+    first_out = tmp_path / "first"
+    second_out = tmp_path / "second"
+    profile_path.write_text(json.dumps(_profile()), encoding="utf-8")
+
+    first_rc = main(
+        [
+            "--profile-json",
+            str(profile_path),
+            "--source-run-id",
+            "run-1",
+            "--source-head-sha",
+            "abc123",
+            "--recorded-at-utc",
+            "2026-05-23T00:00:00Z",
+            "--out-dir",
+            str(first_out),
+            "--format",
+            "json",
+        ]
+    )
+    assert first_rc == 0
+    capsys.readouterr()
+
+    prior_path = first_out / HISTORY_JSONL
+    prior_before = prior_path.read_text(encoding="utf-8")
+
+    second_rc = main(
+        [
+            "--profile-json",
+            str(profile_path),
+            "--prior-history-jsonl",
+            str(prior_path),
+            "--source-run-id",
+            "run-2",
+            "--source-head-sha",
+            "def456",
+            "--recorded-at-utc",
+            "2026-05-23T01:00:00Z",
+            "--out-dir",
+            str(second_out),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert second_rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    summary = json.loads(
+        (second_out / "repo-memory-history-summary.json").read_text(encoding="utf-8")
+    )
+    output_rows = (second_out / HISTORY_JSONL).read_text(encoding="utf-8").splitlines()
+
+    assert prior_path.read_text(encoding="utf-8") == prior_before
+    assert printed["record_count"] == 2
+    assert printed["appended"] is True
+    assert summary["prior_history_collected"] is True
+    assert summary["prior_record_count"] == 1
+    assert len(output_rows) == 2
+
+
+def test_history_cli_rejects_missing_declared_prior_input(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    profile_path = tmp_path / "repo-memory-profile.json"
+    profile_path.write_text(json.dumps(_profile()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--profile-json",
+            str(profile_path),
+            "--prior-history-jsonl",
+            str(tmp_path / "missing.jsonl"),
+            "--source-run-id",
+            "run-1",
+            "--source-head-sha",
+            "abc123",
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 2
+    assert "prior history input does not exist" in capsys.readouterr().out

--- a/tests/test_repo_memory_profile_history_workflow.py
+++ b/tests/test_repo_memory_profile_history_workflow.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/repo-memory-history.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_repo_memory_history_runs_only_from_trusted_main_pushes() -> None:
+    text = _workflow_text()
+
+    assert "name: RepoMemory Profile History" in text
+    assert "push:" in text
+    assert "branches: [main]" in text
+    assert "pull_request:" not in text
+    assert "workflow_run:" not in text
+    assert "contents: read" in text
+    assert "actions: read" in text
+    assert "contents: write" not in text
+    assert "pull-requests: write" not in text
+
+
+def test_repo_memory_history_builds_fresh_live_profile_from_merged_code() -> None:
+    text = _workflow_text()
+
+    workspace = text.index("python -m sdetkit.pr_quality_live_benchmark_workspace")
+    live_report = text.index("python -m sdetkit.replayable_benchmark_harness")
+    profile = text.index("python -m sdetkit.repo_memory")
+    history = text.index("python -m sdetkit.repo_memory_profile_history")
+
+    assert workspace < live_report < profile < history
+    assert "${RUNNER_TEMP}/sdetkit-repo-memory-history-live-repositories" in text
+    assert (
+        "--live-benchmark-report build/repo-memory-history/live-report/benchmark-report.json"
+        in text
+    )
+    assert 'assert profile["inputs"]["live_contract_proven"] is True' in text
+    assert 'assert boundary["automation_allowed"] is False' in text
+    assert 'assert boundary["merge_authorized"] is False' in text
+    assert 'assert boundary["semantic_equivalence_proven"] is False' in text
+
+
+def test_repo_memory_history_imports_only_successful_ancestor_main_history() -> None:
+    text = _workflow_text()
+
+    assert "Select prior trusted main history artifact" in text
+    assert (
+        "actions/workflows/repo-memory-history.yml/runs?branch=main&event=push&status=completed"
+        in text
+    )
+    assert 'select(.conclusion == "success")' in text
+    assert 'git merge-base --is-ancestor "$candidate_head_sha" "$GITHUB_SHA"' in text
+    assert 'gh run download "$prior_run_id"' in text
+    assert "--prior-history-jsonl" in text
+    assert "Prior trusted-main run was selected but supplied no history JSONL artifact." in text
+
+
+def test_repo_memory_history_uploads_snapshot_without_repository_mutation() -> None:
+    text = _workflow_text()
+
+    assert "Upload trusted main RepoMemory history artifact" in text
+    assert "name: repo-memory-profile-history" in text
+    assert "build/repo-memory-history/output/" in text
+    assert "repo-memory-profile-history.jsonl" in text
+    assert "git add " not in text
+    assert "git commit " not in text
+    assert "git push " not in text
+    assert "create-pull-request" not in text
+
+
+def test_repo_memory_history_verifies_no_authority_boundary() -> None:
+    text = _workflow_text()
+
+    assert 'assert summary["latest_record"]["live_contract_proven"] is True' in text
+    assert 'assert boundary["automation_allowed"] is False' in text
+    assert 'assert boundary["merge_authorized"] is False' in text
+    assert 'assert boundary["semantic_equivalence_proven"] is False' in text
+    assert 'assert boundary["prior_history_is_read_only_input"] is True' in text


### PR DESCRIPTION
## Summary
- Adds `repo_memory_profile_history`, a read-only history store for proven RepoMemory profiles.
- Adds a trusted-main-only workflow that regenerates live RepoMemory evidence after merges and records an immutable profile-history snapshot.
- Restores only prior successful ancestor history artifacts from the same trusted `main` workflow chain.
- Treats prior history as read-only input and emits a new JSONL snapshot for each trusted-main run.
- Rejects imported profiles or records that enable automation, merge authorization, or semantic-equivalence claims.
- Updates the reliability-spine audit to mark trusted-main RepoMemory history as implemented.
- Advances the next recommended PR to `feature/pr-quality-trusted-repo-memory-history-visibility`.

## Why
PR #1413 made current live benchmark and RepoMemory evidence visible in PR Quality, but that evidence remained per-run only.

This PR creates a persistent, advisory memory chain from accepted `main` history without allowing a pull request to write its own authoritative memory. Persistence occurs only after merged code reaches `main`, through immutable workflow artifacts.

## Trust boundary
- Trigger: push to `main` only.
- Repository permissions: read-only contents and actions access.
- Prior history source: latest successful ancestor run from the same trusted-main workflow.
- Prior history handling: read-only input.
- Output: new immutable workflow artifact snapshot.
- PR Quality branch mutation: none.
- Automatic patching: false.
- Security dismissal: false.
- Merge authorization: false.
- Semantic equivalence proven: false.
- Network isolation enforcement claim: false.

## Implementation
- `.github/workflows/repo-memory-history.yml`
  - Runs only after trusted `main` pushes.
  - Builds fresh six-scenario Git-grounded live benchmark evidence from merged code.
  - Builds a fresh RepoMemory live-proof profile.
  - Selects only a successful prior workflow run whose head is an ancestor of current `main`.
  - Downloads prior JSONL history as input only.
  - Records and uploads a new immutable history snapshot.

- `src/sdetkit/repo_memory_profile_history.py`
  - Validates read-only RepoMemory profiles.
  - Builds stable run/head-scoped history records.
  - Deduplicates repeated processing of the same record.
  - Rejects imported authority-expanding records.
  - Writes JSONL history plus deterministic JSON/Markdown summaries.

- `src/sdetkit/reliability_spine_alignment.py`
  - Marks trusted-main RepoMemory history as aligned.
  - Removes the now-closed persistent-profile gap.
  - Retains unproven containment and flaky-test registry gaps.

## Verification
- Real two-generation live smoke:
  - built six-scenario Git-grounded benchmark evidence;
  - built real RepoMemory live-proof profile;
  - generated generation 1 history with one record;
  - imported generation 1 read-only and generated generation 2 with two records;
  - replayed generation 2 and confirmed deduplication;
  - confirmed imported JSONL remained byte-identical;
  - confirmed smoke execution did not mutate the source branch.
- `python -m pytest -q tests/test_repo_memory_profile_history.py tests/test_repo_memory_profile_history_workflow.py tests/test_repo_memory.py tests/test_pr_quality_live_benchmark_workspace.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_replayable_isolated_proof_evidence.py tests/test_replayable_benchmark_harness.py tests/test_reliability_spine_alignment.py -o addopts=` → `56 passed`.
- Fresh Python 3.12 full truth lane:
  - `COV_FAIL_UNDER=95 bash quality.sh cov`;
  - `3585 passed, 1 skipped, 3 deselected`;
  - coverage `96.69%`;
  - `blocking failures: none`;
  - `merge/release recommendation: ready-for-merge-review`.
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- Generated roadmap manifest refresh verified with artifact tests → `13 passed`.
- Confirmed zero PR-owned warning/error security findings.

## Risk
- Medium, read-only and post-merge.
- The new workflow first executes only after merge because it is triggered by pushes to `main`.
- The first trusted-main run will start a new history chain when no prior artifact exists.
- Subsequent trusted-main runs import only successful ancestor history artifacts.
- No pull request can write authoritative history through this workflow.
- Rollback: revert this PR; previously uploaded immutable artifacts may remain retained but will no longer be extended.

## Next
`feature/pr-quality-trusted-repo-memory-history-visibility`

That follow-up may display trusted accepted-main history in PR Quality as advisory evidence only, without granting remediation or merge authority.
