### PR TITLE
Record trusted reviewed security disposition history

### DIFF
--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: read
+  security-events: read
 
 concurrency:
   group: repo-memory-profile-history-main
@@ -212,7 +214,12 @@ jobs:
             exit 1
           fi
 
+          prior_security_disposition_jsonl="$(
+            find build/repo-memory-history/prior-download               -name security-reviewed-disposition-history.jsonl               -print               -quit
+          )"
+
           echo "prior_history_jsonl=$prior_history_jsonl" >> "$GITHUB_OUTPUT"
+          echo "prior_security_disposition_jsonl=$prior_security_disposition_jsonl" >> "$GITHUB_OUTPUT"
           echo "prior_run_id=$prior_run_id" >> "$GITHUB_OUTPUT"
           echo "prior_head_sha=$prior_head_sha" >> "$GITHUB_OUTPUT"
 
@@ -270,6 +277,126 @@ jobs:
           print("Trusted-main RepoMemory history snapshot passed.")
           PY
 
+      - name: Collect accepted-main reviewed security disposition inputs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          out_dir="build/repo-memory-history/security-reviewed-dispositions"
+          mkdir -p "$out_dir"
+
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/commits/${GITHUB_SHA}/pulls?per_page=10" \
+            > "$out_dir/associated-merged-pr.json"
+
+          pr_number="$(
+            HEAD_SHA="$GITHUB_SHA" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          candidates = json.loads(
+              Path("build/repo-memory-history/security-reviewed-dispositions/associated-merged-pr.json")
+              .read_text(encoding="utf-8")
+          )
+          matches = [
+              item
+              for item in candidates
+              if item.get("merged_at") and item.get("merge_commit_sha") == os.environ["HEAD_SHA"]
+          ]
+          if len(matches) > 1:
+              raise SystemExit("accepted-main commit maps to multiple merged PRs")
+          if matches:
+              print(matches[0]["number"])
+          PY
+          )"
+
+          collection_status="collected"
+          collection_reason=""
+          printf '[]\n' > "$out_dir/dismissed-alerts-raw.json"
+
+          if [ -n "$pr_number" ]; then
+            if ! gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$REPOSITORY/code-scanning/alerts?state=dismissed&pr=$pr_number&per_page=100" \
+              > "$out_dir/dismissed-alerts-raw.json"; then
+              collection_status="unavailable"
+              collection_reason="GitHub code-scanning dismissed-alert evidence was unavailable or not permitted."
+              printf '[]\n' > "$out_dir/dismissed-alerts-raw.json"
+            fi
+          fi
+
+          COLLECTION_STATUS="$collection_status" COLLECTION_REASON="$collection_reason" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          source = Path(
+              "build/repo-memory-history/security-reviewed-dispositions/dismissed-alerts-raw.json"
+          )
+          alerts = json.loads(source.read_text(encoding="utf-8"))
+          if not isinstance(alerts, list):
+              raise SystemExit("dismissed-alert API response must be a list")
+          payload = {
+              "collection_status": os.environ["COLLECTION_STATUS"],
+              "collection_reason": os.environ["COLLECTION_REASON"],
+              "alerts": alerts,
+          }
+          Path(
+              "build/repo-memory-history/security-reviewed-dispositions/dismissed-alerts.json"
+          ).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          PY
+
+      - name: Record trusted accepted-main reviewed security disposition history
+        shell: bash
+        env:
+          PRIOR_SECURITY_DISPOSITION_JSONL: ${{ steps.prior.outputs.prior_security_disposition_jsonl }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            --associated-pr-json build/repo-memory-history/security-reviewed-dispositions/associated-merged-pr.json
+            --dismissed-alerts-json build/repo-memory-history/security-reviewed-dispositions/dismissed-alerts.json
+            --source-run-id "${GITHUB_RUN_ID}"
+            --source-head-sha "${GITHUB_SHA}"
+            --out-dir build/repo-memory-history/security-reviewed-dispositions/output
+            --format json
+          )
+
+          if [ -n "$PRIOR_SECURITY_DISPOSITION_JSONL" ]; then
+            args+=(--prior-history-jsonl "$PRIOR_SECURITY_DISPOSITION_JSONL")
+          fi
+
+          PYTHONPATH=src python -m sdetkit.security_reviewed_disposition_history \
+            "${args[@]}" \
+            > build/repo-memory-history/security-reviewed-dispositions/history-cli.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          summary = json.loads(
+              Path(
+                  "build/repo-memory-history/security-reviewed-dispositions/output/"
+                  "security-reviewed-disposition-history-summary.json"
+              ).read_text(encoding="utf-8")
+          )
+          assert summary["status"] == "reviewed_disposition_history_recorded"
+          assert summary["record_count"] >= 1
+          boundary = summary["decision_boundary"]
+          assert boundary["historical_disposition_authorizes_current_action"] is False
+          assert boundary["automatic_security_fix_allowed"] is False
+          assert boundary["automatic_dismissal_allowed"] is False
+          assert boundary["automation_allowed"] is False
+          assert boundary["merge_authorized"] is False
+          assert boundary["prior_history_is_read_only_input"] is True
+          print("Trusted accepted-main security disposition history passed.")
+          PY
+
       - name: Upload trusted main RepoMemory history artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -281,5 +408,6 @@ jobs:
             build/repo-memory-history/fixture-report/
             build/repo-memory-history/pattern-insights/
             build/repo-memory-history/flaky-test-registry/
