### PR TITLE
Connect trusted-main flaky registry producer

### DIFF
--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -46,6 +46,7 @@ jobs:
             build/repo-memory-history/fixture-report \
             build/repo-memory-history/live-report \
             build/repo-memory-history/pattern-insights \
+            build/repo-memory-history/flaky-test-registry \
             build/repo-memory-history/profile
 
           live_root="${RUNNER_TEMP}/sdetkit-repo-memory-history-live-repositories"
@@ -106,10 +107,18 @@ jobs:
           )
           PY
 
+          PYTHONPATH=src python -m sdetkit.trusted_flaky_test_registry_producer \
+            --source-run-id "${GITHUB_RUN_ID}" \
+            --source-head-sha "${GITHUB_SHA}" \
+            --out-dir build/repo-memory-history/flaky-test-registry \
+            --format json \
+            > build/repo-memory-history/flaky-test-registry-cli.json
+
           PYTHONPATH=src python -m sdetkit.repo_memory \
             --pattern-insights build/repo-memory-history/pattern-insights/pattern-insights.json \
             --benchmark-report build/repo-memory-history/fixture-report/benchmark-report.json \
             --live-benchmark-report build/repo-memory-history/live-report/benchmark-report.json \
+            --flaky-test-registry-evidence build/repo-memory-history/flaky-test-registry/flaky-test-registry-evidence.json \
             --out-dir build/repo-memory-history/profile \
             --format json \
             > build/repo-memory-history/profile-cli.json
@@ -130,6 +139,16 @@ jobs:
           assert profile["proof_provenance"]["expected_failed_scenario_count"] == 5
           assert profile["proof_provenance"]["network_boundary_blocked_scenario_count"] == 1
           assert profile["proof_provenance"]["anti_cheat_rejection_scenario_count"] == 2
+
+          flaky = profile["flaky_test_registry"]
+          assert flaky["collection_status"] == "collected"
+          assert flaky["entry_count"] == 0
+          assert flaky["source"]["kind"] == "trusted_main_artifact"
+          assert flaky["source"]["workflow"] == "RepoMemory Profile History"
+          assert flaky["source"]["observation_status"] == "no_test_observations_available"
+          assert flaky["source"]["observations_collected"] is False
+          assert flaky["decision_boundary"]["automation_allowed"] is False
+          assert flaky["decision_boundary"]["merge_authorized"] is False
 
           boundary = profile["decision_boundary"]
           assert boundary["automation_allowed"] is False
@@ -261,5 +280,6 @@ jobs:
             build/repo-memory-history/live-report/
             build/repo-memory-history/fixture-report/
             build/repo-memory-history/pattern-insights/
+            build/repo-memory-history/flaky-test-registry/
           if-no-files-found: error
           retention-days: 90

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -14,10 +14,13 @@ REPLAYABLE_BENCHMARK_MODULE = "_".join(("replayable", "benchmark", "harness"))
 REPO_MEMORY_PROFILE_HISTORY_MODULE = "_".join(("repo", "memory", "profile", "history"))
 TRUSTED_HISTORY_EVIDENCE_MODULE = "_".join(("trusted", "history", "evidence"))
 FLAKY_TEST_REGISTRY_EVIDENCE_MODULE = "_".join(("flaky", "test", "registry", "evidence"))
+TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE = "_".join(
+    ("trusted", "flaky", "test", "registry", "producer")
+)
 NEXT_RECOMMENDED_PR = "/".join(
     (
         "feature",
-        "-".join(("trusted", "flaky", "test", "registry", "producer")),
+        "-".join(("trusted", "flaky", "test", "observation", "capture")),
     )
 )
 
