### PR TITLE
Keep mixed remediation evidence review-first

### DIFF
--- a/src/sdetkit/safe_remediation_eligibility.py
+++ b/src/sdetkit/safe_remediation_eligibility.py
@@ -48,6 +48,20 @@ def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
     return any(needle in lowered for needle in needles)
 
 
+SAFE_AUTO_FIX_PATH_PREFIXES = ("src/", "tests/", "tools/")
+
+
+def _is_safe_repo_owned_path(path: str) -> bool:
+    clean = path.strip().replace("\\", "/")
+    if not clean or clean.startswith(("/", "~")):
+        return False
+    if clean in {".", ".."} or "/../" in f"/{clean}/":
+        return False
+    if "<" in clean or ">" in clean:
+        return False
+    return clean.startswith(SAFE_AUTO_FIX_PATH_PREFIXES)
+
+
 SAFE_FORMAT_MARKERS = (
     "end-of-file-fixer",
     "fix end of files",
@@ -139,20 +153,44 @@ def classify_check_failure(
             "proof_commands": [],
         }
 
-    if _contains_any(combined, UNSAFE_REVIEW_MARKERS) and not _contains_any(
-        combined,
-        SAFE_FORMAT_MARKERS,
-    ):
+    unsafe_signal = _contains_any(combined, UNSAFE_REVIEW_MARKERS)
+    formatting_signal = kind == "format_drift" or _contains_any(combined, SAFE_FORMAT_MARKERS)
+
+    if unsafe_signal:
         return {
             "schema_version": SCHEMA_VERSION,
             "safe_to_auto_fix": False,
             "strategy": REVIEW_FIRST_STRATEGY,
             "category": "review_first",
-            "reason": "Failure matches review-first markers and is not formatting-only.",
+            "affected_files": affected_files,
+            "reason": "Review-first evidence dominates any formatting-only signal.",
             "proof_commands": [],
         }
 
-    if kind == "format_drift" or _contains_any(combined, SAFE_FORMAT_MARKERS):
+    if formatting_signal:
+        if not affected_files:
+            return {
+                "schema_version": SCHEMA_VERSION,
+                "safe_to_auto_fix": False,
+                "strategy": REVIEW_FIRST_STRATEGY,
+                "category": "review_first",
+                "affected_files": [],
+                "reason": "Formatting evidence has no identified affected files.",
+                "proof_commands": [],
+            }
+
+        unsafe_files = [value for value in affected_files if not _is_safe_repo_owned_path(value)]
+        if unsafe_files:
+            return {
+                "schema_version": SCHEMA_VERSION,
+                "safe_to_auto_fix": False,
+                "strategy": REVIEW_FIRST_STRATEGY,
+                "category": "review_first",
+                "affected_files": affected_files,
+                "reason": "Formatting evidence includes files outside approved safe-fix paths.",
+                "proof_commands": [],
+            }
+
         return {
             "schema_version": SCHEMA_VERSION,
             "safe_to_auto_fix": True,

--- a/tests/test_check_intelligence_safe_remediation.py
+++ b/tests/test_check_intelligence_safe_remediation.py
@@ -28,6 +28,7 @@ def test_check_intelligence_marks_formatting_failure_safe_to_auto_fix(
                             "ruff format..............................Failed",
                             "- hook id: ruff-format",
                             "- files were modified by this hook",
+                            "Fixing tests/test_example.py",
                             "1 file reformatted",
                         ]
                     ),
@@ -64,3 +65,67 @@ def test_check_intelligence_keeps_type_failure_review_first(tmp_path: Path) -> N
 
     assert failed["safe_to_auto_fix"] is False
     assert failed["safe_remediation"]["strategy"] == "review_first"
+
+
+def test_check_intelligence_blocks_mixed_formatting_and_pytest_from_auto_fix(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Full CI lane",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "output": "\n".join(
+                        [
+                            "ruff format..............................Failed",
+                            "- files were modified by this hook",
+                            "Fixing tests/test_behavior.py",
+                            "1 file reformatted",
+                            "FAILED tests/test_behavior.py::test_contract - AssertionError",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+
+    assert failed["safe_to_auto_fix"] is False
+    assert failed["safe_remediation"]["strategy"] == "review_first"
+    assert failed["safe_remediation"]["category"] == "review_first"
+
+
+def test_check_intelligence_blocks_formatting_without_affected_files(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "autopilot",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "output": "\n".join(
+                        [
+                            "ruff format..............................Failed",
+                            "- files were modified by this hook",
+                            "1 file reformatted",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+
+    assert failed["safe_to_auto_fix"] is False
+    assert failed["safe_remediation"]["strategy"] == "review_first"
+    assert "no identified affected files" in failed["safe_remediation"]["reason"]

--- a/tests/test_safe_remediation_eligibility.py
+++ b/tests/test_safe_remediation_eligibility.py
@@ -11,6 +11,7 @@ def test_safe_remediation_allows_format_hook_modified_files() -> None:
             "line": "- files were modified by this hook",
             "tool": "pre_commit",
             "kind": "format_drift",
+            "context": [{"text": "Fixing tests/test_example.py"}],
         },
     )
 
@@ -29,6 +30,7 @@ def test_safe_remediation_allows_ruff_import_sorting_only() -> None:
             "line": "I001 [*] Import block is un-sorted or un-formatted",
             "tool": "ruff",
             "kind": "format_drift",
+            "context": [{"text": " --> src/sdetkit/example.py:1:1"}],
         },
     )
 
@@ -74,3 +76,81 @@ def test_safe_remediation_extracts_affected_files_from_log_context() -> None:
     assert result["safe_to_auto_fix"] is True
     assert result["strategy"] == "run_pre_commit"
     assert result["affected_files"] == ["tests/test_example.py"]
+
+
+def test_safe_remediation_blocks_mixed_formatting_and_test_failure() -> None:
+    result = eligibility.classify_check_failure(
+        name="Full CI lane",
+        diagnosis={"code": "PYTEST_ASSERTION_FAILURE"},
+        first_failure={
+            "line": "FAILED tests/test_behavior.py::test_contract - AssertionError",
+            "tool": "pytest",
+            "kind": "test_failure",
+        },
+        log_text="ruff format\n1 file reformatted\n",
+    )
+
+    assert result["safe_to_auto_fix"] is False
+    assert result["strategy"] == "review_first"
+    assert result["category"] == "review_first"
+    assert "dominates" in result["reason"]
+
+
+def test_safe_remediation_blocks_mixed_formatting_and_security_signal() -> None:
+    signal = "High " + "entropy string literal detected."
+    result = eligibility.classify_check_failure(
+        name="security-gate",
+        diagnosis={"code": "SEC_HIGH_ENTROPY_STRING"},
+        first_failure={
+            "line": signal + " src/sdetkit/example.py",
+            "tool": "security",
+            "kind": "finding",
+        },
+        log_text="ruff format\n1 file reformatted\n" + signal + "\n",
+    )
+
+    assert result["safe_to_auto_fix"] is False
+    assert result["strategy"] == "review_first"
+    assert result["category"] == "review_first"
+    assert "dominates" in result["reason"]
+
+
+def test_safe_remediation_blocks_formatting_without_affected_files() -> None:
+    result = eligibility.classify_check_failure(
+        name="autopilot",
+        diagnosis={"code": "PRE_COMMIT_FORMAT_DRIFT"},
+        first_failure={
+            "line": "- files were modified by this hook",
+            "tool": "pre_commit",
+            "kind": "format_drift",
+        },
+        log_text="ruff format\n1 file reformatted\n",
+    )
+
+    assert result["safe_to_auto_fix"] is False
+    assert result["strategy"] == "review_first"
+    assert result["affected_files"] == []
+    assert "no identified affected files" in result["reason"]
+
+
+def test_safe_remediation_blocks_formatting_with_unapproved_path_evidence() -> None:
+    result = eligibility.classify_check_failure(
+        name="autopilot",
+        diagnosis={"code": "PRE_COMMIT_FORMAT_DRIFT"},
+        first_failure={
+            "line": "- files were modified by this hook",
+            "tool": "pre_commit",
+            "kind": "format_drift",
+            "context": [
+                {
+                    "text": "Fixing home/runner/work/DevS69-sdetkit/DevS69-sdetkit/tools/maintenance_autopilot.py"
+                },
+                {"text": "Fixing tools/maintenance_autopilot.py"},
+            ],
+        },
+        log_text="ruff format\n1 file reformatted\n",
+    )
+
+    assert result["safe_to_auto_fix"] is False
+    assert result["strategy"] == "review_first"
+    assert "outside approved safe-fix paths" in result["reason"]


### PR DESCRIPTION
## Summary
- Makes review-first evidence dominate formatting markers in safe-remediation eligibility.
- Refuses automatic formatting repair when affected files are missing or include paths outside approved repo-owned locations.
- Preserves the already-allowed formatting-only class when the evidence identifies approved `src/`, `tests/`, or `tools/` files.
- Closes a historical false-safe candidate without expanding automation authority.

## Why
After the exact-failure collection and truthful Ruff diagnosis chain was closed on accepted `main`, a read-only eligibility audit found that the current safe-remediation policy could classify mixed evidence as `formatting_only`.

Three direct policy probes were false-safe on accepted `main`:

```text
mixed_format_and_pytest_assertion_must_be_review_first:
  expected_safe=false
  observed_safe=true

mixed_format_and_security_signal_must_be_review_first:
  expected_safe=false
  observed_safe=true

formatting_without_affected_files_must_not_authorize_execution:
  expected_safe=false
  observed_safe=true
```

The audit also recovered a historical `autopilot` candidate that was marked safe upstream despite containing runtime-failure evidence and an unapproved runner-workspace path.

The existing execution layer already rejects empty or out-of-scope file plans. This PR aligns upstream eligibility and operator reporting with that existing safety boundary before any automatic-fix authority can be expanded.

## Implementation
### `src/sdetkit/safe_remediation_eligibility.py`
- Makes any review-first marker dominate formatting-only signals.
- Requires a non-empty affected-file set before formatting evidence can be eligible for automatic remediation.
- Restricts formatting-safe files to approved repo-owned paths under:
  - `src/`
  - `tests/`
  - `tools/`
- Keeps the deterministic formatting-only strategy unchanged for valid repo-owned formatting evidence.

### Tests
- Preserves proof that repo-owned formatting-only evidence remains eligible.
- Adds direct policy tests proving mixed pytest/formatting and mixed security/formatting evidence remain review-first.
- Adds direct policy tests proving missing affected files and unapproved paths cannot authorize automatic remediation.
- Adds check-intelligence integration tests for the same review-first boundaries.

## Historical replay proof
The previously observed historical `autopilot` candidate is now reclassified correctly:

```text
historical_safe_candidate_reclassified_review_first=true
historical_candidate_runtime_failure_dominates_formatting=true
historical_candidate_contains_unapproved_path_evidence=true
historical_candidate_safe_to_auto_fix=false
historical_candidate_authority_expanded=false
```

This historical candidate is blocked by the stronger review-first runtime evidence boundary; the unapproved-path rejection is independently proven in a direct contract test.

## Safety boundary
This PR narrows safety only:

```text
review_first_dominates_formatting_signal=true
affected_files_required_for_safe_formatting=true
execution_path_allowlist_aligned_upstream=true
safe_formatting_repo_owned_class_preserved=true
safe_to_auto_fix_expanded=false
automation_authority_expanded=false
```

It adds no new safe-fix class and grants no new automation permission.

## Validation completed
Targeted proof was run under Python `3.12.13`:

- focused eligibility/intelligence proof: `75 passed`;
- expanded connected safety-consumer proof: `757 passed`;
- changed-scope SDET scanner delta versus accepted `main`: zero new findings;
- historical false-safe candidate replay passed;
- `python -m mypy src` passed;
- `python -m pre_commit run -a` passed;
- `python scripts/check_generated_artifacts_freshness.py` passed.

A full local coverage cycle is intentionally not claimed. Normal PR CI must provide final full-suite coverage validation.

## Scope
Files changed:

- `src/sdetkit/safe_remediation_eligibility.py`
- `tests/test_check_intelligence_safe_remediation.py`
- `tests/test_safe_remediation_eligibility.py`

## Risk
Low and safety-reducing. The principal effect is that previously permissive mixed or incomplete formatting evidence will now remain review-first. Valid repo-owned formatting-only evidence remains eligible.

## Rollback
Revert this PR. Mixed or incomplete evidence may again be marked safe upstream even when downstream execution would refuse it or a human should review it.

## Next
After merge and accepted-main post-merge verification, review whether the existing valid repo-owned formatting-only class has sufficient execution-proof coverage to permit a tightly controlled remediation loop. Do not expand authority beyond that proven class.
