### PR TITLE
Capture trusted-main raw test observations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fast-ci, smoke-install, repo-audit]
     env:
-      PYTEST_ADDOPTS: "-n auto --junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml"
+      PYTEST_ADDOPTS: "-n auto"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -294,6 +294,7 @@ jobs:
         id: coverage
         env:
           COV_FAIL_UNDER: "95"
+          PYTEST_ADDOPTS: "-n auto --junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml"
         run: bash quality.sh cov
 
       - name: Normalize trusted-main test observations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fast-ci, smoke-install, repo-audit]
     env:
-      PYTEST_ADDOPTS: "-n auto"
+      PYTEST_ADDOPTS: "-n auto --junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -287,10 +287,50 @@ jobs:
       - name: Pre-commit
         run: python -m pre_commit run -a
 
+      - name: Prepare ephemeral test-observation input directory
+        run: mkdir -p "${RUNNER_TEMP}/sdetkit-trusted-test-input"
+
       - name: Coverage gate
+        id: coverage
         env:
           COV_FAIL_UNDER: "95"
         run: bash quality.sh cov
+
+      - name: Normalize trusted-main test observations
+        id: trusted_observations
+        if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.coverage.outcome != 'skipped' }}
+        run: |
+          if [[ ! -s "${RUNNER_TEMP}/sdetkit-trusted-test-input/junit.xml" ]]; then
+            echo "trusted_test_observations=not_available_no_junit"
+            echo "artifact_written=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          PYTHONPATH=src python -m sdetkit.trusted_test_observation_capture \
+            --junit-xml "${RUNNER_TEMP}/sdetkit-trusted-test-input/junit.xml" \
+            --source-workflow "CI" \
+            --source-job "Full CI lane" \
+            --source-run-id "${GITHUB_RUN_ID}" \
+            --source-head-sha "${GITHUB_SHA}" \
+            --event-name "${GITHUB_EVENT_NAME}" \
+            --ref-name "${GITHUB_REF}" \
+            --out-dir build/trusted-test-observations \
+            --format json \
+            > build/trusted-test-observations-cli.json
+
+          echo "artifact_written=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload trusted-main test observation artifact
+        if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.trusted_observations.outputs.artifact_written == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: trusted-test-observations
+          path: |
+            build/trusted-test-observations/trusted-test-observations.json
+            build/trusted-test-observations/trusted-test-observations.md
+            build/trusted-test-observations-cli.json
+          retention-days: 90
+          if-no-files-found: error
 
       - name: Docs build
         run: NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -17,10 +17,11 @@ FLAKY_TEST_REGISTRY_EVIDENCE_MODULE = "_".join(("flaky", "test", "registry", "ev
 TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE = "_".join(
     ("trusted", "flaky", "test", "registry", "producer")
 )
+TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE = "_".join(("trusted", "test", "observation", "capture"))
 NEXT_RECOMMENDED_PR = "/".join(
     (
         "feature",
-        "-".join(("trusted", "flaky", "test", "observation", "capture")),
+        "-".join(("trusted", "flaky", "test", "observation", "history")),
     )
 )
 
@@ -449,6 +450,21 @@ def build_alignment_components() -> list[AlignmentComponent]:
             recommended_next_action="keep live benchmark evidence reporting-only until containment is proven",
         ),
         _component(
+            module=TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
+            role="normalize raw per-test outcomes from real accepted-main Full CI execution without classifying flakiness",
+            status="aligned",
+            stages=("evidence", "reporting"),
+            existing_artifacts=(
+                "trusted-test-observations.json",
+                "trusted-test-observations.md",
+            ),
+            integration_points=(
+                "CI Full CI lane",
+                "quality.sh cov",
+            ),
+            recommended_next_action="aggregate accepted-main observations across trusted runs before any flaky-test classification",
+        ),
+        _component(
             module=TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
             role="emit an explicit trusted-main no-observation flaky-test registry artifact until real per-test history exists",
             status="aligned",
@@ -464,7 +480,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
                 "repo_memory",
             ),
-            recommended_next_action="add a provenance-checked per-test observation source before emitting populated registry entries",
+            recommended_next_action="consume only provenance-checked accepted-main observation history after cross-run aggregation is proven",
         ),
         _component(
             module=FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
@@ -481,9 +497,9 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "repo_memory",
             ),
             gaps=(
-                "trusted per-test observation capture and PR Quality visibility are not yet connected",
+                "accepted-main observation history aggregation, flaky-classification handoff, and PR Quality visibility are not yet connected",
             ),
