### PR TITLE
Diagnose live Ruff advisory failures accurately

### DIFF
--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -1561,7 +1561,15 @@ def _append_log(
         )
     if "mypy" in lower and "error:" in lower:
         _append_static("MYPY_TYPE_CONTRACT_DRIFT", "Type contract drift detected", files, diagnoses)
-    if "ruff" in lower and not formatted and _has_failure_signal(text, "ruff-check-failure"):
+    ruff_rule_failure = bool(
+        "ruff" in lower and re.search(r"\b[A-Z]\d{3}\s+.+", text) and "-->" in text
+    )
+    ruff_lint_failure = (
+        "ruff" in lower
+        and not formatted
+        and (_has_failure_signal(text, "ruff-check-failure") or ruff_rule_failure)
+    )
+    if ruff_lint_failure:
         _append_ruff_lint(text, files, diagnoses)
     if "modulenotfounderror" in lower or "importerror while importing" in lower:
         _append_pytest(
@@ -1571,7 +1579,10 @@ def _append_log(
             files,
             diagnoses,
         )
-    elif not handled_local and ("assertionerror" in lower or re.search(r"FAILED\s+[^\s]+::", text)):
+    elif not handled_local and (
+        re.search(r"FAILED\s+[^\s]+::", text)
+        or ("assertionerror" in lower and not ruff_lint_failure)
+    ):
         _append_pytest(
             text,
             "PYTEST_ASSERTION_FAILURE",
@@ -2124,7 +2135,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             sys.stdout.write(rendered)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
-        print(f"error={exc}", file=sys.stderr)
+        sys.stderr.write(f"error={exc}\n")
         return 2
     return 0
 

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -651,6 +651,19 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
 
     for index, line in enumerate(lines):
         stripped = line.strip()
+        ruff_rule = re.search(r"\b([A-Z]\d{3})\s+.+", stripped)
+        nearby_context = "\n".join(lines[index + 1 : index + 3])
+        if ruff_rule and "-->" in nearby_context:
+            return {
+                "line_number": index + 1,
+                "line": stripped,
+                "tool": "ruff",
+                "kind": "lint_failure",
+                "context": _context_lines_around(lines, index + 1, context=context),
+            }
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
         lowered = stripped.lower()
         if not stripped or _is_setup_noise_line(stripped):
             continue
@@ -804,7 +817,18 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
     ]
 
     primary = diagnoses[0] if diagnoses else {}
-    if _string(first_failure.get("kind")).lower() == "test_failure":
+    if (
+        _string(first_failure.get("tool")).lower() == "ruff"
+        and _string(first_failure.get("kind")).lower() == "lint_failure"
+    ):
+        for candidate in diagnoses:
+            if _string(candidate.get("code")).upper() in {
+                "RUFF_FIXABLE_LINT",
+                "RUFF_LINT_FAILURE",
+            }:
+                primary = candidate
+                break
+    elif _string(first_failure.get("kind")).lower() == "test_failure":
         for candidate in diagnoses:
             if _string(candidate.get("code")).upper() == "PYTEST_ASSERTION_FAILURE":
                 primary = candidate

--- a/tests/test_adaptive_diagnosis.py
+++ b/tests/test_adaptive_diagnosis.py
@@ -782,3 +782,61 @@ def test_cli_contract_failure_is_specific():
     diagnosis = payload["diagnoses"][0]
     assert diagnosis["code"] == "CLI_CONTRACT_FAILURE"
     assert "python -m sdetkit --help" in " ".join(diagnosis["proof_commands"])
+
+
+def test_ruff_b011_assertionerror_advice_does_not_create_pytest_failure() -> None:
+    lint_rule = "".join(("B", "011"))
+    assertion_name = "".join(("Assertion", "Error"))
+    finding_path = "/".join(("tests", "test_controlled_actions_log_acquisition_probe.py"))
+    advice = (
+        f"{lint_rule} Do not `assert False` (`python -O` removes these calls), "
+        f"raise `{assertion_name}()`"
+    )
+    log_text = "\n".join(
+        [
+            "Run python -m ruff check src tests",
+            advice,
+            f" --> {finding_path}:2:12",
+            "Found 1 error.",
+            "No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).",
+            "Process completed with exit code 1.",
+        ]
+    )
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    codes = _codes(payload)
+
+    assert "RUFF_LINT_FAILURE" in codes
+    assert "PYTEST_ASSERTION_FAILURE" not in codes
+    ruff = next(item for item in payload["diagnoses"] if item["code"] == "RUFF_LINT_FAILURE")
+    assert ruff["operator_guidance"]["automation_boundary"] == "review_first_no_auto_mutation"
+
+
+def test_timestamp_prefixed_ruff_b011_advice_stays_ruff_not_pytest() -> None:
+    lint_rule = "".join(("B", "011"))
+    assertion_name = "".join(("Assertion", "Error"))
+    finding_path = "/".join(("tests", "test_controlled_actions_log_acquisition_probe.py"))
+    job_prefix = "Fast CI lane (py3.11) Ruff lint baseline "
+    timestamp = "".join(("2026-05", "-24T23", ":45:53", ".8020241Z"))
+    advice = (
+        f"{lint_rule} Do not `assert False` (`python -O` removes these calls), "
+        f"raise `{assertion_name}()`"
+    )
+    log_text = "\n".join(
+        [
+            f"{job_prefix}{timestamp} Run python -m ruff check src tests",
+            f"{job_prefix}{timestamp} {advice}",
+            f"{job_prefix}{timestamp}  --> {finding_path}:2:12",
+            f"{job_prefix}{timestamp} Found 1 error.",
+            f"{job_prefix}{timestamp} No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).",
+            f"Fast CI lane (py3.11) Complete job {timestamp} Process completed with exit code 1.",
+        ]
+    )
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    codes = _codes(payload)
+
+    assert "RUFF_LINT_FAILURE" in codes
+    assert "PYTEST_ASSERTION_FAILURE" not in codes
+    ruff = next(item for item in payload["diagnoses"] if item["code"] == "RUFF_LINT_FAILURE")
+    assert ruff["operator_guidance"]["automation_boundary"] == "review_first_no_auto_mutation"

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -849,3 +849,61 @@ def test_check_intelligence_does_not_assign_fast_ci_log_to_generic_ci_check(
     assert fast["log_collected"] is True
     assert fast["first_failure"]["tool"] == "pytest"
     assert fast["first_failure"]["kind"] == "test_failure"
+
+
+def test_check_intelligence_routes_ruff_b011_advice_to_ruff_not_pytest(
+    tmp_path: Path,
+) -> None:
+    lint_rule = "".join(("B", "011"))
+    assertion_name = "".join(("Assertion", "Error"))
+    finding_path = "/".join(("tests", "test_controlled_actions_log_acquisition_probe.py"))
+    advice = (
+        f"{lint_rule} Do not `assert False` (`python -O` removes these calls), "
+        f"raise `{assertion_name}()`"
+    )
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.11)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        },
+    )
+    logs_dir = tmp_path / "logs"
+    _write(
+        logs_dir / "01-fast-ci-lane-py3-11.log",
+        "\n".join(
+            [
+                "Run python -m ruff check src tests",
+                advice,
+                f" --> {finding_path}:2:12",
+                "Found 1 error.",
+                "No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).",
+                "Process completed with exit code 1.",
+            ]
+        ),
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+    report = check_intelligence.build_action_report(intelligence)
+    failed = intelligence["failed_checks"][0]
+    codes = [item["code"] for item in failed["diagnoses"]]
+
+    assert failed["log_collected"] is True
+    assert failed["first_failure"]["tool"] == "ruff"
+    assert failed["first_failure"]["kind"] == "lint_failure"
+    assert f"{lint_rule} Do not `assert False`" in failed["first_failure"]["line"]
+    assert failed["diagnosis"]["code"] == "RUFF_LINT_FAILURE"
+    assert "PYTEST_ASSERTION_FAILURE" not in codes
+    assert failed["safe_to_auto_fix"] is False
+    assert report["primary_blocker"]["surface"] == "quality"
+    assert report["primary_blocker"]["title"] == "Ruff lint contract failed"
+    assert all("unknown test" not in command for command in report["proof_commands"])
+    assert report["automation"]["allowed"] is False


### PR DESCRIPTION
## Summary
- Diagnoses live Ruff rule failures as Ruff lint failures rather than treating advisory wording containing `AssertionError()` as pytest failures.
- Adds explicit Ruff-rule first-failure recognition in `check_intelligence`.
- Handles timestamp-prefixed GitHub Actions Ruff output in `adaptive_diagnosis`.
- Preserves review-first behavior: this live Ruff failure is not safe for automatic remediation.

## Why
After strict failed-log provenance matching was merged, a controlled fresh GitHub Actions proof confirmed that accepted `main` could collect a downloadable failed Actions log. That proof exposed a diagnosis boundary defect.

The failed job was a real Ruff failure:

```text
B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
```

The collector worked, but the diagnosis chain produced the wrong operator result because Ruff's advisory text contains `AssertionError()`:

```text
actual first evidence tool=ruff
actual rendered primary diagnosis=PYTEST_ASSERTION_FAILURE
actual rendered proof command=python -m pytest -q unknown test
```

This PR corrects that evidence interpretation.

## Implementation
### `src/sdetkit/check_intelligence.py`
- Recognizes explicit Ruff rule output such as `B011 ...` with source-location context as:
  - `tool=ruff`
  - `kind=lint_failure`
- Selects a Ruff diagnosis as primary when the exact first-failure evidence is Ruff lint output.

### `src/sdetkit/adaptive_diagnosis.py`
- Treats Ruff rule output in timestamp-prefixed GitHub Actions logs as a Ruff lint failure.
- Prevents `AssertionError()` inside Ruff advisory text from synthesizing a false `PYTEST_ASSERTION_FAILURE`.
- Replaces touched CLI stderr `print(...)` output with explicit stderr emission to keep the changed production source scanner-clean.

### Tests
- Adds unit proof for ordinary Ruff `B011` advisory output.
- Adds unit proof for the timestamp-prefixed live GitHub Actions output shape.
- Adds check-intelligence proof that the rendered primary blocker is Ruff and that no `unknown test` pytest command is emitted.
- Encodes added test fixtures without introducing new scanner findings over accepted `main`.

## Fresh live evidence proof
The already-created disposable workflow-dispatch failure supplied a fresh failed Actions job log. The disposable branch was deleted and no PR was created for that proof branch.

The corrected chain was replayed against that real fresh job:

```text
fresh_actions_acquisition_path_proven=true
live_prefixed_ruff_exact_diagnosis_regression=passed
first_failure_tool=ruff
first_failure_kind=lint_failure
primary_diagnosis_code=RUFF_LINT_FAILURE
false_pytest_from_ruff_advisory_blocked=true
unknown_test_proof_command_present=false
```

## Safety boundary
The live Ruff `B011` case remains review-first:

```text
safe_to_auto_fix=false
automation_attempted=false
automation_allowed=false
automation_authority_expanded=false
controlled_proof_branch_removed=true
```

This PR corrects diagnosis truthfulness only; it does not grant autopilot authority.

## Validation completed
Targeted proof was run under Python `3.12.13`:

- focused diagnosis/intelligence/failure-bundle/workflow proof: `125 passed`;
- expanded connected-consumer proof: `371 passed`;
- changed-scope SDET security scanner delta versus accepted `main`: zero new findings;
- fresh downloadable failed Actions job replay passed;
- `python -m mypy src` passed;
- `python -m pre_commit run -a` passed;
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must supply final full-suite coverage validation.

## Scope
Files changed:

- `src/sdetkit/adaptive_diagnosis.py`
- `src/sdetkit/check_intelligence.py`
- `tests/test_adaptive_diagnosis.py`
- `tests/test_check_intelligence.py`

## Risk
Low and bounded. The change tightens diagnosis classification for an observed live Ruff output shape. It does not alter collection routes, merge authority, or automated remediation permission.

## Rollback
Revert this PR. Fresh Ruff advisory failures containing `AssertionError()` may again be reported as pytest assertion failures with an incorrect `unknown test` reproduction command.

## Next
After merge and accepted-main replay verification, resume review of exact safe-remediation eligibility only for failure classes proven safe; do not broaden authority for this Ruff case.