@@ -446,6 +449,24 @@ def build_alignment_components() -> list[AlignmentComponent]:
             recommended_next_action="keep live benchmark evidence reporting-only until containment is proven",
         ),
         _component(
+            module=TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
+            role="emit an explicit trusted-main no-observation flaky-test registry artifact until real per-test history exists",
+            status="aligned",
+            stages=("evidence", "history", "reporting"),
+            existing_artifacts=(
+                "trusted-flaky-test-registry-producer.json",
+                "trusted-flaky-test-registry-producer.md",
+                "flaky-test-registry-evidence.json",
+                "flaky-test-registry-evidence.md",
+            ),
+            integration_points=(
+                "RepoMemory Profile History workflow",
+                FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
+                "repo_memory",
+            ),
+            recommended_next_action="add a provenance-checked per-test observation source before emitting populated registry entries",
+        ),
+        _component(
             module=FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
             role="normalize read-only flaky-test classification evidence for advisory RepoMemory ingestion",
             status="partially_aligned",
@@ -454,11 +475,15 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "flaky-test-registry-evidence.json",
                 "flaky-test-registry-evidence.md",
             ),
-            integration_points=("intelligence flake classify", "repo_memory"),
-            gaps=(
-                "trusted-main flaky-test evidence producer and PR Quality visibility are not yet connected",
+            integration_points=(
+                "intelligence flake classify",
+                TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
+                "repo_memory",
             ),
-            recommended_next_action="connect only provenance-checked trusted-main instability evidence",
+            gaps=(
+                "trusted per-test observation capture and PR Quality visibility are not yet connected",
+            ),
+            recommended_next_action="connect only provenance-checked observations before rendering populated instability history",
         ),
         _component(
             module="repo_memory",
@@ -477,10 +502,12 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "protected_verifier",
                 "pr_quality_runtime_proof_artifacts",
                 REPO_MEMORY_PROFILE_HISTORY_MODULE,
+                FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
+                TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "trusted-main flaky-test evidence producer and PR Quality visibility remain unconnected",
+                "trusted per-test observation capture and PR Quality visibility remain unconnected",
             ),
             recommended_next_action="surface only provenance-checked flaky-test instability context without expanding authority",
         ),
@@ -496,6 +523,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             integration_points=(
                 "repo_memory",
+                TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
                 TRUSTED_HISTORY_EVIDENCE_MODULE,
                 "RepoMemory Profile History workflow",
             ),

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -349,10 +349,23 @@ def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
         raise ValueError("flaky-test registry evidence source kind is not supported")
     if not source_reference:
         raise ValueError("flaky-test registry evidence source reference is required")
+    if _string(source.get("classification_schema")) != "sdetkit.intelligence.flake.v1":
+        raise ValueError("flaky-test registry classification schema is not supported")
     if not _bool(source.get("input_read_only")):
         raise ValueError("flaky-test registry evidence input must be read-only")
     if _bool(source.get("commands_executed_by_reader")):
         raise ValueError("flaky-test registry evidence reader cannot execute commands")
+
+    observation_status = _string(source.get("observation_status"))
+    if source_kind == "trusted_main_artifact":
+        if _string(source.get("workflow")) != "RepoMemory Profile History":
+            raise ValueError("trusted-main flaky-test registry workflow is not supported")
+        if not _string(source.get("run_id")) or not _string(source.get("head_sha")):
+            raise ValueError("trusted-main flaky-test registry provenance is incomplete")
+        if observation_status != "no_test_observations_available":
+            raise ValueError("trusted-main flaky-test registry observation status is not supported")
+        if _bool(source.get("observations_collected")):
+            raise ValueError("trusted-main no-observation registry cannot claim observations")
 
     boundary = _as_dict(payload.get("decision_boundary"))
     expanded = [key for key in denied if _bool(boundary.get(key))]
@@ -411,20 +424,35 @@ def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
         raise ValueError("flaky-test registry evidence summary entry count is inconsistent")
     if _int(summary.get("flaky_test_count")) != len(entries):
         raise ValueError("flaky-test registry evidence summary flaky count is inconsistent")
