### PR TITLE
Surface read-only remediation candidate verification

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -359,6 +359,7 @@ jobs:
             --head-ref HEAD \
             "${claim_args[@]}" \
             --profile ruff_src_tests \
+            --profile pre_commit_all \
             --out-dir build/pr-quality/runtime-proof/isolated-proof \
             --format json \
             > build/pr-quality/runtime-proof/isolated-proof-cli.json \
@@ -463,6 +464,18 @@ jobs:
             --markdown-out build/pr-quality/trajectory-pattern-insights/pattern-insights.md \
             --format json \
             > build/pr-quality/trajectory-pattern-insights/pattern-insights-cli.json
+
+          mkdir -p build/pr-quality/candidate-visibility
+          PYTHONPATH=src python -m sdetkit.pr_quality_candidate_visibility \
+            --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
+            --evidence-graph build/sdetkit/evidence-graph/evidence-graph.json \
+            --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
+            --changed-files build/pr-quality/changed-files.txt \
+            --pattern-insights build/pr-quality/trajectory-pattern-insights/pattern-insights.json \
+            --verification-evidence build/pr-quality/runtime-proof/isolated-proof/verification-evidence.json \
+            --out-dir build/pr-quality/candidate-visibility \
+            --format json \
+            > build/pr-quality/candidate-visibility/candidate-visibility-cli.json
 
           repo_memory_rc=2
           if [ -s build/pr-quality/live-benchmark/fixture-report/benchmark-report.json ] \
@@ -597,6 +610,11 @@ jobs:
             --out build/pr-quality/pr-comment-body.md \
             > build/pr-quality/pr-comment-metadata.json
 
+          if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/candidate-visibility/candidate-visibility.md >> build/pr-quality/pr-comment-body.md
+          fi
+
       - name: Build verified operator evidence loop
         if: always()
         run: |
@@ -657,6 +675,7 @@ jobs:
             build/pr-quality/repo-memory/
             build/pr-quality/trusted-history/
             build/pr-quality/runtime-proof/
+            build/pr-quality/candidate-visibility/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
             build/sdetkit/operator-loop/

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -396,7 +396,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.expansion",
         "module_path": "src/sdetkit/expansion.py",
