### PR TITLE
Prevent cross-check log evidence attribution

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -252,7 +252,6 @@ def _record_log_text(record: JsonObject, logs_dir: Path | None, name: str) -> st
         return ""
 
     slug = _slug(name)
-    compact_slug = slug.replace("-", "")
     exact_candidates = [
         logs_dir / f"{slug}.log",
         logs_dir / f"{slug}.txt",
@@ -263,7 +262,6 @@ def _record_log_text(record: JsonObject, logs_dir: Path | None, name: str) -> st
         if candidate.exists() and candidate.is_file():
             return candidate.read_text(encoding="utf-8", errors="ignore")
 
-    name_tokens = {token for token in slug.split("-") if token}
     readable_files = [
         candidate
         for candidate in sorted(logs_dir.rglob("*"))
@@ -271,22 +269,9 @@ def _record_log_text(record: JsonObject, logs_dir: Path | None, name: str) -> st
     ]
     for candidate in readable_files:
         candidate_slug = _slug(candidate.stem)
-        candidate_compact = candidate_slug.replace("-", "")
-        candidate_tokens = {token for token in candidate_slug.split("-") if token}
-
-        if (
-            slug == candidate_slug
-            or slug in candidate_slug
-            or candidate_slug in slug
-            or compact_slug == candidate_compact
-            or compact_slug in candidate_compact
-            or candidate_compact in compact_slug
-            or (name_tokens and name_tokens.issubset(candidate_tokens))
-        ):
+        collector_slug = re.sub(r"^[0-9]+-", "", candidate_slug)
+        if candidate_slug == slug or collector_slug == slug:
             return candidate.read_text(encoding="utf-8", errors="ignore")
-
-    if len(readable_files) == 1:
-        return readable_files[0].read_text(encoding="utf-8", errors="ignore")
 
     return ""
 

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -771,3 +771,81 @@ def test_check_intelligence_prefers_explicit_pytest_failed_node_over_summary_and
     assert "FAILURES" not in first["line"]
     assert failed["diagnosis"]["code"] == "PYTEST_ASSERTION_FAILURE"
     assert failed["safe_to_auto_fix"] is False
+
+
+def test_check_intelligence_does_not_assign_single_unrelated_log_to_codeql(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {"name": "CodeQL", "status": "completed", "conclusion": "failure"},
+                {
+                    "name": "PR Quality local quality gate",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+            ]
+        },
+    )
+    logs_dir = tmp_path / "logs"
+    _write(
+        logs_dir / "02-pr-quality-local-quality-gate.log",
+        "FAILED tests/test_local_quality.py::test_contract - AssertionError\n",
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+    failed_by_name = {item["name"]: item for item in intelligence["failed_checks"]}
+
+    codeql = failed_by_name["CodeQL"]
+    assert codeql["log_collected"] is False
+    assert not codeql["first_failure"]
+    assert codeql["safe_to_auto_fix"] is False
+
+    local_gate = failed_by_name["PR Quality local quality gate"]
+    assert local_gate["log_collected"] is True
+    assert local_gate["first_failure"]["tool"] == "pytest"
+    assert local_gate["first_failure"]["kind"] == "test_failure"
+
+
+def test_check_intelligence_does_not_assign_fast_ci_log_to_generic_ci_check(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {"name": "ci", "status": "completed", "conclusion": "failure"},
+                {
+                    "name": "Fast CI lane (py3.11)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+            ]
+        },
+    )
+    logs_dir = tmp_path / "logs"
+    _write(
+        logs_dir / "01-fast-ci-lane-py3-11.log",
+        "FAILED tests/test_fast_lane.py::test_contract - AssertionError\n",
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+    failed_by_name = {item["name"]: item for item in intelligence["failed_checks"]}
+
+    generic = failed_by_name["ci"]
+    assert generic["log_collected"] is False
+    assert not generic["first_failure"]
+    assert generic["safe_to_auto_fix"] is False
+
+    fast = failed_by_name["Fast CI lane (py3.11)"]
+    assert fast["log_collected"] is True
+    assert fast["first_failure"]["tool"] == "pytest"
+    assert fast["first_failure"]["kind"] == "test_failure"


### PR DESCRIPTION
## Summary
- Prevents `check_intelligence` from assigning an unrelated log file to a failed check merely because it is the only readable log in an artifact.
- Removes broad substring/token log matching that allowed generic checks such as `ci` to inherit evidence from `Fast CI lane (...)`.
- Preserves strict associations for valid collector-generated numbered log filenames.
- Keeps all remediation and automation authority unchanged.

## Why
After PR #1426 repaired collected matrix-log association and exact pytest-node prioritization, an accepted-main historical replay found a new evidence-integrity defect.

The merged parser could now extract exact evidence from correctly associated logs, but some failed checks with **no mapped preserved log bytes** still appeared to have exact pytest failures. Those diagnoses were borrowed from another failed check's log within the same artifact.

The permissive behavior was caused by two matching rules:

1. a fallback that used the only readable log file regardless of check provenance;
2. broad substring/token matching that could match a generic `ci` record to a `Fast CI lane (...)` log.

This could create exact-looking but incorrectly attributed failure diagnoses.

## Implementation
### `src/sdetkit/check_intelligence.py`
The log association path now:

- retains direct exact matches for `<check-slug>.log` and `<check-name>.log`;
- recognizes collector-numbered files only when stripping their numeric prefix produces the exact requested check slug;
- removes broad substring/compact/token inheritance matching;
- removes the unrelated single-readable-log fallback.

### `tests/test_check_intelligence.py`
Adds contracts proving:

- a lone PR Quality local-gate log is not assigned to an unrelated failed `CodeQL` check;
- a `Fast CI lane (py3.11)` log is not assigned to an unrelated generic `ci` check;
- the correctly corresponding check still receives and parses its log.

## Historical replay proof
The preserved failed-evidence artifact set was replayed through the strict matching path:

```text
strict_log_provenance_replay=passed
historical_failed_checks_compared=42
mapped_new_exact_failures_preserved=27
mapped_new_exact_failures_lost=0
unmapped_evidence_inheritance_blocked=7
unmapped_false_attributions_after_patch=0
```

Correct mapped recoveries remain available:

```text
mapped_validate_and_fast_ci_recovery_preserved=true
```

False attribution is now blocked for unmapped cases, including historical `CodeQL`, `Full CI lane`, and generic `ci` evidence inheritance cases.

## Safety boundary
This PR changes provenance matching only:

```text
safe_to_auto_fix_expanded=false
automation_authority_expanded=false
```

One historical mapped `autopilot` row remained `safe_to_auto_fix=true` because that classification pre-existed this repair and had its own associated evidence; this PR does not create or broaden that authority.

## Validation completed
Targeted proof was run under Python `3.12.13`:

- focused intelligence/failure-bundle/remediation/workflow proof: `86 passed`;
- expanded connected-consumer proof: `191 passed`;
- targeted scanner proof for touched scope: zero findings;
- historical strict-provenance replay passed;
- `python -m mypy src` passed;
- `python -m pre_commit run -a` passed;
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must supply final full-suite coverage validation.

## Scope
Files changed:

- `src/sdetkit/check_intelligence.py`
- `tests/test_check_intelligence.py`

## Risk
Low and bounded. This tightens evidence attribution; the primary risk is rejecting a valid previously loose match. The historical replay proves that all 27 mapped newly recovered failures remain recoverable while false unmapped inheritance is blocked.

## Rollback
Revert this PR. The parser will again be able to borrow unrelated log evidence in artifacts where failed checks do not have strict mapped log provenance.

## Next
After merge and accepted-main replay verification, rerun the remaining-evidence inventory. Only evidence gaps that remain under strict provenance should justify further implementation; automatic remediation authority must not be expanded from unmatched or borrowed evidence.