-            recommended_next_action="connect only provenance-checked observations before rendering populated instability history",
+            recommended_next_action="connect only cross-run provenance-checked classifications before rendering populated instability history",
         ),
         _component(
             module="repo_memory",
@@ -504,10 +520,11 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 REPO_MEMORY_PROFILE_HISTORY_MODULE,
                 FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
                 TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
+                TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "trusted per-test observation capture and PR Quality visibility remain unconnected",
+                "accepted-main observation history aggregation, flaky-classification handoff, and PR Quality visibility remain unconnected",
             ),
             recommended_next_action="surface only provenance-checked flaky-test instability context without expanding authority",
         ),

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -610,8 +610,8 @@ def build_repo_memory_profile(
             ),
         },
         "recommended_next_action": (
-            "Establish trusted per-test observation capture before surfacing "
-            "populated flaky-test history in PR Quality."
+            "Establish trusted accepted-main observation history and classification "
+            "handoff before surfacing populated flaky-test history in PR Quality."
         ),
     }
 

--- a/src/sdetkit/trusted_test_observation_capture.py
+++ b/src/sdetkit/trusted_test_observation_capture.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+SCHEMA_VERSION = "sdetkit.trusted_test_observation_capture.v1"
+STATUS = "trusted_main_observations_captured"
+TRUSTED_WORKFLOW = "CI"
+TRUSTED_JOB = "Full CI lane"
+TRUSTED_EVENT = "push"
+TRUSTED_REF = "refs/heads/main"
+
+DEFAULT_OUT_DIR = Path("build") / "trusted-test-observations"
+OBSERVATIONS_JSON = "trusted-test-observations.json"
+OBSERVATIONS_MD = "trusted-test-observations.md"
+
+JsonObject = dict[str, Any]
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _validate_trusted_main_source(
+    *,
+    source_workflow: str,
+    source_job: str,
+    source_run_id: str,
+    source_head_sha: str,
+    event_name: str,
+    ref_name: str,
+) -> JsonObject:
+    workflow = _text(source_workflow)
+    job = _text(source_job)
+    run_id = _text(source_run_id)
+    head_sha = _text(source_head_sha)
+    event = _text(event_name)
+    ref = _text(ref_name)
+
+    if workflow != TRUSTED_WORKFLOW:
+        raise ValueError("trusted test observation workflow is not supported")
+    if job != TRUSTED_JOB:
+        raise ValueError("trusted test observation job is not supported")
+    if event != TRUSTED_EVENT or ref != TRUSTED_REF:
+        raise ValueError("trusted test observations require a main push source")
+    if not run_id:
+        raise ValueError("trusted test observation source_run_id is required")
+    if not head_sha:
+        raise ValueError("trusted test observation source_head_sha is required")
+
+    return {
+        "workflow": workflow,
+        "job": job,
+        "run_id": run_id,
+        "head_sha": head_sha,
+        "event_name": event,
+        "ref_name": ref,
+        "input_kind": "junit_xml",
+        "identity_handling": "sha256_fingerprint_only",
+        "input_read_only": True,
+        "commands_executed_by_reader": False,
+        "trusted_main": True,
+    }
+
+
+def _load_junit_root(path: Path) -> ET.Element:
+    if not path.exists():
+        raise ValueError("trusted test observation JUnit XML input does not exist")
+    try:
+        return ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        raise ValueError("trusted test observation JUnit XML is malformed") from exc
+
+
+def _outcome(testcase: ET.Element) -> str:
+    if testcase.find("failure") is not None:
+        return "failed"
+    if testcase.find("error") is not None:
+        return "error"
+    if testcase.find("skipped") is not None:
+        return "skipped"
+    return "passed"
+
+
+def _observation(testcase: ET.Element) -> JsonObject:
+    classname = _text(testcase.attrib.get("classname"))
+    name = _text(testcase.attrib.get("name"))
+    if not classname or not name:
+        raise ValueError("trusted test observation testcase lacks classname or name")
+
+    identity = f"{classname}::{name}"
+    return {
+        "test_fingerprint": hashlib.sha256(identity.encode("utf-8")).hexdigest(),
+        "outcome": _outcome(testcase),
+    }
+
+
+def build_observation_report(
+    *,
+    junit_root: ET.Element,
+    source_workflow: str,
+    source_job: str,
+    source_run_id: str,
+    source_head_sha: str,
+    event_name: str,
+    ref_name: str,
+) -> JsonObject:
+    source = _validate_trusted_main_source(
+        source_workflow=source_workflow,
+        source_job=source_job,
+        source_run_id=source_run_id,
+        source_head_sha=source_head_sha,
+        event_name=event_name,
+        ref_name=ref_name,
+    )
+
+    observations = [_observation(testcase) for testcase in junit_root.iter("testcase")]
+    if not observations:
+        raise ValueError("trusted test observation JUnit XML contains no testcase observations")
+
+    observations.sort(key=lambda item: item["test_fingerprint"])
+    fingerprints = [item["test_fingerprint"] for item in observations]
+    if len(fingerprints) != len(set(fingerprints)):
+        raise ValueError("trusted test observation JUnit XML contains duplicate test identities")
+
+    outcomes = Counter(str(item["outcome"]) for item in observations)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": STATUS,
+        "source": source,
+        "observations": observations,
+        "summary": {
+            "observation_count": len(observations),
+            "passed": outcomes["passed"],
+            "failed": outcomes["failed"],
+            "error": outcomes["error"],
+            "skipped": outcomes["skipped"],
+            "flaky_classification_performed": False,
+            "raw_test_identity_emitted": False,
+        },
+        "decision_boundary": {
+            "raw_observation_only": True,
+            "raw_test_identity_emitted": False,
+            "flaky_classification_performed": False,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+        "note": (
+            "This artifact records raw trusted-main test outcomes only. "
+            "It does not classify flakiness or authorize action."
+        ),
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    source = dict(report.get("source", {}))
+    summary = dict(report.get("summary", {}))
+    boundary = dict(report.get("decision_boundary", {}))
+    return "\n".join(
+        [
+            "# Trusted-main test observations",
+            "",
+            f"- Status: `{_text(report.get('status'))}`",
+            f"- Source workflow: `{_text(source.get('workflow'))}`",
+            f"- Source job: `{_text(source.get('job'))}`",
+            f"- Source head sha: `{_text(source.get('head_sha'))}`",
+            f"- Observations: `{int(summary.get('observation_count', 0))}`",
+            f"- Passed: `{int(summary.get('passed', 0))}`",
+            f"- Failed: `{int(summary.get('failed', 0))}`",
+            f"- Errors: `{int(summary.get('error', 0))}`",
+            f"- Skipped: `{int(summary.get('skipped', 0))}`",
+            f"- Identity handling: `{_text(source.get('identity_handling'))}`",
+            "",
+            "## Boundary",
+            "",
+            (
+                "- Raw test identity emitted: "
+                f"`{str(bool(boundary.get('raw_test_identity_emitted'))).lower()}`"
+            ),
+            (
+                "- Flaky classification performed: "
+                f"`{str(bool(boundary.get('flaky_classification_performed'))).lower()}`"
+            ),
+            (
+                "- Current failure suppression allowed: "
+                f"`{str(bool(boundary.get('current_failure_suppression_allowed'))).lower()}`"
+            ),
+            f"- Automation allowed: `{str(bool(boundary.get('automation_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(bool(boundary.get('merge_authorized'))).lower()}`",
+            "",
+        ]
+    )
+
+
+def write_report(report: Mapping[str, Any], *, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / OBSERVATIONS_JSON).write_text(
+        json.dumps(dict(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / OBSERVATIONS_MD).write_text(render_markdown(report), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.trusted_test_observation_capture")
+    parser.add_argument("--junit-xml", type=Path, required=True)
+    parser.add_argument("--source-workflow", required=True)
+    parser.add_argument("--source-job", required=True)
+    parser.add_argument("--source-run-id", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = build_observation_report(
+            junit_root=_load_junit_root(args.junit_xml),
+            source_workflow=args.source_workflow,
+            source_job=args.source_job,
+            source_run_id=args.source_run_id,
+            source_head_sha=args.source_head_sha,
+            event_name=args.event_name,
+            ref_name=args.ref_name,
+        )
+        write_report(report, out_dir=args.out_dir)
+    except (OSError, ValueError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    summary = dict(report["summary"])
+    output = {
+        "status": STATUS,
+        "observation_count": int(summary["observation_count"]),
+        "failed": int(summary["failed"]),
+        "error": int(summary["error"]),
+        "artifact_written": True,
+    }
+    if args.format == "json":
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        for key, value in output.items():
+            print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/trusted_test_observation_capture.py
+++ b/src/sdetkit/trusted_test_observation_capture.py
@@ -62,7 +62,7 @@ def _validate_trusted_main_source(
         "event_name": event,
         "ref_name": ref,
         "input_kind": "junit_xml",
-        "identity_handling": "sha256_fingerprint_only",
+        "identity_handling": "sha256_digest",
         "input_read_only": True,
         "commands_executed_by_reader": False,
         "trusted_main": True,

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -11,6 +11,7 @@ from sdetkit.reliability_spine_alignment import (
     SPINE_STAGES,
     TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
     TRUSTED_HISTORY_EVIDENCE_MODULE,
+    TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
     build_alignment_components,
     build_alignment_report,
     main,
@@ -44,6 +45,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert TRUSTED_HISTORY_EVIDENCE_MODULE in modules
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in modules
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE in modules
+    assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -83,6 +85,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE not in gaps_by_module
     assert TRUSTED_HISTORY_EVIDENCE_MODULE not in gaps_by_module
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE not in gaps_by_module
+    assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
@@ -95,9 +98,9 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert any("containment" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
-    assert any("per-test observation capture" in gap for gap in gaps_by_module["repo_memory"])
+    assert any("observation history aggregation" in gap for gap in gaps_by_module["repo_memory"])
     assert any(
-        "trusted per-test observation capture" in gap
+        "observation history aggregation" in gap
         for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
     )
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
@@ -129,6 +132,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{TRUSTED_HISTORY_EVIDENCE_MODULE}`: `aligned`" in markdown
     assert f"`{FLAKY_TEST_REGISTRY_EVIDENCE_MODULE}`: `partially_aligned`" in markdown
     assert f"`{TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE}`: `aligned`" in markdown
+    assert f"`{TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE}`: `aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -208,6 +212,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         TRUSTED_HISTORY_EVIDENCE_MODULE,
         FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
         TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
+        TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -587,7 +587,7 @@ def test_repo_memory_ingests_trusted_main_no_observation_registry_without_claims
     assert flaky["source"]["observations_collected"] is False
     assert flaky["decision_boundary"]["automation_allowed"] is False
     assert flaky["decision_boundary"]["merge_authorized"] is False
-    assert "trusted per-test observation capture" in profile["recommended_next_action"]
+    assert "trusted accepted-main observation history" in profile["recommended_next_action"]
 
 
 def test_repo_memory_rejects_unsupported_flaky_classification_schema() -> None:

--- a/tests/test_trusted_test_observation_capture.py
+++ b/tests/test_trusted_test_observation_capture.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from sdetkit.trusted_test_observation_capture import (
+    STATUS,
+    build_observation_report,
+    main,
+    render_markdown,
+)
+
+
+def _junit_root() -> ET.Element:
+    return ET.fromstring(
+        """
+        <testsuites>
+          <testsuite name="pytest">
+            <testcase classname="tests.test_alpha" name="test_passes" />
+            <testcase classname="tests.test_alpha" name="test_fails">
+              <failure message="failure text must not be copied">trace</failure>
+            </testcase>
+            <testcase classname="tests.test_beta" name="test_skips">
+              <skipped />
+            </testcase>
+            <testcase classname="tests.test_beta" name="test_errors">
+              <error message="error text must not be copied">trace</error>
+            </testcase>
+          </testsuite>
+        </testsuites>
+        """
+    )
+
+
+def _report() -> dict:
+    return build_observation_report(
+        junit_root=_junit_root(),
+        source_workflow="CI",
+        source_job="Full CI lane",
+        source_run_id="run-1418",
+        source_head_sha="3d601331",
+        event_name="push",
+        ref_name="refs/heads/main",
+    )
+
+
+def test_capture_records_raw_trusted_main_outcomes_without_flake_claims() -> None:
+    report = _report()
+
+    assert report["status"] == STATUS
+    assert report["source"]["trusted_main"] is True
+    assert report["source"]["input_read_only"] is True
+    assert report["summary"]["observation_count"] == 4
+    assert report["summary"]["passed"] == 1
+    assert report["summary"]["failed"] == 1
+    assert report["summary"]["error"] == 1
+    assert report["summary"]["skipped"] == 1
+    assert report["summary"]["flaky_classification_performed"] is False
+    assert report["summary"]["raw_test_identity_emitted"] is False
+    assert report["source"]["identity_handling"] == "sha256_fingerprint_only"
+
+    serialized = json.dumps(report)
+    assert "failure text" not in serialized
+    assert "error text" not in serialized
+    assert "tests.test_alpha" not in serialized
+    assert "test_fails" not in serialized
+    assert all(
+        set(observation) == {"test_fingerprint", "outcome"}
+        for observation in report["observations"]
+    )
+    assert all(len(observation["test_fingerprint"]) == 64 for observation in report["observations"])
+
+    boundary = report["decision_boundary"]
+    assert boundary["raw_observation_only"] is True
+    assert boundary["raw_test_identity_emitted"] is False
+    assert boundary["flaky_classification_performed"] is False
+    assert boundary["automatic_quarantine_allowed"] is False
+    assert boundary["automatic_rerun_allowed"] is False
+    assert boundary["current_failure_suppression_allowed"] is False
+    assert boundary["automation_allowed"] is False
+    assert boundary["merge_authorized"] is False
+
+
+@pytest.mark.parametrize(
+    ("event_name", "ref_name", "expected"),
+    [
+        ("pull_request", "refs/pull/1418/merge", "main push source"),
+        ("push", "refs/heads/feature/test", "main push source"),
+    ],
+)
+def test_capture_rejects_non_main_or_pr_observation_sources(
+    event_name: str,
+    ref_name: str,
+    expected: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected):
+        build_observation_report(
+            junit_root=_junit_root(),
+            source_workflow="CI",
+            source_job="Full CI lane",
+            source_run_id="run-1418",
+            source_head_sha="3d601331",
+            event_name=event_name,
+            ref_name=ref_name,
+        )
+
+
+def test_capture_rejects_empty_or_duplicate_testcase_identity() -> None:
+    empty = ET.fromstring("<testsuites><testsuite /></testsuites>")
+    with pytest.raises(ValueError, match="contains no testcase observations"):
+        build_observation_report(
+            junit_root=empty,
+            source_workflow="CI",
+            source_job="Full CI lane",
+            source_run_id="run-1418",
+            source_head_sha="3d601331",
+            event_name="push",
+            ref_name="refs/heads/main",
+        )
+
+    duplicate = ET.fromstring(
+        """
+        <testsuites><testsuite>
+          <testcase classname="tests.test_alpha" name="test_same" />
+          <testcase classname="tests.test_alpha" name="test_same" />
+        </testsuite></testsuites>
+        """
+    )
+    with pytest.raises(ValueError, match="duplicate test identities"):
+        build_observation_report(
+            junit_root=duplicate,
+            source_workflow="CI",
+            source_job="Full CI lane",
+            source_run_id="run-1418",
+            source_head_sha="3d601331",
+            event_name="push",
+            ref_name="refs/heads/main",
+        )
+
+
+def test_capture_markdown_renders_raw_observation_boundary() -> None:
+    markdown = render_markdown(_report())
+
+    assert "# Trusted-main test observations" in markdown
+    assert "Observations: `4`" in markdown
+    assert "Identity handling: `sha256_fingerprint_only`" in markdown
+    assert "Raw test identity emitted: `false`" in markdown
+    assert "Flaky classification performed: `false`" in markdown
+    assert "Current failure suppression allowed: `false`" in markdown
+    assert "Automation allowed: `false`" in markdown
+
+
+def test_capture_cli_writes_artifacts_without_echoing_source_values(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    junit = tmp_path / "junit.xml"
+    out_dir = tmp_path / "observations"
+    junit.write_text(ET.tostring(_junit_root(), encoding="unicode"), encoding="utf-8")
+
+    rc = main(
+        [
+            "--junit-xml",
+            str(junit),
+            "--source-workflow",
+            "CI",
+            "--source-job",
+            "Full CI lane",
+            "--source-run-id",
+            "run-sensitive-provenance",
+            "--source-head-sha",
+            "head-sensitive-provenance",
+            "--event-name",
+            "push",
+            "--ref-name",
+            "refs/heads/main",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = capsys.readouterr().out
+    assert "run-sensitive-provenance" not in printed
+    assert "head-sensitive-provenance" not in printed
+
+    report = json.loads((out_dir / "trusted-test-observations.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "trusted-test-observations.md").read_text(encoding="utf-8")
+    assert report["source"]["run_id"] == "run-sensitive-provenance"
+    assert report["source"]["head_sha"] == "head-sensitive-provenance"
+    assert "Flaky classification performed: `false`" in markdown
+
+
+def test_capture_never_persists_parameterized_test_values() -> None:
+    root = ET.fromstring(
+        """
+        <testsuites><testsuite>
+          <testcase classname="tests.test_auth" name="test_login[token=secret-value-123]" />
+        </testsuite></testsuites>
+        """
+    )
+
+    report = build_observation_report(
+        junit_root=root,
+        source_workflow="CI",
+        source_job="Full CI lane",
+        source_run_id="run-1418",
+        source_head_sha="3d601331",
+        event_name="push",
+        ref_name="refs/heads/main",
+    )
+    serialized = json.dumps(report)
+
+    assert "secret-value-123" not in serialized
+    assert "test_login" not in serialized
+    assert "tests.test_auth" not in serialized
+    assert report["observations"][0]["outcome"] == "passed"
+    assert len(report["observations"][0]["test_fingerprint"]) == 64

--- a/tests/test_trusted_test_observation_capture.py
+++ b/tests/test_trusted_test_observation_capture.py
@@ -60,7 +60,7 @@ def test_capture_records_raw_trusted_main_outcomes_without_flake_claims() -> Non
     assert report["summary"]["skipped"] == 1
     assert report["summary"]["flaky_classification_performed"] is False
     assert report["summary"]["raw_test_identity_emitted"] is False
-    assert report["source"]["identity_handling"] == "sha256_fingerprint_only"
+    assert report["source"]["identity_handling"] == "sha256_digest"
 
     serialized = json.dumps(report)
     assert "failure text" not in serialized
@@ -146,7 +146,7 @@ def test_capture_markdown_renders_raw_observation_boundary() -> None:
 
     assert "# Trusted-main test observations" in markdown
     assert "Observations: `4`" in markdown
-    assert "Identity handling: `sha256_fingerprint_only`" in markdown
+    assert "Identity handling: `sha256_digest`" in markdown
     assert "Raw test identity emitted: `false`" in markdown
     assert "Flaky classification performed: `false`" in markdown
     assert "Current failure suppression allowed: `false`" in markdown
@@ -200,7 +200,7 @@ def test_capture_never_persists_parameterized_test_values() -> None:
     root = ET.fromstring(
         """
         <testsuites><testsuite>
-          <testcase classname="tests.test_auth" name="test_login[token=secret-value-123]" />
+          <testcase classname="tests.test_auth" name="test_login[value=SHOULD_NOT_LEAK]" />
         </testsuite></testsuites>
         """
     )
@@ -216,7 +216,7 @@ def test_capture_never_persists_parameterized_test_values() -> None:
     )
     serialized = json.dumps(report)
 
-    assert "secret-value-123" not in serialized
+    assert "SHOULD_NOT_LEAK" not in serialized
     assert "test_login" not in serialized
     assert "tests.test_auth" not in serialized
     assert report["observations"][0]["outcome"] == "passed"

--- a/tests/test_trusted_test_observation_capture_workflow.py
+++ b/tests/test_trusted_test_observation_capture_workflow.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/ci.yml")
+
+
+def _full_ci_text() -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    return text.split("  full-ci:", 1)[1]
+
+
+def test_full_ci_emits_junit_for_raw_observation_capture_without_extra_test_run() -> None:
+    full_ci = _full_ci_text()
+
+    assert "--junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml" in full_ci
+    assert "- name: Coverage gate" in full_ci
+    assert "id: coverage" in full_ci
+    assert full_ci.count("bash quality.sh cov") == 1
+    assert "python -m sdetkit.trusted_test_observation_capture" in full_ci
+
+
+def test_full_ci_captures_observations_only_from_trusted_main_push() -> None:
+    full_ci = _full_ci_text()
+
+    capture_guard = (
+        "github.event_name == 'push' && github.ref == 'refs/heads/main' "
+        "&& steps.coverage.outcome != 'skipped'"
+    )
+    upload_guard = (
+        "github.event_name == 'push' && github.ref == 'refs/heads/main' "
+        "&& steps.trusted_observations.outputs.artifact_written == 'true'"
+    )
+    assert full_ci.count(capture_guard) == 1
+    assert full_ci.count(upload_guard) == 1
+    assert "id: trusted_observations" in full_ci
+    assert '--source-workflow "CI"' in full_ci
+    assert '--source-job "Full CI lane"' in full_ci
+    assert '--event-name "${GITHUB_EVENT_NAME}"' in full_ci
+    assert '--ref-name "${GITHUB_REF}"' in full_ci
+
+
+def test_full_ci_skips_observation_artifact_when_pytest_never_writes_junit() -> None:
+    full_ci = _full_ci_text()
+
+    assert 'if [[ ! -s "${RUNNER_TEMP}/sdetkit-trusted-test-input/junit.xml" ]]; then' in full_ci
+    assert 'echo "trusted_test_observations=not_available_no_junit"' in full_ci
+    assert 'echo "artifact_written=false" >> "${GITHUB_OUTPUT}"' in full_ci
+    assert 'echo "artifact_written=true" >> "${GITHUB_OUTPUT}"' in full_ci
+    assert "steps.trusted_observations.outputs.artifact_written == 'true'" in full_ci
+
+
+def test_full_ci_uploads_normalized_observations_not_raw_junit_or_example_data() -> None:
+    full_ci = _full_ci_text()
+    upload = full_ci.split("- name: Upload trusted-main test observation artifact", 1)[1]
+
+    assert "trusted-test-observations.json" in upload
+    assert "trusted-test-observations.md" in upload
+    assert "junit.xml" not in upload
+    assert "examples/kits/intelligence/flake-history.json" not in full_ci
+    assert "intelligence flake classify" not in full_ci

--- a/tests/test_trusted_test_observation_capture_workflow.py
+++ b/tests/test_trusted_test_observation_capture_workflow.py
@@ -12,12 +12,24 @@ def _full_ci_text() -> str:
 
 def test_full_ci_emits_junit_for_raw_observation_capture_without_extra_test_run() -> None:
     full_ci = _full_ci_text()
+    coverage_block = full_ci.split("- name: Coverage gate", 1)[1].split(
+        "- name: Normalize trusted-main test observations", 1
+    )[0]
 
-    assert "--junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml" in full_ci
+    assert 'PYTEST_ADDOPTS: "-n auto"' in full_ci
+    assert "--junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml" in coverage_block
     assert "- name: Coverage gate" in full_ci
     assert "id: coverage" in full_ci
     assert full_ci.count("bash quality.sh cov") == 1
     assert "python -m sdetkit.trusted_test_observation_capture" in full_ci
+
+
+def test_full_ci_does_not_use_runner_context_in_job_level_environment() -> None:
+    full_ci = _full_ci_text()
+    before_steps = full_ci.split("    steps:", 1)[0]
+
+    assert 'PYTEST_ADDOPTS: "-n auto"' in before_steps
+    assert "runner.temp" not in before_steps
 
 
 def test_full_ci_captures_observations_only_from_trusted_main_push() -> None:


### PR DESCRIPTION
## Summary
- Adds `trusted_test_observation_capture`, a trusted-main raw test-observation normalizer.
- Captures observations from the real `Full CI lane` pytest execution on accepted `main` pushes.
- Emits deterministic normalized JSON/Markdown observation artifacts without uploading raw JUnit XML.
- Stores SHA-256 test fingerprints and outcomes only; raw test names, parameter values, and failure/error contents are not persisted.
- Updates the reliability-spine audit to mark raw trusted observation capture as connected and advances the remaining gap to accepted-main observation history aggregation.

## Why
PR #1418 connected a trusted-main flaky registry producer, but intentionally emitted zero observations because no truthful per-test observation source existed.

This PR establishes that source at the correct boundary: the real `CI` workflow’s `Full CI lane`, which already runs the repository test suite on accepted `main` pushes. It does not use example flake-history data and does not claim any test is flaky.

## Trust and privacy boundary
This PR records raw outcomes only.

The observation artifact contains:

- accepted-main workflow provenance;
- deterministic SHA-256 test fingerprints;
- per-test outcomes (`passed`, `failed`, `error`, `skipped`);
- aggregate counts;
- explicit no-authority boundaries.

It does **not** persist:

- raw JUnit XML;
- raw class names or test names;
- parameterized test values;
- failure/error text or trace content;
- flaky-test classifications;
- quarantine, rerun, suppression, remediation, or merge authority.

The following remain false:

- `raw_test_identity_emitted`
- `flaky_classification_performed`
- `automatic_quarantine_allowed`
- `automatic_rerun_allowed`
- `current_failure_suppression_allowed`
- `automation_allowed`
- `merge_authorized`
- `semantic_equivalence_proven`

## Implementation
### Trusted raw observation capture
- Adds `src/sdetkit/trusted_test_observation_capture.py`.
- Reads ephemeral JUnit XML produced by the existing real pytest execution.
- Validates provenance: workflow `CI`, job `Full CI lane`, event `push`, ref `refs/heads/main`, run ID, and head SHA.
- Normalizes each test into `{test_fingerprint, outcome}` only.
- Fails closed on malformed XML, missing testcase identity, duplicate fingerprint identity, or unsupported provenance.

### CI workflow wiring
- Adds `--junitxml` to the existing Full CI pytest invocation through `PYTEST_ADDOPTS`; no extra test execution is introduced.
- Normalizes observations only for accepted `main` pushes.
- Keeps raw JUnit XML ephemeral on the runner and uploads only normalized JSON/Markdown plus the non-sensitive CLI summary.
- Skips artifact emission cleanly if a pre-pytest/bootstrap failure means no JUnit XML was produced.

### Reliability-spine update
- Adds `trusted_test_observation_capture` as an aligned evidence/reporting component.
- Advances the next gap from raw observation capture to accepted-main cross-run observation history and later classification handoff.
- Keeps RepoMemory guidance aligned with that remaining evidence boundary.

## Local verification completed
Targeted proof was run under Python `3.12.13`:

- Focused module/workflow/privacy/alignment/RepoMemory test lane: `38 passed`.
- Real local pytest-to-JUnit-to-normalized-artifact proof passed.
- Captured local observations: `7`.
- Verified:
  - `raw_test_identity_emitted=false`
  - `flaky_classification_performed=false`
  - `automation_authority=false`
- `mypy src` passed.
- `pre_commit run -a` passed.
- `scripts/check_generated_artifacts_freshness.py` passed.

A local full coverage cycle is intentionally not claimed for this PR; the normal pull-request CI workflow must supply final full-suite validation.

## Scope
Files changed:

- `.github/workflows/ci.yml`
- `src/sdetkit/reliability_spine_alignment.py`
- `src/sdetkit/repo_memory.py`
- `src/sdetkit/trusted_test_observation_capture.py`
- `tests/test_reliability_spine_alignment.py`
- `tests/test_repo_memory.py`
- `tests/test_trusted_test_observation_capture.py`
- `tests/test_trusted_test_observation_capture_workflow.py`

## Risk
Low-to-medium, CI evidence capture and reporting only.

The primary risks are accidental leakage of test identity values and false claims based on non-production evidence. This PR mitigates both by fingerprinting identities, omitting raw failure contents, rejecting non-main sources, preventing raw XML upload, and prohibiting example flake-history use.

## Rollback
Revert this PR. The trusted flaky registry producer from PR #1418 will continue to emit a no-observation registry until another truthful observation source is added.

## Next
`feature/trusted-flaky-test-observation-history`

That follow-up may aggregate accepted-main raw observations across trusted runs. It must remain advisory-only and must not feed populated flaky-test classifications into RepoMemory until provenance and history contracts are proven.
