### PR TITLE
Surface trusted disposition context in security diagnosis

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -346,6 +346,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           mkdir -p build/pr-quality
           {
@@ -562,6 +563,32 @@ jobs:
             > build/pr-quality/trusted-history/selected-run-id.txt
           printf '%s\n' "$trusted_history_head_sha" \
             > build/pr-quality/trusted-history/selected-head-sha.txt
+
+          reviewed_disposition_history="$(
+            find build/pr-quality/trusted-history/download \
+              -name security-reviewed-disposition-history.jsonl \
+              -print \
+              -quit
+          )"
+          security_diagnosis_args=(
+            --review-threads-json build/pr-quality/security-review/review-threads.json
+            --code-scanning-alerts-json build/pr-quality/code-scanning/alerts.json
+            --current-head-sha "$HEAD_SHA"
+            --root .
+            --out-dir build/pr-quality/security-diagnosis
+            --format json
+          )
+          if [ "$trusted_history_rc" -eq 0 ] \
+            && [ -n "$reviewed_disposition_history" ] \
+            && [ -f "$reviewed_disposition_history" ]; then
+            security_diagnosis_args+=(
+              --trusted-reviewed-disposition-history-jsonl "$reviewed_disposition_history"
+            )
+          fi
+
+          PYTHONPATH=src python -m sdetkit.security_finding_diagnosis \
+            "${security_diagnosis_args[@]}" \
+            > build/pr-quality/security-diagnosis/trusted-context-cli.json
 
           PYTHONPATH=src python -m sdetkit.pr_quality_runtime_proof_artifacts \
             --isolated-proof build/pr-quality/runtime-proof/isolated-proof/verification-evidence.json \

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -34,6 +34,12 @@ TRUSTED_HISTORY_SEMANTIC_EQUIVALENCE_PROVEN = "_".join(
 )
 AUTOMATIC_SECURITY_FIX_ALLOWED = "_".join(("automatic", "security", "fix", "allowed"))
 AUTOMATIC_DISMISSAL_ALLOWED = "_".join(("automatic", "dismissal", "allowed"))
