### PR TITLE
Collect Check Run annotations for failed checks

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -263,7 +264,11 @@ def _record_log_text(record: JsonObject, logs_dir: Path | None, name: str) -> st
             return candidate.read_text(encoding="utf-8", errors="ignore")
 
     name_tokens = {token for token in slug.split("-") if token}
-    readable_files = [candidate for candidate in sorted(logs_dir.rglob("*")) if candidate.is_file()]
+    readable_files = [
+        candidate
+        for candidate in sorted(logs_dir.rglob("*"))
+        if candidate.is_file() and candidate.suffix.lower() in {".log", ".txt"}
+    ]
     for candidate in readable_files:
         candidate_slug = _slug(candidate.stem)
         candidate_compact = candidate_slug.replace("-", "")
@@ -493,6 +498,8 @@ def _possible_changed_files_gate_fallout(record: JsonObject, log_text: str) -> b
 
 def _failure_tool_for_line(line: str) -> str:
     lowered = line.lower()
+    if "github check annotation" in lowered:
+        return "github_checks"
     if "known vulnerabilit" in lowered and "package" in lowered:
         return "pip-audit"
     if "ruff" in lowered:
@@ -512,6 +519,8 @@ def _failure_tool_for_line(line: str) -> str:
 
 def _failure_kind_for_line(line: str) -> str:
     lowered = line.lower()
+    if "github check annotation" in lowered:
+        return "check_run_annotation"
     if "known vulnerabilit" in lowered and "package" in lowered:
         return "dependency_vulnerability"
     if (
@@ -695,6 +704,27 @@ def _is_unknown_diagnosis(diagnosis: JsonObject) -> bool:
 def _fallback_check_diagnosis(name: str, first_failure: JsonObject) -> JsonObject:
     lowered = name.lower()
     first_line = _string(first_failure.get("line"))
+    first_kind = _string(first_failure.get("kind")).lower()
+
+    if "security" in lowered and first_kind == "check_run_annotation":
+        return {
+            "code": "SECURITY_FINDING_REVIEW_REQUIRED",
+            "title": "Security check annotation requires review",
+            "risk_surface": "security",
+            "diagnosis": (
+                "A failed custom security check produced sanitized GitHub Check Run "
+                f"annotation evidence. First collected annotation: {first_line}"
+            ),
+            "recommended_fix": [
+                "Review the current security check annotations for the PR.",
+                "Fix the flagged surface or dismiss a reviewed false positive with a reason.",
+                "Do not use annotation evidence as authority for automatic remediation.",
+            ],
+            "proof_commands": [
+                "python -m sdetkit security check --root . --format json",
+                "python -m pre_commit run -a",
+            ],
+        }
 
     if "codeql" in lowered:
         return {
@@ -815,7 +845,10 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
             ],
         }
     fallback = _fallback_check_diagnosis(name, first_failure)
-    if fallback and _is_unknown_diagnosis(primary):
+    if fallback and (
+        _string(first_failure.get("kind")).lower() == "check_run_annotation"
+        or _is_unknown_diagnosis(primary)
+    ):
         primary = fallback
 
     safe_remediation = safe_remediation_eligibility.classify_check_failure(
@@ -1611,7 +1644,7 @@ def main(argv: list[str] | None = None) -> int:
         action_report=action_report,
         out_dir=args.out_dir,
     )
-    print(json.dumps(artifacts, indent=2, sort_keys=True))
+    sys.stdout.write(json.dumps(artifacts, indent=2, sort_keys=True) + "\n")
     return 0
 
 

--- a/src/sdetkit/failed_check_log_collection.py
+++ b/src/sdetkit/failed_check_log_collection.py
@@ -4,10 +4,12 @@ import argparse
 import json
 import re
 import shlex
+import sys
 from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "sdetkit.pr_quality.failed_check_logs.v1"
+ANNOTATION_SCHEMA_VERSION = "sdetkit.pr_quality.failed_check_annotations.v1"
 
 JsonObject = dict[str, Any]
 