+    if source_kind == "trusted_main_artifact" and entries:
+        raise ValueError("trusted-main no-observation registry cannot contain entries")
+
+    normalized_source: JsonObject = {
+        "kind": source_kind,
+        "reference": source_reference,
+        "classification_schema": _string(source.get("classification_schema")),
+        "input_read_only": True,
+        "commands_executed_by_reader": False,
+    }
+    if source_kind == "trusted_main_artifact":
+        normalized_source.update(
+            {
+                "workflow": _string(source.get("workflow")),
+                "run_id": _string(source.get("run_id")),
+                "head_sha": _string(source.get("head_sha")),
+                "observation_status": observation_status,
+                "observations_collected": False,
+            }
+        )
 
     return {
         "collection_status": "collected",
         "status": "advisory_registry_collected",
-        "source": {
-            "kind": source_kind,
-            "reference": source_reference,
-            "classification_schema": _string(source.get("classification_schema")),
-            "input_read_only": True,
-            "commands_executed_by_reader": False,
-        },
+        "source": normalized_source,
         "entries": entries,
         "entry_count": len(entries),
-        "note": (
+        "note": _string(payload.get("note"))
+        or (
             "Flaky-test evidence is advisory context only and cannot suppress "
             "a current failing contract."
         ),
@@ -582,7 +610,8 @@ def build_repo_memory_profile(
             ),
         },
         "recommended_next_action": (
-            "Surface runtime-proof and anti-cheat artifacts in PR Quality before any automation wiring."
+            "Establish trusted per-test observation capture before surfacing "
+            "populated flaky-test history in PR Quality."
         ),
     }
 
@@ -593,6 +622,7 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
     provenance = _as_dict(profile.get("proof_provenance"))
     failure_patterns = _as_dict(profile.get("failure_patterns"))
     flaky = _as_dict(profile.get("flaky_test_registry"))
