### PR TITLE
Disable unverified remediation workflow writes

### DIFF
--- a/.github/workflows/maintenance-autopilot.yml
+++ b/.github/workflows/maintenance-autopilot.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
 
@@ -39,7 +39,6 @@ jobs:
             PYTHONPATH=src python tools/maintenance_autopilot.py \
               --owner "${{ github.repository_owner }}" \
               --repo "${{ github.event.repository.name }}" \
-              --commit-safe-fixes \
               --max-remediation-attempts 3 \
               --remediation-cooldown-runs 2 \
               --out-dir build/maintenance/autopilot
@@ -48,7 +47,6 @@ jobs:
               --owner "${{ github.repository_owner }}" \
               --repo "${{ github.event.repository.name }}" \
               --run-live-if-token \
-              --auto-remediate-safe \
               --max-remediation-attempts 3 \
               --remediation-cooldown-runs 2 \
               --out-dir build/maintenance/autopilot
@@ -189,34 +187,3 @@ jobs:
           with urllib.request.urlopen(req, timeout=30) as resp:
               print(f"webhook status: {resp.status}")
           PY
-
-      - name: Detect successful auto-remediation changes
-        id: remediation_changes
-        run: |
-          python - <<'PY'
-          import json
-          from pathlib import Path
-
-          report = json.loads(Path("build/maintenance/autopilot/autopilot-report.json").read_text(encoding="utf-8"))
-          items = report.get("follow_up", {}).get("auto_remediation", [])
-          has_success = any(bool(x.get("attempted")) and bool(x.get("ok")) for x in items if isinstance(x, dict))
-          print(f"run_cpr={'true' if has_success else 'false'}")
-          out = Path(".github_output_tmp")
-          out.write_text(f"run_cpr={'true' if has_success else 'false'}\n", encoding="utf-8")
-          PY
-          cat .github_output_tmp >> "$GITHUB_OUTPUT"
-          rm -f .github_output_tmp
-
-      - name: Create pull request for successful auto-remediation
-        if: github.event_name != 'pull_request' && steps.remediation_changes.outputs.run_cpr == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
-        with:
-          commit-message: "chore(maintenance): apply safe autopilot remediation"
-          title: "chore(maintenance): safe autopilot remediation"
-          body: |
-            Automated safe remediation was applied by maintenance autopilot.
-
-            - workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            - artifacts: maintenance-autopilot
-          branch: automation/maintenance-autopilot-remediation
-          base: main

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
   checks: read
@@ -329,18 +329,6 @@ jobs:
           )
           PY
 
-      - name: Commit approved safe formatting fixes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PYTHONPATH=src python tools/maintenance_autopilot.py \
-            --owner "${{ github.repository_owner }}" \
-            --repo "${{ github.event.repository.name }}" \
-            --commit-safe-fixes \
-            --check-intelligence-json build/pr-quality/check-intelligence/check-intelligence.json \
-            --pr-quality-safe-bridge-only \
-            --out-dir build/pr-quality/safe-formatting-autopilot
-
       - name: Build PR comment body
         env:
           GH_TOKEN: ${{ github.token }}
@@ -663,7 +651,6 @@ jobs:
             build/pr-quality/security-review/
             build/pr-quality/code-scanning/
             build/pr-quality/security-diagnosis/
-            build/pr-quality/safe-formatting-autopilot/
             build/pr-quality/trajectory/
             build/pr-quality/trajectory-pattern-insights/
             build/pr-quality/live-benchmark/

--- a/tests/test_maintenance_autopilot_workflow_safety.py
+++ b/tests/test_maintenance_autopilot_workflow_safety.py
@@ -7,27 +7,50 @@ WORKFLOW = (
 )
 
 
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
 def test_workflow_runs_on_pull_request() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
+    text = _workflow_text()
+
     assert "on:" in text
     assert "pull_request:" in text
 
 
-def test_pull_request_branch_avoids_live_remediation_flags() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    assert 'if [ "${{ github.event_name }}" = "pull_request" ]; then' in text
-    assert "--run-live-if-token" in text
-    assert "--auto-remediate-safe" in text
-    pr_branch = text.split('if [ "${{ github.event_name }}" = "pull_request" ]; then', 1)[1].split(
-        "else", 1
-    )[0]
+def test_workflow_preserves_reporting_permissions_without_repository_write() -> None:
+    text = _workflow_text()
+    permissions = text.split("jobs:", 1)[0]
+
+    assert "contents: read" in permissions
+    assert "contents: write" not in permissions
+    assert "issues: write" in permissions
+    assert "pull-requests: write" in permissions
+
+
+def test_pull_request_branch_cannot_commit_unverified_remediation() -> None:
+    text = _workflow_text()
+    pr_branch = text.split(
+        'if [ "${{ github.event_name }}" = "pull_request" ]; then',
+        1,
+    )[1].split("else", 1)[0]
+
+    assert "--commit-safe-fixes" not in pr_branch
     assert "--run-live-if-token" not in pr_branch
     assert "--auto-remediate-safe" not in pr_branch
 
 
-def test_side_effect_steps_are_guarded_for_non_pr_events() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
+def test_non_pr_workflow_does_not_open_unverified_remediation_pull_request() -> None:
+    text = _workflow_text()
+
+    assert "--auto-remediate-safe" not in text
+    assert "Detect successful auto-remediation changes" not in text
+    assert "Create pull request for successful auto-remediation" not in text
+
+
+def test_security_follow_up_side_effects_remain_non_pr_only() -> None:
+    text = _workflow_text()
+
     assert "Open/update security follow-up issue when actionable findings exist" in text
     assert "if: github.event_name != 'pull_request'" in text
     assert "Send webhook notification for actionable security follow-up" in text