@@ -26,6 +28,7 @@ _SUCCESS_CONCLUSIONS = {
 }
 
 _ACTIONS_URL_PATTERN = re.compile(r"/actions/runs/(?P<run_id>[0-9]+)(?:/job/(?P<job_id>[0-9]+))?")
+_CHECK_RUN_URL_PATTERN = re.compile(r"/(?:check-runs|runs)/(?P<check_run_id>[0-9]+)")
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -102,8 +105,8 @@ def _is_failed(record: JsonObject) -> bool:
 
 
 def _record_url(record: JsonObject) -> str:
-    # GitHub check-runs include both an API URL and one or more human/action URLs.
-    # The API URL cannot be parsed by `gh run view`; prefer Actions/job URLs.
+    # Prefer human/action URLs in operator artifacts; retain API URL separately
+    # when resolving Check Run annotations.
     for key in ("details_url", "html_url", "target_url", "url"):
         value = _string(record.get(key))
         if value:
@@ -134,6 +137,19 @@ def _actions_run_job(url: str) -> tuple[str, str]:
     return match.group("run_id") or "", match.group("job_id") or ""
 
 
+def _check_run_id(record: JsonObject, url: str) -> str:
+    for candidate in (
+        _string(record.get("url")),
+        _string(record.get("details_url")),
+        _string(record.get("html_url")),
+        url,
+    ):
+        match = _CHECK_RUN_URL_PATTERN.search(candidate)
+        if match:
+            return match.group("check_run_id") or ""
+    return ""
+
+
 def _collect_existing_log(record: JsonObject, target: Path) -> bool:
     if target.exists() and target.stat().st_size > 0:
         return True
@@ -151,6 +167,64 @@ def _collect_existing_log(record: JsonObject, target: Path) -> bool:
         return target.exists() and target.stat().st_size > 0
 
     return False
