### PR TITLE
Surface security diagnoses in PR Quality

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -578,6 +578,7 @@ jobs:
             --evidence-narrative build/pr-quality/pr-evidence-narrative.json \
             --trajectory-jsonl build/pr-quality/trajectory/trajectory.jsonl \
             --runtime-proof-artifacts build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json \
+            --security-finding-diagnosis build/pr-quality/security-diagnosis/security-finding-diagnosis.json \
             --out build/pr-quality/pr-comment-body.md \
             > build/pr-quality/pr-comment-metadata.json
 

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,8 @@ TRUSTED_HISTORY_MERGE_AUTHORIZED = "_".join(("trusted", "history", "merge", "aut
 TRUSTED_HISTORY_SEMANTIC_EQUIVALENCE_PROVEN = "_".join(
     ("trusted", "history", "semantic", "equivalence", "proven")
 )
+AUTOMATIC_SECURITY_FIX_ALLOWED = "_".join(("automatic", "security", "fix", "allowed"))
+AUTOMATIC_DISMISSAL_ALLOWED = "_".join(("automatic", "dismissal", "allowed"))
 
 BANNED_EDUCATIONAL_PHRASES = (
     "Quality is green, so the review focus is not coverage.",
@@ -291,6 +294,72 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
                 f"- Code scanning {freshness} finding: `{location}` "
                 f"(`{rule_id}`, severity=`{severity}`), action=`{action}`"
             )
+
+    return lines
+
+
+def _security_finding_diagnosis_lines(security_finding_diagnosis: JsonObject | None) -> list[str]:
+    report = _as_dict(security_finding_diagnosis)
+    if not report:
+        return []
+
+    summary = _as_dict(report.get("summary"))
+    boundary = _as_dict(report.get("decision_boundary"))
+    lines = [
+        f"- Collection status: `{_string(report.get('collection_status') or 'unknown')}`",
+        f"- Open findings: `{_int(summary.get('open_findings'))}`",
+        f"- Current findings: `{_int(summary.get('current_findings'))}`",
+        f"- Stale findings: `{_int(summary.get('stale_findings'))}`",
+        (
+            "- Metadata false-positive candidates: "
+            f"`{_int(summary.get('scanner_metadata_false_positive_candidates'))}`"
+        ),
+        (
+            "- Test-fixture candidates: "
+            f"`{_int(summary.get('intentional_test_fixture_candidates'))}`"
+        ),
+        (f"- Mechanical fix proposals: `{_int(summary.get('safe_mechanical_fix_candidates'))}`"),
+        f"- True-positive fixes required: `{_int(summary.get('true_positive_fix_required'))}`",
+        (
+            "- Automatic security fix allowed: "
+            f"`{str(bool(boundary.get(AUTOMATIC_SECURITY_FIX_ALLOWED, False))).lower()}`"
+        ),
+        (
+            "- Automatic dismissal allowed: "
+            f"`{str(bool(boundary.get(AUTOMATIC_DISMISSAL_ALLOWED, False))).lower()}`"
+        ),
+    ]
+
+    findings = [_as_dict(item) for item in _as_list(report.get("diagnoses")) if _as_dict(item)]
+    if not findings:
+        lines.append("- Findings: none")
+        return lines
+
+    lines.append("- Findings:")
+    for finding in findings[:5]:
+        path = _string(finding.get("path") or "unknown")
+        line = _string(finding.get("line"))
+        location = f"{path}:{line}" if line else path
+        rule_id = _string(finding.get("rule_id") or "unknown")
+        tool = _string(finding.get("tool") or "unknown")
+        freshness = _string(finding.get("freshness") or "unknown")
+        classification = _string(finding.get("classification") or "unknown")
+        action = _string(finding.get("recommended_action") or "review_current_finding")
+        lines.append(
+            f"  - `{rule_id}` at `{location}`: tool=`{tool}`, "
+            f"freshness=`{freshness}`, classification=`{classification}`, action=`{action}`"
+        )
+        proposal = _string(finding.get("fix_proposal"))
+        if proposal:
+            lines.append(f"    - Proposal: {proposal}")
+        lines.append(
+            "    - Human review required: "
+            f"`{str(bool(finding.get('human_review_required', True))).lower()}`"
+        )
+
+    remaining = len(findings) - 5
+    if remaining > 0:
+        lines.append(f"  - ... `{remaining}` more")
 
     return lines
 
@@ -922,6 +991,7 @@ def render_comment_body(
     safe_fix_outcome: JsonObject | None = None,
     trajectory_records: list[JsonObject] | None = None,
     runtime_proof_artifacts: JsonObject | None = None,
+    security_finding_diagnosis: JsonObject | None = None,
 ) -> str:
     evidence_narrative = evidence_narrative or {}
     safe_fix_outcome = safe_fix_outcome or _as_dict(check_intelligence.get("safe_fix_outcome"))
@@ -960,6 +1030,10 @@ def render_comment_body(
 
     if evidence_signal_lines:
         lines.extend(["## " + evidence_signal_heading, "", *evidence_signal_lines, ""])
+
+    security_diagnosis = _security_finding_diagnosis_lines(security_finding_diagnosis)
+    if security_diagnosis:
+        lines.extend(["## Security finding diagnosis", "", *security_diagnosis, ""])
 
     patch_plan = _patch_plan_lines(evidence_narrative)
     if patch_plan:
@@ -1045,6 +1119,7 @@ def write_comment_body(
     evidence_narrative_path: Path | None = None,
     trajectory_jsonl_path: Path | None = None,
     runtime_proof_artifacts_path: Path | None = None,
+    security_finding_diagnosis_path: Path | None = None,
     failure_bundle_out_dir: Path | None = None,
     pr_number: int = 0,
     head_sha: str = "",
@@ -1055,6 +1130,7 @@ def write_comment_body(
     evidence_narrative = _read_json(evidence_narrative_path)
     trajectory_records = _read_jsonl(trajectory_jsonl_path)
     runtime_proof_artifacts = _read_json(runtime_proof_artifacts_path)
+    security_finding_diagnosis = _read_json(security_finding_diagnosis_path)
 
     body = render_comment_body(
         action_report=action_report,
@@ -1062,6 +1138,7 @@ def write_comment_body(
         evidence_narrative=evidence_narrative,
         trajectory_records=trajectory_records,
         runtime_proof_artifacts=runtime_proof_artifacts,
+        security_finding_diagnosis=security_finding_diagnosis,
     )
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(body, encoding="utf-8")
@@ -1241,6 +1318,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--evidence-narrative", type=Path)
     parser.add_argument("--trajectory-jsonl", type=Path)
     parser.add_argument("--runtime-proof-artifacts", type=Path)
+    parser.add_argument("--security-finding-diagnosis", type=Path)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--failure-bundle-out-dir", type=Path)
     parser.add_argument("--pr-number", type=int, default=0)
@@ -1257,13 +1335,14 @@ def main(argv: list[str] | None = None) -> int:
         evidence_narrative_path=args.evidence_narrative,
         trajectory_jsonl_path=args.trajectory_jsonl,
         runtime_proof_artifacts_path=args.runtime_proof_artifacts,
+        security_finding_diagnosis_path=args.security_finding_diagnosis,
         out=args.out,
         failure_bundle_out_dir=args.failure_bundle_out_dir,
         pr_number=args.pr_number,
         head_sha=args.head_sha,
         base_sha=args.base_sha,
     )
-    print(json.dumps(result, indent=2, sort_keys=True))
+    sys.stdout.write(json.dumps(result, indent=2, sort_keys=True) + "\n")
     return 0
 
 

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -23,7 +23,7 @@ SECURITY_FINDING_DIAGNOSIS_MODULE = "_".join(("security", "finding", "diagnosis"
 NEXT_RECOMMENDED_PR = "/".join(
     (
         "feature",
-        "-".join(("security", "diagnosis", "pr", "quality", "visibility")),
+        "-".join(("security", "reviewed", "disposition", "history")),
     )
 )
 
@@ -299,7 +299,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
         _component(
             module=SECURITY_FINDING_DIAGNOSIS_MODULE,
             role="diagnose current and stale security findings into sanitized fix-or-review proposals without authorizing action",
-            status="partially_aligned",
+            status="aligned",
             stages=("evidence", "diagnosis", "decision", "reporting"),
             existing_artifacts=(
                 "security-finding-diagnosis.json",
@@ -308,13 +308,10 @@ def build_alignment_components() -> list[AlignmentComponent]:
             integration_points=(
                 "security_review_evidence",
                 "check_intelligence",
+                "pr_quality_action_report",
                 "PR Quality workflow",
             ),
-            gaps=(
-                "diagnosis artifacts are uploaded but are not yet rendered in the PR Quality operator narrative",
-                "automatic security fixes and automatic dismissals remain intentionally disallowed",
-            ),
-            recommended_next_action="surface sanitized security diagnosis proposals in PR Quality while preserving human authority",
+            recommended_next_action="record human-reviewed fix and dismissal dispositions before considering any security automation",
         ),
         _component(
             module="adaptive_diagnosis",

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1897,3 +1897,117 @@ def test_write_comment_body_exports_trusted_history_visibility_metadata(
     assert result[report.TRUSTED_HISTORY_AUTOMATION_ALLOWED] is False
     assert result[report.TRUSTED_HISTORY_MERGE_AUTHORIZED] is False
     assert result[report.TRUSTED_HISTORY_SEMANTIC_EQUIVALENCE_PROVEN] is False
+
+
+def test_action_report_renders_sanitized_security_diagnosis_without_authority() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    security_diagnosis = {
+        "collection_status": "collected",
+        "summary": {
+            "open_findings": 1,
+            "current_findings": 1,
+            "stale_findings": 0,
+            "scanner_metadata_false_positive_candidates": 0,
+            "intentional_test_fixture_candidates": 0,
+            "safe_mechanical_fix_candidates": 1,
+            "true_positive_fix_required": 0,
+        },
+        "decision_boundary": {
+            report.AUTOMATIC_SECURITY_FIX_ALLOWED: False,
+            report.AUTOMATIC_DISMISSAL_ALLOWED: False,
+        },
+        "diagnoses": [
+            {
+                "tool": "sdetkit-security-gate",
+                "rule_id": "SEC_DEBUG_PRINT",
+                "path": "src/sdetkit/reporter.py",
+                "line": 22,
+                "freshness": "current",
+                "classification": "_".join(("safe", "mechanical", "fix", "candidate")),
+                "recommended_action": "_".join(("propose", "stdout", "emission", "repair")),
+                "fix_proposal": "Replace direct output with explicit stdout emission.",
+                "human_review_required": True,
+            }
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        security_finding_diagnosis=security_diagnosis,
+    )
+
+    assert "## Security finding diagnosis" in body
+    assert "Current findings: `1`" in body
+    assert "Mechanical fix proposals: `1`" in body
+    assert "Automatic security fix allowed: `false`" in body
+    assert "Automatic dismissal allowed: `false`" in body
+    assert "SEC_DEBUG_PRINT" in body
+    assert "src/sdetkit/reporter.py:22" in body
+    assert "Human review required: `true`" in body
+    assert "Replace direct output with explicit stdout emission." in body
+
+
+def test_write_comment_body_loads_security_diagnosis_artifact_for_operator_visibility(
+    tmp_path: Path,
+) -> None:
+    action_path = _write_json(
+        tmp_path / "action-report.json",
+        {
+            "status": "green",
+            "primary_blocker": {},
+            "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+            "recommended_actions": [],
+            "proof_commands": [],
+        },
+    )
+    intelligence_path = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "checks_seen": 1,
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "security_review": {"collected": True, "unresolved_findings": 0},
+        },
+    )
+    diagnosis_path = _write_json(
+        tmp_path / "security-finding-diagnosis.json",
+        {
+            "collection_status": "collected",
+            "summary": {"open_findings": 0, "current_findings": 0, "stale_findings": 0},
+            "decision_boundary": {
+                report.AUTOMATIC_SECURITY_FIX_ALLOWED: False,
+                report.AUTOMATIC_DISMISSAL_ALLOWED: False,
+            },
+            "diagnoses": [],
+        },
+    )
+    out = tmp_path / "comment.md"
+
+    report.write_comment_body(
+        action_report_path=action_path,
+        check_intelligence_path=intelligence_path,
+        security_finding_diagnosis_path=diagnosis_path,
+        out=out,
+    )
+
+    body = out.read_text(encoding="utf-8")
+    assert "## Security finding diagnosis" in body
+    assert "Open findings: `0`" in body
+    assert "Findings: none" in body
+    assert "Automatic dismissal allowed: `false`" in body

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -89,7 +89,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE not in gaps_by_module
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
-    assert SECURITY_FINDING_DIAGNOSIS_MODULE in gaps_by_module
+    assert SECURITY_FINDING_DIAGNOSIS_MODULE not in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
@@ -109,12 +109,6 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
     assert any("verified" in gap for gap in gaps_by_module["network_boundary"])
     assert any("external filesystem" in gap for gap in gaps_by_module["proof_runtime_guard"])
-    assert any(
-        "operator narrative" in gap for gap in gaps_by_module[SECURITY_FINDING_DIAGNOSIS_MODULE]
-    )
-    assert any(
-        "automatic dismissals" in gap for gap in gaps_by_module[SECURITY_FINDING_DIAGNOSIS_MODULE]
-    )
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -142,7 +136,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{FLAKY_TEST_REGISTRY_EVIDENCE_MODULE}`: `partially_aligned`" in markdown
     assert f"`{TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE}`: `aligned`" in markdown
     assert f"`{TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE}`: `aligned`" in markdown
-    assert f"`{SECURITY_FINDING_DIAGNOSIS_MODULE}`: `partially_aligned`" in markdown
+    assert f"`{SECURITY_FINDING_DIAGNOSIS_MODULE}`: `aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:

--- a/tests/test_security_finding_diagnosis_workflow.py
+++ b/tests/test_security_finding_diagnosis_workflow.py
@@ -37,3 +37,16 @@ def test_pr_quality_uploads_security_diagnosis_artifact_without_automation() -> 
     )[0]
     assert "dismiss" not in diagnosis_block.lower()
     assert "commit-safe-fixes" not in diagnosis_block
+
+
+def test_pr_quality_passes_security_diagnosis_artifact_to_operator_comment_renderer() -> None:
+    text = _workflow_text()
+
+    assert "python -m sdetkit.pr_quality_action_report" in text
+    assert (
+        "--security-finding-diagnosis build/pr-quality/security-diagnosis/security-finding-diagnosis.json"
+        in text
+    )
+    assert text.index("Diagnose security findings read-only") < text.index(
+        "python -m sdetkit.pr_quality_action_report"
+    )


### PR DESCRIPTION
## Summary
- Renders the existing sanitized `security-finding-diagnosis.json` artifact directly in the PR Quality operator comment.
- Shows diagnosis counts, rule/location/tool/freshness/classification, proposed review action, and human-review requirement.
- Passes the diagnosis artifact into `pr_quality_action_report` after it has already been generated by the PR Quality workflow.
- Marks `security_finding_diagnosis` as operator-visible in the reliability-spine audit.
- Keeps automatic security fixes and automatic dismissals disabled.

## Why
PR #1420 established read-only, sanitized security diagnosis artifacts, but maintainers still had to open the uploaded artifact to see the diagnosis. This PR closes that reporting gap: the SDET Quality Gate comment can now state whether a finding is current or stale, what class it belongs to, what review action is proposed, and that no security action was automatically authorized.

## Operator-visible output
The PR Quality comment can now include a section such as:

```text
Security finding diagnosis
- Current findings: 1
- Mechanical fix proposals: 1
- Automatic security fix allowed: false
- Automatic dismissal allowed: false
- SEC_DEBUG_PRINT at src/sdetkit/reporter.py:22:
  classification=safe_mechanical_fix_candidate
  action=propose_stdout_emission_repair
  Human review required: true
```

The rendered content comes only from the already-sanitized diagnosis artifact. Raw flagged source-line contents are not introduced into the comment.

## Implementation
### `src/sdetkit/pr_quality_action_report.py`
- Accepts `--security-finding-diagnosis`.
- Reads the sanitized diagnosis artifact.
- Renders summary counts, individual finding metadata, proposals, and authority boundaries.
- Preserves normal green/review/proof signal behavior.
- Uses explicit stdout emission for the touched CLI path so it remains scanner-clean.

### `.github/workflows/pr-quality-comment.yml`
- Passes `build/pr-quality/security-diagnosis/security-finding-diagnosis.json` into the PR Quality comment renderer.

### Reliability-spine audit
- Updates `security_finding_diagnosis` from `partially_aligned` to `aligned` for its current diagnosis/reporting purpose.
- Records the next recommended PR as:

```text
feature/security-reviewed-disposition-history
```

That next step should store human-reviewed fix/dismissal dispositions as trusted evidence before any consideration of security automation.

## Security boundary
This PR adds visibility only. It does not authorize action.

The following remain false:

- `automatic_security_fix_allowed`
- `automatic_dismissal_allowed`

The comment explicitly surfaces those values so an operator can see that a proposed repair or review classification has not granted execution authority.

## Local verification completed
Targeted proof was run under Python `3.12.13`:

- Connected PR Quality visibility/security-diagnosis/alignment tests: `60 passed`.
- Targeted SDET security scan on touched visibility scope: zero findings.
- `python -m mypy src` passed.
- `python -m pre_commit run -a` passed.
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must provide final full-suite validation.

## Scope
Files changed:

- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/pr_quality_action_report.py`
- `src/sdetkit/reliability_spine_alignment.py`
- `tests/test_pr_quality_action_report.py`
- `tests/test_reliability_spine_alignment.py`
- `tests/test_security_finding_diagnosis_workflow.py`

## Risk
Low-to-medium: this changes the PR Quality operator comment content and renderer inputs. It does not change scanner rules, classification logic, remediation authority, or dismissal authority.

## Rollback
Revert this PR. The sanitized diagnosis artifacts introduced by PR #1420 remain available as uploaded PR Quality evidence, but no longer appear in the rendered comment.

## Next
`feature/security-reviewed-disposition-history`

The next lane should record human-reviewed security outcomes as provenance-checked evidence while continuing to prohibit automatic fixes and dismissals.