-        "tests_referencing_module": 25
+        "tests_referencing_module": 26
       },
       {
         "contract_script_paths": [
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 116
+        "tests_referencing_module": 118
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/pr_quality_candidate_visibility.py
+++ b/src/sdetkit/pr_quality_candidate_visibility.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit import (
+    diagnostic_vector_engine,
+    patch_scorer,
+    protected_verifier,
+    remediation_plan_engine,
+)
+
+SCHEMA_VERSION = "sdetkit.pr_quality.candidate_visibility.v1"
+RESULT_JSON = "candidate-visibility.json"
+RESULT_MD = "candidate-visibility.md"
+DEFAULT_OUT_DIR = Path("build") / "pr-quality" / "candidate-visibility"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    return sorted({_string(item) for item in _as_list(value) if _string(item)})
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _read_changed_files(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return sorted(
+        {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+    )
+
+
+def _candidate_files(plan: Mapping[str, Any]) -> list[str]:
+    exact_scope = _as_dict(plan.get("exact_fix_scope"))
+    return _string_list(exact_scope.get("allowed_files")) or _string_list(
+        plan.get("affected_files")
+    )
+
+
+def _approved_formatting_candidate(record: Mapping[str, Any]) -> bool:
+    safe_remediation = _as_dict(record.get("safe_remediation"))
+    approved_strategies = {
+        "run_pre_commit",
+        "ruff_format",
+        "eof_fixer",
+        "trim_trailing_whitespace",
+    }
+    return (
+        record.get("safe_to_auto_fix") is True
+        and safe_remediation.get("safe_to_auto_fix") is True
+        and _string(safe_remediation.get("category")).lower() == "formatting_only"
+        and _string(safe_remediation.get("strategy")).lower() in approved_strategies
+    )
+
+
+def _read_only_candidate_record(record: Mapping[str, Any]) -> JsonObject:
+    normalized = dict(record)
+    if _approved_formatting_candidate(record):
+        normalized["surface"] = "formatting"
+    return normalized
+
+
+def _read_only_candidate_intelligence(payload: Mapping[str, Any]) -> JsonObject:
+    normalized = dict(payload)
+    normalized["failed_checks"] = [
+        _read_only_candidate_record(_as_dict(item))
+        for item in _as_list(payload.get("failed_checks"))
+    ]
+    return normalized
+
+
+def _read_only_candidate_action_report(payload: Mapping[str, Any]) -> JsonObject:
+    normalized = dict(payload)
+    primary = _as_dict(payload.get("primary_blocker"))
+    if primary:
+        normalized["primary_blocker"] = _read_only_candidate_record(primary)
+    return normalized
+
+
+def build_candidate_visibility(
+    *,
+    check_intelligence: Mapping[str, Any],
+    evidence_graph: Mapping[str, Any],
+    pr_quality_action_report: Mapping[str, Any],
+    changed_files: list[str],
+    pattern_insights: Mapping[str, Any],
+    verification_evidence: Mapping[str, Any],
+) -> JsonObject:
+    diagnostic_vector = diagnostic_vector_engine.build_diagnostic_vector(
+        check_intelligence=_read_only_candidate_intelligence(check_intelligence),
+        evidence_graph=evidence_graph,
+        pr_quality_action_report=_read_only_candidate_action_report(pr_quality_action_report),
+    )
+    remediation_plan = remediation_plan_engine.build_remediation_plan(diagnostic_vector)
+    plans = [_as_dict(item) for item in _as_list(remediation_plan.get("plans")) if _as_dict(item)]
+    candidates = [plan for plan in plans if plan.get("safe_to_auto_fix") is True]
+    review_first = [plan for plan in plans if plan.get("safe_to_auto_fix") is not True]
+    observed_pr_changed_files = sorted(set(changed_files))
+    payload: JsonObject = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "no_candidate",
+        "candidate_count": len(candidates),
+        "review_first_plan_count": len(review_first),
+        "candidate_files": [],
+        "observed_pr_changed_files": observed_pr_changed_files,
+        "diagnostic_vector": diagnostic_vector,
+        "remediation_plan": remediation_plan,
+        "patch_score": {},
+        "protected_verifier": {},
+        "decision_boundary": {
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "reason": ("Candidate evidence is read-only and does not authorize mutation or merge."),
+        },
+    }
+
+    if not candidates:
+        return payload
+
+    if len(candidates) != 1 or review_first:
+        payload["status"] = "candidate_held_review_first"
+        payload["decision_boundary"]["reason"] = (
+            "Candidate evidence is mixed with review-first plans; "
+            "no candidate verification is claimed."
+        )
+        return payload
+
+    candidate = candidates[0]
+    candidate_files = _candidate_files(candidate)
+    payload["candidate_files"] = candidate_files
+    score = patch_scorer.score_patch(
+        remediation_plan=remediation_plan,
+        proposed_patch={
+            "patch_id": "pr-quality-read-only-candidate",
+            "changed_files": candidate_files,
+        },
+        pattern_insights=pattern_insights,
+        diagnosis_id=_string(candidate.get("diagnosis_id")),
+    )
+    verification = protected_verifier.verify_candidate(
+        patch_score=score,
+        verification_evidence=verification_evidence,
+    )
+    verification_decision = _as_dict(verification.get("decision"))
+    structurally_verified = verification_decision.get("structural_verification_passed") is True
+    payload["status"] = (
+        "candidate_structurally_verified"
+        if structurally_verified
+        else "candidate_review_first_after_verification"
+    )
+    payload["patch_score"] = score
+    payload["protected_verifier"] = verification
+    payload["decision_boundary"]["reason"] = (
+        "Structural evidence was observed, but semantic equivalence, "
+        "automated mutation, and merge authorization remain unavailable."
+        if structurally_verified
+        else "ProtectedVerifier found blocking current evidence; "
+        "the candidate remains review-first."
+    )
+    return payload
+
+
+def render_markdown(payload: Mapping[str, Any]) -> str:
+    candidate_count = int(payload.get("candidate_count", 0) or 0)
+    if candidate_count == 0:
+        return ""
+
+    boundary = _as_dict(payload.get("decision_boundary"))
+    score = _as_dict(payload.get("patch_score"))
+    score_decision = _as_dict(score.get("decision"))
+    verification = _as_dict(payload.get("protected_verifier"))
+    verification_decision = _as_dict(verification.get("decision"))
+    candidate_files = _string_list(payload.get("candidate_files"))
+    observed_files = _string_list(payload.get("observed_pr_changed_files"))
+    lines = [
+        "## Read-only remediation candidate verification",
+        "",
+        f"- Status: `{_string(payload.get('status') or 'unknown')}`",
+        f"- Candidates observed: `{candidate_count}`",
+        (f"- Review-first plans observed: `{int(payload.get('review_first_plan_count', 0) or 0)}`"),
+        ("- Candidate scope: " + (", ".join(f"`{path}`" for path in candidate_files) or "none")),
+        (
+            "- Observed PR changed files: "
+            + (", ".join(f"`{path}`" for path in observed_files) or "none")
+        ),
+        (f"- Automation allowed: `{str(bool(boundary.get('automation_allowed', False))).lower()}`"),
+        (f"- Merge authorized: `{str(bool(boundary.get('merge_authorized', False))).lower()}`"),
+        (
+            "- Semantic equivalence proven: "
+            f"`{str(bool(boundary.get('semantic_equivalence_proven', False))).lower()}`"
+        ),
+        f"- Boundary reason: {_string(boundary.get('reason') or 'none')}",
+    ]
+
+    if score:
+        lines.extend(
+            [
+                f"- Patch score: `{int(score.get('score', 0) or 0)}`",
+                (f"- PatchScorer decision: `{_string(score_decision.get('status') or 'unknown')}`"),
+                "- PatchScorer automation allowed: `false`",
+            ]
+        )
+
+    if verification:
+        lines.extend(
+            [
+                (
+                    "- ProtectedVerifier decision: "
+                    f"`{_string(verification_decision.get('status') or 'unknown')}`"
+                ),
+                (
+                    "- Structural verification passed: "
+                    f"`{str(bool(verification_decision.get('structural_verification_passed', False))).lower()}`"
+                ),
+                "- ProtectedVerifier automation allowed: `false`",
+                "- ProtectedVerifier merge authorized: `false`",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_visibility(payload: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result_json = out_dir / RESULT_JSON
+    result_md = out_dir / RESULT_MD
+    result_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    result_md.write_text(render_markdown(payload), encoding="utf-8")
+
+    paths = {
+        "candidate_visibility_json": result_json.as_posix(),
+        "candidate_visibility_markdown": result_md.as_posix(),
+    }
+    paths.update(
+        diagnostic_vector_engine.write_diagnostic_vector(
+            _as_dict(payload.get("diagnostic_vector")),
+            out_dir / "diagnostic-vector",
+        )
+    )
+    paths.update(
+        remediation_plan_engine.write_remediation_plan(
+            _as_dict(payload.get("remediation_plan")),
+            out_dir / "remediation-plan",
+        )
+    )
+
+    score = _as_dict(payload.get("patch_score"))
+    if score:
+        paths.update(patch_scorer.write_patch_score(score, out_dir=out_dir / "patch-score"))
+
+    verification = _as_dict(payload.get("protected_verifier"))
+    if verification:
+        paths.update(
+            protected_verifier.write_result(
+                verification,
+                out_dir=out_dir / "protected-verifier",
+            )
+        )
+
+    return paths
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.pr_quality_candidate_visibility")
+    parser.add_argument("--check-intelligence", type=Path, required=True)
+    parser.add_argument("--evidence-graph", type=Path, required=True)
+    parser.add_argument("--pr-quality-action-report", type=Path, required=True)
+    parser.add_argument("--changed-files", type=Path, required=True)
+    parser.add_argument("--pattern-insights", type=Path, required=True)
+    parser.add_argument("--verification-evidence", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_candidate_visibility(
+            check_intelligence=_read_json(args.check_intelligence),
+            evidence_graph=_read_json(args.evidence_graph),
+            pr_quality_action_report=_read_json(args.pr_quality_action_report),
+            changed_files=_read_changed_files(args.changed_files),
+            pattern_insights=_read_json(args.pattern_insights),
+            verification_evidence=_read_json(args.verification_evidence),
+        )
+        artifacts = write_visibility(payload, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "artifacts": artifacts,
+                    "status": payload["status"],
+                    "candidate_count": payload["candidate_count"],
+                    "decision_boundary": payload["decision_boundary"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"status: {payload['status']}")
+        print(f"candidate_count: {payload['candidate_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_quality_candidate_visibility.py
+++ b/tests/test_pr_quality_candidate_visibility.py
@@ -8,6 +8,10 @@ from sdetkit.pr_quality_candidate_visibility import (
     main,
     render_markdown,
 )
+from sdetkit.protected_verifier import (
+    CHANGED_FILE_INVENTORY_MISMATCH,
+    OUTSIDE_SCORED_SCOPE,
+)
 
 
 def _formatting_failure() -> dict:
@@ -120,8 +124,8 @@ def test_candidate_visibility_keeps_broader_pr_diff_review_first() -> None:
     assert payload["observed_pr_changed_files"] == observed
     assert payload["patch_score"]["decision"]["status"] == "candidate_for_protected_verification"
     assert verification["decision"]["status"] == "blocked_review_first"
-    assert "CHANGED_FILE_INVENTORY_MISMATCH" in codes
-    assert "OUTSIDE_SCORED_SCOPE" in codes
+    assert CHANGED_FILE_INVENTORY_MISMATCH in codes
+    assert OUTSIDE_SCORED_SCOPE in codes
     assert verification["decision"]["automation_allowed"] is False
     assert verification["decision"]["merge_authorized"] is False
 

--- a/tests/test_pr_quality_candidate_visibility.py
+++ b/tests/test_pr_quality_candidate_visibility.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.pr_quality_candidate_visibility import (
+    build_candidate_visibility,
+    main,
+    render_markdown,
+)
+
+
+def _formatting_failure() -> dict:
+    return {
+        "failed_checks": [
+            {
+                "name": "PR Quality local quality gate",
+                "surface": "quality",
+                "diagnosis": {
+                    "title": "Pre-commit formatting drift",
+                    "code": "PRE_COMMIT_FORMAT_DRIFT",
+                },
+                "first_failure": {
+                    "line": "ruff format..............................Failed",
+                    "line_number": 30,
+                    "tool": "ruff",
+                    "kind": "format_drift",
+                },
+                "safe_to_auto_fix": True,
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "category": "formatting_only",
+                    "affected_files": ["src/sdetkit/example.py"],
+                },
+            }
+        ]
+    }
+
+
+def _pattern_insights() -> dict:
+    return {
+        "recurring_review_first_surfaces": [],
+        "recurring_safe_fix_patterns": [
+            {"failure_class": "formatting_only", "action": "run_pre_commit", "count": 2}
+        ],
+    }
+
+
+def _verification_evidence(changed_files: list[str] | None = None) -> dict:
+    return {
+        "changed_files": changed_files or ["src/sdetkit/example.py"],
+        "proof_results": [
+            {"command": "python -m pre_commit run -a", "status": "passed", "exit_code": 0}
+        ],
+    }
+
+
+def test_candidate_visibility_normalizes_only_its_read_only_view() -> None:
+    intelligence = _formatting_failure()
+    payload = build_candidate_visibility(
+        check_intelligence=intelligence,
+        evidence_graph={},
+        pr_quality_action_report={},
+        changed_files=["src/sdetkit/example.py"],
+        pattern_insights=_pattern_insights(),
+        verification_evidence=_verification_evidence(),
+    )
+
+    assert intelligence["failed_checks"][0]["surface"] == "quality"
+    assert payload["diagnostic_vector"]["diagnoses"][0]["failure_surface"] == "formatting"
+
+
+def test_candidate_visibility_exposes_matching_structural_proof_without_authority() -> None:
+    payload = build_candidate_visibility(
+        check_intelligence=_formatting_failure(),
+        evidence_graph={},
+        pr_quality_action_report={},
+        changed_files=["src/sdetkit/example.py"],
+        pattern_insights=_pattern_insights(),
+        verification_evidence=_verification_evidence(),
+    )
+
+    score = payload["patch_score"]
+    verification = payload["protected_verifier"]
+    assert payload["status"] == "candidate_structurally_verified"
+    assert payload["candidate_files"] == ["src/sdetkit/example.py"]
+    assert payload["observed_pr_changed_files"] == ["src/sdetkit/example.py"]
+    assert score["decision"]["status"] == "candidate_for_protected_verification"
+    assert score["decision"]["automation_allowed"] is False
+    assert verification["decision"]["status"] == "structurally_verified_candidate"
+    assert verification["decision"]["automation_allowed"] is False
+    assert verification["decision"]["merge_authorized"] is False
+    assert payload["decision_boundary"]["automation_allowed"] is False
+    assert payload["decision_boundary"]["merge_authorized"] is False
+
+    markdown = render_markdown(payload)
+    assert "Read-only remediation candidate verification" in markdown
+    assert "Candidate scope: `src/sdetkit/example.py`" in markdown
+    assert "PatchScorer decision: `candidate_for_protected_verification`" in markdown
+    assert "ProtectedVerifier decision: `structurally_verified_candidate`" in markdown
+    assert "Automation allowed: `false`" in markdown
+
+
+def test_candidate_visibility_keeps_broader_pr_diff_review_first() -> None:
+    observed = ["src/sdetkit/example.py", "src/sdetkit/feature.py"]
+    payload = build_candidate_visibility(
+        check_intelligence=_formatting_failure(),
+        evidence_graph={},
+        pr_quality_action_report={},
+        changed_files=observed,
+        pattern_insights=_pattern_insights(),
+        verification_evidence=_verification_evidence(observed),
+    )
+
+    verification = payload["protected_verifier"]
+    codes = {finding["code"] for finding in verification["findings"]}
+    assert payload["status"] == "candidate_review_first_after_verification"
+    assert payload["candidate_files"] == ["src/sdetkit/example.py"]
+    assert payload["observed_pr_changed_files"] == observed
+    assert payload["patch_score"]["decision"]["status"] == "candidate_for_protected_verification"
+    assert verification["decision"]["status"] == "blocked_review_first"
+    assert "CHANGED_FILE_INVENTORY_MISMATCH" in codes
+    assert "OUTSIDE_SCORED_SCOPE" in codes
+    assert verification["decision"]["automation_allowed"] is False
+    assert verification["decision"]["merge_authorized"] is False
+
+
+def test_candidate_visibility_stays_quiet_without_candidate() -> None:
+    payload = build_candidate_visibility(
+        check_intelligence={"failed_checks": []},
+        evidence_graph={},
+        pr_quality_action_report={},
+        changed_files=[],
+        pattern_insights={},
+        verification_evidence={},
+    )
+
+    assert payload["status"] == "no_candidate"
+    assert payload["candidate_count"] == 0
+    assert payload["patch_score"] == {}
+    assert payload["protected_verifier"] == {}
+    assert render_markdown(payload) == ""
+
+
+def test_candidate_visibility_cli_writes_read_only_artifacts(tmp_path: Path, capsys) -> None:
+    inputs = {
+        "check-intelligence.json": _formatting_failure(),
+        "evidence-graph.json": {},
+        "action-report.json": {},
+        "pattern-insights.json": _pattern_insights(),
+        "verification-evidence.json": _verification_evidence(),
+    }
+    for name, payload in inputs.items():
+        (tmp_path / name).write_text(json.dumps(payload), encoding="utf-8")
+    (tmp_path / "changed-files.txt").write_text("src/sdetkit/example.py\n", encoding="utf-8")
+
+    out_dir = tmp_path / "visibility"
+    rc = main(
+        [
+            "--check-intelligence",
+            str(tmp_path / "check-intelligence.json"),
+            "--evidence-graph",
+            str(tmp_path / "evidence-graph.json"),
+            "--pr-quality-action-report",
+            str(tmp_path / "action-report.json"),
+            "--changed-files",
+            str(tmp_path / "changed-files.txt"),
+            "--pattern-insights",
+            str(tmp_path / "pattern-insights.json"),
+            "--verification-evidence",
+            str(tmp_path / "verification-evidence.json"),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["status"] == "candidate_structurally_verified"
+    assert printed["decision_boundary"]["automation_allowed"] is False
+    assert (out_dir / "candidate-visibility.json").exists()
+    assert (out_dir / "candidate-visibility.md").exists()
+    assert (out_dir / "diagnostic-vector" / "diagnostic-vector.json").exists()
+    assert (out_dir / "remediation-plan" / "remediation-plan.json").exists()
+    assert (out_dir / "patch-score" / "patch-score.json").exists()
+    assert (out_dir / "protected-verifier" / "protected-verifier-result.json").exists()
+
+
+def test_candidate_visibility_normalizes_matching_action_report_without_suppressing_candidate() -> (
+    None
+):
+    failed_check = _formatting_failure()["failed_checks"][0]
+    action_report = {"primary_blocker": dict(failed_check)}
+    payload = build_candidate_visibility(
+        check_intelligence=_formatting_failure(),
+        evidence_graph={},
+        pr_quality_action_report=action_report,
+        changed_files=["src/sdetkit/example.py"],
+        pattern_insights=_pattern_insights(),
+        verification_evidence=_verification_evidence(),
+    )
+
+    assert action_report["primary_blocker"]["surface"] == "quality"
+    assert payload["candidate_count"] == 1
+    assert payload["review_first_plan_count"] == 0
+    assert payload["status"] == "candidate_structurally_verified"
+    assert payload["protected_verifier"]["decision"]["automation_allowed"] is False
+    assert payload["protected_verifier"]["decision"]["merge_authorized"] is False

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -530,3 +530,42 @@ def test_pr_quality_comment_workflow_requires_trusted_history_visibility_after_p
     assert "if trusted_history_merge_authorized:" in verify_visibility
     assert "if trusted_history_semantic_equivalence_proven:" in verify_visibility
     assert "after diagnostic comment publication" in verify_visibility
+
+
+def test_pr_quality_workflow_publishes_read_only_candidate_verification_visibility() -> None:
+    text = _workflow_text()
+
+    candidate_step = text.index("python -m sdetkit.pr_quality_candidate_visibility")
+    report_step = text.index("python -m sdetkit.pr_quality_action_report")
+    append_step = text.index("cat build/pr-quality/candidate-visibility/candidate-visibility.md")
+
+    assert candidate_step < report_step < append_step
+    assert (
+        "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in text
+    )
+    assert "--evidence-graph build/sdetkit/evidence-graph/evidence-graph.json" in text
+    assert "--changed-files build/pr-quality/changed-files.txt" in text
+    assert (
+        "--pattern-insights build/pr-quality/trajectory-pattern-insights/pattern-insights.json"
+        in text
+    )
+    assert (
+        "--verification-evidence build/pr-quality/runtime-proof/isolated-proof/verification-evidence.json"
+        in text
+    )
+    assert "build/pr-quality/candidate-visibility/" in text
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_captures_required_pre_commit_candidate_proof() -> None:
+    text = _workflow_text()
+
+    assert "--profile ruff_src_tests" in text
+    assert "--profile pre_commit_all" in text
+    assert (
+        "--verification-evidence build/pr-quality/runtime-proof/isolated-proof/verification-evidence.json"
+        in text
+    )
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text


### PR DESCRIPTION
## Summary
- Adds read-only PR Quality visibility for remediation candidates through DiagnosticVector, RemediationPlan, PatchScorer, and ProtectedVerifier.
- Keeps legacy remediation behavior unchanged and performs formatting-candidate normalization only inside the new PR-comment visibility adapter.
- Captures the already allowlisted `pre_commit_all` isolated proof profile required for formatting candidate verification.
- Appends candidate verification evidence to the PR Quality comment only when a candidate is observed.
- Refreshes the required roadmap manifest inventory generated from the added test references.

## Why
After workflow write containment, PR Quality no longer had active unverified mutation authority, but it also did not expose the repository's existing read-only PatchScorer and ProtectedVerifier results for formatting candidates.

This PR supplies that missing evidence chain without granting execution or merge authority.

## Design corrections proven during implementation
- A global `diagnostic_vector_engine` normalization was rejected because it broke the existing end-to-end review-first remediation contract.
- Candidate normalization is therefore confined to the new read-only visibility adapter.
- PatchScorer evaluates the candidate's declared narrow file scope; ProtectedVerifier compares it with observed current proof evidence and blocks broader or mismatched scope.
- Both `check-intelligence.json` and its duplicated `action-report.json` blocker are normalized within the read-only view so candidate reporting is not suppressed by duplicate input records.

## Safety boundary
```text
repository_content_write_added=false
commit_or_push_path_added=false
automatic_dismissal_added=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
legacy_remediation_contract_changed=false
patch_scorer_scope=candidate_declared_narrow_scope
protected_verifier_observed_scope=current_proof_evidence
broader_or_mismatched_scope=review_first
```

## Scope
- `.github/workflows/pr-quality-comment.yml`
- `docs/roadmap/manifest.json`
- `src/sdetkit/pr_quality_candidate_visibility.py`
- `tests/test_pr_quality_candidate_visibility.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

The manifest update is generated bookkeeping: the new tests increase text-reference inventory counts for existing `sdetkit.expansion` and `sdetkit.proof` entries. It is not a functional change to either module.

## Local validation
- Focused candidate/verifier, legacy end-to-end, workflow, and manifest suite: `89 passed`.
- Full pytest suite: `3690 passed, 1 skipped`.
- `python -m py_compile src/sdetkit/pr_quality_candidate_visibility.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `git diff --cached --check`: passed.

## Risk
Medium. The PR changes the PR Quality evidence surface and generated artifacts, but retains explicit no-authority contracts and preserves the existing legacy review-first remediation scenario.

## Next
Validate live PR Quality candidate evidence on real failure artifacts before designing any explicit remediation authorization contract.