+
+
+def _safe_annotation_title(value: Any) -> str:
+    text = _string(value).replace("\r", " ").replace("\n", " ")
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r"[A-Za-z0-9_=-]{24,}", "<redacted-long-token-like-text>", text)
+    return text[:160]
+
+
+def sanitize_check_run_annotations(
+    *,
+    raw_annotations_json: Path,
+    annotation_log_target: Path,
+    annotation_json_target: Path,
+) -> JsonObject:
+    payload = json.loads(raw_annotations_json.read_text(encoding="utf-8"))
+    annotations = payload if isinstance(payload, list) else []
+
+    sanitized: list[JsonObject] = []
+    lines: list[str] = []
+    for raw_item in annotations:
+        item = _as_dict(raw_item)
+        level = _string(item.get("annotation_level") or "notice").lower()
+        path = _string(item.get("path"))
+        line = int(item.get("start_line") or 0)
+        title = _safe_annotation_title(item.get("title") or "Check annotation")
+        if not path or line <= 0 or not title:
+            continue
+        sanitized.append(
+            {
+                "annotation_level": level,
+                "path": path,
+                "start_line": line,
+                "end_line": int(item.get("end_line") or line),
+                "title": title,
+                "message_present": bool(_string(item.get("message"))),
+                "raw_details_present": bool(_string(item.get("raw_details"))),
+            }
+        )
+        lines.append(f"GitHub check annotation {level}: {title} at {path}:{line}")
+
+    report = {
+        "schema_version": ANNOTATION_SCHEMA_VERSION,
+        "source": "github_check_run_annotations",
+        "annotation_count": len(sanitized),
+        "raw_message_text_persisted": False,
+        "raw_details_text_persisted": False,
+        "annotations": sanitized,
+    }
+    _write_json(annotation_json_target, report)
+
+    if lines:
+        annotation_log_target.parent.mkdir(parents=True, exist_ok=True)
+        annotation_log_target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    elif annotation_log_target.exists():
+        annotation_log_target.unlink()
+
+    return report
 
 
 def build_failed_check_log_manifest(
@@ -171,8 +245,22 @@ def build_failed_check_log_manifest(
         name = _check_name(record, index)
         url = _record_url(record)
         run_id, job_id = _actions_run_job(url)
+        check_run_id = _check_run_id(record, url)
         log_path = log_dir / f"{index + 1:02d}-{_slug(name)}.log"
+        annotation_path = log_dir / f"{index + 1:02d}-{_slug(name)}.annotations.json"
         collected = _collect_existing_log(record, log_path)
+        annotation_collected = annotation_path.exists() and collected
+
+        if annotation_collected:
+            evidence_source = "github_check_run_annotations"
+        elif collected:
+            evidence_source = "existing_log"
+        elif run_id:
+            evidence_source = "github_actions_log"
+        elif check_run_id:
+            evidence_source = "github_check_run_annotations"
+        else:
+            evidence_source = "uncollectible"
 
         logs.append(
             {
@@ -182,7 +270,12 @@ def build_failed_check_log_manifest(
                 "url": url,
                 "run_id": run_id,
                 "job_id": job_id,
+                "check_run_id": check_run_id,
                 "download_supported": bool(run_id),
+                "annotation_collection_supported": bool(check_run_id and not run_id),
+                "annotation_collected": annotation_collected,
+                "annotation_path": annotation_path.as_posix(),
+                "evidence_source": evidence_source,
                 "log_path": log_path.as_posix(),
                 "collected": collected,
             }
@@ -194,6 +287,9 @@ def build_failed_check_log_manifest(
         "logs_dir": log_dir.as_posix(),
         "failed_check_count": len(logs),
         "collected_log_count": len([item for item in logs if bool(item.get("collected", False))]),
+        "annotation_collected_count": len(
+            [item for item in logs if bool(item.get("annotation_collected", False))]
+        ),
         "logs": logs,
     }
 
@@ -209,28 +305,65 @@ def render_download_script(manifest: JsonObject) -> str:
     for item in [_as_dict(value) for value in _as_list(manifest.get("logs"))]:
         run_id = _string(item.get("run_id"))
         job_id = _string(item.get("job_id"))
+        check_run_id = _string(item.get("check_run_id"))
         log_path = _string(item.get("log_path"))
-        if not run_id or not log_path:
+        annotation_path = _string(item.get("annotation_path"))
+        collected = bool(item.get("collected", False))
+        if not log_path or collected:
             continue
 
-        quoted_run = shlex.quote(run_id)
         quoted_log = shlex.quote(log_path)
-        quoted_err = shlex.quote(f"{log_path}.stderr")
-        job_args = f" --job {shlex.quote(job_id)}" if job_id else ""
+        if run_id:
+            quoted_run = shlex.quote(run_id)
+            quoted_err = shlex.quote(f"{log_path}.stderr")
+            job_args = f" --job {shlex.quote(job_id)}" if job_id else ""
+            lines.extend(
+                [
+                    f"echo collecting_failed_check_log={shlex.quote(_string(item.get('check_name')))}",
+                    (
+                        f"gh run view {quoted_run}{job_args} --log-failed > {quoted_log} "
+                        f"2> {quoted_err} || "
+                        f"gh run view {quoted_run}{job_args} --log > {quoted_log} "
+                        f"2>> {quoted_err} || true"
+                    ),
+                    f"if [ ! -s {quoted_log} ]; then rm -f {quoted_log}; fi",
+                    "",
+                ]
+            )
+            continue
 
-        lines.extend(
-            [
-                f"echo collecting_failed_check_log={shlex.quote(_string(item.get('check_name')))}",
-                (
-                    f"gh run view {quoted_run}{job_args} --log-failed > {quoted_log} "
-                    f"2> {quoted_err} || "
-                    f"gh run view {quoted_run}{job_args} --log > {quoted_log} "
-                    f"2>> {quoted_err} || true"
-                ),
-                f"if [ ! -s {quoted_log} ]; then rm -f {quoted_log}; fi",
-                "",
-            ]
-        )
+        if check_run_id and annotation_path:
+            quoted_annotations = shlex.quote(annotation_path)
+            lines.extend(
+                [
+                    (
+                        "repository="
+                        '"${GITHUB_REPOSITORY:-${REPOSITORY_OWNER:-}/${REPOSITORY_NAME:-}}"'
+                    ),
+                    (
+                        f'raw_annotations="${{RUNNER_TEMP:-/tmp}}/'
+                        f'sdetkit-check-run-{check_run_id}-annotations.json"'
+                    ),
+                    (
+                        f"echo collecting_failed_check_annotations="
+                        f"{shlex.quote(_string(item.get('check_name')))}"
+                    ),
+                    (
+                        f'if gh api -H "Accept: application/vnd.github+json" '
+                        f'"repos/${{repository}}/check-runs/{check_run_id}/annotations?per_page=100" '
+                        f'> "$raw_annotations"; then'
+                    ),
+                    (
+                        "  PYTHONPATH=src python -m sdetkit.failed_check_log_collection "
+                        '--sanitize-annotations-json "$raw_annotations" '
+                        f"--annotation-log-target {quoted_log} "
+                        f"--annotation-json-target {quoted_annotations} || true"
+                    ),
+                    "fi",
+                    'rm -f "$raw_annotations"',
+                    "",
+                ]
+            )
 
     return "\n".join(lines).rstrip() + "\n"
 
@@ -258,24 +391,40 @@ def write_failed_check_log_artifacts(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.failed_check_log_collection")
-    parser.add_argument("--checks-json", type=Path, required=True)
+    parser.add_argument("--checks-json", type=Path)
     parser.add_argument("--out-dir", type=Path, default=Path("build/pr-quality/check-logs"))
     parser.add_argument(
         "--no-script",
         action="store_true",
-        help="Do not write the GitHub Actions log download script.",
+        help="Do not write the GitHub evidence download script.",
     )
+    parser.add_argument("--sanitize-annotations-json", type=Path)
+    parser.add_argument("--annotation-log-target", type=Path)
+    parser.add_argument("--annotation-json-target", type=Path)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.sanitize_annotations_json is not None:
+        if args.annotation_log_target is None or args.annotation_json_target is None:
+            raise SystemExit("annotation log and JSON targets are required for sanitization")
+        report = sanitize_check_run_annotations(
+            raw_annotations_json=args.sanitize_annotations_json,
+            annotation_log_target=args.annotation_log_target,
+            annotation_json_target=args.annotation_json_target,
+        )
+        sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        return 0
+
+    if args.checks_json is None:
+        raise SystemExit("--checks-json is required unless sanitizing annotations")
     manifest = write_failed_check_log_artifacts(
         checks_json=args.checks_json,
         out_dir=args.out_dir,
         write_script=not bool(args.no_script),
     )
-    print(json.dumps(manifest, indent=2, sort_keys=True))
+    sys.stdout.write(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
     return 0
 
 

--- a/src/sdetkit/safe_remediation_eligibility.py
+++ b/src/sdetkit/safe_remediation_eligibility.py
@@ -128,6 +128,17 @@ def classify_check_failure(
         "\n".join(value for value in (first_line, context_text, log_text) if value)
     )
 
+    if kind == "check_run_annotation":
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "safe_to_auto_fix": False,
+            "strategy": REVIEW_FIRST_STRATEGY,
+            "category": "review_first",
+            "affected_files": affected_files,
+            "reason": "Sanitized Check Run annotation evidence is review-first and cannot authorize mutation.",
+            "proof_commands": [],
+        }
+
     if _contains_any(combined, UNSAFE_REVIEW_MARKERS) and not _contains_any(
         combined,
         SAFE_FORMAT_MARKERS,

--- a/tests/test_non_actions_check_annotation_evidence.py
+++ b/tests/test_non_actions_check_annotation_evidence.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import check_intelligence, safe_remediation_eligibility
+from sdetkit import failed_check_log_collection as collection
+
+
+def _failed_security_check() -> dict:
+    return {
+        "name": "sdetkit-security-gate",
+        "status": "completed",
+        "conclusion": "failure",
+        "head_sha": "pr-head",
+        "current_pr_head_sha": "pr-head",
+        "url": "https://api.github.com/repos/sherif69-sa/DevS69-sdetkit/check-runs/77563773066",
+        "details_url": "https://github.com/sherif69-sa/DevS69-sdetkit/runs/77563773066",
+        "required": False,
+    }
+
+
+def _write_checks(path: Path) -> Path:
+    path.write_text(json.dumps({"check_runs": [_failed_security_check()]}), encoding="utf-8")
+    return path
+
+
+def test_manifest_routes_non_actions_failed_check_to_annotation_collection(tmp_path: Path) -> None:
+    manifest = collection.build_failed_check_log_manifest(
+        checks_json=_write_checks(tmp_path / "checks.json"),
+        out_dir=tmp_path / "out",
+    )
+
+    item = manifest["logs"][0]
+    assert item["run_id"] == ""
+    assert item["check_run_id"] == "77563773066"
+    assert item["download_supported"] is False
+    assert item["annotation_collection_supported"] is True
+    assert item["evidence_source"] == "github_check_run_annotations"
+
+    script = collection.render_download_script(manifest)
+    assert "check-runs/77563773066/annotations?per_page=100" in script
+    assert "--sanitize-annotations-json" in script
+    assert 'rm -f "$raw_annotations"' in script
+
+
+def test_sanitizer_persists_only_safe_annotation_metadata_and_exact_line(tmp_path: Path) -> None:
+    raw_path = tmp_path / "raw.json"
+    log_path = tmp_path / "out" / "01-sdetkit-security-gate.log"
+    evidence_path = tmp_path / "out" / "01-sdetkit-security-gate.annotations.json"
+    raw_message = "Sensitive flagged source excerpt should never persist."
+    raw_details = "Raw internal detail should never persist."
+    raw_path.write_text(
+        json.dumps(
+            [
+                {
+                    "annotation_level": "failure",
+                    "path": "tests/test_trusted_test_observation_capture.py",
+                    "start_line": 203,
+                    "end_line": 203,
+                    "title": "Secret-like pattern",
+                    "message": raw_message,
+                    "raw_details": raw_details,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = collection.sanitize_check_run_annotations(
+        raw_annotations_json=raw_path,
+        annotation_log_target=log_path,
+        annotation_json_target=evidence_path,
+    )
+
+    serialized = evidence_path.read_text(encoding="utf-8")
+    line = log_path.read_text(encoding="utf-8")
+    assert report["annotation_count"] == 1
+    assert report["raw_message_text_persisted"] is False
+    assert report["raw_details_text_persisted"] is False
+    assert raw_message not in serialized
+    assert raw_details not in serialized
+    assert raw_message not in line
+    assert raw_details not in line
+    assert (
+        "GitHub check annotation failure: Secret-like pattern at "
+        "tests/test_trusted_test_observation_capture.py:203"
+    ) in line
+
+
+def test_annotation_evidence_becomes_exact_security_diagnosis_but_never_safe_fix(
+    tmp_path: Path,
+) -> None:
+    checks_path = _write_checks(tmp_path / "checks.json")
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "01-sdetkit-security-gate.log").write_text(
+        "GitHub check annotation failure: Secret-like pattern at "
+        "tests/test_trusted_test_observation_capture.py:203\n",
+        encoding="utf-8",
+    )
+    (logs_dir / "01-sdetkit-security-gate.annotations.json").write_text(
+        json.dumps(
+            {
+                "annotation_count": 1,
+                "annotations": [{"annotation_level": "failure"}],
+                "raw_message_text_persisted": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks_path,
+        logs_dir=logs_dir,
+        current_head_sha="pr-head",
+    )
+    failure = intelligence["failed_checks"][0]
+    first = failure["first_failure"]
+
+    assert failure["log_collected"] is True
+    assert first["tool"] == "github_checks"
+    assert first["kind"] == "check_run_annotation"
+    assert "tests/test_trusted_test_observation_capture.py:203" in first["line"]
+    assert failure["diagnosis"]["code"] == "SECURITY_FINDING_REVIEW_REQUIRED"
+    assert failure["surface"] == "security"
+    assert failure["safe_to_auto_fix"] is False
+    assert failure["safe_remediation"]["category"] == "review_first"
+
+
+def test_formatting_like_check_annotation_remains_review_first() -> None:
+    result = safe_remediation_eligibility.classify_check_failure(
+        name="custom-check",
+        first_failure={
+            "kind": "check_run_annotation",
+            "line": "GitHub check annotation failure: ruff format would reformat src/sdetkit/a.py:1",
+        },
+    )
+    assert result["safe_to_auto_fix"] is False
+    assert result["strategy"] == safe_remediation_eligibility.REVIEW_FIRST_STRATEGY
+    assert "cannot authorize mutation" in result["reason"]

--- a/tests/test_pr_quality_failed_check_log_workflow.py
+++ b/tests/test_pr_quality_failed_check_log_workflow.py
@@ -22,3 +22,17 @@ def test_pr_quality_workflow_uploads_failed_check_log_artifacts() -> None:
 
     assert "build/pr-quality/check-logs/" in workflow
     assert "build/pr-quality/check-intelligence/" in workflow
+
+
+def test_pr_quality_existing_collector_invocation_carries_check_annotation_evidence_to_intelligence() -> (
+    None
+):
+    workflow = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+
+    assert "checks: read" in workflow
+    assert "python -m sdetkit.failed_check_log_collection" in workflow
+    assert "bash build/pr-quality/check-logs/download-failed-check-logs.sh || true" in workflow
+    assert "--logs-dir build/pr-quality/check-logs/failed-check-logs" in workflow
+    assert workflow.index(
+        "bash build/pr-quality/check-logs/download-failed-check-logs.sh"
+    ) < workflow.index("python -m sdetkit.check_intelligence")


### PR DESCRIPTION
## Summary
- Extends the existing failed-check evidence collector to collect **sanitized GitHub Check Run annotations** for failed custom checks that do not expose downloadable GitHub Actions logs.
- Routes sanitized annotation evidence into the existing `check_intelligence` first-failure path.
- Surfaces exact file/line failure context in PR Quality for non-Actions failures such as `sdetkit-security-gate`.
- Forces annotation-only evidence to remain review-first and ineligible for automatic remediation.

## Why this PR exists
After the security phase closed, a no-change audit of the existing exact-failure/remediation chain found that the repo already had:

- failed GitHub Actions log collection;
- first-failure parsing;
- failure-bundle/operator rendering;
- formatting-only safe-remediation eligibility;
- guarded autopilot commit/push behavior.

The real gap was narrower. A prior failed PR Quality artifact showed:

```text
failed_check=sdetkit-security-gate
failed_checks=1
collected_log_count=0
first_failure_present=false
safe_fix_attempted=false
```

Forensic review proved this was not a missing parser or missing remediation engine. `sdetkit-security-gate` was a **GitHub Check Run**, not an Actions job:

```text
details_url=https://github.com/sherif69-sa/DevS69-sdetkit/runs/77563773066
actions_url_parseable=false
```

The current collector could not download an Actions log from that check.

## Real evidence source proven
A read-only API proof of the failed check run established that it exposes precise annotations:

```text
check_run_name=sdetkit-security-gate
check_run_conclusion=failure
api_annotations_collected_count=3
non_actions_exact_evidence_available=true
evidence_source=github_check_run_annotations
```

The real annotations included exact path/line metadata such as:

```text
Secret-like pattern at tests/test_trusted_test_observation_capture.py:203
```

## Implementation
### `failed_check_log_collection.py`
The existing collector now:

- detects failed Check Run IDs from `/check-runs/<id>` and `/runs/<id>` sources when no Actions run/job is present;
- emits a read-only annotation collection command in its existing evidence-download script;
- sanitizes collected annotations to persist only:
  - annotation level,
  - path,
  - start/end line,
  - bounded title,
  - booleans indicating whether message/raw details existed;
- never persists raw annotation message text or raw-detail text;
- synthesizes a safe `.log` diagnostic line for the existing first-failure parser;
- records `annotation_collection_supported`, `annotation_collected`, `annotation_path`, and `evidence_source`.

### `check_intelligence.py`
The existing intelligence engine now:

- recognizes synthesized annotation diagnostic lines as:
  - `tool=github_checks`
  - `kind=check_run_annotation`;
- diagnoses security-gate annotation evidence as review-required security evidence;
- reads diagnostic `.log`/`.txt` inputs only, preventing adjacent annotation JSON metadata from shadowing the intended diagnostic log;
- uses explicit stdout JSON emission in the touched CLI output path to satisfy scanner hygiene.

### `safe_remediation_eligibility.py`
Annotation-derived evidence is fail-closed:

```text
safe_to_auto_fix=false
category=review_first
reason=Sanitized Check Run annotation evidence is review-first and cannot authorize mutation.
```

Even formatting-looking text inside a Check Run annotation remains ineligible for automatic mutation.

## Existing workflow reused
No PR Quality workflow mutation was needed. The existing workflow already:

1. builds failed-check evidence inputs;
2. executes the generated evidence collection script;
3. rebuilds the manifest;
4. passes collected evidence into `check_intelligence`;
5. renders the operator comment.

This PR upgrades the collector used by that existing path.

## Real live-chain proof
The exact previously undiagnosed failed check was replayed read-only through the new path:

```text
live_non_actions_annotation_chain=passed
failed_check_name=sdetkit-security-gate
evidence_source=github_check_run_annotations
annotation_collected_count=3
exact_first_failure=GitHub check annotation failure: Secret-like pattern at tests/test_trusted_test_observation_capture.py:203
operator_comment_exact_failure_visible=true
annotation_metadata_log_shadowing_prevented=true
raw_annotation_message_persisted=false
raw_annotation_details_persisted=false
safe_to_auto_fix=false
automation_allowed=false
```

## Validation completed
Targeted proof was run under Python `3.12.13`:

- focused annotation-evidence and PR Quality rendering/workflow proof: `43 passed`;
- expanded connected-consumer proof across collection, intelligence, failure bundle, evidence graph, action-report, remediation, trajectory, and workflow consumers: `186 passed`;
- targeted scanner proof on changed evidence scope: zero findings;
- `python -m mypy src` passed;
- `python -m pre_commit run -a` passed;
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must supply final full-suite coverage validation.

## Scope
Files changed:

- `src/sdetkit/check_intelligence.py`
- `src/sdetkit/failed_check_log_collection.py`
- `src/sdetkit/safe_remediation_eligibility.py`
- `tests/test_non_actions_check_annotation_evidence.py`
- `tests/test_pr_quality_failed_check_log_workflow.py`

## Safety boundary
This PR adds diagnosis evidence, not mutation authority:

```text
raw_annotation_message_persisted=false
raw_annotation_details_persisted=false
annotation_evidence_auto_fix_allowed=false
automation_allowed=false
security_dismissal_allowed=false
```

Security check annotations may tell the operator exactly what needs review. They cannot authorize automatic fixes or dismissals.

## Risk
Medium but bounded. The collector now handles an additional read-only evidence source, and intelligence now reads only diagnostic text files for log parsing. The live replay and connected tests prove the new route while preserving review-first behavior.

## Rollback
Revert this PR. Custom Check Run failures revert to being visible only as failed checks without exact collected annotation evidence.

## Next
After merge and one PR Quality/live artifact verification, continue the reliability lane by auditing remaining evidence sources that still report failed checks without exact first-failure visibility. Automatic fixes should remain restricted to already-proven formatting-only Actions-log cases.