+    flaky_source = _as_dict(flaky.get("source"))
     boundary = _as_dict(profile.get("decision_boundary"))
 
     lines = [
@@ -703,6 +733,11 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
             "",
             f"- Collection status: `{_string(flaky.get('collection_status'))}`",
             f"- Status: `{_string(flaky.get('status'))}`",
+            f"- Source kind: `{_string(flaky_source.get('kind')) or 'not_reported'}`",
+            (
+                "- Observation status: "
+                f"`{_string(flaky_source.get('observation_status')) or 'not_reported'}`"
+            ),
             f"- Entries: `{len(_as_list(flaky.get('entries')))}`",
             (
                 "- Automatic quarantine allowed: "

--- a/src/sdetkit/trusted_flaky_test_registry_producer.py
+++ b/src/sdetkit/trusted_flaky_test_registry_producer.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.flaky_test_registry_evidence import (
+    SOURCE_SCHEMA_VERSION,
+    build_flaky_test_registry_evidence,
+    write_evidence,
+)
+
+SCHEMA_VERSION = "sdetkit.trusted_flaky_test_registry_producer.v1"
+SOURCE_WORKFLOW = "RepoMemory Profile History"
+SOURCE_CONNECTED = "trusted_main_source_connected"
+NO_TEST_OBSERVATIONS = "no_test_observations_available"
+
+DEFAULT_OUT_DIR = Path("build") / "trusted-flaky-test-registry"
+PRODUCER_JSON = "trusted-flaky-test-registry-producer.json"
+PRODUCER_MD = "trusted-flaky-test-registry-producer.md"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _empty_classification_report() -> JsonObject:
+    return {
+        "schema_version": SOURCE_SCHEMA_VERSION,
+        "tests": [],
+        "summary": {
+            "flaky": 0,
+            "stable_failing": 0,
+            "stable_passing": 0,
+        },
+    }
+
+
+def build_trusted_registry_evidence(
+    *,
+    source_run_id: str,
+    source_head_sha: str,
+) -> JsonObject:
+    run_id = _string(source_run_id)
+    head_sha = _string(source_head_sha)
+    if not run_id:
+        raise ValueError("trusted flaky-test producer source_run_id is required")
+    if not head_sha:
+        raise ValueError("trusted flaky-test producer source_head_sha is required")
+
+    evidence = build_flaky_test_registry_evidence(
+        classification_report=_empty_classification_report(),
+        source_kind="trusted_main_artifact",
+        source_reference=f"{SOURCE_WORKFLOW}:run={run_id}:head={head_sha}",
+    )
+
+    source = _as_dict(evidence.get("source"))
+    source.update(
+        {
+            "workflow": SOURCE_WORKFLOW,
+            "run_id": run_id,
+            "head_sha": head_sha,
+            "observation_status": NO_TEST_OBSERVATIONS,
+            "observations_collected": False,
+        }
+    )
+    evidence["source"] = source
+
+    summary = _as_dict(evidence.get("summary"))
+    summary.update(
+        {
+            "observation_status": NO_TEST_OBSERVATIONS,
+            "observation_count": 0,
+        }
+    )
+    evidence["summary"] = summary
+    evidence["note"] = (
+        "Trusted-main producer is connected, but no per-test observation "
+        "history source is available; no flaky-test entries are claimed."
+    )
+    return evidence
+
+
+def build_producer_report(evidence: Mapping[str, Any]) -> JsonObject:
+    source = _as_dict(evidence.get("source"))
+    summary = _as_dict(evidence.get("summary"))
+    boundary = _as_dict(evidence.get("decision_boundary"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": SOURCE_CONNECTED,
+        "source": dict(source),
+        "registry": {
+            "schema_version": _string(evidence.get("schema_version")),
+            "collection_status": _string(evidence.get("collection_status")),
+            "status": _string(evidence.get("status")),
+            "entry_count": int(summary.get("entry_count", 0)),
+            "observation_status": _string(summary.get("observation_status")),
+            "observation_count": int(summary.get("observation_count", 0)),
+        },
+        "decision_boundary": dict(boundary),
+        "note": _string(evidence.get("note")),
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    source = _as_dict(report.get("source"))
+    registry = _as_dict(report.get("registry"))
+    boundary = _as_dict(report.get("decision_boundary"))
+    return "\n".join(
+        [
+            "# Trusted-main flaky-test registry producer",
+            "",
+            f"- Status: `{_string(report.get('status'))}`",
+            f"- Source workflow: `{_string(source.get('workflow'))}`",
+            f"- Source run id: `{_string(source.get('run_id'))}`",
+            f"- Source head sha: `{_string(source.get('head_sha'))}`",
+            f"- Observation status: `{_string(registry.get('observation_status'))}`",
+            f"- Observation count: `{int(registry.get('observation_count', 0))}`",
+            f"- Registry entries: `{int(registry.get('entry_count', 0))}`",
+            "",
+            "## Boundary",
+            "",
+            "- No flaky-test observations are claimed without a trusted observation source.",
+            (
+                "- Automatic quarantine allowed: "
+                f"`{str(bool(boundary.get('automatic_quarantine_allowed'))).lower()}`"
+            ),
+            (
+                "- Automatic rerun allowed: "
+                f"`{str(bool(boundary.get('automatic_rerun_allowed'))).lower()}`"
+            ),
+            (
+                "- Current failure suppression allowed: "
+                f"`{str(bool(boundary.get('current_failure_suppression_allowed'))).lower()}`"
+            ),
+            (f"- Automation allowed: `{str(bool(boundary.get('automation_allowed'))).lower()}`"),
+            (f"- Merge authorized: `{str(bool(boundary.get('merge_authorized'))).lower()}`"),
+            "",
+        ]
+    )
+
+
+def write_artifacts(
+    evidence: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    out_dir: Path,
+) -> dict[str, str]:
+    artifacts = write_evidence(evidence, out_dir=out_dir)
+    producer_json = out_dir / PRODUCER_JSON
+    producer_markdown = out_dir / PRODUCER_MD
+    producer_json.write_text(
+        json.dumps(dict(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    producer_markdown.write_text(render_markdown(report), encoding="utf-8")
+    artifacts["producer_json"] = producer_json.as_posix()
+    artifacts["producer_markdown"] = producer_markdown.as_posix()
+    return artifacts
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.trusted_flaky_test_registry_producer")
+    parser.add_argument("--source-run-id", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        evidence = build_trusted_registry_evidence(
+            source_run_id=args.source_run_id,
+            source_head_sha=args.source_head_sha,
+        )
+        report = build_producer_report(evidence)
+        artifacts = write_artifacts(evidence, report, out_dir=args.out_dir)
+    except (OSError, ValueError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": report["status"],
+                    "artifacts": artifacts,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"status={report['status']}")
+        for key, value in artifacts.items():
+            print(f"{key}={value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -9,6 +9,7 @@ from sdetkit.reliability_spine_alignment import (
     PR_QUALITY_LIVE_WORKSPACE_MODULE,
     REPO_MEMORY_PROFILE_HISTORY_MODULE,
     SPINE_STAGES,
+    TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
     TRUSTED_HISTORY_EVIDENCE_MODULE,
     build_alignment_components,
     build_alignment_report,
@@ -42,6 +43,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE in modules
     assert TRUSTED_HISTORY_EVIDENCE_MODULE in modules
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in modules
+    assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -80,6 +82,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE not in gaps_by_module
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE not in gaps_by_module
     assert TRUSTED_HISTORY_EVIDENCE_MODULE not in gaps_by_module
+    assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
@@ -92,9 +95,9 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert any("containment" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
-    assert any("flaky-test evidence producer" in gap for gap in gaps_by_module["repo_memory"])
+    assert any("per-test observation capture" in gap for gap in gaps_by_module["repo_memory"])
     assert any(
-        "trusted-main flaky-test evidence producer" in gap
+        "trusted per-test observation capture" in gap
         for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
     )
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
@@ -125,6 +128,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{REPO_MEMORY_PROFILE_HISTORY_MODULE}`: `aligned`" in markdown
     assert f"`{TRUSTED_HISTORY_EVIDENCE_MODULE}`: `aligned`" in markdown
     assert f"`{FLAKY_TEST_REGISTRY_EVIDENCE_MODULE}`: `partially_aligned`" in markdown
+    assert f"`{TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE}`: `aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -203,6 +207,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         REPO_MEMORY_PROFILE_HISTORY_MODULE,
         TRUSTED_HISTORY_EVIDENCE_MODULE,
         FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
+        TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -22,6 +22,10 @@ from sdetkit.repo_memory import (
     main,
     render_markdown,
 )
+from sdetkit.trusted_flaky_test_registry_producer import (
+    NO_TEST_OBSERVATIONS,
+    build_trusted_registry_evidence,
+)
 
 FIXTURES = Path("tests/fixtures/remediation_benchmark")
 SCENARIOS = [
@@ -562,3 +566,80 @@ def test_repo_memory_cli_accepts_advisory_flaky_registry_evidence(
     assert saved["flaky_test_registry"]["entry_count"] == 1
     assert saved["flaky_test_registry"]["decision_boundary"]["automation_allowed"] is False
     assert "Current failure suppression allowed: `false`" in markdown
+
+
+def test_repo_memory_ingests_trusted_main_no_observation_registry_without_claims() -> None:
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=_benchmark_report(),
+        flaky_test_registry_evidence=build_trusted_registry_evidence(
+            source_run_id="run-1417",
+            source_head_sha="a5545fa1",
+        ),
+    )
+
+    flaky = profile["flaky_test_registry"]
+    assert flaky["collection_status"] == "collected"
+    assert flaky["entry_count"] == 0
+    assert flaky["entries"] == []
+    assert flaky["source"]["kind"] == "trusted_main_artifact"
+    assert flaky["source"]["observation_status"] == NO_TEST_OBSERVATIONS
+    assert flaky["source"]["observations_collected"] is False
+    assert flaky["decision_boundary"]["automation_allowed"] is False
+    assert flaky["decision_boundary"]["merge_authorized"] is False
+    assert "trusted per-test observation capture" in profile["recommended_next_action"]
+
+
+def test_repo_memory_rejects_unsupported_flaky_classification_schema() -> None:
+    evidence = _flaky_registry_evidence()
+    evidence["source"]["classification_schema"] = "unsupported.classification.v1"
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            flaky_test_registry_evidence=evidence,
+        )
+    except ValueError as exc:
+        assert "classification schema is not supported" in str(exc)
+    else:
+        raise AssertionError("expected unsupported classification schema to be rejected")
+
+
+def test_repo_memory_rejects_entries_in_trusted_no_observation_registry() -> None:
+    evidence = build_trusted_registry_evidence(
+        source_run_id="run-1417",
+        source_head_sha="a5545fa1",
+    )
+    evidence["entries"] = [_flaky_registry_evidence()["entries"][0]]
+    evidence["summary"]["entry_count"] = 1
+    evidence["summary"]["flaky_test_count"] = 1
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            flaky_test_registry_evidence=evidence,
+        )
+    except ValueError as exc:
+        assert "no-observation registry cannot contain entries" in str(exc)
+    else:
+        raise AssertionError("expected false trusted-main entry claim to be rejected")
+
+
+def test_repo_memory_markdown_renders_trusted_no_observation_status() -> None:
+    markdown = render_markdown(
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            flaky_test_registry_evidence=build_trusted_registry_evidence(
+                source_run_id="run-1417",
+                source_head_sha="a5545fa1",
+            ),
+        )
+    )
+
+    assert "Source kind: `trusted_main_artifact`" in markdown
+    assert "Observation status: `no_test_observations_available`" in markdown
+    assert "Entries: `0`" in markdown
+    assert "Automation allowed by flaky-test history: `false`" in markdown

--- a/tests/test_repo_memory_profile_history_workflow.py
+++ b/tests/test_repo_memory_profile_history_workflow.py
@@ -28,10 +28,11 @@ def test_repo_memory_history_builds_fresh_live_profile_from_merged_code() -> Non
 
     workspace = text.index("python -m sdetkit.pr_quality_live_benchmark_workspace")
     live_report = text.index("python -m sdetkit.replayable_benchmark_harness")
+    producer = text.index("python -m sdetkit.trusted_flaky_test_registry_producer")
     profile = text.index("python -m sdetkit.repo_memory")
     history = text.index("python -m sdetkit.repo_memory_profile_history")
 
-    assert workspace < live_report < profile < history
+    assert workspace < live_report < producer < profile < history
     assert "${RUNNER_TEMP}/sdetkit-repo-memory-history-live-repositories" in text
     assert (
         "--live-benchmark-report build/repo-memory-history/live-report/benchmark-report.json"
@@ -41,6 +42,17 @@ def test_repo_memory_history_builds_fresh_live_profile_from_merged_code() -> Non
     assert 'assert boundary["automation_allowed"] is False' in text
     assert 'assert boundary["merge_authorized"] is False' in text
     assert 'assert boundary["semantic_equivalence_proven"] is False' in text
+    assert '--source-run-id "${GITHUB_RUN_ID}"' in text
+    assert '--source-head-sha "${GITHUB_SHA}"' in text
+    assert (
+        "--flaky-test-registry-evidence build/repo-memory-history/flaky-test-registry/flaky-test-registry-evidence.json"
+        in text
+    )
+    assert 'assert flaky["entry_count"] == 0' in text
+    assert (
+        'assert flaky["source"]["observation_status"] == "no_test_observations_available"' in text
+    )
+    assert 'assert flaky["source"]["observations_collected"] is False' in text
 
 
 def test_repo_memory_history_imports_only_successful_ancestor_main_history() -> None:
@@ -64,6 +76,7 @@ def test_repo_memory_history_uploads_snapshot_without_repository_mutation() -> N
     assert "Upload trusted main RepoMemory history artifact" in text
     assert "name: repo-memory-profile-history" in text
     assert "build/repo-memory-history/output/" in text
+    assert "build/repo-memory-history/flaky-test-registry/" in text
     assert "repo-memory-profile-history.jsonl" in text
     assert "git add " not in text
     assert "git commit " not in text
@@ -79,3 +92,11 @@ def test_repo_memory_history_verifies_no_authority_boundary() -> None:
     assert 'assert boundary["merge_authorized"] is False' in text
     assert 'assert boundary["semantic_equivalence_proven"] is False' in text
     assert 'assert boundary["prior_history_is_read_only_input"] is True' in text
+
+
+def test_repo_memory_history_never_uses_example_flake_history_as_trusted_evidence() -> None:
+    text = _workflow_text()
+
+    assert "python -m sdetkit.trusted_flaky_test_registry_producer" in text
+    assert "examples/kits/intelligence/flake-history.json" not in text
+    assert "python -m sdetkit intelligence flake classify" not in text

--- a/tests/test_trusted_flaky_test_registry_producer.py
+++ b/tests/test_trusted_flaky_test_registry_producer.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.trusted_flaky_test_registry_producer import (
+    NO_TEST_OBSERVATIONS,
+    SOURCE_CONNECTED,
+    build_producer_report,
+    build_trusted_registry_evidence,
+    main,
+    render_markdown,
+)
+
+
+def test_trusted_producer_emits_explicit_no_observation_registry_without_authority() -> None:
+    evidence = build_trusted_registry_evidence(
+        source_run_id="run-1417",
+        source_head_sha="a5545fa1",
+    )
+
+    assert evidence["collection_status"] == "collected"
+    assert evidence["status"] == "advisory_registry_collected"
+    assert evidence["entries"] == []
+    assert evidence["summary"]["entry_count"] == 0
+    assert evidence["summary"]["observation_status"] == NO_TEST_OBSERVATIONS
+    assert evidence["source"]["kind"] == "trusted_main_artifact"
+    assert evidence["source"]["workflow"] == "RepoMemory Profile History"
+    assert evidence["source"]["observations_collected"] is False
+    assert evidence["source"]["observation_status"] == NO_TEST_OBSERVATIONS
+
+    boundary = evidence["decision_boundary"]
+    assert boundary["automatic_quarantine_allowed"] is False
+    assert boundary["automatic_rerun_allowed"] is False
+    assert boundary["current_failure_suppression_allowed"] is False
+    assert boundary["automation_allowed"] is False
+    assert boundary["merge_authorized"] is False
+
+
+def test_trusted_producer_rejects_missing_workflow_provenance() -> None:
+    with pytest.raises(ValueError, match="source_run_id is required"):
+        build_trusted_registry_evidence(source_run_id="", source_head_sha="a5545fa1")
+
+    with pytest.raises(ValueError, match="source_head_sha is required"):
+        build_trusted_registry_evidence(source_run_id="run-1417", source_head_sha="")
+
+
+def test_trusted_producer_report_explains_no_claim_boundary() -> None:
+    report = build_producer_report(
+        build_trusted_registry_evidence(
+            source_run_id="run-1417",
+            source_head_sha="a5545fa1",
+        )
+    )
+    markdown = render_markdown(report)
+
+    assert report["status"] == SOURCE_CONNECTED
+    assert report["registry"]["observation_count"] == 0
+    assert "# Trusted-main flaky-test registry producer" in markdown
+    assert "Observation status: `no_test_observations_available`" in markdown
+    assert "No flaky-test observations are claimed" in markdown
+    assert "Automation allowed: `false`" in markdown
+
+
+def test_trusted_producer_cli_writes_registry_and_producer_artifacts(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out_dir = tmp_path / "trusted-registry"
+
+    rc = main(
+        [
+            "--source-run-id",
+            "run-1417",
+            "--source-head-sha",
+            "a5545fa1",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    registry = json.loads(
+        (out_dir / "flaky-test-registry-evidence.json").read_text(encoding="utf-8")
+    )
+    report = json.loads(
+        (out_dir / "trusted-flaky-test-registry-producer.json").read_text(encoding="utf-8")
+    )
+    markdown = (out_dir / "trusted-flaky-test-registry-producer.md").read_text(encoding="utf-8")
+
+    assert printed["status"] == SOURCE_CONNECTED
+    assert registry["source"]["observation_status"] == NO_TEST_OBSERVATIONS
+    assert registry["entries"] == []
+    assert report["registry"]["entry_count"] == 0
+    assert "Current failure suppression allowed: `false`" in markdown


### PR DESCRIPTION
## Summary
- Adds `trusted_flaky_test_registry_producer`, a trusted-main producer contract for RepoMemory flaky-test evidence.
- Wires the producer into the existing `RepoMemory Profile History` workflow on accepted `main` pushes.
- Emits an explicit collected registry with `no_test_observations_available` and zero entries until a truthful per-test observation source exists.
- Extends RepoMemory ingestion to validate flaky-test classification schema and trusted-main provenance before accepting evidence.
- Records the new connected producer in the reliability-spine audit and advances the remaining gap to trusted per-test observation capture.

## Why
PR #1417 added read-only flaky-test registry ingestion into RepoMemory, but intentionally left the trusted-main producer unconnected.

The repository currently has no trusted per-test rerun-history source. The only existing flake-history input is demonstration data used by the intelligence classifier examples and tests. This PR closes the producer connection honestly: accepted-main history now emits a provenance-checked registry artifact, while explicitly claiming that no test observations are available yet.

## Trust boundary
This PR does **not** claim that any test is flaky.

The trusted-main producer emits:

- `source.kind=trusted_main_artifact`
- `source.workflow=RepoMemory Profile History`
- source run ID and accepted-main head SHA provenance
- `source.classification_schema=sdetkit.intelligence.flake.v1`
- `source.observation_status=no_test_observations_available`
- `source.observations_collected=false`
- zero registry entries

The following boundaries remain false:

- automatic quarantine
- automatic rerun
- current-failure suppression
- automation authority
- merge authority
- semantic-equivalence proof

Example flake-history data is not used as trusted-main evidence.

## Implementation
### Trusted producer
- Adds `src/sdetkit/trusted_flaky_test_registry_producer.py`.
- Builds a deterministic trusted-main registry evidence artifact.
- Emits JSON and Markdown producer reports.
- Requires source run ID and source head SHA.
- Produces zero observation claims until a trusted observation source is implemented.

### RepoMemory ingestion hardening
- Validates `source.classification_schema` before ingesting registry evidence.
- Validates trusted-main producer provenance fields.
- Rejects trusted-main no-observation artifacts that attempt to include registry entries.
- Renders source kind and observation status in the RepoMemory Markdown profile.
- Updates the recommended next action to require trusted per-test observation capture before populated PR Quality visibility.

### Accepted-main workflow wiring
- Runs `trusted_flaky_test_registry_producer` inside `.github/workflows/repo-memory-history.yml`.
- Passes its evidence artifact into `sdetkit.repo_memory`.
- Verifies zero entries, no observations claimed, and no authority granted.
- Uploads the trusted flaky-test registry artifacts alongside the RepoMemory history output.

### Reliability-spine alignment
- Adds `trusted_flaky_test_registry_producer` as an aligned reporting/history component.
- Replaces the producer gap with the remaining trusted per-test observation-capture gap.
- Advances the next recommended PR to `feature/trusted-flaky-test-observation-capture`.

## Verification
### Workflow-equivalent producer chain
Executed under Python `3.12.13`:

1. Built fixture and Git-grounded live benchmark inputs.
2. Produced a trusted-main flaky registry artifact.
3. Ingested it into RepoMemory.
4. Recorded the RepoMemory trusted history snapshot.
5. Asserted:
   - `trusted_observation_claims=0`
   - `flaky_registry_entries=0`
   - `automation_authority=false`
   - `merge_authority=false`
   - automatic quarantine, rerun, and current-failure suppression are false.

### Connected proof
- `ruff check` passed.
- Connected test lane passed: `56 passed`.
- `mypy src` passed.
- `pre_commit run -a` passed.
- `scripts/check_generated_artifacts_freshness.py` passed:
  - feature-registry docs table is up to date;
  - real-repo adoption goldens are up to date.

### Final Python 3.12 truth lane
Executed once after branch scope stabilized:

- `COV_FAIL_UNDER=95 bash quality.sh cov`
- Result: `3618 passed, 1 skipped, 3 deselected`
- Coverage: `96.69%`
- Blocking failures: none
- Recommendation: `ready-for-merge-review`

## Scope
Files changed:

- `.github/workflows/repo-memory-history.yml`
- `src/sdetkit/reliability_spine_alignment.py`
- `src/sdetkit/repo_memory.py`
- `src/sdetkit/trusted_flaky_test_registry_producer.py`
- `tests/test_reliability_spine_alignment.py`
- `tests/test_repo_memory.py`
- `tests/test_repo_memory_profile_history_workflow.py`
- `tests/test_trusted_flaky_test_registry_producer.py`

## Risk
Low-to-medium, reporting and trusted-history wiring only.

The primary risk would be falsely treating untrusted or example data as accepted-main flaky-test evidence. This PR prevents that by producing an explicit no-observation registry, testing that the workflow never references example flake-history input, and failing closed on unsupported provenance or false entry claims.

## Rollback
Revert this PR. RepoMemory retains the PR #1417 advisory registry ingestion capability, while trusted-main history returns to generating profiles without a connected flaky-test registry producer.

## Next
`feature/trusted-flaky-test-observation-capture`

That follow-up may add a real provenance-checked per-test observation source. Until such evidence exists, populated flaky-test history and PR Quality visibility must remain unimplemented.