+TRUSTED_REVIEWED_DISPOSITION_HISTORY = "_".join(("trusted", "reviewed", "disposition", "history"))
+TRUSTED_REVIEWED_DISPOSITION_CONTEXT = "_".join(("trusted", "reviewed", "disposition", "context"))
+MATCHING_REVIEWED_DISPOSITION_COUNT = "_".join(("matching", "reviewed", "disposition", "count"))
+HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
+    ("historical", "disposition", "authorizes", "current", "action")
+)
 
 BANNED_EDUCATIONAL_PHRASES = (
     "Quality is green, so the review focus is not coverage.",
@@ -305,6 +311,7 @@ def _security_finding_diagnosis_lines(security_finding_diagnosis: JsonObject | N
 
     summary = _as_dict(report.get("summary"))
     boundary = _as_dict(report.get("decision_boundary"))
+    trusted_history = _as_dict(report.get(TRUSTED_REVIEWED_DISPOSITION_HISTORY))
     lines = [
         f"- Collection status: `{_string(report.get('collection_status') or 'unknown')}`",
         f"- Open findings: `{_int(summary.get('open_findings'))}`",
@@ -320,6 +327,18 @@ def _security_finding_diagnosis_lines(security_finding_diagnosis: JsonObject | N
         ),
         (f"- Mechanical fix proposals: `{_int(summary.get('safe_mechanical_fix_candidates'))}`"),
         f"- True-positive fixes required: `{_int(summary.get('true_positive_fix_required'))}`",
+        (
+            "- Trusted reviewed disposition context: "
+            f"`{_string(trusted_history.get('status') or 'not_collected')}`"
+        ),
+        (
+            "- Current findings with verified prior review context: "
+            f"`{_int(trusted_history.get('matched_current_findings'))}`"
+        ),
+        (
+            "- Historical disposition authorizes current action: "
+            f"`{str(bool(boundary.get(HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION, False))).lower()}`"
+        ),
         (
             "- Automatic security fix allowed: "
             f"`{str(bool(boundary.get(AUTOMATIC_SECURITY_FIX_ALLOWED, False))).lower()}`"
@@ -352,6 +371,15 @@ def _security_finding_diagnosis_lines(security_finding_diagnosis: JsonObject | N
         proposal = _string(finding.get("fix_proposal"))
         if proposal:
             lines.append(f"    - Proposal: {proposal}")
+        disposition_context = _as_dict(finding.get(TRUSTED_REVIEWED_DISPOSITION_CONTEXT))
+        matched_prior = _int(disposition_context.get(MATCHING_REVIEWED_DISPOSITION_COUNT))
+        if matched_prior:
+            lines.append(f"    - Verified prior reviewed dispositions: `{matched_prior}`")
+            reason = _string(disposition_context.get("latest_reviewed_reason") or "unknown")
+            lines.append(f"    - Latest prior reviewed reason: `{reason}`")
+            lines.append(
+                "    - Prior disposition is advisory evidence only; current action remains manual."
+            )
         lines.append(
             "    - Human review required: "
             f"`{str(bool(finding.get('human_review_required', True))).lower()}`"

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -26,7 +26,7 @@ SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE = "_".join(
 NEXT_RECOMMENDED_PR = "/".join(
     (
         "feature",
-        "-".join(("security", "disposition", "diagnosis", "context")),
+        "-".join(("exact", "failure", "extraction", "safe", "remediation")),
     )
 )
 
@@ -318,20 +318,21 @@ def build_alignment_components() -> list[AlignmentComponent]:
         ),
         _component(
             module=SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE,
-            role="record sanitized human-reviewed dismissed security findings from accepted-main merged PR evidence without authorizing reuse",
-            status="partially_aligned",
-            stages=("evidence", "history", "reporting"),
+            role="record sanitized human-reviewed dismissed security findings from accepted-main merged PR evidence and expose verified advisory context without authorizing reuse",
+            status="aligned",
+            stages=("evidence", "diagnosis", "history", "reporting"),
             existing_artifacts=(
                 "security-reviewed-disposition-history.jsonl",
                 "security-reviewed-disposition-history-summary.json",
                 "security-reviewed-disposition-history-summary.md",
             ),
-            integration_points=("RepoMemory Profile History workflow",),
-            gaps=(
-                "trusted reviewed disposition history is not yet consumed as advisory context by security finding diagnosis",
-                "historical dismissals must never authorize current finding actions",
+            integration_points=(
+                "RepoMemory Profile History workflow",
+                "security_finding_diagnosis",
+                "pr_quality_action_report",
+                "PR Quality workflow",
             ),
-            recommended_next_action="feed reviewed disposition history into diagnosis as read-only context while preserving manual authority",
+            recommended_next_action="preserve manual security authority while advancing exact failure extraction and safe remediation",
         ),
         _component(
             module="adaptive_diagnosis",

--- a/src/sdetkit/security_finding_diagnosis.py
+++ b/src/sdetkit/security_finding_diagnosis.py
@@ -21,6 +21,18 @@ SCHEMA_VERSION = "sdetkit.security-finding-diagnosis.v1"
 DEFAULT_OUT_DIR = Path("build") / "pr-quality" / "security-diagnosis"
 JSON_NAME = "security-finding-diagnosis.json"
 MARKDOWN_NAME = "security-finding-diagnosis.md"
+TRUSTED_DISPOSITION_RECORD_SCHEMA = ".".join(
+    ("sdetkit", "security", "reviewed", "disposition", "history", "record", "v2")
+)
+TRUSTED_REVIEWED_DISPOSITION_HISTORY = "_".join(("trusted", "reviewed", "disposition", "history"))
+TRUSTED_REVIEWED_DISPOSITION_CONTEXT = "_".join(("trusted", "reviewed", "disposition", "context"))
+MATCHING_REVIEWED_DISPOSITION_COUNT = "_".join(("matching", "reviewed", "disposition", "count"))
+HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
+    ("historical", "disposition", "authorizes", "current", "action")
+)
+PR_SCOPE_VERIFICATION = "_".join(("pr", "scope", "verification"))
+CHANGED_PATHS_PROVEN = "_".join(("changed", "paths", "proven"))
+PATH_IN_MERGED_PR_CHANGED_FILES = "_".join(("path", "in", "merged", "pr", "changed", "files"))
 
 JsonObject = dict[str, Any]
 
@@ -53,6 +65,21 @@ def _read_json(path: Path | None) -> Any:
 def _write_json(path: Path, payload: JsonObject) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_jsonl(path: Path | None) -> list[JsonObject]:
+    if path is None or not path.exists():
+        return []
+
+    records: list[JsonObject] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object on line {line_number} in {path}")
+        records.append(payload)
+    return records
 
 
 def _thread_nodes(payload: Any) -> list[JsonObject]:
@@ -130,6 +157,85 @@ def _location(alert: JsonObject) -> tuple[str, int, str]:
         _int_value(location.get("start_line")),
         _string(instance.get("commit_sha")),
     )
+
+
+def _trusted_reviewed_disposition_index(
+    history_path: Path | None,
+) -> tuple[JsonObject, dict[tuple[str, str, str], list[JsonObject]]]:
+    if history_path is None or not history_path.exists():
+        return {
+            "status": "not_collected",
+            "record_count": 0,
+            "reviewed_disposition_count": 0,
+            "advisory_only": True,
+            HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
+        }, {}
+
+    records = _read_jsonl(history_path)
+    index: dict[tuple[str, str, str], list[JsonObject]] = {}
+    count = 0
+    for record in records:
+        if _string(record.get("schema_version")) != TRUSTED_DISPOSITION_RECORD_SCHEMA:
+            raise ValueError("trusted reviewed disposition history is not verified v2")
+        source = _as_dict(record.get("source"))
+        if source.get(PR_SCOPE_VERIFICATION) != CHANGED_PATHS_PROVEN:
+            raise ValueError("trusted reviewed disposition record lacks changed-path provenance")
+        boundary = _as_dict(record.get("decision_boundary"))
+        if bool(boundary.get(HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION, False)):
+            raise ValueError(
+                "trusted reviewed disposition history expands current action authority"
+            )
+        if bool(boundary.get("automatic_security_fix_allowed", False)) or bool(
+            boundary.get("automatic_dismissal_allowed", False)
+        ):
+            raise ValueError(
+                "trusted reviewed disposition history expands security automation authority"
+            )
+        for raw_item in _as_list(record.get("reviewed_dispositions")):
+            item = _as_dict(raw_item)
+            if item.get(PATH_IN_MERGED_PR_CHANGED_FILES) is not True:
+                raise ValueError("trusted reviewed disposition lacks merged-PR changed-file proof")
+            key = (
+                _string(item.get("tool")),
+                _string(item.get("rule_id")),
+                _string(item.get("path")),
+            )
+            if not all(key):
+                raise ValueError("trusted reviewed disposition lacks exact-match identity")
+            index.setdefault(key, []).append(item)
+            count += 1
+
+    return {
+        "status": "verified_v2_read_only",
+        "record_count": len(records),
+        "reviewed_disposition_count": count,
+        "advisory_only": True,
+        HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
+    }, index
+
+
+def _trusted_reviewed_disposition_context(
+    *,
+    tool: str,
+    rule_id: str,
+    path: str,
+    freshness: str,
+    disposition_index: dict[tuple[str, str, str], list[JsonObject]],
+) -> JsonObject:
+    matches = disposition_index.get((tool, rule_id, path), []) if freshness == "current" else []
+    latest = (
+        sorted(matches, key=lambda item: _string(item.get("dismissed_at")), reverse=True)[0]
+        if matches
+        else {}
+    )
+    return {
+        "status": "verified_prior_review_match" if matches else "no_verified_prior_review_match",
+        MATCHING_REVIEWED_DISPOSITION_COUNT: len(matches),
+        "latest_reviewed_pull_number": _int_value(latest.get("pull_number")),
+        "latest_reviewed_reason": _string(latest.get("dismissed_reason")),
+        "advisory_only": True,
+        HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
+    }
 
 
 def _finding_id(tool: str, rule_id: str, path: str, line: int, number: Any) -> str:
@@ -320,6 +426,7 @@ def diagnose_alert(
     current_head_sha: str,
     root: Path,
     review_locations: set[tuple[str, int]],
+    reviewed_disposition_index: dict[tuple[str, str, str], list[JsonObject]] | None = None,
 ) -> JsonObject:
     tool = _tool_name(alert)
     rule_id = _rule_id(alert)
@@ -333,6 +440,13 @@ def diagnose_alert(
         source_line=source_line,
         freshness=freshness,
     )
+    disposition_context = _trusted_reviewed_disposition_context(
+        tool=tool,
+        rule_id=rule_id,
+        path=path,
+        freshness=freshness,
+        disposition_index=reviewed_disposition_index or {},
+    )
 
     return {
         "finding_id": _finding_id(tool, rule_id, path, line, alert.get("number")),
@@ -345,6 +459,7 @@ def diagnose_alert(
         "freshness": freshness,
         "review_thread_present": (path, line) in review_locations,
         **diagnosis,
+        TRUSTED_REVIEWED_DISPOSITION_CONTEXT: disposition_context,
         "source_context_examined": bool(source_line),
         "sensitive_source_text_emitted": False,
         "human_review_required": True,
@@ -360,9 +475,13 @@ def build_security_finding_diagnosis(
     review_threads: Path | None,
     current_head_sha: str,
     root: Path,
+    trusted_reviewed_disposition_history_jsonl: Path | None = None,
 ) -> JsonObject:
     collection_status, alerts = _alert_records(_read_json(code_scanning_alerts))
     review_locations = _current_review_locations(_read_json(review_threads))
+    trusted_history, reviewed_disposition_index = _trusted_reviewed_disposition_index(
+        trusted_reviewed_disposition_history_jsonl
+    )
 
     diagnoses: list[JsonObject] = []
     for alert in alerts:
@@ -374,6 +493,7 @@ def build_security_finding_diagnosis(
                 current_head_sha=current_head_sha,
                 root=root,
                 review_locations=review_locations,
+                reviewed_disposition_index=reviewed_disposition_index,
             )
         )
 
@@ -385,11 +505,23 @@ def build_security_finding_diagnosis(
         )
     )
     counts = Counter(_string(item.get("classification")) for item in diagnoses)
+    matched_current_findings = sum(
+        1
+        for item in diagnoses
+        if _int_value(
+            _as_dict(item.get(TRUSTED_REVIEWED_DISPOSITION_CONTEXT)).get(
+                MATCHING_REVIEWED_DISPOSITION_COUNT
+            )
+        )
+        > 0
+    )
+    trusted_history["matched_current_findings"] = matched_current_findings
 
     return {
         "schema_version": SCHEMA_VERSION,
         "collection_status": collection_status,
         "current_head_sha": current_head_sha,
+        TRUSTED_REVIEWED_DISPOSITION_HISTORY: trusted_history,
         "diagnoses": diagnoses,
         "summary": {
             "open_findings": len(diagnoses),
@@ -411,6 +543,7 @@ def build_security_finding_diagnosis(
             "automatic_dismissal_allowed": False,
             "automation_allowed": False,
             "merge_authorized": False,
+            HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
         },
     }
 
@@ -418,6 +551,7 @@ def build_security_finding_diagnosis(
 def render_markdown(report: JsonObject) -> str:
     summary = _as_dict(report.get("summary"))
     boundary = _as_dict(report.get("decision_boundary"))
+    trusted_history = _as_dict(report.get(TRUSTED_REVIEWED_DISPOSITION_HISTORY))
     lines = [
         "# Security Finding Diagnosis",
         "",
@@ -425,6 +559,14 @@ def render_markdown(report: JsonObject) -> str:
         f"- Open findings: `{summary.get('open_findings', 0)}`",
         f"- Current findings: `{summary.get('current_findings', 0)}`",
         f"- Stale findings: `{summary.get('stale_findings', 0)}`",
+        (
+            "- Trusted reviewed disposition context: "
+            f"`{_string(trusted_history.get('status') or 'not_collected')}`"
+        ),
+        (
+            "- Current findings with verified prior review context: "
+            f"`{_int_value(trusted_history.get('matched_current_findings'))}`"
+        ),
         (
             "- Scanner metadata false-positive candidates: "
             f"`{summary.get('scanner_metadata_false_positive_candidates', 0)}`"
@@ -445,6 +587,10 @@ def render_markdown(report: JsonObject) -> str:
             "- Automatic dismissal allowed: "
             f"`{str(bool(boundary.get('automatic_dismissal_allowed'))).lower()}`"
         ),
+        (
+            "- Historical disposition authorizes current action: "
+            f"`{str(bool(boundary.get(HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION))).lower()}`"
+        ),
         (f"- Safe mechanical fix candidates: `{summary.get('safe_mechanical_fix_candidates', 0)}`"),
         f"- True-positive fixes required: `{summary.get('true_positive_fix_required', 0)}`",
         "",
@@ -452,6 +598,7 @@ def render_markdown(report: JsonObject) -> str:
 
     for item in _as_list(report.get("diagnoses")):
         finding = _as_dict(item)
+        disposition_context = _as_dict(finding.get(TRUSTED_REVIEWED_DISPOSITION_CONTEXT))
         lines.extend(
             [
                 f"## `{_string(finding.get('rule_id'))}` — {_string(finding.get('path'))}",
@@ -461,6 +608,14 @@ def render_markdown(report: JsonObject) -> str:
                 f"- Classification: `{_string(finding.get('classification'))}`",
                 f"- Recommended action: `{_string(finding.get('recommended_action'))}`",
                 f"- Human review required: `{str(bool(finding.get('human_review_required'))).lower()}`",
+                (
+                    "- Verified prior reviewed dispositions: "
+                    f"`{_int_value(disposition_context.get(MATCHING_REVIEWED_DISPOSITION_COUNT))}`"
+                ),
+                (
+                    "- Historical disposition authorizes current action: "
+                    f"`{str(bool(disposition_context.get(HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION))).lower()}`"
+                ),
                 f"- Diagnosis: {_string(finding.get('diagnosis'))}",
                 "",
             ]
@@ -473,6 +628,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--code-scanning-alerts-json", type=Path)
     parser.add_argument("--review-threads-json", type=Path)
     parser.add_argument("--current-head-sha", required=True)
+    parser.add_argument("--trusted-reviewed-disposition-history-jsonl", type=Path)
     parser.add_argument("--root", type=Path, default=Path("."))
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--format", choices=["text", "json"], default="text")
@@ -486,6 +642,7 @@ def main(argv: list[str] | None = None) -> int:
         review_threads=args.review_threads_json,
         current_head_sha=args.current_head_sha,
         root=args.root,
+        trusted_reviewed_disposition_history_jsonl=args.trusted_reviewed_disposition_history_jsonl,
     )
     _write_json(args.out_dir / JSON_NAME, report)
     (args.out_dir / MARKDOWN_NAME).write_text(render_markdown(report), encoding="utf-8")
@@ -498,6 +655,10 @@ def main(argv: list[str] | None = None) -> int:
         "diagnosis_only": True,
         "automatic_security_fix_allowed": False,
         "automatic_dismissal_allowed": False,
+        "trusted_reviewed_disposition_history_status": _as_dict(
+            report.get(TRUSTED_REVIEWED_DISPOSITION_HISTORY)
+        ).get("status", "not_collected"),
+        HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
     }
     rendered = (
         json.dumps(output, indent=2, sort_keys=True)

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2011,3 +2011,71 @@ def test_write_comment_body_loads_security_diagnosis_artifact_for_operator_visib
     assert "Open findings: `0`" in body
     assert "Findings: none" in body
     assert "Automatic dismissal allowed: `false`" in body
+
+
+def test_action_report_renders_verified_prior_disposition_as_advisory_only() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    security_diagnosis = {
+        "collection_status": "collected",
+        "summary": {
+            "open_findings": 1,
+            "current_findings": 1,
+            "stale_findings": 0,
+            "safe_mechanical_fix_candidates": 1,
+            "true_positive_fix_required": 0,
+        },
+        report.TRUSTED_REVIEWED_DISPOSITION_HISTORY: {
+            "status": "verified_v2_read_only",
+            "matched_current_findings": 1,
+        },
+        "decision_boundary": {
+            report.AUTOMATIC_SECURITY_FIX_ALLOWED: False,
+            report.AUTOMATIC_DISMISSAL_ALLOWED: False,
+            report.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
+        },
+        "diagnoses": [
+            {
+                "tool": "sdetkit-security-gate",
+                "rule_id": "SEC_DEBUG_PRINT",
+                "path": "src/sdetkit/reporter.py",
+                "line": 22,
+                "freshness": "current",
+                "classification": "safe_mechanical_fix_candidate",
+                "recommended_action": "propose_stdout_emission_repair",
+                "human_review_required": True,
+                report.TRUSTED_REVIEWED_DISPOSITION_CONTEXT: {
+                    report.MATCHING_REVIEWED_DISPOSITION_COUNT: 1,
+                    "latest_reviewed_reason": "false positive",
+                    report.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
+                },
+            }
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        security_finding_diagnosis=security_diagnosis,
+    )
+
+    assert "Trusted reviewed disposition context: `verified_v2_read_only`" in body
+    assert "Current findings with verified prior review context: `1`" in body
+    assert "Historical disposition authorizes current action: `false`" in body
+    assert "Verified prior reviewed dispositions: `1`" in body
+    assert "Latest prior reviewed reason: `false positive`" in body
+    assert "Prior disposition is advisory evidence only; current action remains manual." in body
+    assert "Human review required: `true`" in body

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -92,7 +92,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
     assert SECURITY_FINDING_DIAGNOSIS_MODULE not in gaps_by_module
-    assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE in gaps_by_module
+    assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE not in gaps_by_module
     assert any("protected_verifier" in gap for gap in gaps_by_module["maintenance_autopilot"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["patch_scorer"])
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
@@ -112,14 +112,6 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
     assert any("verified" in gap for gap in gaps_by_module["network_boundary"])
     assert any("external filesystem" in gap for gap in gaps_by_module["proof_runtime_guard"])
-    assert any(
-        "advisory context" in gap
-        for gap in gaps_by_module[SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE]
-    )
-    assert any(
-        "never authorize current" in gap
-        for gap in gaps_by_module[SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE]
-    )
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -148,7 +140,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE}`: `aligned`" in markdown
     assert f"`{TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE}`: `aligned`" in markdown
     assert f"`{SECURITY_FINDING_DIAGNOSIS_MODULE}`: `aligned`" in markdown
-    assert f"`{SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE}`: `partially_aligned`" in markdown
+    assert f"`{SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE}`: `aligned`" in markdown
 
 
 def test_alignment_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:

--- a/tests/test_security_finding_diagnosis.py
+++ b/tests/test_security_finding_diagnosis.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from sdetkit import security_finding_diagnosis as diagnosis
 
 
@@ -349,3 +351,116 @@ def test_debug_print_proposes_mechanical_repair_without_authorizing_fix(
     assert finding["safe_to_auto_fix"] is False
     assert finding["automation_allowed"] is False
     assert report["summary"]["safe_mechanical_fix_candidates"] == 1
+
+
+def _verified_disposition_history(tmp_path: Path, *, path: str = "src/sdetkit/reporter.py") -> Path:
+    history_path = tmp_path / "trusted-reviewed-disposition-history.jsonl"
+    record = {
+        "schema_version": diagnosis.TRUSTED_DISPOSITION_RECORD_SCHEMA,
+        "source": {diagnosis.PR_SCOPE_VERIFICATION: diagnosis.CHANGED_PATHS_PROVEN},
+        "decision_boundary": {
+            diagnosis.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION: False,
+            "automatic_security_fix_allowed": False,
+            "automatic_dismissal_allowed": False,
+        },
+        "reviewed_dispositions": [
+            {
+                "tool": "sdetkit-security-gate",
+                "rule_id": "SEC_DEBUG_PRINT",
+                "path": path,
+                "pull_number": 1401,
+                "dismissed_at": "2026-05-24T01:00:00Z",
+                "dismissed_reason": "false positive",
+                diagnosis.PATH_IN_MERGED_PR_CHANGED_FILES: True,
+            }
+        ],
+    }
+    history_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+    return history_path
+
+
+def test_verified_v2_history_adds_advisory_context_without_changing_current_action(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    source = root / "src" / "sdetkit" / "reporter.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text('print("operator output")\n', encoding="utf-8")
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [_alert(number=93, rule_id="SEC_DEBUG_PRINT", path="src/sdetkit/reporter.py", line=1)],
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=None,
+        current_head_sha="pr-head",
+        root=root,
+        trusted_reviewed_disposition_history_jsonl=_verified_disposition_history(tmp_path),
+    )
+
+    finding = report["diagnoses"][0]
+    context = finding[diagnosis.TRUSTED_REVIEWED_DISPOSITION_CONTEXT]
+    assert finding["classification"] == "safe_mechanical_fix_candidate"
+    assert finding["recommended_action"] == "propose_stdout_emission_repair"
+    assert context[diagnosis.MATCHING_REVIEWED_DISPOSITION_COUNT] == 1
+    assert context["latest_reviewed_pull_number"] == 1401
+    assert context["advisory_only"] is True
+    assert context[diagnosis.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION] is False
+    assert finding["safe_to_auto_fix"] is False
+    assert finding["auto_dismiss_allowed"] is False
+    history = report[diagnosis.TRUSTED_REVIEWED_DISPOSITION_HISTORY]
+    assert history["status"] == "verified_v2_read_only"
+    assert history["matched_current_findings"] == 1
+    assert (
+        report["decision_boundary"][diagnosis.HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION]
+        is False
+    )
+
+
+def test_stale_alert_never_consumes_prior_disposition_as_current_context(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [
+            _alert(
+                number=94,
+                rule_id="SEC_DEBUG_PRINT",
+                path="src/sdetkit/reporter.py",
+                line=1,
+                commit_sha="old-head",
+            )
+        ],
+    )
+
+    report = diagnosis.build_security_finding_diagnosis(
+        code_scanning_alerts=alerts,
+        review_threads=None,
+        current_head_sha="new-head",
+        root=root,
+        trusted_reviewed_disposition_history_jsonl=_verified_disposition_history(tmp_path),
+    )
+
+    context = report["diagnoses"][0][diagnosis.TRUSTED_REVIEWED_DISPOSITION_CONTEXT]
+    assert context[diagnosis.MATCHING_REVIEWED_DISPOSITION_COUNT] == 0
+    assert report[diagnosis.TRUSTED_REVIEWED_DISPOSITION_HISTORY]["matched_current_findings"] == 0
+
+
+def test_unverified_disposition_history_is_rejected_before_diagnosis_context(
+    tmp_path: Path,
+) -> None:
+    history_path = tmp_path / "unverified.jsonl"
+    history_path.write_text(
+        json.dumps({"schema_version": "sdetkit.security.reviewed.disposition.history.record.v1"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="not verified v2"):
+        diagnosis.build_security_finding_diagnosis(
+            code_scanning_alerts=None,
+            review_threads=None,
+            current_head_sha="pr-head",
+            root=tmp_path,
+            trusted_reviewed_disposition_history_jsonl=history_path,
+        )

--- a/tests/test_security_finding_diagnosis_workflow.py
+++ b/tests/test_security_finding_diagnosis_workflow.py
@@ -50,3 +50,33 @@ def test_pr_quality_passes_security_diagnosis_artifact_to_operator_comment_rende
     assert text.index("Diagnose security findings read-only") < text.index(
         "python -m sdetkit.pr_quality_action_report"
     )
+
+
+def test_pr_quality_refreshes_diagnosis_with_verified_v2_disposition_history_before_comment() -> (
+    None
+):
+    text = _workflow_text()
+
+    assert "security-reviewed-disposition-history.jsonl" in text
+    assert "--trusted-reviewed-disposition-history-jsonl" in text
+    assert "build/pr-quality/security-diagnosis/trusted-context-cli.json" in text
+    assert "HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in text
+    assert text.index("security-reviewed-disposition-history.jsonl") < text.index(
+        "--trusted-reviewed-disposition-history-jsonl"
+    )
+    assert text.index("--trusted-reviewed-disposition-history-jsonl") < text.index(
+        "python -m sdetkit.pr_quality_action_report"
+    )
+
+
+def test_pr_quality_disposition_context_refresh_does_not_add_security_mutation() -> None:
+    text = _workflow_text()
+    refresh = text.split('reviewed_disposition_history="$(', 1)[1].split(
+        "PYTHONPATH=src python -m sdetkit.pr_quality_runtime_proof_artifacts", 1
+    )[0]
+
+    assert "security_finding_diagnosis" in refresh
+    assert "--trusted-reviewed-disposition-history-jsonl" in refresh
+    assert "PATCH" not in refresh
+    assert "dismissed_comment" not in refresh
+    assert "commit-safe-fixes" not in refresh


### PR DESCRIPTION
## Summary
- Completes the security evidence loop by feeding only verified v2 reviewed-disposition history into `security_finding_diagnosis` as read-only advisory context.
- Surfaces exact prior-review context in the SDET Quality Gate comment for current matching findings.
- Requires exact tool/rule/path matching and ignores historical context for stale findings.
- Preserves current classification and recommended action regardless of history matches.
- Marks the reviewed-disposition history bridge aligned and returns the next repo priority to exact failure extraction and safe remediation.

## Why
The preceding security PRs established:

1. Read-only sanitized diagnosis artifacts.
2. Operator-visible diagnosis in PR Quality.
3. Trusted accepted-main reviewed-disposition history.
4. Verified v2 provenance filtering that excludes dismissals outside the merged PR changed-file scope.

This final bridge makes verified history useful to reviewers. When a current finding exactly matches a prior human-reviewed disposition, the comment can say so. It remains context, not permission.

## Verified input boundary
The diagnosis engine consumes history only when records are verified v2 records:

```text
sdetkit.security.reviewed.disposition.history.record.v2
```

Each consumed record must prove:

```text
pr_scope_verification=changed_paths_proven
path_in_merged_pr_changed_files=true
historical_disposition_authorizes_current_action=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
```

Unverified v1 history is rejected as diagnosis context.

## Advisory matching rule
For a **current** finding only, prior review context is matched using the exact identity tuple:

```text
tool + rule_id + path
```

Stale findings do not receive prior-review matching context.

When a match exists, diagnosis may report:

```text
trusted_reviewed_disposition_context=verified_prior_review_match
matching_reviewed_disposition_count=<n>
latest_reviewed_pull_number=<pr>
latest_reviewed_reason=<reason>
advisory_only=true
historical_disposition_authorizes_current_action=false
```

The matched history does not change the finding classification or recommended action.

## PR Quality operator visibility
The SDET Quality Gate comment can now render:

```text
Trusted reviewed disposition context: verified_v2_read_only
Current findings with verified prior review context: <n>
Historical disposition authorizes current action: false
Verified prior reviewed dispositions: <n>
Latest prior reviewed reason: <reason>
Prior disposition is advisory evidence only; current action remains manual.
```

This lets maintainers see trusted precedent directly in the review comment without granting automated action.

## Workflow integration
`.github/workflows/pr-quality-comment.yml` now refreshes the sanitized diagnosis after accepted-main trusted history has been selected, passing the verified reviewed-disposition JSONL only when it exists and trusted-history verification succeeded.

The refresh step:

- reads only trusted evidence artifacts;
- generates sanitized diagnosis output;
- performs no alert mutations;
- performs no auto-fix commit;
- performs no dismissal.

## Safety boundary
This PR explicitly preserves:

```text
classification_changed_by_history=false
historical_disposition_authorizes_current_action=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
```

A previous human dismissal can guide review, but never authorize a new dismissal, code fix, merge, or automation decision.

## Real accepted-main v2 proof
The real post-merge artifact from PR #1423 was already proven clean before this branch began:

```text
accepted_main_security_disposition_v2_artifact=verified
ignored_unverified_v1_record_count=1
alerts_returned_by_pr_filter=30
alerts_excluded_outside_changed_paths=30
latest_verified_reviewed_disposition_count=0
final_context_bridge_safe_to_start=true
```

This PR then consumed that real verified v2 artifact read-only and proved:

```text
real_v2_history_diagnosis_context=passed
trusted_v2_history_status=verified_v2_read_only
false_historical_context_matches=0
classification_changed_by_history=false
historical_disposition_authorizes_current_action=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
```

## Local verification completed
Targeted proof was run under Python `3.12.13`:

- Connected security diagnosis, PR Quality rendering/workflow, alignment, and reviewed-history tests: `76 passed`.
- Targeted SDET security scan on final bridge scope: zero findings.
- Real verified-v2 diagnosis-context proof passed.
- `python -m mypy src` passed.
- `python -m pre_commit run -a` passed.
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must provide final full-suite validation.

## Scope
Files changed:

- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/pr_quality_action_report.py`
- `src/sdetkit/reliability_spine_alignment.py`
- `src/sdetkit/security_finding_diagnosis.py`
- `tests/test_pr_quality_action_report.py`
- `tests/test_reliability_spine_alignment.py`
- `tests/test_security_finding_diagnosis.py`
- `tests/test_security_finding_diagnosis_workflow.py`

## Risk
Medium but bounded: this modifies diagnosis reporting and PR Quality workflow ordering. The risk is limited because only verified v2 history can be consumed; matching is exact and advisory; stale alerts receive no prior-review context; and all action authority remains false.

## Rollback
Revert this PR. Verified v2 reviewed-disposition history remains available as a trusted artifact, but it is no longer presented as diagnosis context in PR Quality.

## Security phase completion
After this PR merges and one accepted-main/PR Quality proof confirms the context boundary, the security phase is complete.

## Next
```text
feature/exact-failure-extraction-safe-remediation
```

That next lane should return focus to precise CI failure extraction and safe remediation eligibility, keeping unknown or security-sensitive cases review-first.
