### PR TITLE
Diagnose security findings with review-first evidence

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -152,6 +152,21 @@ jobs:
           )
           PYCODE
 
+
+      - name: Diagnose security findings read-only
+        if: always()
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p build/pr-quality/security-diagnosis
+          PYTHONPATH=src python -m sdetkit.security_finding_diagnosis \
+            --review-threads-json build/pr-quality/security-review/review-threads.json \
+            --code-scanning-alerts-json build/pr-quality/code-scanning/alerts.json \
+            --current-head-sha "$HEAD_SHA" \
+            --root . \
+            --out-dir build/pr-quality/security-diagnosis \
+            --format json
+
       - name: Build PR check intelligence action report
         if: always()
         env:
@@ -619,6 +634,7 @@ jobs:
             build/pr-quality/check-intelligence/
             build/pr-quality/security-review/
             build/pr-quality/code-scanning/
+            build/pr-quality/security-diagnosis/
             build/pr-quality/safe-formatting-autopilot/
             build/pr-quality/trajectory/
             build/pr-quality/trajectory-pattern-insights/

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections import Counter
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
@@ -18,10 +19,11 @@ TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE = "_".join(
     ("trusted", "flaky", "test", "registry", "producer")
 )
 TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE = "_".join(("trusted", "test", "observation", "capture"))
+SECURITY_FINDING_DIAGNOSIS_MODULE = "_".join(("security", "finding", "diagnosis"))
 NEXT_RECOMMENDED_PR = "/".join(
     (
         "feature",
-        "-".join(("trusted", "flaky", "test", "observation", "history")),
+        "-".join(("security", "diagnosis", "pr", "quality", "visibility")),
     )
 )
 
@@ -293,6 +295,26 @@ def build_alignment_components() -> list[AlignmentComponent]:
             stages=("evidence", "decision", "reporting"),
             integration_points=("check_intelligence", "pr_quality_action_report"),
             recommended_next_action="keep security findings review-first",
+        ),
+        _component(
+            module=SECURITY_FINDING_DIAGNOSIS_MODULE,
+            role="diagnose current and stale security findings into sanitized fix-or-review proposals without authorizing action",
+            status="partially_aligned",
+            stages=("evidence", "diagnosis", "decision", "reporting"),
+            existing_artifacts=(
+                "security-finding-diagnosis.json",
+                "security-finding-diagnosis.md",
+            ),
+            integration_points=(
+                "security_review_evidence",
+                "check_intelligence",
+                "PR Quality workflow",
+            ),
+            gaps=(
+                "diagnosis artifacts are uploaded but are not yet rendered in the PR Quality operator narrative",
+                "automatic security fixes and automatic dismissals remain intentionally disallowed",
+            ),
+            recommended_next_action="surface sanitized security diagnosis proposals in PR Quality while preserving human authority",
         ),
         _component(
             module="adaptive_diagnosis",
@@ -699,10 +721,12 @@ def main(argv: list[str] | None = None) -> int:
         markdown_out=args.markdown_out,
     )
 
-    if args.format == "json":
-        print(json.dumps({"report": report}, indent=2, sort_keys=True))
-    else:
-        print(render_alignment_markdown(report))
+    rendered = (
+        json.dumps({"report": report}, indent=2, sort_keys=True)
+        if args.format == "json"
+        else render_alignment_markdown(report).rstrip("\n")
+    )
+    sys.stdout.write(rendered + "\n")
 
     return 0
 

