### PR TITLE
Verify security disposition history against PR scope

### DIFF
--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -317,13 +317,21 @@ jobs:
 
           collection_status="collected"
           collection_reason=""
+          printf '[]\n' > "$out_dir/changed-files.json"
           printf '[]\n' > "$out_dir/dismissed-alerts-raw.json"
 
           if [ -n "$pr_number" ]; then
-            if ! gh api \
+            gh api --paginate \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$REPOSITORY/pulls/$pr_number/files?per_page=100" \
+              --jq '.[]' \
+              | jq -s '.' > "$out_dir/changed-files.json"
+
+            if ! gh api --paginate \
               -H "Accept: application/vnd.github+json" \
               "repos/$REPOSITORY/code-scanning/alerts?state=dismissed&pr=$pr_number&per_page=100" \
-              > "$out_dir/dismissed-alerts-raw.json"; then
+              --jq '.[]' \
+              | jq -s '.' > "$out_dir/dismissed-alerts-raw.json"; then
               collection_status="unavailable"
               collection_reason="GitHub code-scanning dismissed-alert evidence was unavailable or not permitted."
               printf '[]\n' > "$out_dir/dismissed-alerts-raw.json"
@@ -360,6 +368,7 @@ jobs:
 
           args=(
             --associated-pr-json build/repo-memory-history/security-reviewed-dispositions/associated-merged-pr.json
+            --changed-files-json build/repo-memory-history/security-reviewed-dispositions/changed-files.json
             --dismissed-alerts-json build/repo-memory-history/security-reviewed-dispositions/dismissed-alerts.json
             --source-run-id "${GITHUB_RUN_ID}"
             --source-head-sha "${GITHUB_SHA}"
@@ -387,6 +396,8 @@ jobs:
           )
           assert summary["status"] == "reviewed_disposition_history_recorded"
           assert summary["record_count"] >= 1
+          assert summary["latest_record"]["pr_scope_verification"] == "changed_paths_proven"
+          assert summary["latest_record"]["alerts_excluded_outside_changed_paths"] >= 0
           boundary = summary["decision_boundary"]
           assert boundary["historical_disposition_authorizes_current_action"] is False
           assert boundary["automatic_security_fix_allowed"] is False

--- a/src/sdetkit/security_reviewed_disposition_history.py
+++ b/src/sdetkit/security_reviewed_disposition_history.py
@@ -17,8 +17,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = ".".join(("sdetkit", "security", "reviewed", "disposition", "history", "v1"))
+SCHEMA_VERSION = ".".join(("sdetkit", "security", "reviewed", "disposition", "history", "v2"))
 RECORD_SCHEMA_VERSION = ".".join(
+    ("sdetkit", "security", "reviewed", "disposition", "history", "record", "v2")
+)
+UNVERIFIED_RECORD_SCHEMA_VERSION = ".".join(
     ("sdetkit", "security", "reviewed", "disposition", "history", "record", "v1")
 )
 DEFAULT_OUT_DIR = Path("build") / "repo-memory-history" / "security-reviewed-dispositions"
@@ -37,6 +40,17 @@ HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
     ("historical", "disposition", "authorizes", "current", "action")
 )
 PRIOR_HISTORY_READ_ONLY_INPUT = "_".join(("prior", "history", "is", "read", "only", "input"))
+PR_SCOPE_VERIFICATION = "_".join(("pr", "scope", "verification"))
+CHANGED_PATHS_PROVEN = "_".join(("changed", "paths", "proven"))
+PATH_IN_MERGED_PR_CHANGED_FILES = "_".join(("path", "in", "merged", "pr", "changed", "files"))
+MERGED_PR_CHANGED_PATH_COUNT = "_".join(("merged", "pr", "changed", "path", "count"))
+ALERTS_RETURNED_BY_PR_FILTER = "_".join(("alerts", "returned", "by", "pr", "filter"))
+ALERTS_EXCLUDED_OUTSIDE_CHANGED_PATHS = "_".join(
+    ("alerts", "excluded", "outside", "changed", "paths")
+)
+IGNORED_UNVERIFIED_PRIOR_RECORD_COUNT = "_".join(
+    ("ignored", "unverified", "prior", "record", "count")
+)
 
 JsonObject = dict[str, Any]
 
@@ -137,6 +151,24 @@ def _select_merged_pr(payload: Any, *, source_head_sha: str) -> JsonObject:
     return matches[0] if matches else {}
 
 