-    assert "Create pull request for successful auto-remediation" in text

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -20,11 +20,12 @@ def test_pr_quality_comment_workflow_has_queue_safe_concurrency_and_timeout() ->
     assert "timeout-minutes: 20" in text
 
 
-def test_pr_quality_comment_workflow_has_comment_permissions() -> None:
+def test_pr_quality_comment_workflow_has_comment_permissions_without_repository_write() -> None:
     text = _workflow_text()
     permissions = text.split("jobs:", 1)[0]
 
-    assert "contents: write" in permissions
+    assert "contents: read" in permissions
+    assert "contents: write" not in permissions
     assert "issues: write" in permissions
     assert "pull-requests: write" in permissions
     assert "checks: read" in permissions
@@ -205,40 +206,34 @@ def test_pr_quality_comment_workflow_passes_evidence_narrative_into_final_commen
     assert action_report_step < evidence_arg < comment_out
 
 
-def test_pr_quality_workflow_runs_safe_formatting_autopilot_bridge() -> None:
-    text = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+def test_pr_quality_workflow_does_not_execute_unverified_safe_formatting() -> None:
+    text = _workflow_text()
 
-    check_intelligence = text.index("python -m sdetkit.check_intelligence")
-    bridge = text.index("Commit approved safe formatting fixes")
-    narrative = text.index("--out build/pr-quality/pr-evidence-narrative.md")
-
-    assert check_intelligence < bridge < narrative
-    assert "tools/maintenance_autopilot.py" in text
-    assert "--commit-safe-fixes" in text
-    assert (
-        "--check-intelligence-json build/pr-quality/check-intelligence/check-intelligence.json"
-        in text
-    )
-    assert "--pr-quality-safe-bridge-only" in text
-    assert "--out-dir build/pr-quality/safe-formatting-autopilot" in text
-    assert "build/pr-quality/safe-formatting-autopilot/" in text
+    assert "Commit approved safe formatting fixes" not in text
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text
+    assert "build/pr-quality/safe-formatting-autopilot/" not in text
+    assert "python -m sdetkit.check_intelligence" in text
+    assert "python -m sdetkit.pr_quality_action_report" in text
 
 
-def test_pr_quality_workflow_grants_contents_write_for_safe_branch_commit() -> None:
-    text = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+def test_pr_quality_workflow_keeps_repository_contents_read_only() -> None:
+    text = _workflow_text()
     permissions = text.split("jobs:", 1)[0]
 
     assert "permissions:" in permissions
-    assert "contents: write" in permissions
+    assert "contents: read" in permissions
+    assert "contents: write" not in permissions
 
 
-def test_pr_quality_workflow_uploads_safe_fix_outcome_artifacts() -> None:
+def test_pr_quality_workflow_preserves_reporting_without_safe_fix_execution_artifacts() -> None:
     text = _workflow_text()
 
-    assert "build/pr-quality/safe-formatting-autopilot/" in text
-    assert "Commit approved safe formatting fixes" in text
+    assert "build/pr-quality/safe-formatting-autopilot/" not in text
+    assert "Commit approved safe formatting fixes" not in text
     assert "Build PR comment body" in text
-    assert text.index("Commit approved safe formatting fixes") < text.index("Build PR comment body")
+    assert "python -m sdetkit.check_intelligence" in text
+    assert "python -m sdetkit.pr_quality_action_report" in text
 
 
 def test_pr_quality_comment_workflow_builds_and_passes_trajectory_artifact() -> None:


### PR DESCRIPTION
## Summary
- Removes the active PR Quality workflow path that could commit and push formatting remediation before verifier authorization exists.
- Removes pull-request `--commit-safe-fixes` execution from the maintenance-autopilot workflow.
- Removes scheduled/manual `--auto-remediate-safe` execution and automatic remediation PR creation.
- Narrows both affected workflows from `contents: write` to `contents: read`.
- Updates workflow contract tests to assert the new read-only boundary.

## Why
Accepted `main` narrows safe-remediation eligibility, but active workflows could still execute and push repository changes. The current verification contracts do not authorize that behavior: `patch_scorer` is read-only, and `protected_verifier` reports `automation_allowed=false` and `merge_authorized=false`.

## Safety boundary
```text
workflow_repository_content_write_removed=true
pr_quality_commit_safe_fixes_removed=true
maintenance_pr_commit_safe_fixes_removed=true
maintenance_auto_remediate_safe_removed=true
automatic_remediation_pr_creation_removed=true
diagnosis_and_reporting_preserved=true
security_follow_up_preserved=true
automation_authority_expanded=false
```

## Validation completed
- Focused workflow and remediation-boundary suite: `74 passed`.
- ProtectedVerifier suite: `6 passed`.
- `python -m mypy src` passed.
- `python -m pre_commit run -a` passed.
- `python scripts/check_generated_artifacts_freshness.py` passed.
- `git diff --check` passed.

## Scope
- `.github/workflows/maintenance-autopilot.yml`
- `.github/workflows/pr-quality-comment.yml`
- `tests/test_maintenance_autopilot_workflow_safety.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

## Risk
Medium and safety-reducing. Automated repository-content remediation is disabled in the two active workflow paths. Diagnostic reporting and guarded non-PR security follow-up behavior remain available.

## Next
Introduce read-only PatchScorer and ProtectedVerifier visibility for remediation candidates before separately considering any explicitly proven execution authority.
