### PR TITLE
Recover exact failures from collected matrix logs

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -150,7 +150,7 @@ def _string(value: Any) -> str:
 
 
 def _slug(value: str) -> str:
-    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip().lower()).strip("-")
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", value.strip().lower()).strip("-")
     return slug or "check"
 
 
@@ -374,6 +374,14 @@ _SETUP_NOISE_CONTAINS = (
 def _is_setup_noise_line(line: str) -> bool:
     lowered = line.strip().lower()
     if not lowered:
+        return True
+    if "cache not found for input keys:" in lowered:
+        return True
+    if "cache entry deserialization failed" in lowered:
+        return True
+    if "python -m pytest" in lowered and not any(
+        token in lowered for token in ("failed", "failure", "error", "traceback", "assertion")
+    ):
         return True
     return lowered.startswith(_SETUP_NOISE_PREFIXES) or any(
         token in lowered for token in _SETUP_NOISE_CONTAINS
@@ -643,6 +651,21 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
 
     for index, line in enumerate(lines):
         stripped = line.strip()
+        pytest_node = re.search(
+            r"\bFAILED\s+((?:tests|src|tools|docs)/\S+::\S+)",
+            stripped,
+        )
+        if pytest_node:
+            return {
+                "line_number": index + 1,
+                "line": stripped,
+                "tool": "pytest",
+                "kind": "test_failure",
+                "context": _context_lines_around(lines, index + 1, context=context),
+            }
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
         lowered = stripped.lower()
         if not stripped or _is_setup_noise_line(stripped):
             continue
@@ -796,6 +819,11 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
     ]
 
     primary = diagnoses[0] if diagnoses else {}
+    if _string(first_failure.get("kind")).lower() == "test_failure":
+        for candidate in diagnoses:
+            if _string(candidate.get("code")).upper() == "PYTEST_ASSERTION_FAILURE":
+                primary = candidate
+                break
     runtime_traceback = _as_dict(first_failure.get("traceback"))
     if runtime_traceback and (
         not primary

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -638,3 +638,136 @@ def test_check_intelligence_keeps_stale_code_scanning_alert_visible_non_blocking
     assert intelligence["code_scanning_review"]["stale_alerts"] == 1
     assert action["status"] == "green"
     assert action["primary_blocker"] == {}
+
+
+def test_check_intelligence_associates_collector_log_for_dotted_matrix_version(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Validate (ubuntu-latest / py3.13)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        },
+    )
+    logs_dir = tmp_path / "logs"
+    _write(
+        logs_dir / "15-validate-ubuntu-latest-py3-13.log",
+        "\n".join(
+            [
+                "Validate (ubuntu-latest / py3.13) FAILED "
+                "tests/test_workflow_contract.py::test_uploads_bundle - AssertionError",
+                "Validate (ubuntu-latest / py3.13) 1 failed, 20 passed in 1.00s",
+                "Validate (ubuntu-latest / py3.13) Process completed with exit code 1.",
+            ]
+        ),
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+
+    failed = intelligence["failed_checks"][0]
+    assert failed["log_collected"] is True
+    assert failed["first_failure"]["tool"] == "pytest"
+    assert failed["first_failure"]["kind"] == "test_failure"
+    assert "tests/test_workflow_contract.py" in failed["first_failure"]["line"]
+    assert failed["safe_to_auto_fix"] is False
+
+
+def test_check_intelligence_skips_cache_miss_and_pytest_invocation_before_failed_node(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Validate (macos-latest / py3.13)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        },
+    )
+    logs_dir = tmp_path / "logs"
+    _write(
+        logs_dir / "09-validate-macos-latest-py3-13.log",
+        "\n".join(
+            [
+                "Validate (macos-latest / py3.13) Cache not found for input keys: macOS-py3.13-abcdef",
+                "Validate (macos-latest / py3.13) ##[group]Run python -m pytest -q",
+                "Validate (macos-latest / py3.13) python -m pytest -q",
+                "Validate (macos-latest / py3.13) FAILED tests/test_widget.py::test_contract - AssertionError",
+                "Validate (macos-latest / py3.13) 1 failed, 20 passed in 1.00s",
+            ]
+        ),
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+
+    failed = intelligence["failed_checks"][0]
+    first = failed["first_failure"]
+    assert failed["log_collected"] is True
+    assert first["tool"] == "pytest"
+    assert first["kind"] == "test_failure"
+    assert "tests/test_widget.py::test_contract" in first["line"]
+    assert "Cache not found" not in first["line"]
+    assert "python -m pytest" not in first["line"]
+    assert failed["diagnosis"]["code"] == "PYTEST_ASSERTION_FAILURE"
+    assert failed["safe_to_auto_fix"] is False
+
+
+def test_check_intelligence_prefers_explicit_pytest_failed_node_over_summary_and_cache_warning(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Validate (macos-latest / py3.13)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        },
+    )
+    logs_dir = tmp_path / "logs"
+    _write(
+        logs_dir / "09-validate-macos-latest-py3-13.log",
+        "\n".join(
+            [
+                "Validate (macos-latest / py3.13) WARNING: Cache entry deserialization failed, entry ignored",
+                "Validate (macos-latest / py3.13) python -m pytest -q",
+                "Validate (macos-latest / py3.13) =================================== FAILURES ===================================",
+                "Validate (macos-latest / py3.13) FAILED tests/test_widget.py::test_contract - AssertionError",
+                "Validate (macos-latest / py3.13) 1 failed, 20 passed in 1.00s",
+            ]
+        ),
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+
+    failed = intelligence["failed_checks"][0]
+    first = failed["first_failure"]
+    assert failed["log_collected"] is True
+    assert first["tool"] == "pytest"
+    assert first["kind"] == "test_failure"
+    assert "FAILED tests/test_widget.py::test_contract" in first["line"]
+    assert "Cache entry deserialization failed" not in first["line"]
+    assert "FAILURES" not in first["line"]
+    assert failed["diagnosis"]["code"] == "PYTEST_ASSERTION_FAILURE"
+    assert failed["safe_to_auto_fix"] is False


### PR DESCRIPTION
## Summary
- Aligns `check_intelligence` log-file association with the existing collector filename normalization so collected matrix-job logs are no longer missed when names contain versions such as `py3.13`.
- Prioritizes explicit pytest failed-node evidence over benign cache warnings, command invocations, and generic `FAILURES` headings.
- Selects `PYTEST_ASSERTION_FAILURE` as the primary diagnosis when exact pytest failure evidence is present.
- Keeps automatic remediation authority unchanged.

## Why
The accepted-main evidence audit found a real connection defect rather than a missing parser:

```text
collected_file_not_associated_by_original_intelligence=27
```

The collector had already persisted log files such as:

```text
15-validate-ubuntu-latest-py3-13.log
```

but intelligence looked for a slug retaining the dot from:

```text
Validate (ubuntu-latest / py3.13)
```

so valid collected log evidence never reached exact failure extraction.

After aligning that contract, replay exposed a second exactness issue: generic scanning selected setup/noise lines before the real failed pytest node, including cache warnings, `python -m pytest -q`, and a generic `FAILURES` header. This PR fixes both parts within the same narrow intelligence boundary.

## Real preserved-evidence proof
A preserved historical failed matrix set from run `26324767631` was replayed through the corrected intelligence engine. All six failed Validate jobs now associate their collected logs and identify the actual failed pytest node:

```text
real_collected_log_association_and_pytest_node_priority=passed
validate_failed_checks_recovered=6
validate_logs_associated=6
validate_exact_pytest_nodes_extracted=6
```

Each recovered job resolves to:

```text
tool=pytest
kind=test_failure
code=PYTEST_ASSERTION_FAILURE
safe_to_auto_fix=false
```

The exact failed node extracted on each job was:

```text
tests/test_pr_quality_adaptive_sentinel_workflow.py::test_pr_quality_workflow_uploads_adaptive_sentinel_artifacts
```

## Noise and misclassification boundaries
The replay also proved:

```text
benign_cache_noise_selected_as_failure=false
pytest_command_invocation_selected_as_failure=false
generic_failures_header_selected_as_failure=false
release_misclassification_selected_as_primary=false
```

## Safety boundary
This PR improves evidence association and diagnosis precision only:

```text
safe_to_auto_fix_expanded=false
automation_authority_expanded=false
```

The recovered Validate test failures remain human-review cases and do not become eligible for autopilot mutation.

## Validation completed
Targeted proof was run under Python `3.12.13`:

- focused intelligence/failure-bundle/remediation/workflow proof: `84 passed`;
- expanded connected-consumer proof: `189 passed`;
- targeted scanner proof for touched source: zero findings;
- real preserved six-job Validate replay passed;
- `python -m mypy src` passed;
- `python -m pre_commit run -a` passed;
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must supply final full-suite coverage validation.

## Scope
Files changed:

- `src/sdetkit/check_intelligence.py`
- `tests/test_check_intelligence.py`

## Risk
Low and bounded. The change is confined to evidence association and exact first-failure prioritization in an already-existing intelligence path, with regression coverage and real archived evidence replay.

## Rollback
Revert this PR. Previously collected matrix logs with dotted runtime versions will again remain unassociated, and noisy generic lines may be selected over exact pytest failures.

## Next
After merge and accepted-main replay verification, rerun the failed-evidence inventory to determine whether any genuine acquisition or association gaps remain. Do not expand auto-fix authority unless a separately proven safe-fix case requires it.