+def _changed_paths(payload: Any) -> set[str]:
+    files = payload if isinstance(payload, list) else _as_list(_as_dict(payload).get("files"))
+    paths: set[str] = set()
+    for item in files:
+        data = _as_dict(item)
+        for key in ("filename", "previous_filename"):
+            item_path = _text(data.get(key))
+            if item_path:
+                paths.add(item_path)
+    return paths
+
+
+def _alert_path(alert: Mapping[str, Any]) -> str:
+    instance = _as_dict(alert.get("most_recent_instance"))
+    location = _as_dict(instance.get("location"))
+    return _text(location.get("path"))
+
+
 def _alert_payload(payload: Any) -> tuple[str, str, list[JsonObject]]:
     if isinstance(payload, list):
         return COLLECTED, "", [_as_dict(item) for item in payload if isinstance(item, dict)]
@@ -181,6 +213,7 @@ def _sanitize_dismissed_alert(alert: Mapping[str, Any], *, pull_number: int) -> 
         "dismissed_at": dismissed_at,
         "dismissed_reason": dismissed_reason,
         "dismissed_comment_present": bool(_text(alert.get("dismissed_comment"))),
+        PATH_IN_MERGED_PR_CHANGED_FILES: True,
     }
     return {
         "disposition_id": _stable_hash(stable),
@@ -195,17 +228,39 @@ def validate_record(record: Mapping[str, Any]) -> None:
         _as_dict(record.get("decision_boundary")),
         source="reviewed security disposition record",
     )
+    source = _as_dict(record.get("source"))
+    if (
+        _bool(source.get("merged_pr_present"))
+        and source.get(PR_SCOPE_VERIFICATION) != CHANGED_PATHS_PROVEN
+    ):
+        raise ValueError("reviewed disposition record lacks merged-PR changed-path provenance")
     for disposition in _as_list(record.get("reviewed_dispositions")):
         item = _as_dict(disposition)
         if _text(item.get("state")) != DISMISSED:
             raise ValueError("reviewed disposition record contains non-dismissed security state")
         if "dismissed_comment" in item:
             raise ValueError("reviewed disposition record must not persist dismissal comment text")
