### PR TITLE
Ingest advisory flaky-test evidence into RepoMemory

### DIFF
--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -396,7 +396,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.expansion",
         "module_path": "src/sdetkit/expansion.py",
-        "tests_referencing_module": 24
+        "tests_referencing_module": 25
       },
       {
         "contract_script_paths": [
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 115
+        "tests_referencing_module": 116
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/flaky_test_registry_evidence.py
+++ b/src/sdetkit/flaky_test_registry_evidence.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.flaky_test_registry_evidence.v1"
+SOURCE_SCHEMA_VERSION = "sdetkit.intelligence.flake.v1"
+DEFAULT_OUT_DIR = Path("build") / "flaky-test-registry"
+EVIDENCE_JSON = "flaky-test-registry-evidence.json"
+EVIDENCE_MD = "flaky-test-registry-evidence.md"
+
+COLLECTED = "collected"
+STATUS = "advisory_registry_collected"
+VALID_SOURCE_KINDS = {
+    "operator_review_input",
+    "trusted_main_artifact",
+}
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def build_flaky_test_registry_evidence(
+    *,
+    classification_report: Mapping[str, Any],
+    source_kind: str,
+    source_reference: str,
+) -> JsonObject:
+    if source_kind not in VALID_SOURCE_KINDS:
+        raise ValueError(f"unsupported flaky-test evidence source kind: {source_kind}")
+
+    source_reference_value = _string(source_reference)
+    if not source_reference_value:
+        raise ValueError("flaky-test evidence source reference is required")
+
+    if _string(classification_report.get("schema_version")) != SOURCE_SCHEMA_VERSION:
+        raise ValueError("unsupported flaky-test classification report schema")
+
+    raw_tests = classification_report.get("tests")
+    if not isinstance(raw_tests, list):
+        raise ValueError("flaky-test classification report must contain a tests array")
+
+    entries: list[JsonObject] = []
+    allowed_classifications = {"flaky", "stable-failing", "stable-passing"}
+
+    for raw_item in raw_tests:
+        if not isinstance(raw_item, dict):
+            raise ValueError("flaky-test classification report contains a non-object entry")
+
+        item = raw_item
+        classification = _string(item.get("classification"))
+        if classification not in allowed_classifications:
+            raise ValueError(f"unsupported flaky-test classification: {classification}")
+        if classification != "flaky":
+            continue
+
+        test_id = _string(item.get("test_id"))
+        fingerprint = _string(item.get("fingerprint"))
+        runs = _int(item.get("runs"))
+        failures = _int(item.get("failures"))
+        passes = _int(item.get("passes"))
+
+        if not test_id or not fingerprint:
+            raise ValueError("flaky-test entry requires test_id and fingerprint")
+        if runs < 2 or failures < 1 or passes < 1:
+            raise ValueError("flaky-test entry does not prove mixed pass/fail observations")
+
+        entries.append(
+            {
+                "test_id": test_id,
+                "fingerprint": fingerprint,
+                "classification": "flaky",
+                "observed_runs": runs,
+                "observed_failures": failures,
+                "observed_passes": passes,
+                "decision": "instability_context_only",
+                "review_first": True,
+                "automatic_quarantine_allowed": False,
+                "automatic_rerun_allowed": False,
+                "current_failure_suppression_allowed": False,
+                "automation_allowed": False,
+            }
+        )
+
+    entries.sort(key=lambda item: (str(item["test_id"]), str(item["fingerprint"])))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "collection_status": COLLECTED,
+        "status": STATUS,
+        "source": {
+            "kind": source_kind,
+            "reference": source_reference_value,
+            "classification_schema": SOURCE_SCHEMA_VERSION,
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+        },
+        "summary": {
+            "entry_count": len(entries),
+            "flaky_test_count": len(entries),
+        },
+        "entries": entries,
+        "decision_boundary": {
+            "advisory_only": True,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "reason": (
+                "Flaky-test history is advisory context only; current failures "
+                "remain active until independently diagnosed and proven."
+            ),
+        },
+    }
+
+
+def render_markdown(evidence: Mapping[str, Any]) -> str:
+    source = _as_dict(evidence.get("source"))
+    summary = _as_dict(evidence.get("summary"))
+    boundary = _as_dict(evidence.get("decision_boundary"))
+    entries = [_as_dict(item) for item in _as_list(evidence.get("entries"))]
+
+    lines = [
+        "# Flaky-test registry evidence",
+        "",
+        f"- Schema: `{_string(evidence.get('schema_version'))}`",
+        f"- Status: `{_string(evidence.get('status'))}`",
+        f"- Source kind: `{_string(source.get('kind'))}`",
+        f"- Input read-only: `{str(bool(source.get('input_read_only'))).lower()}`",
+        f"- Entries: `{_int(summary.get('entry_count'))}`",
+        "",
+        "## Instability context",
+        "",
+    ]
+
+    if entries:
+        for entry in entries:
+            lines.append(
+                f"- test=`{_string(entry.get('test_id'))}`, "
+                f"runs=`{_int(entry.get('observed_runs'))}`, "
+                f"failures=`{_int(entry.get('observed_failures'))}`, "
+                f"passes=`{_int(entry.get('observed_passes'))}`, "
+                "decision=`instability_context_only`"
+            )
+    else:
+        lines.append("- none observed")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            (
+                "- Automatic quarantine allowed: "
+                f"`{str(bool(boundary.get('automatic_quarantine_allowed'))).lower()}`"
+            ),
+            (
+                "- Automatic rerun allowed: "
+                f"`{str(bool(boundary.get('automatic_rerun_allowed'))).lower()}`"
+            ),
+            (
+                "- Current failure suppression allowed: "
+                f"`{str(bool(boundary.get('current_failure_suppression_allowed'))).lower()}`"
+            ),
+            (f"- Automation allowed: `{str(bool(boundary.get('automation_allowed'))).lower()}`"),
+            (f"- Merge authorized: `{str(bool(boundary.get('merge_authorized'))).lower()}`"),
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_evidence(evidence: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / EVIDENCE_JSON
+    markdown_path = out_dir / EVIDENCE_MD
+    json_path.write_text(
+        json.dumps(dict(evidence), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(evidence), encoding="utf-8")
+    return {
+        "flaky_test_registry_evidence_json": json_path.as_posix(),
+        "flaky_test_registry_evidence_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.flaky_test_registry_evidence")
+    parser.add_argument("--classification-report", type=Path, required=True)
+    parser.add_argument(
+        "--source-kind",
+        choices=sorted(VALID_SOURCE_KINDS),
+        required=True,
+    )
+    parser.add_argument("--source-reference", default="")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        evidence = build_flaky_test_registry_evidence(
+            classification_report=_read_json(args.classification_report),
+            source_kind=args.source_kind,
+            source_reference=args.source_reference,
+        )
+        artifacts = write_evidence(evidence, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": "written",
+                    "artifacts": artifacts,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print("flaky_test_registry_evidence_written=true")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -13,10 +13,11 @@ PR_QUALITY_LIVE_WORKSPACE_MODULE = "_".join(("pr", "quality", "live", "benchmark
 REPLAYABLE_BENCHMARK_MODULE = "_".join(("replayable", "benchmark", "harness"))
 REPO_MEMORY_PROFILE_HISTORY_MODULE = "_".join(("repo", "memory", "profile", "history"))
 TRUSTED_HISTORY_EVIDENCE_MODULE = "_".join(("trusted", "history", "evidence"))
+FLAKY_TEST_REGISTRY_EVIDENCE_MODULE = "_".join(("flaky", "test", "registry", "evidence"))
 NEXT_RECOMMENDED_PR = "/".join(
     (
         "feature",
-        "-".join(("repo", "memory", "flaky", "test", "registry", "ingestion")),
+        "-".join(("trusted", "flaky", "test", "registry", "producer")),
     )
 )
 
@@ -445,6 +446,21 @@ def build_alignment_components() -> list[AlignmentComponent]:
             recommended_next_action="keep live benchmark evidence reporting-only until containment is proven",
         ),
         _component(
+            module=FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
+            role="normalize read-only flaky-test classification evidence for advisory RepoMemory ingestion",
+            status="partially_aligned",
+            stages=("evidence", "history", "reporting"),
+            existing_artifacts=(
+                "flaky-test-registry-evidence.json",
+                "flaky-test-registry-evidence.md",
+            ),
+            integration_points=("intelligence flake classify", "repo_memory"),
+            gaps=(
+                "trusted-main flaky-test evidence producer and PR Quality visibility are not yet connected",
+            ),
+            recommended_next_action="connect only provenance-checked trusted-main instability evidence",
+        ),
+        _component(
             module="repo_memory",
             role="produce local repo-specific memory profiles from trajectory and benchmark evidence",
             status="partially_aligned",
@@ -464,9 +480,9 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "flaky-test registry ingestion is not implemented",
+                "trusted-main flaky-test evidence producer and PR Quality visibility remain unconnected",
             ),
-            recommended_next_action="ingest read-only flaky-test history without expanding authority",
+            recommended_next_action="surface only provenance-checked flaky-test instability context without expanding authority",
         ),
         _component(
             module=REPO_MEMORY_PROFILE_HISTORY_MODULE,

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -18,7 +18,7 @@ from sdetkit.replayable_benchmark_harness import (
     VERIFICATION_EVIDENCE_SOURCE,
 )
 
-SCHEMA_VERSION = "sdetkit.repo_memory.v4"
+SCHEMA_VERSION = "sdetkit.repo_memory.v5"
 DEFAULT_OUT_DIR = Path("build") / "repo-memory"
 PROFILE_JSON = "repo-memory-profile.json"
 PROFILE_MD = "repo-memory-profile.md"
@@ -315,6 +315,123 @@ def _live_benchmark_rejections(
     return records
 
 
+def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
+    denied = {
+        "automatic_quarantine_allowed": False,
+        "automatic_rerun_allowed": False,
+        "current_failure_suppression_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    payload = _as_dict(evidence)
+    if not payload:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "entries": [],
+            "entry_count": 0,
+            "note": "No flaky-test evidence source is connected to RepoMemory yet.",
+            "decision_boundary": denied,
+        }
+
+    if _string(payload.get("schema_version")) != "sdetkit.flaky_test_registry_evidence.v1":
+        raise ValueError("flaky-test registry evidence schema is not supported")
+    if _string(payload.get("collection_status")) != "collected":
+        raise ValueError("flaky-test registry evidence must be collected before ingestion")
+    if _string(payload.get("status")) != "advisory_registry_collected":
+        raise ValueError("flaky-test registry evidence status is not supported")
+
+    source = _as_dict(payload.get("source"))
+    source_kind = _string(source.get("kind"))
+    source_reference = _string(source.get("reference"))
+    if source_kind not in {"operator_review_input", "trusted_main_artifact"}:
+        raise ValueError("flaky-test registry evidence source kind is not supported")
+    if not source_reference:
+        raise ValueError("flaky-test registry evidence source reference is required")
+    if not _bool(source.get("input_read_only")):
+        raise ValueError("flaky-test registry evidence input must be read-only")
+    if _bool(source.get("commands_executed_by_reader")):
+        raise ValueError("flaky-test registry evidence reader cannot execute commands")
+
+    boundary = _as_dict(payload.get("decision_boundary"))
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    if expanded:
+        raise ValueError("flaky-test registry evidence expands authority: " + ", ".join(expanded))
+
+    raw_entries = payload.get("entries")
+    if not isinstance(raw_entries, list):
+        raise ValueError("flaky-test registry evidence must contain an entries array")
+
+    entries: list[JsonObject] = []
+    for raw_item in raw_entries:
+        if not isinstance(raw_item, dict):
+            raise ValueError("flaky-test registry evidence contains a non-object entry")
+
+        item_expanded = [key for key in denied if _bool(raw_item.get(key))]
+        if item_expanded:
+            raise ValueError(
+                "flaky-test registry entry expands authority: " + ", ".join(item_expanded)
+            )
+
+        test_id = _string(raw_item.get("test_id"))
+        fingerprint = _string(raw_item.get("fingerprint"))
+        runs = _int(raw_item.get("observed_runs"))
+        failures = _int(raw_item.get("observed_failures"))
+        passes = _int(raw_item.get("observed_passes"))
+
+        if _string(raw_item.get("classification")) != "flaky":
+            raise ValueError("flaky-test registry entry must classify a flaky test")
+        if not test_id or not fingerprint:
+            raise ValueError("flaky-test registry entry requires test_id and fingerprint")
+        if runs < 2 or failures < 1 or passes < 1:
+            raise ValueError("flaky-test registry entry lacks mixed pass/fail observations")
+        if _string(raw_item.get("decision")) != "instability_context_only":
+            raise ValueError("flaky-test registry entry decision is not supported")
+        if not _bool(raw_item.get("review_first")):
+            raise ValueError("flaky-test registry entry must remain review-first")
+
+        entries.append(
+            {
+                "test_id": test_id,
+                "fingerprint": fingerprint,
+                "classification": "flaky",
+                "observed_runs": runs,
+                "observed_failures": failures,
+                "observed_passes": passes,
+                "decision": "instability_context_only",
+                "review_first": True,
+                **denied,
+            }
+        )
+
+    entries.sort(key=lambda item: (item["test_id"], item["fingerprint"]))
+    summary = _as_dict(payload.get("summary"))
+    if _int(summary.get("entry_count")) != len(entries):
+        raise ValueError("flaky-test registry evidence summary entry count is inconsistent")
+    if _int(summary.get("flaky_test_count")) != len(entries):
+        raise ValueError("flaky-test registry evidence summary flaky count is inconsistent")
+
+    return {
+        "collection_status": "collected",
+        "status": "advisory_registry_collected",
+        "source": {
+            "kind": source_kind,
+            "reference": source_reference,
+            "classification_schema": _string(source.get("classification_schema")),
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+        },
+        "entries": entries,
+        "entry_count": len(entries),
+        "note": (
+            "Flaky-test evidence is advisory context only and cannot suppress "
+            "a current failing contract."
+        ),
+        "decision_boundary": denied,
+    }
+
+
 def _escalation_rules() -> list[JsonObject]:
     return [
         {
@@ -341,6 +458,12 @@ def _escalation_rules() -> list[JsonObject]:
             "decision": "keep_advisory",
             "automation_allowed": False,
         },
+        {
+            "rule_id": "flaky_history_never_suppresses_current_failure",
+            "when": "read-only flaky-test instability evidence is collected",
+            "decision": "review_first",
+            "automation_allowed": False,
+        },
     ]
 
 
@@ -349,8 +472,10 @@ def build_repo_memory_profile(
     pattern_insights: Mapping[str, Any],
     benchmark_report: Mapping[str, Any],
     live_benchmark_report: Mapping[str, Any] | None = None,
+    flaky_test_registry_evidence: Mapping[str, Any] | None = None,
 ) -> JsonObject:
     live_report = dict(live_benchmark_report or {})
+    flaky_registry = _flaky_test_registry(flaky_test_registry_evidence or {})
     benchmark_proven = _benchmark_contract_proven(benchmark_report)
     live_proven = _live_contract_proven(live_report)
     safe_fix_history = _safe_fix_history(
@@ -443,11 +568,7 @@ def build_repo_memory_profile(
         "safe_fix_history": safe_fix_history,
         "known_safe_candidate_count": len(supported_candidates),
         "live_safe_candidate_count": len(live_supported_candidates),
-        "flaky_test_registry": {
-            "collection_status": "not_collected",
-            "entries": [],
-            "note": "No flaky-test evidence source is connected to RepoMemory yet.",
-        },
+        "flaky_test_registry": flaky_registry,
         "escalation_rules": _escalation_rules(),
         "unproven_boundaries": unproven_boundaries,
         "decision_boundary": {
@@ -581,7 +702,20 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
             "## Flaky test registry",
             "",
             f"- Collection status: `{_string(flaky.get('collection_status'))}`",
+            f"- Status: `{_string(flaky.get('status'))}`",
             f"- Entries: `{len(_as_list(flaky.get('entries')))}`",
+            (
+                "- Automatic quarantine allowed: "
+                f"`{str(_bool(_as_dict(flaky.get('decision_boundary')).get('automatic_quarantine_allowed'))).lower()}`"
+            ),
+            (
+                "- Current failure suppression allowed: "
+                f"`{str(_bool(_as_dict(flaky.get('decision_boundary')).get('current_failure_suppression_allowed'))).lower()}`"
+            ),
+            (
+                "- Automation allowed by flaky-test history: "
+                f"`{str(_bool(_as_dict(flaky.get('decision_boundary')).get('automation_allowed'))).lower()}`"
+            ),
             "",
             "## Escalation rules",
             "",
@@ -633,6 +767,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--pattern-insights", type=Path, required=True)
     parser.add_argument("--benchmark-report", type=Path, required=True)
     parser.add_argument("--live-benchmark-report", type=Path)
+    parser.add_argument("--flaky-test-registry-evidence", type=Path)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--format", choices=["text", "json"], default="text")
     return parser
@@ -647,6 +782,11 @@ def main(argv: list[str] | None = None) -> int:
             benchmark_report=_read_json(args.benchmark_report),
             live_benchmark_report=(
                 _read_json(args.live_benchmark_report) if args.live_benchmark_report else None
+            ),
+            flaky_test_registry_evidence=(
+                _read_json(args.flaky_test_registry_evidence)
+                if args.flaky_test_registry_evidence
+                else None
             ),
         )
         artifacts = write_profile(profile, out_dir=args.out_dir)

--- a/tests/test_flaky_test_registry_evidence.py
+++ b/tests/test_flaky_test_registry_evidence.py
@@ -129,7 +129,6 @@ def test_flaky_test_registry_cli_writes_deterministic_artifacts(tmp_path: Path, 
     assert "Automation allowed: `false`" in markdown
 
 
-
 def test_flaky_test_registry_rejects_missing_source_reference_and_malformed_report() -> None:
     with pytest.raises(ValueError, match="source reference is required"):
         build_flaky_test_registry_evidence(

--- a/tests/test_flaky_test_registry_evidence.py
+++ b/tests/test_flaky_test_registry_evidence.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.flaky_test_registry_evidence import (
+    STATUS,
+    build_flaky_test_registry_evidence,
+    main,
+    render_markdown,
+)
+
+
+def _classification_report() -> dict:
+    return {
+        "schema_version": "sdetkit.intelligence.flake.v1",
+        "tests": [
+            {
+                "test_id": "tests/test_service.py::test_retry_path",
+                "classification": "flaky",
+                "signal": "nondeterministic-rerun",
+                "next_step": "Quarantine test and capture deterministic evidence.",
+                "runs": 3,
+                "failures": 1,
+                "passes": 2,
+                "fingerprint": "abcd1234",
+            },
+            {
+                "test_id": "tests/test_service.py::test_stable_failure",
+                "classification": "stable-failing",
+                "runs": 2,
+                "failures": 2,
+                "passes": 0,
+                "fingerprint": "stable0001",
+            },
+        ],
+        "summary": {
+            "flaky": 1,
+            "stable_failing": 1,
+            "stable_passing": 0,
+        },
+    }
+
+
+def test_flaky_test_registry_normalizes_flake_evidence_without_authority() -> None:
+    evidence = build_flaky_test_registry_evidence(
+        classification_report=_classification_report(),
+        source_kind="operator_review_input",
+        source_reference="local-proof",
+    )
+
+    assert evidence["status"] == STATUS
+    assert evidence["summary"]["entry_count"] == 1
+    entry = evidence["entries"][0]
+    assert entry["test_id"] == "tests/test_service.py::test_retry_path"
+    assert entry["decision"] == "instability_context_only"
+    assert "next_step" not in entry
+    assert entry["automatic_quarantine_allowed"] is False
+    assert entry["current_failure_suppression_allowed"] is False
+
+    boundary = evidence["decision_boundary"]
+    assert boundary["automation_allowed"] is False
+    assert boundary["merge_authorized"] is False
+    assert boundary["semantic_equivalence_proven"] is False
+
+
+def test_flaky_test_registry_rejects_unproven_flaky_entry() -> None:
+    report = _classification_report()
+    report["tests"][0]["passes"] = 0
+
+    try:
+        build_flaky_test_registry_evidence(
+            classification_report=report,
+            source_kind="operator_review_input",
+            source_reference="local-proof",
+        )
+    except ValueError as exc:
+        assert "mixed pass/fail observations" in str(exc)
+    else:
+        raise AssertionError("expected invalid flaky evidence to be rejected")
+
+
+def test_flaky_test_registry_markdown_exposes_review_first_boundary() -> None:
+    markdown = render_markdown(
+        build_flaky_test_registry_evidence(
+            classification_report=_classification_report(),
+            source_kind="operator_review_input",
+            source_reference="local-proof",
+        )
+    )
+
+    assert "# Flaky-test registry evidence" in markdown
+    assert "decision=`instability_context_only`" in markdown
+    assert "Automatic quarantine allowed: `false`" in markdown
+    assert "Current failure suppression allowed: `false`" in markdown
+    assert "Merge authorized: `false`" in markdown
+
+
+def test_flaky_test_registry_cli_writes_deterministic_artifacts(tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "classification.json"
+    out_dir = tmp_path / "registry"
+    input_path.write_text(json.dumps(_classification_report()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--classification-report",
+            str(input_path),
+            "--source-kind",
+            "operator_review_input",
+            "--source-reference",
+            "local-proof",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "flaky-test-registry-evidence.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "flaky-test-registry-evidence.md").read_text(encoding="utf-8")
+
+    assert printed["status"] == "written"
+    assert saved["status"] == STATUS
+    assert saved["source"]["input_read_only"] is True
+    assert "Automation allowed: `false`" in markdown
+
+
+
+def test_flaky_test_registry_rejects_missing_source_reference_and_malformed_report() -> None:
+    with pytest.raises(ValueError, match="source reference is required"):
+        build_flaky_test_registry_evidence(
+            classification_report=_classification_report(),
+            source_kind="trusted_main_artifact",
+            source_reference="",
+        )
+
+    malformed = {
+        "schema_version": "sdetkit.intelligence.flake.v1",
+        "tests": "not-a-list",
+    }
+    with pytest.raises(ValueError, match="tests array"):
+        build_flaky_test_registry_evidence(
+            classification_report=malformed,
+            source_kind="operator_review_input",
+            source_reference="local-proof",
+        )
+
+
+def test_flaky_test_registry_rejects_non_object_or_unknown_classification_entry() -> None:
+    malformed = _classification_report()
+    malformed["tests"] = ["not-an-object"]
+
+    with pytest.raises(ValueError, match="non-object entry"):
+        build_flaky_test_registry_evidence(
+            classification_report=malformed,
+            source_kind="operator_review_input",
+            source_reference="local-proof",
+        )
+
+    unknown = _classification_report()
+    unknown["tests"][0]["classification"] = "maybe-flaky"
+
+    with pytest.raises(ValueError, match="unsupported flaky-test classification"):
+        build_flaky_test_registry_evidence(
+            classification_report=unknown,
+            source_kind="operator_review_input",
+            source_reference="local-proof",
+        )

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from sdetkit.reliability_spine_alignment import (
+    FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
     NEXT_RECOMMENDED_PR,
     PR_QUALITY_LIVE_WORKSPACE_MODULE,
     REPO_MEMORY_PROFILE_HISTORY_MODULE,
@@ -40,6 +41,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE in modules
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE in modules
     assert TRUSTED_HISTORY_EVIDENCE_MODULE in modules
+    assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -78,6 +80,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE not in gaps_by_module
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE not in gaps_by_module
     assert TRUSTED_HISTORY_EVIDENCE_MODULE not in gaps_by_module
+    assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
@@ -89,7 +92,11 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert any("containment" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
-    assert any("flaky-test registry" in gap for gap in gaps_by_module["repo_memory"])
+    assert any("flaky-test evidence producer" in gap for gap in gaps_by_module["repo_memory"])
+    assert any(
+        "trusted-main flaky-test evidence producer" in gap
+        for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
+    )
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
     assert any("verified" in gap for gap in gaps_by_module["network_boundary"])
     assert any("external filesystem" in gap for gap in gaps_by_module["proof_runtime_guard"])
@@ -117,6 +124,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{PR_QUALITY_LIVE_WORKSPACE_MODULE}`: `aligned`" in markdown
     assert f"`{REPO_MEMORY_PROFILE_HISTORY_MODULE}`: `aligned`" in markdown
     assert f"`{TRUSTED_HISTORY_EVIDENCE_MODULE}`: `aligned`" in markdown
+    assert f"`{FLAKY_TEST_REGISTRY_EVIDENCE_MODULE}`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -194,6 +202,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         PR_QUALITY_LIVE_WORKSPACE_MODULE,
         REPO_MEMORY_PROFILE_HISTORY_MODULE,
         TRUSTED_HISTORY_EVIDENCE_MODULE,
+        FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -149,6 +149,45 @@ def _live_benchmark_report() -> dict:
     }
 
 
+def _flaky_registry_evidence() -> dict:
+    return {
+        "schema_version": "sdetkit.flaky_test_registry_evidence.v1",
+        "collection_status": "collected",
+        "status": "advisory_registry_collected",
+        "source": {
+            "kind": "operator_review_input",
+            "reference": "local-proof",
+            "classification_schema": "sdetkit.intelligence.flake.v1",
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+        },
+        "entries": [
+            {
+                "test_id": "tests/test_service.py::test_retry_path",
+                "fingerprint": "abcd1234",
+                "classification": "flaky",
+                "observed_runs": 3,
+                "observed_failures": 1,
+                "observed_passes": 2,
+                "decision": "instability_context_only",
+                "review_first": True,
+            }
+        ],
+        "summary": {
+            "entry_count": 1,
+            "flaky_test_count": 1,
+        },
+        "decision_boundary": {
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
 def _pattern_insights() -> dict:
     return {
         "schema_version": "sdetkit.trajectory_pattern_insights.v1",
@@ -175,7 +214,7 @@ def test_repo_memory_records_benchmark_supported_candidate_without_automation() 
         benchmark_report=_benchmark_report(),
     )
 
-    assert profile["schema_version"] == "sdetkit.repo_memory.v4"
+    assert profile["schema_version"] == "sdetkit.repo_memory.v5"
     assert profile["profile_status"] == "benchmark_supported_memory"
     assert profile["memory_mode"] == "read_only_profile"
     assert profile["inputs"]["benchmark_contract_proven"] is True
@@ -401,3 +440,126 @@ def test_repo_memory_cli_accepts_live_benchmark_report(tmp_path: Path, capsys) -
     assert "Live safe candidates: `1`" in markdown
     assert "Network boundary blocked scenarios: `1`" in markdown
     assert "Anti-cheat rejection scenarios: `2`" in markdown
+
+
+def test_repo_memory_ingests_flaky_test_registry_as_advisory_context_only() -> None:
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=_benchmark_report(),
+        flaky_test_registry_evidence=_flaky_registry_evidence(),
+    )
+
+    flaky = profile["flaky_test_registry"]
+    assert flaky["collection_status"] == "collected"
+    assert flaky["status"] == "advisory_registry_collected"
+    assert flaky["entry_count"] == 1
+    assert flaky["entries"][0]["decision"] == "instability_context_only"
+    assert flaky["decision_boundary"]["automatic_quarantine_allowed"] is False
+    assert flaky["decision_boundary"]["current_failure_suppression_allowed"] is False
+    assert flaky["decision_boundary"]["automation_allowed"] is False
+
+    boundary = profile["decision_boundary"]
+    assert boundary["automation_allowed"] is False
+    assert boundary["merge_authorized"] is False
+    assert boundary["semantic_equivalence_proven"] is False
+
+
+def test_repo_memory_rejects_authority_expanding_flaky_test_registry() -> None:
+    evidence = _flaky_registry_evidence()
+    evidence["decision_boundary"]["current_failure_suppression_allowed"] = True
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            flaky_test_registry_evidence=evidence,
+        )
+    except ValueError as exc:
+        assert "expands authority" in str(exc)
+    else:
+        raise AssertionError("expected authority-expanding flaky evidence to be rejected")
+
+
+def test_repo_memory_markdown_renders_flaky_history_no_authority_boundary() -> None:
+    markdown = render_markdown(
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            flaky_test_registry_evidence=_flaky_registry_evidence(),
+        )
+    )
+
+    assert "Status: `advisory_registry_collected`" in markdown
+    assert "Automatic quarantine allowed: `false`" in markdown
+    assert "Current failure suppression allowed: `false`" in markdown
+    assert "Automation allowed by flaky-test history: `false`" in markdown
+
+
+
+def test_repo_memory_rejects_hidden_entry_authority_and_bad_registry_schema() -> None:
+    hidden_authority = _flaky_registry_evidence()
+    hidden_authority["entries"][0]["automation_allowed"] = True
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            flaky_test_registry_evidence=hidden_authority,
+        )
+    except ValueError as exc:
+        assert "entry expands authority" in str(exc)
+    else:
+        raise AssertionError("expected entry-level authority expansion to be rejected")
+
+    unsupported = _flaky_registry_evidence()
+    unsupported["schema_version"] = "unsupported.registry.v1"
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            flaky_test_registry_evidence=unsupported,
+        )
+    except ValueError as exc:
+        assert "schema is not supported" in str(exc)
+    else:
+        raise AssertionError("expected unsupported registry schema to be rejected")
+
+
+def test_repo_memory_cli_accepts_advisory_flaky_registry_evidence(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    flaky_path = tmp_path / "flaky-test-registry-evidence.json"
+    out_dir = tmp_path / "repo-memory-with-flaky-context"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+    flaky_path.write_text(json.dumps(_flaky_registry_evidence()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--flaky-test-registry-evidence",
+            str(flaky_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    capsys.readouterr()
+    saved = json.loads((out_dir / "repo-memory-profile.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "repo-memory-profile.md").read_text(encoding="utf-8")
+
+    assert saved["flaky_test_registry"]["collection_status"] == "collected"
+    assert saved["flaky_test_registry"]["entry_count"] == 1
+    assert saved["flaky_test_registry"]["decision_boundary"]["automation_allowed"] is False
+    assert "Current failure suppression allowed: `false`" in markdown

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -495,7 +495,6 @@ def test_repo_memory_markdown_renders_flaky_history_no_authority_boundary() -> N
     assert "Automation allowed by flaky-test history: `false`" in markdown
 
 
-
 def test_repo_memory_rejects_hidden_entry_authority_and_bad_registry_schema() -> None:
     hidden_authority = _flaky_registry_evidence()
     hidden_authority["entries"][0]["automation_allowed"] = True


### PR DESCRIPTION
## Summary
- Adds `flaky_test_registry_evidence`, a read-only validator and normalizer for existing `sdetkit.intelligence.flake.v1` classification output.
- Extends RepoMemory to ingest flaky-test instability context through an explicit advisory-only registry.
- Rejects authority-expanding flaky-test evidence, including any attempt to allow automatic quarantine, automatic rerun, current-failure suppression, remediation authority, merge authority, or semantic-equivalence claims.
- Updates the reliability-spine audit to mark advisory registry ingestion as implemented while leaving trusted-main producer and PR Quality visibility wiring as future work.
- Refreshes the deterministic roadmap manifest reference counts for the new source/test surface.

## Why
RepoMemory already contained an explicit `flaky_test_registry` placeholder with `collection_status=not_collected`, while the repository already had a flake-classification contract through `sdetkit intelligence flake classify`.

This PR closes the ingestion-contract gap without falsely treating example CI data as trusted repository history. It allows RepoMemory to record validated instability context only when a caller supplies an explicit read-only evidence input.

## Trust boundary
- Input contract: existing `sdetkit.intelligence.flake.v1` classification report.
- Accepted evidence source kinds: explicit review input or future trusted-main artifact input.
- Evidence handling: read-only validation and normalization.
- Current failing-test suppression: false.
- Automatic quarantine: false.
- Automatic rerun: false.
- Automatic patching/remediation: false.
- Merge authorization: false.
- Semantic-equivalence claims: false.
- PR Quality workflow wiring: not added in this PR.
- Trusted-main flaky-test producer: not added in this PR.

## Implementation
- `src/sdetkit/flaky_test_registry_evidence.py`
  - Validates flake-classification reports.
  - Keeps only mixed pass/fail flaky observations with stable test ID and fingerprint.
  - Emits deterministic JSON and Markdown evidence artifacts.
  - Removes legacy quarantine-style advice from the normalized registry output.
  - Encodes explicit no-authority fields.

- `src/sdetkit/repo_memory.py`
  - Advances the schema to `sdetkit.repo_memory.v5`.
  - Accepts optional `--flaky-test-registry-evidence` input.
  - Ingests validated registry entries as `instability_context_only`.
  - Fails closed on authority-expanding registry evidence.
  - Renders registry status and no-suppression/no-automation boundaries.

- `src/sdetkit/reliability_spine_alignment.py`
  - Adds `flaky_test_registry_evidence` as a partially aligned read-only integration layer.
  - Replaces the closed ingestion gap with the remaining trusted-producer/PR Quality visibility gap.
  - Advances the next recommended PR to a provenance-checked trusted flaky-test producer.

- Tests
  - Adds validator, CLI, rendering, and authority-rejection tests.
  - Extends RepoMemory tests for read-only ingestion and fail-closed behavior.
  - Extends reliability-spine tests for the new implemented layer and remaining gap.

## Verification
- Python `3.12.13` fresh virtual environment.
- CLI ingestion smoke through the existing classifier contract:
  - generated `sdetkit.intelligence.flake.v1` evidence;
  - normalized it through `flaky_test_registry_evidence`;
  - ingested it into RepoMemory;
  - confirmed at least one advisory entry;
  - confirmed automatic quarantine, automatic rerun, current-failure suppression, automation, and merge authority are all false.
- Connected Python 3.12 proof:
  - `python -m ruff check src tests`
  - `python -m pytest -q tests/test_flaky_test_registry_evidence.py tests/test_repo_memory.py tests/test_repo_memory_profile_history.py tests/test_trusted_history_evidence.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_action_report.py tests/test_reliability_spine_alignment.py -o addopts=`
  - Result: `78 passed`.
- `python -m mypy src`
- `python -m pre_commit run -a`
- `python scripts/check_generated_artifacts_freshness.py`
  - feature-registry docs table up to date;
  - real-repo adoption goldens up to date.
- Full Python 3.12 truth lane:
  - `COV_FAIL_UNDER=95 bash quality.sh cov`
  - Result: `3605 passed, 1 skipped, 3 deselected`
  - Coverage: `96.69%`
  - Blocking failures: none
  - Merge/release recommendation: `ready-for-merge-review`.

## Risk
- Low-to-medium, read-only evidence ingestion and reporting only.
- This PR does not create a trusted source of flaky-test history.
- This PR intentionally does not wire example CI flake artifacts into PR Quality.
- Invalid or authority-expanding registry evidence fails closed.
- No existing failing test may be hidden, suppressed, quarantined, retried automatically, or converted into merge authority by this layer.

## Rollback
Revert this PR. RepoMemory returns to reporting flaky-test registry evidence as not collected.

## Next
`feature/trusted-flaky-test-registry-producer`

A follow-up should establish a provenance-checked trusted-main flaky-test evidence source before considering PR Quality visibility. It must remain advisory-only and preserve all no-authority boundaries.