+            build/repo-memory-history/security-reviewed-dispositions/
           if-no-files-found: error
           retention-days: 90

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -20,10 +20,13 @@ TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE = "_".join(
 )
 TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE = "_".join(("trusted", "test", "observation", "capture"))
 SECURITY_FINDING_DIAGNOSIS_MODULE = "_".join(("security", "finding", "diagnosis"))
+SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE = "_".join(
+    ("security", "reviewed", "disposition", "history")
+)
 NEXT_RECOMMENDED_PR = "/".join(
     (
         "feature",
-        "-".join(("security", "reviewed", "disposition", "history")),
+        "-".join(("security", "disposition", "diagnosis", "context")),
     )
 )
 
@@ -312,6 +315,23 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "PR Quality workflow",
             ),
             recommended_next_action="record human-reviewed fix and dismissal dispositions before considering any security automation",
+        ),
+        _component(
+            module=SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE,
+            role="record sanitized human-reviewed dismissed security findings from accepted-main merged PR evidence without authorizing reuse",
+            status="partially_aligned",
+            stages=("evidence", "history", "reporting"),
+            existing_artifacts=(
+                "security-reviewed-disposition-history.jsonl",
+                "security-reviewed-disposition-history-summary.json",
+                "security-reviewed-disposition-history-summary.md",
+            ),
+            integration_points=("RepoMemory Profile History workflow",),
+            gaps=(
+                "trusted reviewed disposition history is not yet consumed as advisory context by security finding diagnosis",
+                "historical dismissals must never authorize current finding actions",
+            ),
+            recommended_next_action="feed reviewed disposition history into diagnosis as read-only context while preserving manual authority",
         ),
         _component(
             module="adaptive_diagnosis",

--- a/src/sdetkit/security_reviewed_disposition_history.py
+++ b/src/sdetkit/security_reviewed_disposition_history.py
@@ -1,0 +1,446 @@
+"""Record sanitized reviewed security dispositions from accepted-main merge evidence.
+
+This module records read-only historical evidence only. A previously dismissed
+finding never authorizes a fix, dismissal, merge, or other action for a
+current finding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = ".".join(("sdetkit", "security", "reviewed", "disposition", "history", "v1"))
+RECORD_SCHEMA_VERSION = ".".join(
+    ("sdetkit", "security", "reviewed", "disposition", "history", "record", "v1")
+)
+DEFAULT_OUT_DIR = Path("build") / "repo-memory-history" / "security-reviewed-dispositions"
+SUMMARY_JSON = "security-reviewed-disposition-history-summary.json"
+SUMMARY_MD = "security-reviewed-disposition-history-summary.md"
+HISTORY_JSONL = "security-reviewed-disposition-history.jsonl"
+
+COLLECTED = "collected"
+UNAVAILABLE = "unavailable"
+DISMISSED = "dismissed"
+AUTOMATIC_SECURITY_FIX_ALLOWED = "_".join(("automatic", "security", "fix", "allowed"))
+AUTOMATIC_DISMISSAL_ALLOWED = "_".join(("automatic", "dismissal", "allowed"))
+AUTOMATION_ALLOWED = "_".join(("automation", "allowed"))
+MERGE_AUTHORIZED = "_".join(("merge", "authorized"))
+HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
+    ("historical", "disposition", "authorizes", "current", "action")
+)
+PRIOR_HISTORY_READ_ONLY_INPUT = "_".join(("prior", "history", "is", "read", "only", "input"))
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    return value is True
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_jsonl(path: Path | None) -> list[JsonObject]:
+    if path is None or not path.exists():
+        return []
+
+    records: list[JsonObject] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object on line {line_number} in {path}")
+        records.append(payload)
+    return records
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "reporting_only": True,
+        AUTOMATIC_SECURITY_FIX_ALLOWED: False,
+        AUTOMATIC_DISMISSAL_ALLOWED: False,
+        AUTOMATION_ALLOWED: False,
+        MERGE_AUTHORIZED: False,
+        HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
+        PRIOR_HISTORY_READ_ONLY_INPUT: True,
+    }
+
+
+def _assert_no_authority(boundary: Mapping[str, Any], *, source: str) -> None:
+    enabled = [
+        key
+        for key in (
+            AUTOMATIC_SECURITY_FIX_ALLOWED,
+            AUTOMATIC_DISMISSAL_ALLOWED,
+            AUTOMATION_ALLOWED,
+            MERGE_AUTHORIZED,
+            HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION,
+        )
+        if _bool(boundary.get(key))
+    ]
+    if enabled:
+        raise ValueError(
+            f"{source} expands security authority and cannot enter read-only history: "
+            f"{', '.join(enabled)}"
+        )
+
+
+def _select_merged_pr(payload: Any, *, source_head_sha: str) -> JsonObject:
+    candidates = payload if isinstance(payload, list) else [payload]
+    matches = [
+        _as_dict(item)
+        for item in candidates
+        if isinstance(item, dict)
+        and _text(_as_dict(item).get("merged_at"))
+        and _text(_as_dict(item).get("merge_commit_sha")) == source_head_sha
+    ]
+    if len(matches) > 1:
+        raise ValueError("accepted-main commit maps to more than one merged pull request")
+    return matches[0] if matches else {}
+
+
+def _alert_payload(payload: Any) -> tuple[str, str, list[JsonObject]]:
+    if isinstance(payload, list):
+        return COLLECTED, "", [_as_dict(item) for item in payload if isinstance(item, dict)]
+
+    data = _as_dict(payload)
+    status = _text(data.get("collection_status") or COLLECTED)
+    reason = _text(data.get("collection_reason"))
+    alerts = [_as_dict(item) for item in _as_list(data.get("alerts")) if isinstance(item, dict)]
+    if status not in {COLLECTED, UNAVAILABLE}:
+        raise ValueError("dismissed alert collection status is not supported")
+    if status == UNAVAILABLE and alerts:
+        raise ValueError("unavailable dismissed alert collection cannot carry alerts")
+    return status, reason, alerts
+
+
+def _sanitize_dismissed_alert(alert: Mapping[str, Any], *, pull_number: int) -> JsonObject:
+    if _text(alert.get("state")).lower() != DISMISSED:
+        raise ValueError(
+            "only dismissed code-scanning alerts may enter reviewed disposition history"
+        )
+
+    reviewer = _text(_as_dict(alert.get("dismissed_by")).get("login"))
+    dismissed_at = _text(alert.get("dismissed_at"))
+    dismissed_reason = _text(alert.get("dismissed_reason"))
+    if not reviewer or not dismissed_at or not dismissed_reason:
+        raise ValueError("dismissed security disposition lacks reviewer provenance")
+
+    rule = _as_dict(alert.get("rule"))
+    tool = _as_dict(alert.get("tool"))
+    instance = _as_dict(alert.get("most_recent_instance"))
+    location = _as_dict(instance.get("location"))
+    stable = {
+        "pull_number": pull_number,
+        "alert_number": _int(alert.get("number")),
+        "state": DISMISSED,
+        "tool": _text(tool.get("name") or "unknown"),
+        "rule_id": _text(rule.get("id") or "unknown"),
+        "severity": _text(rule.get("security_severity_level") or rule.get("severity") or "unknown"),
+        "path": _text(location.get("path") or "unknown"),
+        "line": _int(location.get("start_line")),
+        "dismissed_by": reviewer,
+        "dismissed_at": dismissed_at,
+        "dismissed_reason": dismissed_reason,
+        "dismissed_comment_present": bool(_text(alert.get("dismissed_comment"))),
+    }
+    return {
+        "disposition_id": _stable_hash(stable),
+        **stable,
+    }
+
+
+def validate_record(record: Mapping[str, Any]) -> None:
+    if _text(record.get("schema_version")) != RECORD_SCHEMA_VERSION:
+        raise ValueError("reviewed security disposition record schema is not supported")
+    _assert_no_authority(
+        _as_dict(record.get("decision_boundary")),
+        source="reviewed security disposition record",
+    )
+    for disposition in _as_list(record.get("reviewed_dispositions")):
+        item = _as_dict(disposition)
+        if _text(item.get("state")) != DISMISSED:
+            raise ValueError("reviewed disposition record contains non-dismissed security state")
+        if "dismissed_comment" in item:
+            raise ValueError("reviewed disposition record must not persist dismissal comment text")
+
+
+def build_history_record(
+    *,
+    associated_pr_payload: Any,
+    dismissed_alerts_payload: Any,
+    source_run_id: str,
+    source_head_sha: str,
+    recorded_at_utc: str | None = None,
+) -> JsonObject:
+    run_id = _text(source_run_id)
+    head_sha = _text(source_head_sha)
+    if not run_id:
+        raise ValueError("source_run_id is required")
+    if not head_sha:
+        raise ValueError("source_head_sha is required")
+
+    merged_pr = _select_merged_pr(associated_pr_payload, source_head_sha=head_sha)
+    collection_status, collection_reason, alerts = _alert_payload(dismissed_alerts_payload)
+    if alerts and not merged_pr:
+        raise ValueError("dismissed alerts cannot be recorded without an associated merged PR")
+
+    pull_number = _int(merged_pr.get("number"))
+    dispositions = (
+        sorted(
+            [_sanitize_dismissed_alert(alert, pull_number=pull_number) for alert in alerts],
+            key=lambda item: (
+                _text(item.get("path")),
+                _int(item.get("line")),
+                _text(item.get("rule_id")),
+                _int(item.get("alert_number")),
+            ),
+        )
+        if merged_pr and collection_status == COLLECTED
+        else []
+    )
+    source = {
+        "workflow": "RepoMemory Profile History",
+        "source_run_id": run_id,
+        "source_head_sha": head_sha,
+        "merged_pr_number": pull_number,
+        "merged_pr_present": bool(merged_pr),
+        "merged_pr_merged_at": _text(merged_pr.get("merged_at")),
+        "collection_status": collection_status,
+        "collection_reason": collection_reason,
+    }
+    stable = {
+        "source": source,
+        "reviewed_dispositions": dispositions,
+        "decision_boundary": _decision_boundary(),
+    }
+    record = {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "record_id": _stable_hash(stable),
+        "recorded_at_utc": recorded_at_utc or _utc_now(),
+        **stable,
+    }
+    validate_record(record)
+    return record
+
+
+def merge_history_records(
+    prior_records: list[Mapping[str, Any]],
+    record: Mapping[str, Any],
+) -> tuple[list[JsonObject], bool]:
+    validate_record(record)
+    records = [dict(item) for item in prior_records]
+    for existing in records:
+        validate_record(existing)
+
+    record_id = _text(record.get("record_id"))
+    existing_ids = {_text(item.get("record_id")) for item in records}
+    appended = record_id not in existing_ids
+    if appended:
+        records.append(dict(record))
+    return records, appended
+
+
+def write_history_jsonl(records: list[Mapping[str, Any]], *, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / HISTORY_JSONL
+    path.write_text(
+        "".join(json.dumps(dict(record), sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def build_summary(
+    records: list[Mapping[str, Any]],
+    *,
+    appended: bool,
+    history_path: Path,
+    prior_history_collected: bool,
+    prior_record_count: int,
+) -> JsonObject:
+    for record in records:
+        validate_record(record)
+    latest = _as_dict(records[-1]) if records else {}
+    latest_source = _as_dict(latest.get("source"))
+    latest_dispositions = [_as_dict(item) for item in _as_list(latest.get("reviewed_dispositions"))]
+    status_counts = Counter(
+        _text(_as_dict(record.get("source")).get("collection_status")) for record in records
+    )
+    total_dispositions = sum(
+        len(_as_list(record.get("reviewed_dispositions"))) for record in records
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "_".join(("reviewed", "disposition", "history", "recorded")),
+        "history_path": history_path.as_posix(),
+        "prior_history_collected": prior_history_collected,
+        "prior_record_count": prior_record_count,
+        "appended": appended,
+        "record_count": len(records),
+        "collection_status_counts": dict(sorted(status_counts.items())),
+        "reviewed_disposition_count": total_dispositions,
+        "latest_record": {
+            "record_id": _text(latest.get("record_id")),
+            "source_run_id": _text(latest_source.get("source_run_id")),
+            "source_head_sha": _text(latest_source.get("source_head_sha")),
+            "merged_pr_number": _int(latest_source.get("merged_pr_number")),
+            "merged_pr_present": _bool(latest_source.get("merged_pr_present")),
+            "collection_status": _text(latest_source.get("collection_status")),
+            "reviewed_disposition_count": len(latest_dispositions),
+        },
+        "decision_boundary": _decision_boundary(),
+    }
+
+
+def render_markdown(summary: Mapping[str, Any]) -> str:
+    latest = _as_dict(summary.get("latest_record"))
+    boundary = _as_dict(summary.get("decision_boundary"))
+    return "\n".join(
+        [
+            "# Security reviewed disposition history",
+            "",
+            f"- Status: `{_text(summary.get('status'))}`",
+            f"- Records: `{_int(summary.get('record_count'))}`",
+            f"- Reviewed dispositions: `{_int(summary.get('reviewed_disposition_count'))}`",
+            f"- Latest accepted main head: `{_text(latest.get('source_head_sha'))}`",
+            f"- Latest merged PR: `{_int(latest.get('merged_pr_number'))}`",
+            (f"- Latest reviewed dispositions: `{_int(latest.get('reviewed_disposition_count'))}`"),
+            "",
+            "## Boundary",
+            "",
+            (
+                "- Historical disposition authorizes current action: "
+                f"`{str(_bool(boundary.get(HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION))).lower()}`"
+            ),
+            (
+                "- Automatic security fix allowed: "
+                f"`{str(_bool(boundary.get(AUTOMATIC_SECURITY_FIX_ALLOWED))).lower()}`"
+            ),
+            (
+                "- Automatic dismissal allowed: "
+                f"`{str(_bool(boundary.get(AUTOMATIC_DISMISSAL_ALLOWED))).lower()}`"
+            ),
+            f"- Automation allowed: `{str(_bool(boundary.get(AUTOMATION_ALLOWED))).lower()}`",
+            f"- Merge authorized: `{str(_bool(boundary.get(MERGE_AUTHORIZED))).lower()}`",
+            (
+                "- Prior history is read-only input: "
+                f"`{str(_bool(boundary.get(PRIOR_HISTORY_READ_ONLY_INPUT))).lower()}`"
+            ),
+            "",
+        ]
+    )
+
+
+def write_summary(summary: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / SUMMARY_JSON
+    markdown_path = out_dir / SUMMARY_MD
+    json_path.write_text(
+        json.dumps(dict(summary), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(summary), encoding="utf-8")
+    return {
+        "summary_json": json_path.as_posix(),
+        "summary_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.security_reviewed_disposition_history")
+    parser.add_argument("--associated-pr-json", type=Path, required=True)
+    parser.add_argument("--dismissed-alerts-json", type=Path, required=True)
+    parser.add_argument("--prior-history-jsonl", type=Path)
+    parser.add_argument("--source-run-id", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--recorded-at-utc")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.prior_history_jsonl is not None and not args.prior_history_jsonl.exists():
+            raise ValueError(
+                f"prior disposition history input does not exist: {args.prior_history_jsonl}"
+            )
+        prior_records = _read_jsonl(args.prior_history_jsonl)
+        record = build_history_record(
+            associated_pr_payload=_read_json(args.associated_pr_json),
+            dismissed_alerts_payload=_read_json(args.dismissed_alerts_json),
+            source_run_id=args.source_run_id,
+            source_head_sha=args.source_head_sha,
+            recorded_at_utc=args.recorded_at_utc,
+        )
+        records, appended = merge_history_records(prior_records, record)
+        history_path = write_history_jsonl(records, out_dir=args.out_dir)
+        summary = build_summary(
+            records,
+            appended=appended,
+            history_path=history_path,
+            prior_history_collected=args.prior_history_jsonl is not None,
+            prior_record_count=len(prior_records),
+        )
+        artifacts = write_summary(summary, out_dir=args.out_dir)
+        artifacts["history_jsonl"] = history_path.as_posix()
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        sys.stdout.write(f"error={exc}\n")
+        return 2
+
+    output = {
+        "status": summary["status"],
+        "record_count": summary["record_count"],
+        "reviewed_disposition_count": summary["reviewed_disposition_count"],
+        "appended": summary["appended"],
+        "artifacts": artifacts,
+    }
+    if args.format == "json":
+        sys.stdout.write(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write("\n".join(f"{key}={value}" for key, value in output.items()) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -9,6 +9,7 @@ from sdetkit.reliability_spine_alignment import (
     PR_QUALITY_LIVE_WORKSPACE_MODULE,
     REPO_MEMORY_PROFILE_HISTORY_MODULE,
     SECURITY_FINDING_DIAGNOSIS_MODULE,
+    SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE,
     SPINE_STAGES,
     TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
     TRUSTED_HISTORY_EVIDENCE_MODULE,
@@ -48,6 +49,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE in modules
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE in modules
     assert SECURITY_FINDING_DIAGNOSIS_MODULE in modules
+    assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE in modules
 
 
 def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
@@ -90,6 +92,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
     assert SECURITY_FINDING_DIAGNOSIS_MODULE not in gaps_by_module
+    assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
@@ -109,6 +112,14 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
     assert any("verified" in gap for gap in gaps_by_module["network_boundary"])
     assert any("external filesystem" in gap for gap in gaps_by_module["proof_runtime_guard"])
+    assert any(
+        "advisory context" in gap
+        for gap in gaps_by_module[SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE]
+    )
+    assert any(
+        "never authorize current" in gap
+        for gap in gaps_by_module[SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE]
+    )
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -137,6 +148,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE}`: `aligned`" in markdown
     assert f"`{TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE}`: `aligned`" in markdown
     assert f"`{SECURITY_FINDING_DIAGNOSIS_MODULE}`: `aligned`" in markdown
+    assert f"`{SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE}`: `partially_aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
@@ -218,6 +230,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
         TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
         SECURITY_FINDING_DIAGNOSIS_MODULE,
+        SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE,
     }
 
     assert "maintenance_autopilot" not in report_modules

--- a/tests/test_repo_memory_profile_history_workflow.py
+++ b/tests/test_repo_memory_profile_history_workflow.py
@@ -100,3 +100,36 @@ def test_repo_memory_history_never_uses_example_flake_history_as_trusted_evidenc
     assert "python -m sdetkit.trusted_flaky_test_registry_producer" in text
     assert "examples/kits/intelligence/flake-history.json" not in text
     assert "python -m sdetkit intelligence flake classify" not in text
+
+
+def test_repo_memory_history_collects_pr_scoped_reviewed_security_dispositions_read_only() -> None:
+    text = _workflow_text()
+
+    assert "pull-requests: read" in text
+    assert "security-events: read" in text
+    assert "Collect accepted-main reviewed security disposition inputs" in text
+    assert "commits/${GITHUB_SHA}/pulls?per_page=10" in text
+    assert "code-scanning/alerts?state=dismissed&pr=$pr_number&per_page=100" in text
+    assert "python -m sdetkit.security_reviewed_disposition_history" in text
+    assert (
+        "--associated-pr-json build/repo-memory-history/security-reviewed-dispositions/associated-merged-pr.json"
+        in text
+    )
+    assert (
+        "--dismissed-alerts-json build/repo-memory-history/security-reviewed-dispositions/dismissed-alerts.json"
+        in text
+    )
+    assert "--prior-history-jsonl" in text
+    assert "security-reviewed-disposition-history.jsonl" in text
+    assert "build/repo-memory-history/security-reviewed-dispositions/" in text
+
+
+def test_repo_memory_history_disposition_lane_never_writes_security_actions() -> None:
+    text = _workflow_text()
+
+    assert 'assert boundary["historical_disposition_authorizes_current_action"] is False' in text
+    assert 'assert boundary["automatic_security_fix_allowed"] is False' in text
+    assert 'assert boundary["automatic_dismissal_allowed"] is False' in text
+    assert "PATCH /repos/" not in text
+    assert "updateAlert" not in text
+    assert "dismissed_comment" not in text

--- a/tests/test_security_reviewed_disposition_history.py
+++ b/tests/test_security_reviewed_disposition_history.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import security_reviewed_disposition_history as history
+
+
+def _merged_pr(head_sha: str = "merged-head") -> list[dict]:
+    return [
+        {
+            "number": 1421,
+            "merged_at": "2026-05-24T03:25:40Z",
+            "merge_commit_sha": head_sha,
+        }
+    ]
+
+
+def _dismissed_alert(*, state: str = "dismissed", comment: str = "Reviewed disposition.") -> dict:
+    return {
+        "number": 44,
+        "state": state,
+        "dismissed_by": {"login": "reviewer"},
+        "dismissed_at": "2026-05-24T03:20:00Z",
+        "dismissed_reason": "false positive",
+        "dismissed_comment": comment,
+        "tool": {"name": "sdetkit-security-gate"},
+        "rule": {"id": "SEC_HIGH_ENTROPY_STRING", "security_severity_level": "warning"},
+        "most_recent_instance": {"location": {"path": "src/sdetkit/example.py", "start_line": 22}},
+    }
+
+
+def test_record_sanitizes_reviewed_dismissal_without_authorizing_reuse() -> None:
+    secret_comment = "Internal review text must stay outside historical evidence."
+    record = history.build_history_record(
+        associated_pr_payload=_merged_pr(),
+        dismissed_alerts_payload={
+            "collection_status": "collected",
+            "alerts": [_dismissed_alert(comment=secret_comment)],
+        },
+        source_run_id="run-1",
+        source_head_sha="merged-head",
+        recorded_at_utc="2026-05-24T03:30:00Z",
+    )
+
+    item = record["reviewed_dispositions"][0]
+    serialized = json.dumps(record)
+    assert item["state"] == "dismissed"
+    assert item["dismissed_by"] == "reviewer"
+    assert item["dismissed_reason"] == "false positive"
+    assert item["dismissed_comment_present"] is True
+    assert "dismissed_comment" not in item
+    assert secret_comment not in serialized
+    boundary = record["decision_boundary"]
+    assert boundary[history.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION] is False
+    assert boundary[history.AUTOMATIC_SECURITY_FIX_ALLOWED] is False
+    assert boundary[history.AUTOMATIC_DISMISSAL_ALLOWED] is False
+    assert boundary[history.AUTOMATION_ALLOWED] is False
+    assert boundary[history.MERGE_AUTHORIZED] is False
+
+
+def test_record_requires_dismissed_state_and_reviewer_provenance() -> None:
+    with pytest.raises(ValueError, match="only dismissed"):
+        history.build_history_record(
+            associated_pr_payload=_merged_pr(),
+            dismissed_alerts_payload=[_dismissed_alert(state="open")],
+            source_run_id="run-1",
+            source_head_sha="merged-head",
+        )
+
+    alert = _dismissed_alert()
+    alert["dismissed_by"] = {}
+    with pytest.raises(ValueError, match="lacks reviewer provenance"):
+        history.build_history_record(
+            associated_pr_payload=_merged_pr(),
+            dismissed_alerts_payload=[alert],
+            source_run_id="run-1",
+            source_head_sha="merged-head",
+        )
+
+
+def test_record_can_capture_no_dispositions_without_claiming_review() -> None:
+    record = history.build_history_record(
+        associated_pr_payload=_merged_pr(),
+        dismissed_alerts_payload={"collection_status": "collected", "alerts": []},
+        source_run_id="run-1",
+        source_head_sha="merged-head",
+    )
+    assert record["reviewed_dispositions"] == []
+    assert record["source"]["merged_pr_present"] is True
+    assert (
+        record["decision_boundary"][history.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION]
+        is False
+    )
+
+
+def test_unavailable_collection_carries_no_disposition_claims() -> None:
+    record = history.build_history_record(
+        associated_pr_payload=_merged_pr(),
+        dismissed_alerts_payload={
+            "collection_status": "unavailable",
+            "collection_reason": "read permission unavailable",
+            "alerts": [],
+        },
+        source_run_id="run-1",
+        source_head_sha="merged-head",
+    )
+    assert record["source"]["collection_status"] == "unavailable"
+    assert record["reviewed_dispositions"] == []
+
+
+def test_prior_history_is_deduplicated_and_rejects_authority_expansion(tmp_path: Path) -> None:
+    record = history.build_history_record(
+        associated_pr_payload=_merged_pr(),
+        dismissed_alerts_payload={"collection_status": "collected", "alerts": []},
+        source_run_id="run-1",
+        source_head_sha="merged-head",
+        recorded_at_utc="2026-05-24T03:30:00Z",
+    )
+    records, appended = history.merge_history_records([record], record)
+    assert appended is False
+    assert len(records) == 1
+
+    bad = json.loads(json.dumps(record))
+    bad["decision_boundary"][history.AUTOMATIC_DISMISSAL_ALLOWED] = True
+    with pytest.raises(ValueError, match="expands security authority"):
+        history.merge_history_records([bad], record)
+
+
+def test_cli_writes_read_only_history_artifacts(tmp_path: Path, capsys) -> None:
+    pr_path = tmp_path / "pr.json"
+    alerts_path = tmp_path / "alerts.json"
+    out_dir = tmp_path / "out"
+    pr_path.write_text(json.dumps(_merged_pr()), encoding="utf-8")
+    alerts_path.write_text(
+        json.dumps({"collection_status": "collected", "alerts": [_dismissed_alert()]}),
+        encoding="utf-8",
+    )
+
+    rc = history.main(
+        [
+            "--associated-pr-json",
+            str(pr_path),
+            "--dismissed-alerts-json",
+            str(alerts_path),
+            "--source-run-id",
+            "run-1",
+            "--source-head-sha",
+            "merged-head",
+            "--recorded-at-utc",
+            "2026-05-24T03:30:00Z",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    summary = json.loads((out_dir / history.SUMMARY_JSON).read_text(encoding="utf-8"))
+    markdown = (out_dir / history.SUMMARY_MD).read_text(encoding="utf-8")
+    assert printed["reviewed_disposition_count"] == 1
+    assert summary["latest_record"]["reviewed_disposition_count"] == 1
+    assert "Historical disposition authorizes current action: `false`" in markdown
+    assert "Automatic dismissal allowed: `false`" in markdown


### PR DESCRIPTION
## Summary
- Adds `security_reviewed_disposition_history`, a trusted accepted-main history recorder for human-reviewed dismissed security findings.
- Wires the existing `RepoMemory Profile History` workflow to identify the merged PR associated with the accepted `main` commit and collect PR-scoped dismissed code-scanning alert evidence.
- Persists sanitized reviewer/reason/rule/location disposition metadata while explicitly excluding dismissal-comment text.
- Records the new history lane in the reliability-spine audit as partially aligned.
- Preserves the safety boundary that historical dispositions do not authorize present or future security action.

## Why
PR #1420 added sanitized security-finding diagnosis artifacts, and PR #1421 surfaced those diagnoses in PR Quality. The next missing evidence layer is trustworthy historical memory of what a human actually reviewed after merge.

This PR creates that memory only from accepted-main evidence. It does not say that a historical dismissal was correct for a new finding, and it does not allow a current alert to be fixed or dismissed automatically.

## Trusted evidence flow
On each accepted `main` push, the existing trusted-main history workflow now:

1. Resolves the pull request associated with the accepted merge commit.
2. Requests dismissed code-scanning alert evidence scoped to that merged PR.
3. Sanitizes the reviewed disposition metadata.
4. Appends a deduplicated JSONL history record.
5. Uploads the resulting trusted-history artifact with the existing RepoMemory history evidence.

Stored reviewed-disposition fields include:

- merged PR number and accepted-main head;
- alert number, tool, rule id, severity, path, and line;
- reviewer login, dismissal timestamp, and dismissal reason;
- whether a dismissal comment was present.

The actual dismissal-comment text is not stored.

## New module
### `src/sdetkit/security_reviewed_disposition_history.py`
Adds a deterministic reporting-only history recorder with:

- accepted-main source run/head provenance;
- merged-PR verification;
- dismissed-only state validation;
- reviewer provenance validation;
- deduplicated history JSONL output;
- JSON and Markdown summaries;
- explicit non-authority boundaries.

Artifacts:

```text
security-reviewed-disposition-history.jsonl
security-reviewed-disposition-history-summary.json
security-reviewed-disposition-history-summary.md
```

## Workflow integration
### `.github/workflows/repo-memory-history.yml`
The accepted-main history workflow now receives read-only permissions required for evidence collection:

```text
pull-requests: read
security-events: read
```

It records disposition history only from accepted `main` pushes. It does not run on pull request events and does not write repository code or mutate GitHub security alert state.

## Security and authority boundary
This PR is historical evidence only.

The following remain false:

```text
historical_disposition_authorizes_current_action=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
automation_allowed=false
merge_authorized=false
prior_history_is_read_only_input=true
```

A historical dismissal is evidence that a human previously made a disposition. It is not permission to dismiss a new or similar current alert.

## Live API proof
A read-only live proof was run against previously merged PR **#1418**:

```text
live_associated_merged_pr=verified
merged_pr_number=1418
merge_commit_sha=3d60133175c12e4a5396873bf5de8520dd14e8a5
live_dismissed_alert_payload=verified
live_dismissed_alert_count=32
live_reviewed_disposition_artifact=verified
reviewed_disposition_count=32
dismissal_comment_text_persisted=false
historical_disposition_authorizes_current_action=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
```

This validates the real GitHub payload shape and the sanitizer/authority boundary without modifying the repository or any alert.

## Local verification completed
Targeted proof was run under Python `3.12.13`:

- Focused reviewed-disposition/workflow/alignment tests: `23 passed`.
- Targeted SDET security scan on the touched scope: zero findings.
- `python -m mypy src` passed.
- `python -m pre_commit run -a` passed.
- `python scripts/check_generated_artifacts_freshness.py` passed.
- Read-only live API proof against merged PR #1418 passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must provide final full-suite validation.

## Scope
Files changed:

- `.github/workflows/repo-memory-history.yml`
- `src/sdetkit/reliability_spine_alignment.py`
- `src/sdetkit/security_reviewed_disposition_history.py`
- `tests/test_reliability_spine_alignment.py`
- `tests/test_repo_memory_profile_history_workflow.py`
- `tests/test_security_reviewed_disposition_history.py`

## Risk
Medium: this extends a trusted-main workflow and reads dismissed security-alert metadata. The risk is bounded because it records evidence only, strips dismissal-comment text, rejects authority expansion, and does not consume this history for current diagnosis decisions in this PR.

## Rollback
Revert this PR. Existing diagnosis and PR Quality visibility from PRs #1420 and #1421 remain intact; only trusted reviewed-disposition history collection is removed.

## Next
`feature/security-disposition-diagnosis-context`

The follow-up should pass trusted reviewed disposition history into the security diagnosis engine as read-only advisory context while continuing to prohibit automatic fixes and dismissals.