+        if item.get(PATH_IN_MERGED_PR_CHANGED_FILES) is not True:
+            raise ValueError("reviewed disposition is not proven to be in merged-PR changed files")
+
+
+def _import_verified_prior_records(records: list[JsonObject]) -> tuple[list[JsonObject], int]:
+    verified: list[JsonObject] = []
+    ignored_unverified = 0
+    for record in records:
+        schema = _text(record.get("schema_version"))
+        if schema == UNVERIFIED_RECORD_SCHEMA_VERSION:
+            ignored_unverified += 1
+            continue
+        validate_record(record)
+        verified.append(record)
+    return verified, ignored_unverified
 
 
 def build_history_record(
     *,
     associated_pr_payload: Any,
+    changed_files_payload: Any,
     dismissed_alerts_payload: Any,
     source_run_id: str,
     source_head_sha: str,
@@ -219,14 +274,20 @@ def build_history_record(
         raise ValueError("source_head_sha is required")
 
     merged_pr = _select_merged_pr(associated_pr_payload, source_head_sha=head_sha)
+    changed_paths = _changed_paths(changed_files_payload)
     collection_status, collection_reason, alerts = _alert_payload(dismissed_alerts_payload)
     if alerts and not merged_pr:
         raise ValueError("dismissed alerts cannot be recorded without an associated merged PR")
+    if merged_pr and not changed_paths:
+        raise ValueError("merged PR changed-file provenance is required for disposition history")
 
     pull_number = _int(merged_pr.get("number"))
+    scoped_alerts = [
+        alert for alert in alerts if _alert_path(alert) and _alert_path(alert) in changed_paths
+    ]
     dispositions = (
         sorted(
-            [_sanitize_dismissed_alert(alert, pull_number=pull_number) for alert in alerts],
+            [_sanitize_dismissed_alert(alert, pull_number=pull_number) for alert in scoped_alerts],
             key=lambda item: (
                 _text(item.get("path")),
                 _int(item.get("line")),
@@ -246,6 +307,10 @@ def build_history_record(
         "merged_pr_merged_at": _text(merged_pr.get("merged_at")),
         "collection_status": collection_status,
         "collection_reason": collection_reason,
+        PR_SCOPE_VERIFICATION: CHANGED_PATHS_PROVEN if merged_pr else "",
+        MERGED_PR_CHANGED_PATH_COUNT: len(changed_paths),
+        ALERTS_RETURNED_BY_PR_FILTER: len(alerts),
+        ALERTS_EXCLUDED_OUTSIDE_CHANGED_PATHS: len(alerts) - len(scoped_alerts),
     }
     stable = {
         "source": source,
@@ -296,6 +361,7 @@ def build_summary(
     history_path: Path,
     prior_history_collected: bool,
     prior_record_count: int,
+    ignored_unverified_prior_record_count: int,
 ) -> JsonObject:
     for record in records:
         validate_record(record)
@@ -314,6 +380,7 @@ def build_summary(
         "history_path": history_path.as_posix(),
         "prior_history_collected": prior_history_collected,
         "prior_record_count": prior_record_count,
+        IGNORED_UNVERIFIED_PRIOR_RECORD_COUNT: ignored_unverified_prior_record_count,
         "appended": appended,
         "record_count": len(records),
         "collection_status_counts": dict(sorted(status_counts.items())),
@@ -326,6 +393,11 @@ def build_summary(
             "merged_pr_present": _bool(latest_source.get("merged_pr_present")),
             "collection_status": _text(latest_source.get("collection_status")),
             "reviewed_disposition_count": len(latest_dispositions),
+            PR_SCOPE_VERIFICATION: _text(latest_source.get(PR_SCOPE_VERIFICATION)),
+            ALERTS_RETURNED_BY_PR_FILTER: _int(latest_source.get(ALERTS_RETURNED_BY_PR_FILTER)),
+            ALERTS_EXCLUDED_OUTSIDE_CHANGED_PATHS: _int(
+                latest_source.get(ALERTS_EXCLUDED_OUTSIDE_CHANGED_PATHS)
+            ),
         },
         "decision_boundary": _decision_boundary(),
     }
@@ -341,8 +413,17 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
             f"- Status: `{_text(summary.get('status'))}`",
             f"- Records: `{_int(summary.get('record_count'))}`",
             f"- Reviewed dispositions: `{_int(summary.get('reviewed_disposition_count'))}`",
+            (
+                "- Ignored unverified prior records: "
+                f"`{_int(summary.get(IGNORED_UNVERIFIED_PRIOR_RECORD_COUNT))}`"
+            ),
             f"- Latest accepted main head: `{_text(latest.get('source_head_sha'))}`",
             f"- Latest merged PR: `{_int(latest.get('merged_pr_number'))}`",
+            f"- Latest PR scope verification: `{_text(latest.get(PR_SCOPE_VERIFICATION))}`",
+            (
+                "- Latest excluded out-of-scope alerts: "
+                f"`{_int(latest.get(ALERTS_EXCLUDED_OUTSIDE_CHANGED_PATHS))}`"
+            ),
             (f"- Latest reviewed dispositions: `{_int(latest.get('reviewed_disposition_count'))}`"),
             "",
             "## Boundary",
@@ -388,6 +469,7 @@ def write_summary(summary: Mapping[str, Any], *, out_dir: Path) -> dict[str, str
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.security_reviewed_disposition_history")
     parser.add_argument("--associated-pr-json", type=Path, required=True)
+    parser.add_argument("--changed-files-json", type=Path, required=True)
     parser.add_argument("--dismissed-alerts-json", type=Path, required=True)
     parser.add_argument("--prior-history-jsonl", type=Path)
     parser.add_argument("--source-run-id", required=True)
@@ -405,9 +487,11 @@ def main(argv: list[str] | None = None) -> int:
             raise ValueError(
                 f"prior disposition history input does not exist: {args.prior_history_jsonl}"
             )
-        prior_records = _read_jsonl(args.prior_history_jsonl)
+        raw_prior_records = _read_jsonl(args.prior_history_jsonl)
+        prior_records, ignored_unverified = _import_verified_prior_records(raw_prior_records)
         record = build_history_record(
             associated_pr_payload=_read_json(args.associated_pr_json),
+            changed_files_payload=_read_json(args.changed_files_json),
             dismissed_alerts_payload=_read_json(args.dismissed_alerts_json),
             source_run_id=args.source_run_id,
             source_head_sha=args.source_head_sha,
@@ -420,7 +504,8 @@ def main(argv: list[str] | None = None) -> int:
             appended=appended,
             history_path=history_path,
             prior_history_collected=args.prior_history_jsonl is not None,
-            prior_record_count=len(prior_records),
+            prior_record_count=len(raw_prior_records),
+            ignored_unverified_prior_record_count=ignored_unverified,
         )
         artifacts = write_summary(summary, out_dir=args.out_dir)
         artifacts["history_jsonl"] = history_path.as_posix()
@@ -432,6 +517,7 @@ def main(argv: list[str] | None = None) -> int:
         "status": summary["status"],
         "record_count": summary["record_count"],
         "reviewed_disposition_count": summary["reviewed_disposition_count"],
+        IGNORED_UNVERIFIED_PRIOR_RECORD_COUNT: summary[IGNORED_UNVERIFIED_PRIOR_RECORD_COUNT],
         "appended": summary["appended"],
         "artifacts": artifacts,
     }

--- a/tests/test_repo_memory_profile_history_workflow.py
+++ b/tests/test_repo_memory_profile_history_workflow.py
@@ -133,3 +133,20 @@ def test_repo_memory_history_disposition_lane_never_writes_security_actions() ->
     assert "PATCH /repos/" not in text
     assert "updateAlert" not in text
     assert "dismissed_comment" not in text
+
+
+def test_repo_memory_history_filters_dismissed_security_evidence_to_merged_pr_changed_paths() -> (
+    None
+):
+    text = _workflow_text()
+    assert "pulls/$pr_number/files?per_page=100" in text
+    assert "changed-files.json" in text
+    assert (
+        "--changed-files-json build/repo-memory-history/security-reviewed-dispositions/changed-files.json"
+        in text
+    )
+    assert (
+        'assert summary["latest_record"]["pr_scope_verification"] == "changed_paths_proven"' in text
+    )
+    assert 'assert summary["latest_record"]["alerts_excluded_outside_changed_paths"] >= 0' in text
+    assert "gh api --paginate" in text

--- a/tests/test_security_reviewed_disposition_history.py
+++ b/tests/test_security_reviewed_disposition_history.py
@@ -9,16 +9,19 @@ from sdetkit import security_reviewed_disposition_history as history
 
 
 def _merged_pr(head_sha: str = "merged-head") -> list[dict]:
-    return [
-        {
-            "number": 1421,
-            "merged_at": "2026-05-24T03:25:40Z",
-            "merge_commit_sha": head_sha,
-        }
-    ]
+    return [{"number": 1422, "merged_at": "2026-05-24T03:44:54Z", "merge_commit_sha": head_sha}]
 
 
-def _dismissed_alert(*, state: str = "dismissed", comment: str = "Reviewed disposition.") -> dict:
+def _changed_files(*paths: str) -> list[dict]:
+    return [{"filename": path} for path in paths]
+
+
+def _dismissed_alert(
+    *,
+    path: str = "src/sdetkit/example.py",
+    state: str = "dismissed",
+    comment: str = "Reviewed disposition.",
+) -> dict:
     return {
         "number": 44,
         "state": state,
@@ -28,141 +31,146 @@ def _dismissed_alert(*, state: str = "dismissed", comment: str = "Reviewed dispo
         "dismissed_comment": comment,
         "tool": {"name": "sdetkit-security-gate"},
         "rule": {"id": "SEC_HIGH_ENTROPY_STRING", "security_severity_level": "warning"},
-        "most_recent_instance": {"location": {"path": "src/sdetkit/example.py", "start_line": 22}},
+        "most_recent_instance": {"location": {"path": path, "start_line": 22}},
     }
 
 
-def test_record_sanitizes_reviewed_dismissal_without_authorizing_reuse() -> None:
-    secret_comment = "Internal review text must stay outside historical evidence."
-    record = history.build_history_record(
+def _build(*, alerts: list[dict], paths: tuple[str, ...] = ("src/sdetkit/example.py",)) -> dict:
+    return history.build_history_record(
         associated_pr_payload=_merged_pr(),
-        dismissed_alerts_payload={
-            "collection_status": "collected",
-            "alerts": [_dismissed_alert(comment=secret_comment)],
-        },
+        changed_files_payload=_changed_files(*paths),
+        dismissed_alerts_payload={"collection_status": "collected", "alerts": alerts},
         source_run_id="run-1",
         source_head_sha="merged-head",
         recorded_at_utc="2026-05-24T03:30:00Z",
     )
 
+
+def test_record_sanitizes_scoped_reviewed_dismissal_without_authorizing_reuse() -> None:
+    secret_comment = "Internal review text must stay outside historical evidence."
+    record = _build(alerts=[_dismissed_alert(comment=secret_comment)])
     item = record["reviewed_dispositions"][0]
     serialized = json.dumps(record)
     assert item["state"] == "dismissed"
-    assert item["dismissed_by"] == "reviewer"
-    assert item["dismissed_reason"] == "false positive"
-    assert item["dismissed_comment_present"] is True
+    assert item[history.PATH_IN_MERGED_PR_CHANGED_FILES] is True
     assert "dismissed_comment" not in item
     assert secret_comment not in serialized
+    assert record["source"][history.PR_SCOPE_VERIFICATION] == history.CHANGED_PATHS_PROVEN
     boundary = record["decision_boundary"]
     assert boundary[history.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION] is False
     assert boundary[history.AUTOMATIC_SECURITY_FIX_ALLOWED] is False
     assert boundary[history.AUTOMATIC_DISMISSAL_ALLOWED] is False
-    assert boundary[history.AUTOMATION_ALLOWED] is False
-    assert boundary[history.MERGE_AUTHORIZED] is False
 
 
-def test_record_requires_dismissed_state_and_reviewer_provenance() -> None:
-    with pytest.raises(ValueError, match="only dismissed"):
-        history.build_history_record(
-            associated_pr_payload=_merged_pr(),
-            dismissed_alerts_payload=[_dismissed_alert(state="open")],
-            source_run_id="run-1",
-            source_head_sha="merged-head",
-        )
-
-    alert = _dismissed_alert()
-    alert["dismissed_by"] = {}
-    with pytest.raises(ValueError, match="lacks reviewer provenance"):
-        history.build_history_record(
-            associated_pr_payload=_merged_pr(),
-            dismissed_alerts_payload=[alert],
-            source_run_id="run-1",
-            source_head_sha="merged-head",
-        )
-
-
-def test_record_can_capture_no_dispositions_without_claiming_review() -> None:
-    record = history.build_history_record(
-        associated_pr_payload=_merged_pr(),
-        dismissed_alerts_payload={"collection_status": "collected", "alerts": []},
-        source_run_id="run-1",
-        source_head_sha="merged-head",
+def test_pr_filtered_alerts_outside_merged_changed_paths_are_excluded() -> None:
+    record = _build(
+        alerts=[
+            _dismissed_alert(path="src/sdetkit/unrelated_old_file.py"),
+            _dismissed_alert(path="tests/test_unrelated_old_file.py"),
+        ],
+        paths=("src/sdetkit/new_history.py",),
     )
     assert record["reviewed_dispositions"] == []
-    assert record["source"]["merged_pr_present"] is True
-    assert (
-        record["decision_boundary"][history.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION]
-        is False
-    )
+    source = record["source"]
+    assert source[history.ALERTS_RETURNED_BY_PR_FILTER] == 2
+    assert source[history.ALERTS_EXCLUDED_OUTSIDE_CHANGED_PATHS] == 2
+    assert source[history.PR_SCOPE_VERIFICATION] == history.CHANGED_PATHS_PROVEN
 
 
-def test_unavailable_collection_carries_no_disposition_claims() -> None:
+def test_record_accepts_renamed_previous_path_as_pr_scope_provenance() -> None:
     record = history.build_history_record(
         associated_pr_payload=_merged_pr(),
+        changed_files_payload=[
+            {"filename": "src/sdetkit/new_name.py", "previous_filename": "src/sdetkit/old_name.py"}
+        ],
         dismissed_alerts_payload={
-            "collection_status": "unavailable",
-            "collection_reason": "read permission unavailable",
-            "alerts": [],
+            "collection_status": "collected",
+            "alerts": [_dismissed_alert(path="src/sdetkit/old_name.py")],
         },
         source_run_id="run-1",
         source_head_sha="merged-head",
     )
-    assert record["source"]["collection_status"] == "unavailable"
-    assert record["reviewed_dispositions"] == []
+    assert len(record["reviewed_dispositions"]) == 1
+    assert record["reviewed_dispositions"][0][history.PATH_IN_MERGED_PR_CHANGED_FILES] is True
 
 
-def test_prior_history_is_deduplicated_and_rejects_authority_expansion(tmp_path: Path) -> None:
-    record = history.build_history_record(
-        associated_pr_payload=_merged_pr(),
-        dismissed_alerts_payload={"collection_status": "collected", "alerts": []},
-        source_run_id="run-1",
-        source_head_sha="merged-head",
-        recorded_at_utc="2026-05-24T03:30:00Z",
-    )
+def test_record_requires_dismissed_state_and_reviewer_provenance_for_scoped_alert() -> None:
+    with pytest.raises(ValueError, match="only dismissed"):
+        _build(alerts=[_dismissed_alert(state="open")])
+    alert = _dismissed_alert()
+    alert["dismissed_by"] = {}
+    with pytest.raises(ValueError, match="lacks reviewer provenance"):
+        _build(alerts=[alert])
+
+
+def test_merged_record_requires_changed_file_provenance() -> None:
+    with pytest.raises(ValueError, match="changed-file provenance"):
+        history.build_history_record(
+            associated_pr_payload=_merged_pr(),
+            changed_files_payload=[],
+            dismissed_alerts_payload={"collection_status": "collected", "alerts": []},
+            source_run_id="run-1",
+            source_head_sha="merged-head",
+        )
+
+
+def test_verified_v2_history_deduplicates_and_rejects_authority_expansion() -> None:
+    record = _build(alerts=[])
     records, appended = history.merge_history_records([record], record)
     assert appended is False
     assert len(records) == 1
-
     bad = json.loads(json.dumps(record))
     bad["decision_boundary"][history.AUTOMATIC_DISMISSAL_ALLOWED] = True
     with pytest.raises(ValueError, match="expands security authority"):
         history.merge_history_records([bad], record)
 
 
-def test_cli_writes_read_only_history_artifacts(tmp_path: Path, capsys) -> None:
+def test_cli_ignores_unverified_v1_prior_chain_and_writes_v2_artifacts(
+    tmp_path: Path, capsys
+) -> None:
     pr_path = tmp_path / "pr.json"
+    changed_path = tmp_path / "files.json"
     alerts_path = tmp_path / "alerts.json"
+    prior_path = tmp_path / "prior.jsonl"
     out_dir = tmp_path / "out"
     pr_path.write_text(json.dumps(_merged_pr()), encoding="utf-8")
+    changed_path.write_text(json.dumps(_changed_files("src/sdetkit/example.py")), encoding="utf-8")
     alerts_path.write_text(
         json.dumps({"collection_status": "collected", "alerts": [_dismissed_alert()]}),
         encoding="utf-8",
     )
-
+    prior_path.write_text(
+        json.dumps({"schema_version": history.UNVERIFIED_RECORD_SCHEMA_VERSION}) + "\n",
+        encoding="utf-8",
+    )
     rc = history.main(
         [
             "--associated-pr-json",
             str(pr_path),
+            "--changed-files-json",
+            str(changed_path),
             "--dismissed-alerts-json",
             str(alerts_path),
+            "--prior-history-jsonl",
+            str(prior_path),
             "--source-run-id",
-            "run-1",
+            "run-2",
             "--source-head-sha",
             "merged-head",
-            "--recorded-at-utc",
-            "2026-05-24T03:30:00Z",
             "--out-dir",
             str(out_dir),
             "--format",
             "json",
         ]
     )
-
     assert rc == 0
     printed = json.loads(capsys.readouterr().out)
     summary = json.loads((out_dir / history.SUMMARY_JSON).read_text(encoding="utf-8"))
-    markdown = (out_dir / history.SUMMARY_MD).read_text(encoding="utf-8")
-    assert printed["reviewed_disposition_count"] == 1
-    assert summary["latest_record"]["reviewed_disposition_count"] == 1
-    assert "Historical disposition authorizes current action: `false`" in markdown
-    assert "Automatic dismissal allowed: `false`" in markdown
+    records = [
+        json.loads(line)
+        for line in (out_dir / history.HISTORY_JSONL).read_text(encoding="utf-8").splitlines()
+    ]
+    assert printed[history.IGNORED_UNVERIFIED_PRIOR_RECORD_COUNT] == 1
+    assert summary[history.IGNORED_UNVERIFIED_PRIOR_RECORD_COUNT] == 1
+    assert summary["record_count"] == 1
+    assert records[0]["schema_version"] == history.RECORD_SCHEMA_VERSION


### PR DESCRIPTION
## Summary
- Repairs `security_reviewed_disposition_history` so a dismissed alert is recorded only when its finding path is proven to belong to the merged PR's changed-file scope.
- Upgrades reviewed-disposition history from unverified `v1` to changed-path-verified `v2`.
- Explicitly discards unverified v1 prior records instead of carrying contaminated history into future advisory use.
- Records how many PR-filtered dismissed alerts were excluded because they were outside the merged PR's changed files.
- Preserves all no-authority boundaries.

## Why this correction is required
After PR #1422 merged, the accepted-main workflow succeeded, but post-merge verification exposed a provenance defect:

```text
PR #1422 changed files: 6
GitHub PR-filtered dismissed alerts returned: 30
Recorded reviewed dispositions on PR #1422 changed-file scope: 0
```

The v1 collector trusted all dismissed alerts returned by GitHub's PR-filtered code-scanning endpoint. In the real accepted-main artifact, that admitted 30 dismissals from paths not changed by PR #1422. Those records are unsafe as future advisory input.

This PR fixes the evidence boundary before `feature/security-disposition-diagnosis-context` is allowed to consume trusted history.

## Corrected provenance rule
A reviewed dismissed alert may enter trusted security disposition history only when:

1. The accepted `main` commit resolves to the merged PR.
2. The PR changed-file list is collected.
3. The dismissed alert path matches a PR changed file or its `previous_filename` for a rename.
4. The alert still carries dismissed-state and reviewer provenance.
5. The persisted record contains no dismissal-comment text and no action authority.

## V2 history behavior
`security_reviewed_disposition_history` now emits verified v2 records with:

- `pr_scope_verification=changed_paths_proven`
- `merged_pr_changed_path_count`
- `alerts_returned_by_pr_filter`
- `alerts_excluded_outside_changed_paths`
- `path_in_merged_pr_changed_files=true` on every persisted disposition

The module treats existing v1 records as unverified and ignores them when building the verified v2 chain:

```text
contaminated_v1_history_imported=false
```

## Workflow change
`.github/workflows/repo-memory-history.yml` now:

- collects merged-PR changed files through the GitHub API;
- passes `changed-files.json` into the disposition-history recorder;
- supports pagination for changed files and dismissed-alert collection;
- asserts changed-path provenance in the trusted-main proof step.

This remains a read-only accepted-main evidence workflow. It does not modify code-scanning alerts.

## Real regression proof
A read-only replay was executed against the exact PR #1422 accepted-main case that revealed the defect:

```text
live_pr1422_pr_filtered_alert_count=30
pr1422_provenance_regression=passed
pr1422_api_returned_dismissals=30
pr1422_out_of_scope_dismissals_excluded=30
pr1422_verified_reviewed_dispositions=0
```

This is the truthful result for PR #1422: no reviewed disposition is proven attributable to that PR's changed-file scope.

## Safety boundary
The correction does not authorize any security action:

```text
historical_disposition_authorizes_current_action=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
automation_allowed=false
merge_authorized=false
```

## Local verification completed
Targeted proof was run under Python `3.12.13`:

- Focused provenance-v2/workflow/alignment tests: `25 passed`.
- Targeted SDET security scan on corrective source scope: zero findings.
- Real PR #1422 provenance regression replay passed.
- `python -m mypy src` passed.
- `python -m pre_commit run -a` passed.
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must provide final full-suite validation.

## Scope
Files changed:

- `.github/workflows/repo-memory-history.yml`
- `src/sdetkit/security_reviewed_disposition_history.py`
- `tests/test_repo_memory_profile_history_workflow.py`
- `tests/test_security_reviewed_disposition_history.py`

## Risk
Medium but necessary: this resets the trusted security-disposition history chain from unverified v1 records to verified v2 records. This is preferable to preserving records already proven to be out of scope for the merged PR that produced them.

## Rollback
Reverting this PR would restore the known provenance flaw and must not be used before the final diagnosis-context bridge.

## Next
After this fix merges and accepted-main v2 output is proven clean:

```text
feature/security-disposition-diagnosis-context
```

That final bridge may consume only verified v2 history as read-only advisory context and must continue to prohibit automatic fixes or dismissals.