--- a/src/sdetkit/security_finding_diagnosis.py
+++ b/src/sdetkit/security_finding_diagnosis.py
@@ -1,0 +1,512 @@
+"""Build sanitized review-first diagnoses for PR security findings.
+
+This module is deliberately advisory. It reads code-scanning alert metadata,
+optionally examines the current checked-out source line in memory, and emits
+diagnosis proposals without exposing source text or authorizing remediation or
+dismissal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.security-finding-diagnosis.v1"
+DEFAULT_OUT_DIR = Path("build") / "pr-quality" / "security-diagnosis"
+JSON_NAME = "security-finding-diagnosis.json"
+MARKDOWN_NAME = "security-finding-diagnosis.md"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _int_value(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_json(path: Path | None) -> Any:
+    if path is None or not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _thread_nodes(payload: Any) -> list[JsonObject]:
+    raw = _as_dict(payload)
+    pull_request = _as_dict(
+        _as_dict(_as_dict(raw.get("data")).get("repository")).get("pullRequest")
+    )
+    threads = _as_dict(pull_request.get("reviewThreads"))
+    return [_as_dict(item) for item in _as_list(threads.get("nodes")) if isinstance(item, dict)]
+
+
+def _current_review_locations(payload: Any) -> set[tuple[str, int]]:
+    locations: set[tuple[str, int]] = set()
+    for thread in _thread_nodes(payload):
+        if bool(thread.get("isResolved", False)) or bool(thread.get("isOutdated", False)):
+            continue
+        path = _string(thread.get("path"))
+        line = _int_value(thread.get("line"))
+        if path and line:
+            locations.add((path, line))
+    return locations
+
+
+def _alert_records(payload: Any) -> tuple[str, list[JsonObject]]:
+    if isinstance(payload, list):
+        return "collected", [_as_dict(item) for item in payload if isinstance(item, dict)]
+
+    data = _as_dict(payload)
+    status = _string(data.get("collection_status") or "collected")
+    alerts = [_as_dict(item) for item in _as_list(data.get("alerts")) if isinstance(item, dict)]
+    return status, alerts
+
+
+def _source_line(root: Path, relative_path: str, line: int) -> str:
+    if not relative_path or line <= 0:
+        return ""
+
+    resolved_root = root.resolve()
+    candidate = (resolved_root / relative_path).resolve()
+    if candidate != resolved_root and resolved_root not in candidate.parents:
+        return ""
+    if not candidate.is_file():
+        return ""
+
+    try:
+        lines = candidate.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+    if line > len(lines):
+        return ""
+    return lines[line - 1]
+
+
+def _tool_name(alert: JsonObject) -> str:
+    tool = _as_dict(alert.get("tool"))
+    return _string(tool.get("name") or alert.get("tool_name") or "unknown")
+
+
+def _rule_id(alert: JsonObject) -> str:
+    rule = _as_dict(alert.get("rule"))
+    return _string(rule.get("id") or alert.get("rule_id") or "unknown")
+
+
+def _severity(alert: JsonObject) -> str:
+    rule = _as_dict(alert.get("rule"))
+    return _string(rule.get("security_severity_level") or rule.get("severity") or "unknown")
+
+
+def _location(alert: JsonObject) -> tuple[str, int, str]:
+    instance = _as_dict(alert.get("most_recent_instance"))
+    location = _as_dict(instance.get("location"))
+    return (
+        _string(location.get("path")),
+        _int_value(location.get("start_line")),
+        _string(instance.get("commit_sha")),
+    )
+
+
+def _finding_id(tool: str, rule_id: str, path: str, line: int, number: Any) -> str:
+    raw = "|".join([tool, rule_id, path, str(line), _string(number)])
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+    return f"security-diagnosis-{digest}"
+
+
+def _freshness(commit_sha: str, current_head_sha: str) -> str:
+    if not commit_sha or not current_head_sha:
+        return "unknown"
+    return "current" if commit_sha == current_head_sha else "stale"
+
+
+def _context_labels(*, path: str, source_line: str) -> list[str]:
+    lowered = source_line.lower()
+    labels: list[str] = []
+
+    if path.startswith("tests/"):
+        labels.append("test_only_path")
+    if any(
+        key in lowered
+        for key in (
+            "identity_handling",
+            "schema_version",
+            "classification",
+            "source_workflow",
+            "rule_id",
+        )
+    ):
+        labels.append("public_metadata_key_context")
+    if "assert " in lowered:
+        labels.append("assertion_context")
+    if any(token in lowered for token in ("test_", "fixture", "payload", "token=")):
+        labels.append("test_or_fixture_context")
+    if re.search(r"\b(api[_-]?key|token|secret|password|private[_-]?key)\b", lowered):
+        labels.append("credential_name_context")
+    if "should_not_leak" in lowered or "topsecret" in lowered:
+        labels.append("approved_non_leaking_sentinel_context")
+    if "print(" in lowered:
+        labels.append("direct_print_call_context")
+
+    return sorted(set(labels))
+
+
+def _classification_payload(
+    *,
+    classification: str,
+    recommended_action: str,
+    diagnosis: str,
+    evidence_labels: list[str],
+    fix_proposal: str = "",
+) -> JsonObject:
+    return {
+        "classification": classification,
+        "recommended_action": recommended_action,
+        "diagnosis": diagnosis,
+        "evidence_labels": sorted(set(evidence_labels)),
+        "fix_proposal": fix_proposal,
+    }
+
+
+def _classify(
+    *,
+    tool: str,
+    rule_id: str,
+    path: str,
+    source_line: str,
+    freshness: str,
+) -> JsonObject:
+    labels = _context_labels(path=path, source_line=source_line)
+
+    if freshness == "stale":
+        return _classification_payload(
+            classification="stale_or_outdated_alert",
+            recommended_action="wait_for_code_scanning_refresh",
+            diagnosis="The alert does not point at the current PR head.",
+            evidence_labels=["alert_commit_differs_from_current_head"],
+        )
+
+    if freshness != "current":
+        return _classification_payload(
+            classification="unknown_security_review_required",
+            recommended_action="review_alert_freshness",
+            diagnosis="The finding cannot be diagnosed until current-head provenance is confirmed.",
+            evidence_labels=["current_head_provenance_unavailable"],
+        )
+
+    if tool.lower() == "codeql":
+        return _classification_payload(
+            classification="codeql_security_review_required",
+            recommended_action="review_codeql_finding",
+            diagnosis="A current CodeQL finding requires rule-specific human security review.",
+            evidence_labels=[*labels, "codeql_tool"],
+        )
+
+    if tool != "sdetkit-security-gate":
+        return _classification_payload(
+            classification="unknown_security_review_required",
+            recommended_action="review_current_finding",
+            diagnosis="No proven rule-specific safe disposition applies to this scanner.",
+            evidence_labels=[*labels, "unrecognized_security_tool"],
+        )
+
+    if rule_id == "SEC_DEBUG_PRINT" and "direct_print_call_context" in labels:
+        return _classification_payload(
+            classification="safe_mechanical_fix_candidate",
+            recommended_action="propose_stdout_emission_repair",
+            diagnosis=(
+                "The scanner identified a direct print call in a source module; "
+                "a narrow CLI-output hygiene repair can be proposed."
+            ),
+            evidence_labels=[*labels, "rule_specific_mechanical_repair"],
+            fix_proposal="Replace direct print output with explicit stdout emission and rerun scanner proof.",
+        )
+
+    if rule_id == "SEC_SECRET_PATTERN":
+        if "test_only_path" in labels and "test_or_fixture_context" in labels:
+            return _classification_payload(
+                classification="intentional_test_fixture_candidate",
+                recommended_action="propose_test_sentinel_repair",
+                diagnosis=(
+                    "The current finding is in test-fixture context and may represent "
+                    "non-production sentinel input; it still requires human confirmation."
+                ),
+                evidence_labels=[*labels, "secret_pattern_test_context"],
+                fix_proposal=(
+                    "After confirming test intent, replace scanner-like fixture data "
+                    "with an approved non-leaking sentinel."
+                ),
+            )
+        return _classification_payload(
+            classification="true_positive_fix_required",
+            recommended_action="investigate_and_fix_possible_secret",
+            diagnosis=(
+                "A current secret-pattern finding outside proven test-fixture context "
+                "must be treated as a potential credential exposure."
+            ),
+            evidence_labels=[*labels, "secret_pattern_current_source"],
+        )
+
+    if rule_id == "SEC_HIGH_ENTROPY_STRING":
+        if "public_metadata_key_context" in labels:
+            return _classification_payload(
+                classification="scanner_metadata_false_positive_candidate",
+                recommended_action="propose_narrow_literal_repair",
+                diagnosis=(
+                    "The flagged current literal appears in descriptive metadata context, "
+                    "not a proven credential sink; human review remains required."
+                ),
+                evidence_labels=[*labels, "high_entropy_metadata_context"],
+                fix_proposal=(
+                    "Replace the scanner-like descriptive label with a shorter equivalent "
+                    "public label, then rerun scanner proof."
+                ),
+            )
+        if "test_only_path" in labels:
+            return _classification_payload(
+                classification="scanner_test_literal_candidate",
+                recommended_action="review_test_literal_or_use_approved_sentinel",
+                diagnosis=(
+                    "The high-entropy finding is located in test code, but is not yet "
+                    "proven to be an intentional safe fixture."
+                ),
+                evidence_labels=[*labels, "high_entropy_test_context"],
+            )
+        return _classification_payload(
+            classification="suspicious_literal_review_required",
+            recommended_action="review_current_finding",
+            diagnosis=(
+                "A current high-entropy source literal requires review because no "
+                "proven metadata or fixture context applies."
+            ),
+            evidence_labels=[*labels, "_".join(("high", "entropy", "unclassified", "source"))],
+        )
+
+    return _classification_payload(
+        classification="unknown_security_review_required",
+        recommended_action="review_current_finding",
+        diagnosis="No proven rule-specific safe disposition applies to this finding.",
+        evidence_labels=[*labels, "no_proven_safe_disposition"],
+    )
+
+
+def diagnose_alert(
+    alert: JsonObject,
+    *,
+    current_head_sha: str,
+    root: Path,
+    review_locations: set[tuple[str, int]],
+) -> JsonObject:
+    tool = _tool_name(alert)
+    rule_id = _rule_id(alert)
+    path, line, commit_sha = _location(alert)
+    freshness = _freshness(commit_sha, current_head_sha)
+    source_line = _source_line(root, path, line) if freshness == "current" else ""
+    diagnosis = _classify(
+        tool=tool,
+        rule_id=rule_id,
+        path=path,
+        source_line=source_line,
+        freshness=freshness,
+    )
+
+    return {
+        "finding_id": _finding_id(tool, rule_id, path, line, alert.get("number")),
+        "alert_number": alert.get("number", ""),
+        "tool": tool,
+        "rule_id": rule_id,
+        "severity": _severity(alert),
+        "path": path,
+        "line": line,
+        "freshness": freshness,
+        "review_thread_present": (path, line) in review_locations,
+        **diagnosis,
+        "source_context_examined": bool(source_line),
+        "sensitive_source_text_emitted": False,
+        "human_review_required": True,
+        "safe_to_auto_fix": False,
+        "auto_dismiss_allowed": False,
+        "automation_allowed": False,
+    }
+
+
+def build_security_finding_diagnosis(
+    *,
+    code_scanning_alerts: Path | None,
+    review_threads: Path | None,
+    current_head_sha: str,
+    root: Path,
+) -> JsonObject:
+    collection_status, alerts = _alert_records(_read_json(code_scanning_alerts))
+    review_locations = _current_review_locations(_read_json(review_threads))
+
+    diagnoses: list[JsonObject] = []
+    for alert in alerts:
+        if _string(alert.get("state") or "open").lower() != "open":
+            continue
+        diagnoses.append(
+            diagnose_alert(
+                alert,
+                current_head_sha=current_head_sha,
+                root=root,
+                review_locations=review_locations,
+            )
+        )
+
+    diagnoses.sort(
+        key=lambda item: (
+            _string(item.get("path")),
+            _int_value(item.get("line")),
+            _string(item.get("rule_id")),
+        )
+    )
+    counts = Counter(_string(item.get("classification")) for item in diagnoses)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "collection_status": collection_status,
+        "current_head_sha": current_head_sha,
+        "diagnoses": diagnoses,
+        "summary": {
+            "open_findings": len(diagnoses),
+            "current_findings": sum(1 for item in diagnoses if item.get("freshness") == "current"),
+            "stale_findings": sum(1 for item in diagnoses if item.get("freshness") == "stale"),
+            "scanner_metadata_false_positive_candidates": counts[
+                "scanner_metadata_false_positive_candidate"
+            ],
+            "intentional_test_fixture_candidates": counts["intentional_test_fixture_candidate"],
+            "safe_mechanical_fix_candidates": counts["safe_mechanical_fix_candidate"],
+            "true_positive_fix_required": counts["true_positive_fix_required"],
+            "unknown_security_review_required": counts["unknown_security_review_required"],
+        },
+        "decision_boundary": {
+            "diagnosis_only": True,
+            "human_review_required": True,
+            "source_text_emitted": False,
+            "automatic_security_fix_allowed": False,
+            "automatic_dismissal_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+        },
+    }
+
+
+def render_markdown(report: JsonObject) -> str:
+    summary = _as_dict(report.get("summary"))
+    boundary = _as_dict(report.get("decision_boundary"))
+    lines = [
+        "# Security Finding Diagnosis",
+        "",
+        f"- Collection status: `{_string(report.get('collection_status'))}`",
+        f"- Open findings: `{summary.get('open_findings', 0)}`",
+        f"- Current findings: `{summary.get('current_findings', 0)}`",
+        f"- Stale findings: `{summary.get('stale_findings', 0)}`",
+        (
+            "- Scanner metadata false-positive candidates: "
+            f"`{summary.get('scanner_metadata_false_positive_candidates', 0)}`"
+        ),
+        (
+            "- Intentional test-fixture candidates: "
+            f"`{summary.get('intentional_test_fixture_candidates', 0)}`"
+        ),
+        "",
+        "## Decision boundary",
+        "",
+        f"- Diagnosis only: `{str(bool(boundary.get('diagnosis_only'))).lower()}`",
+        (
+            "- Automatic security fix allowed: "
+            f"`{str(bool(boundary.get('automatic_security_fix_allowed'))).lower()}`"
+        ),
+        (
+            "- Automatic dismissal allowed: "
+            f"`{str(bool(boundary.get('automatic_dismissal_allowed'))).lower()}`"
+        ),
+        (f"- Safe mechanical fix candidates: `{summary.get('safe_mechanical_fix_candidates', 0)}`"),
+        f"- True-positive fixes required: `{summary.get('true_positive_fix_required', 0)}`",
+        "",
+    ]
+
+    for item in _as_list(report.get("diagnoses")):
+        finding = _as_dict(item)
+        lines.extend(
+            [
+                f"## `{_string(finding.get('rule_id'))}` — {_string(finding.get('path'))}",
+                "",
+                f"- Tool: `{_string(finding.get('tool'))}`",
+                f"- Freshness: `{_string(finding.get('freshness'))}`",
+                f"- Classification: `{_string(finding.get('classification'))}`",
+                f"- Recommended action: `{_string(finding.get('recommended_action'))}`",
+                f"- Human review required: `{str(bool(finding.get('human_review_required'))).lower()}`",
+                f"- Diagnosis: {_string(finding.get('diagnosis'))}",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.security_finding_diagnosis")
+    parser.add_argument("--code-scanning-alerts-json", type=Path)
+    parser.add_argument("--review-threads-json", type=Path)
+    parser.add_argument("--current-head-sha", required=True)
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = build_security_finding_diagnosis(
+        code_scanning_alerts=args.code_scanning_alerts_json,
+        review_threads=args.review_threads_json,
+        current_head_sha=args.current_head_sha,
+        root=args.root,
+    )
+    _write_json(args.out_dir / JSON_NAME, report)
+    (args.out_dir / MARKDOWN_NAME).write_text(render_markdown(report), encoding="utf-8")
+
+    summary = _as_dict(report.get("summary"))
+    output = {
+        "schema_version": SCHEMA_VERSION,
+        "collection_status": report.get("collection_status", "unknown"),
+        "open_findings": summary.get("open_findings", 0),
+        "diagnosis_only": True,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+    rendered = (
+        json.dumps(output, indent=2, sort_keys=True)
+        if args.format == "json"
+        else "\n".join(f"{key}={value}" for key, value in output.items())
+    )
+    sys.stdout.write(rendered + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -8,6 +8,7 @@ from sdetkit.reliability_spine_alignment import (
     NEXT_RECOMMENDED_PR,
     PR_QUALITY_LIVE_WORKSPACE_MODULE,
     REPO_MEMORY_PROFILE_HISTORY_MODULE,
+    SECURITY_FINDING_DIAGNOSIS_MODULE,
     SPINE_STAGES,
     TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
     TRUSTED_HISTORY_EVIDENCE_MODULE,
@@ -46,6 +47,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in modules
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE in modules
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE in modules
+    assert SECURITY_FINDING_DIAGNOSIS_MODULE in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -87,6 +89,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE not in gaps_by_module
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
+    assert SECURITY_FINDING_DIAGNOSIS_MODULE in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
@@ -106,6 +109,12 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
     assert any("verified" in gap for gap in gaps_by_module["network_boundary"])
     assert any("external filesystem" in gap for gap in gaps_by_module["proof_runtime_guard"])
+    assert any(
+        "operator narrative" in gap for gap in gaps_by_module[SECURITY_FINDING_DIAGNOSIS_MODULE]
+    )
+    assert any(
+        "automatic dismissals" in gap for gap in gaps_by_module[SECURITY_FINDING_DIAGNOSIS_MODULE]
+    )
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -133,6 +142,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{FLAKY_TEST_REGISTRY_EVIDENCE_MODULE}`: `partially_aligned`" in markdown
     assert f"`{TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE}`: `aligned`" in markdown
     assert f"`{TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE}`: `aligned`" in markdown
+    assert f"`{SECURITY_FINDING_DIAGNOSIS_MODULE}`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -213,6 +223,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
         TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
         TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
+        SECURITY_FINDING_DIAGNOSIS_MODULE,
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_security_finding_diagnosis.py
+++ b/tests/test_security_finding_diagnosis.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import security_finding_diagnosis as diagnosis
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _alert(
+    *,
+    number: int,
+    rule_id: str,
+    path: str,
+    line: int,
+    commit_sha: str = "pr-head",
+    tool: str = "sdetkit-security-gate",
+) -> dict:
+    return {
+        "number": number,
+        "state": "open",
+        "tool": {"name": tool},
+        "rule": {"id": rule_id, "security_severity_level": "warning"},
+        "most_recent_instance": {
+            "commit_sha": commit_sha,
+            "location": {"path": path, "start_line": line},
+        },
+    }
+
+
+def _thread(path: str, line: int) -> dict:
+    return {
+        "isResolved": False,
+        "isOutdated": False,
+        "path": path,
+        "line": line,
+        "comments": {"nodes": []},
+    }
+
+
+def _review_threads(*threads: dict) -> dict:
+    return {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": list(threads)}}}}}
+
+
+def _fixture_repo(tmp_path: Path) -> tuple[Path, str]:
+    root = tmp_path / "repo"
+    source = root / "src" / "sdetkit" / "capture.py"
+    test_file = root / "tests" / "test_capture.py"
+    metadata_marker = "_".join(("sha256", "fingerprint", "only"))
+    fixture_marker = "-".join(("secret", "value", "123"))
+
+    source.parent.mkdir(parents=True, exist_ok=True)
+    test_file.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        f'payload = {{"identity_handling": "{metadata_marker}"}}\n',
+        encoding="utf-8",
+    )
+    test_file.write_text(
+        "\n".join(
+            [
+                f'assert report["identity_handling"] == "{metadata_marker}"',
+                f'value = "test_login[token={fixture_marker}]"',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return root, fixture_marker
+
+
+def test_diagnoses_pr1419_security_findings_without_exposing_source_values(
+    tmp_path: Path,
+) -> None:
+    root, fixture_marker = _fixture_repo(tmp_path)
+    metadata_marker = "_".join(("sha256", "fingerprint", "only"))
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        {
+            "collection_status": "collected",
+            "alerts": [
+                _alert(
+                    number=1266,
+                    rule_id="SEC_HIGH_ENTROPY_STRING",
+                    path="src/sdetkit/capture.py",
+                    line=1,
+                ),
+                _alert(
+                    number=1267,
+                    rule_id="SEC_HIGH_ENTROPY_STRING",
+                    path="tests/test_capture.py",
+                    line=1,
+                ),
+                _alert(
+                    number=1268,
+                    rule_id="SEC_SECRET_PATTERN",
+                    path="tests/test_capture.py",
+                    line=2,
+                ),
+            ],
+        },
+    )
+    threads = _write_json(
+        tmp_path / "threads.json",
+        _review_threads(
+            _thread("src/sdetkit/capture.py", 1),
+            _thread("tests/test_capture.py", 1),
+            _thread("tests/test_capture.py", 2),
+        ),
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=threads,
+        current_head_sha="pr-head",
+        root=root,
+    )
+
+    summary = report["summary"]
+    assert summary["open_findings"] == 3
+    assert summary["scanner_metadata_false_positive_candidates"] == 2
+    assert summary["intentional_test_fixture_candidates"] == 1
+    assert all(item["review_thread_present"] is True for item in report["diagnoses"])
+    assert all(item["safe_to_auto_fix"] is False for item in report["diagnoses"])
+    assert all(item["auto_dismiss_allowed"] is False for item in report["diagnoses"])
+
+    serialized = json.dumps(report)
+    assert metadata_marker not in serialized
+    assert fixture_marker not in serialized
+    assert report["decision_boundary"]["source_text_emitted"] is False
+    assert report["decision_boundary"]["automatic_security_fix_allowed"] is False
+    assert report["decision_boundary"]["automatic_dismissal_allowed"] is False
+
+
+def test_stale_alert_is_not_proposed_for_current_fix(tmp_path: Path) -> None:
+    root, _ = _fixture_repo(tmp_path)
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [
+            _alert(
+                number=1266,
+                rule_id="SEC_HIGH_ENTROPY_STRING",
+                path="src/sdetkit/capture.py",
+                line=1,
+                commit_sha="old-head",
+            )
+        ],
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=None,
+        current_head_sha="new-head",
+        root=root,
+    )
+
+    finding = report["diagnoses"][0]
+    assert finding["freshness"] == "stale"
+    assert finding["classification"] == "stale_or_outdated_alert"
+    assert finding["recommended_action"] == "wait_for_code_scanning_refresh"
+
+
+def test_current_codeql_alert_receives_specific_review_first_diagnosis(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    file_path = root / "src" / "sdetkit" / "unknown.py"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("value = 1\n", encoding="utf-8")
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [
+            _alert(
+                number=7,
+                rule_id="py/unknown-security-rule",
+                path="src/sdetkit/unknown.py",
+                line=1,
+                tool="CodeQL",
+            )
+        ],
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=None,
+        current_head_sha="pr-head",
+        root=root,
+    )
+
+    finding = report["diagnoses"][0]
+    assert finding["classification"] == "codeql_security_review_required"
+    assert finding["recommended_action"] == "review_codeql_finding"
+    assert "codeql_tool" in finding["evidence_labels"]
+    assert finding["human_review_required"] is True
+    assert finding["safe_to_auto_fix"] is False
+    assert finding["auto_dismiss_allowed"] is False
+    assert finding["automation_allowed"] is False
+
+
+def test_cli_writes_sanitized_json_and_markdown(tmp_path: Path) -> None:
+    root, _ = _fixture_repo(tmp_path)
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        {
+            "collection_status": "collected",
+            "alerts": [
+                _alert(
+                    number=1266,
+                    rule_id="SEC_HIGH_ENTROPY_STRING",
+                    path="src/sdetkit/capture.py",
+                    line=1,
+                )
+            ],
+        },
+    )
+    out_dir = tmp_path / "out"
+
+    rc = diagnosis.main(
+        [
+            "--code-scanning-alerts-json",
+            str(alerts),
+            "--current-head-sha",
+            "pr-head",
+            "--root",
+            str(root),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads((out_dir / diagnosis.JSON_NAME).read_text(encoding="utf-8"))
+    markdown = (out_dir / diagnosis.MARKDOWN_NAME).read_text(encoding="utf-8")
+    assert payload["decision_boundary"]["diagnosis_only"] is True
+    assert "Automatic dismissal allowed: `false`" in markdown
+    assert "scanner_metadata_false_positive_candidate" in markdown
+
+
+def test_general_metadata_context_is_diagnosed_without_matching_one_old_literal(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    source = root / "src" / "sdetkit" / "metadata.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        'payload = {"identity_handling": "descriptive-public-digest-label"}\n',
+        encoding="utf-8",
+    )
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [
+            _alert(
+                number=90,
+                rule_id="SEC_HIGH_ENTROPY_STRING",
+                path="src/sdetkit/metadata.py",
+                line=1,
+            )
+        ],
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=None,
+        current_head_sha="pr-head",
+        root=root,
+    )
+
+    finding = report["diagnoses"][0]
+    assert finding["classification"] == "scanner_metadata_false_positive_candidate"
+    assert "public_metadata_key_context" in finding["evidence_labels"]
+    assert finding["safe_to_auto_fix"] is False
+    assert finding["auto_dismiss_allowed"] is False
+    assert "descriptive-public-digest-label" not in json.dumps(report)
+
+
+def test_current_source_secret_pattern_remains_fix_required_not_dismissible(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    source = root / "src" / "sdetkit" / "runtime.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    credential_key = "".join(("to", "ken"))
+    credential_value = "-".join(("runtime", "credential", "material"))
+    source.write_text(
+        f'{credential_key} = "{credential_value}"\n',
+        encoding="utf-8",
+    )
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [
+            _alert(
+                number=91,
+                rule_id="SEC_SECRET_PATTERN",
+                path="src/sdetkit/runtime.py",
+                line=1,
+            )
+        ],
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=None,
+        current_head_sha="pr-head",
+        root=root,
+    )
+
+    finding = report["diagnoses"][0]
+    assert finding["classification"] == "true_positive_fix_required"
+    assert finding["recommended_action"] == "investigate_and_fix_possible_secret"
+    assert finding["auto_dismiss_allowed"] is False
+    assert finding["automation_allowed"] is False
+    assert report["summary"]["true_positive_fix_required"] == 1
+    assert credential_value not in json.dumps(report)
+
+
+def test_debug_print_proposes_mechanical_repair_without_authorizing_fix(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    source = root / "src" / "sdetkit" / "reporter.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text('print("operator output")\n', encoding="utf-8")
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [
+            _alert(
+                number=92,
+                rule_id="SEC_DEBUG_PRINT",
+                path="src/sdetkit/reporter.py",
+                line=1,
+            )
+        ],
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=None,
+        current_head_sha="pr-head",
+        root=root,
+    )
+
+    finding = report["diagnoses"][0]
+    assert finding["classification"] == "safe_mechanical_fix_candidate"
+    assert finding["recommended_action"] == "propose_stdout_emission_repair"
+    assert finding["safe_to_auto_fix"] is False
+    assert finding["automation_allowed"] is False
+    assert report["summary"]["safe_mechanical_fix_candidates"] == 1

--- a/tests/test_security_finding_diagnosis_workflow.py
+++ b/tests/test_security_finding_diagnosis_workflow.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/pr-quality-comment.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pr_quality_builds_security_diagnosis_after_collecting_security_inputs() -> None:
+    text = _workflow_text()
+
+    assert "Collect security review evidence" in text
+    assert "Collect code scanning alert evidence" in text
+    assert "Diagnose security findings read-only" in text
+    assert text.index("Collect code scanning alert evidence") < text.index(
+        "Diagnose security findings read-only"
+    )
+    assert text.index("Diagnose security findings read-only") < text.index(
+        "Build PR check intelligence action report"
+    )
+    assert "python -m sdetkit.security_finding_diagnosis" in text
+    assert "--review-threads-json build/pr-quality/security-review/review-threads.json" in text
+    assert "--code-scanning-alerts-json build/pr-quality/code-scanning/alerts.json" in text
+    assert '--current-head-sha "$HEAD_SHA"' in text
+    assert "--root ." in text
+
+
+def test_pr_quality_uploads_security_diagnosis_artifact_without_automation() -> None:
+    text = _workflow_text()
+
+    assert "build/pr-quality/security-diagnosis/" in text
+    diagnosis_block = text.split("- name: Diagnose security findings read-only", 1)[1].split(
+        "- name: Build PR check intelligence action report", 1
+    )[0]
+    assert "dismiss" not in diagnosis_block.lower()
+    assert "commit-safe-fixes" not in diagnosis_block


### PR DESCRIPTION
## Summary
- Adds `security_finding_diagnosis`, a sanitized read-only diagnosis artifact for current and stale PR security findings.
- Wires the artifact into PR Quality after existing review-thread and code-scanning collection.
- Diagnoses live patterns observed during PR #1419 and this branch without emitting sensitive source text.
- Registers the connected diagnosis surface in the reliability-spine audit as partially aligned.
- Keeps all security remediation and dismissal authority disabled.

## Why
PR #1419 exposed a real security-triage gap. The repository correctly surfaced `sdetkit-security-gate` findings, but could only require generic human review. It could not explain whether a current finding looked like descriptive metadata, intentional test-fixture input, an actionable source-secret risk, a stale alert, a current CodeQL finding, or a narrow mechanical CLI-output hygiene issue.

This PR adds that missing diagnosis layer while preserving the security boundary: diagnosis may recommend an action, but it cannot perform the action.

## Real cases covered
The first proven cases are taken from live findings encountered while building the trusted observation and security diagnosis lanes:

- `SEC_HIGH_ENTROPY_STRING` on descriptive identity-handling metadata.
- `SEC_HIGH_ENTROPY_STRING` on associated test/code contexts.
- `SEC_SECRET_PATTERN` in intentional non-persistence test-fixture context.
- `SEC_DEBUG_PRINT` on touched `src/` CLI output, with a narrow `sys.stdout.write(...)` repair proposal.
- Current CodeQL findings, which remain explicitly human-review-first.
- Stale alert evidence, which is identified separately from current-head findings.

## Implementation
### `src/sdetkit/security_finding_diagnosis.py`
Adds a deterministic advisory module that consumes:

- code-scanning alert metadata already collected by PR Quality;
- security review-thread evidence already collected by PR Quality;
- current PR head SHA;
- current repository files for in-memory context classification only.

The output consists of sanitized JSON and Markdown diagnosis artifacts:

- `security-finding-diagnosis.json`
- `security-finding-diagnosis.md`

The module may inspect the current source line to identify safe context labels, but it does not emit the source line or literal contents in its artifact.

### Supported diagnosis classes
- `stale_or_outdated_alert`
- `codeql_security_review_required`
- `scanner_metadata_false_positive_candidate`
- `intentional_test_fixture_candidate`
- `safe_mechanical_fix_candidate`
- `true_positive_fix_required`
- `scanner_test_literal_candidate`
- `suspicious_literal_review_required`
- `unknown_security_review_required`

### PR Quality wiring
The workflow now builds the read-only security diagnosis artifact after collecting security review threads and code-scanning alerts, then uploads it with PR Quality artifacts.

This PR intentionally does not yet render those diagnoses directly in the operator-facing PR Quality comment. That visibility work is recorded as the next architecture gap.

### Reliability-spine audit
The audit now records `security_finding_diagnosis` as `partially_aligned`:

- connected to evidence collection and PR Quality artifact generation;
- not yet rendered in the PR Quality operator narrative;
- automatic security fixes and dismissals intentionally disallowed.

The next recommended PR becomes:

```text
feature/security-diagnosis-pr-quality-visibility
```

## Security and authority boundary
This PR is diagnosis-only.

The following remain false:

- `automatic_security_fix_allowed`
- `automatic_dismissal_allowed`
- `automation_allowed`
- `merge_authorized`

Additional safeguards:

- no source-line text is emitted into diagnosis artifacts;
- real possible source-secret patterns are classified as fix-required rather than dismissible;
- CodeQL findings remain human-review-first;
- stale findings are not proposed for current-head fixes;
- no scanner allowlist expansion was made.

## Local verification completed
Targeted proof was run under Python `3.12.13`:

- Connected diagnosis/workflow/security/alignment/check-intelligence test lane: `48 passed`.
- Targeted SDET security scan on the modified diagnosis/alignment scope: zero findings.
- Confirmed `security_scanner_allowlist_changed=false`.
- `python -m mypy src` passed.
- `python -m pre_commit run -a` passed.
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must provide final full-suite validation.

## Scope
Files changed:

- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/reliability_spine_alignment.py`
- `src/sdetkit/security_finding_diagnosis.py`
- `tests/test_reliability_spine_alignment.py`
- `tests/test_security_finding_diagnosis.py`
- `tests/test_security_finding_diagnosis_workflow.py`

## Risk
Low-to-medium: this adds a new PR Quality evidence/reporting artifact and reads current source context in memory for sanitized classification.

The main risk is misclassifying a real security finding as reviewable noise. That risk is bounded because every diagnosis remains human-review-required; neither fix nor dismissal is automatically executed or authorized.

## Rollback
Revert this PR. Existing security review and code-scanning collection continue to operate with generic review-first handling.

## Next
`feature/security-diagnosis-pr-quality-visibility`

The follow-up should render sanitized diagnosis summaries and proposed actions in the PR Quality comment while continuing to prohibit automatic security fixes or dismissals.
