### PR TITLE
Validate read-only candidate evidence with controlled fixtures

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -610,10 +610,21 @@ jobs:
             --out build/pr-quality/pr-comment-body.md \
             > build/pr-quality/pr-comment-metadata.json
 
+          mkdir -p build/pr-quality/candidate-validation
+          PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
+            --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
+            --scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json \
+            --out-dir build/pr-quality/candidate-validation \
+            --format json \
+            > build/pr-quality/candidate-validation/candidate-validation-cli.json
+
           if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then
             printf '\n' >> build/pr-quality/pr-comment-body.md
             cat build/pr-quality/candidate-visibility/candidate-visibility.md >> build/pr-quality/pr-comment-body.md
           fi
+
+          printf '\n' >> build/pr-quality/pr-comment-body.md
+          cat build/pr-quality/candidate-validation/candidate-validation.md >> build/pr-quality/pr-comment-body.md
 
       - name: Build verified operator evidence loop
         if: always()
@@ -676,6 +687,7 @@ jobs:
             build/pr-quality/trusted-history/
             build/pr-quality/runtime-proof/
             build/pr-quality/candidate-visibility/
+            build/pr-quality/candidate-validation/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
             build/sdetkit/operator-loop/

--- a/src/sdetkit/pr_quality_candidate_validation.py
+++ b/src/sdetkit/pr_quality_candidate_validation.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from sdetkit.pr_quality_candidate_visibility import (
+    build_candidate_visibility,
+)
+from sdetkit.pr_quality_candidate_visibility import (
+    render_markdown as render_candidate_markdown,
+)
+
+SCHEMA_VERSION = "sdetkit.pr_quality.candidate_validation.v1"
+DEFAULT_OUT_DIR = Path("build") / "pr-quality" / "candidate-validation"
+REPORT_JSON = "candidate-validation.json"
+REPORT_MD = "candidate-validation.md"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read_scenario(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    if not _string(payload.get("scenario_id")):
+        raise ValueError(f"scenario_id is required in {path}")
+    if not _string(payload.get("expected_status")):
+        raise ValueError(f"expected_status is required in {path}")
+    if not _string(payload.get("expected_verifier_status")):
+        raise ValueError(f"expected_verifier_status is required in {path}")
+    return payload
+
+
+def evaluate_scenario(payload: Mapping[str, Any], *, source_path: Path) -> JsonObject:
+    visibility = build_candidate_visibility(
+        check_intelligence=_as_dict(payload.get("check_intelligence")),
+        evidence_graph=_as_dict(payload.get("evidence_graph")),
+        pr_quality_action_report=_as_dict(payload.get("pr_quality_action_report")),
+        changed_files=[_string(item) for item in _as_list(payload.get("changed_files"))],
+        pattern_insights=_as_dict(payload.get("pattern_insights")),
+        verification_evidence=_as_dict(payload.get("verification_evidence")),
+    )
+    decision = _as_dict(visibility.get("decision_boundary"))
+    verifier = _as_dict(_as_dict(visibility.get("protected_verifier")).get("decision"))
+    rendered = render_candidate_markdown(visibility)
+    expected_status = _string(payload.get("expected_status"))
+    expected_verifier_status = _string(payload.get("expected_verifier_status"))
+    passed = (
+        visibility.get("status") == expected_status
+        and verifier.get("status") == expected_verifier_status
+        and decision.get("automation_allowed") is False
+        and decision.get("merge_authorized") is False
+        and decision.get("semantic_equivalence_proven") is False
+        and verifier.get("automation_allowed") is False
+        and verifier.get("merge_authorized") is False
+        and rendered.startswith("## Read-only remediation candidate verification\n")
+    )
+    return {
+        "scenario_id": _string(payload.get("scenario_id")),
+        "source_path": source_path.as_posix(),
+        "expected_status": expected_status,
+        "observed_status": _string(visibility.get("status")),
+        "expected_verifier_status": expected_verifier_status,
+        "observed_verifier_status": _string(verifier.get("status")),
+        "candidate_renderer_exercised": bool(rendered),
+        "candidate_markdown": rendered,
+        "automation_allowed": bool(decision.get("automation_allowed", False)),
+        "merge_authorized": bool(decision.get("merge_authorized", False)),
+        "semantic_equivalence_proven": bool(decision.get("semantic_equivalence_proven", False)),
+        "passed": passed,
+    }
+
+
+def build_validation_report(scenario_paths: Sequence[Path]) -> JsonObject:
+    scenarios = [
+        evaluate_scenario(_read_scenario(path), source_path=path) for path in scenario_paths
+    ]
+    passed_count = sum(1 for scenario in scenarios if scenario["passed"] is True)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "passed" if passed_count == len(scenarios) else "failed",
+        "scenario_count": len(scenarios),
+        "passed_count": passed_count,
+        "scenarios": scenarios,
+        "boundary": {
+            "controlled_fixture_inputs_only": True,
+            "contributes_to_current_pr_decision": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    boundary = _as_dict(report.get("boundary"))
+    lines = [
+        "## Controlled read-only candidate evidence validation",
+        "",
+        "- Evidence type: `deterministic_fixture_validation`",
+        "- Current PR decision input: `false`",
+        f"- Validation status: `{_string(report.get('status') or 'unknown')}`",
+        f"- Scenarios passed: `{int(report.get('passed_count', 0) or 0)}/{int(report.get('scenario_count', 0) or 0)}`",
+        f"- Automation allowed: `{str(bool(boundary.get('automation_allowed', False))).lower()}`",
+        f"- Merge authorized: `{str(bool(boundary.get('merge_authorized', False))).lower()}`",
+        (
+            "- Semantic equivalence proven: "
+            f"`{str(bool(boundary.get('semantic_equivalence_proven', False))).lower()}`"
+        ),
+        "- Interpretation: this section validates the read-only evidence renderer; it does not identify a remediation candidate in the current PR.",
+        "",
+        "### Controlled scenario outcomes",
+        "",
+    ]
+    for scenario in _as_list(report.get("scenarios")):
+        row = _as_dict(scenario)
+        lines.extend(
+            [
+                f"- `{_string(row.get('scenario_id'))}`: "
+                f"status=`{_string(row.get('observed_status'))}`, "
+                f"verifier=`{_string(row.get('observed_verifier_status'))}`, "
+                f"passed=`{str(bool(row.get('passed', False))).lower()}`, "
+                "automation_allowed=`false`, merge_authorized=`false`",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_report(report: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / REPORT_JSON
+    markdown_path = out_dir / REPORT_MD
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(report), encoding="utf-8")
+    return {
+        "candidate_validation_json": json_path.as_posix(),
+        "candidate_validation_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.pr_quality_candidate_validation")
+    parser.add_argument("--scenario", action="append", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = build_validation_report(args.scenario)
+        artifacts = write_report(report, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": report["status"],
+                    "scenario_count": report["scenario_count"],
+                    "passed_count": report["passed_count"],
+                    "boundary": report["boundary"],
+                    "artifacts": artifacts,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"status: {report['status']}")
+        print(f"scenarios: {report['passed_count']}/{report['scenario_count']}")
+
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json
+++ b/tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json
@@ -1,0 +1,85 @@
+{
+  "scenario_id": "broader_diff_remains_review_first",
+  "expected_status": "candidate_review_first_after_verification",
+  "expected_verifier_status": "blocked_review_first",
+  "check_intelligence": {
+    "failed_checks": [
+      {
+        "name": "PR Quality local quality gate",
+        "surface": "quality",
+        "diagnosis": {
+          "title": "Pre-commit formatting drift",
+          "code": "PRE_COMMIT_FORMAT_DRIFT"
+        },
+        "first_failure": {
+          "line": "ruff format..............................Failed",
+          "line_number": 30,
+          "tool": "ruff",
+          "kind": "format_drift"
+        },
+        "safe_to_auto_fix": true,
+        "safe_remediation": {
+          "safe_to_auto_fix": true,
+          "strategy": "run_pre_commit",
+          "category": "formatting_only",
+          "affected_files": [
+            "src/sdetkit/example.py"
+          ]
+        }
+      }
+    ]
+  },
+  "evidence_graph": {},
+  "pr_quality_action_report": {
+    "primary_blocker": {
+      "name": "PR Quality local quality gate",
+      "surface": "quality",
+      "diagnosis": {
+        "title": "Pre-commit formatting drift",
+        "code": "PRE_COMMIT_FORMAT_DRIFT"
+      },
+      "first_failure": {
+        "line": "ruff format..............................Failed",
+        "line_number": 30,
+        "tool": "ruff",
+        "kind": "format_drift"
+      },
+      "safe_to_auto_fix": true,
+      "safe_remediation": {
+        "safe_to_auto_fix": true,
+        "strategy": "run_pre_commit",
+        "category": "formatting_only",
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ]
+      }
+    }
+  },
+  "changed_files": [
+    "src/sdetkit/example.py",
+    "src/sdetkit/feature.py"
+  ],
+  "pattern_insights": {
+    "recurring_review_first_surfaces": [],
+    "recurring_safe_fix_patterns": [
+      {
+        "failure_class": "formatting_only",
+        "action": "run_pre_commit",
+        "count": 2
+      }
+    ]
+  },
+  "verification_evidence": {
+    "changed_files": [
+      "src/sdetkit/example.py",
+      "src/sdetkit/feature.py"
+    ],
+    "proof_results": [
+      {
+        "command": "python -m pre_commit run -a",
+        "status": "passed",
+        "exit_code": 0
+      }
+    ]
+  }
+}

--- a/tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json
+++ b/tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json
@@ -1,0 +1,83 @@
+{
+  "scenario_id": "formatting_candidate_structurally_verified",
+  "expected_status": "candidate_structurally_verified",
+  "expected_verifier_status": "structurally_verified_candidate",
+  "check_intelligence": {
+    "failed_checks": [
+      {
+        "name": "PR Quality local quality gate",
+        "surface": "quality",
+        "diagnosis": {
+          "title": "Pre-commit formatting drift",
+          "code": "PRE_COMMIT_FORMAT_DRIFT"
+        },
+        "first_failure": {
+          "line": "ruff format..............................Failed",
+          "line_number": 30,
+          "tool": "ruff",
+          "kind": "format_drift"
+        },
+        "safe_to_auto_fix": true,
+        "safe_remediation": {
+          "safe_to_auto_fix": true,
+          "strategy": "run_pre_commit",
+          "category": "formatting_only",
+          "affected_files": [
+            "src/sdetkit/example.py"
+          ]
+        }
+      }
+    ]
+  },
+  "evidence_graph": {},
+  "pr_quality_action_report": {
+    "primary_blocker": {
+      "name": "PR Quality local quality gate",
+      "surface": "quality",
+      "diagnosis": {
+        "title": "Pre-commit formatting drift",
+        "code": "PRE_COMMIT_FORMAT_DRIFT"
+      },
+      "first_failure": {
+        "line": "ruff format..............................Failed",
+        "line_number": 30,
+        "tool": "ruff",
+        "kind": "format_drift"
+      },
+      "safe_to_auto_fix": true,
+      "safe_remediation": {
+        "safe_to_auto_fix": true,
+        "strategy": "run_pre_commit",
+        "category": "formatting_only",
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ]
+      }
+    }
+  },
+  "changed_files": [
+    "src/sdetkit/example.py"
+  ],
+  "pattern_insights": {
+    "recurring_review_first_surfaces": [],
+    "recurring_safe_fix_patterns": [
+      {
+        "failure_class": "formatting_only",
+        "action": "run_pre_commit",
+        "count": 2
+      }
+    ]
+  },
+  "verification_evidence": {
+    "changed_files": [
+      "src/sdetkit/example.py"
+    ],
+    "proof_results": [
+      {
+        "command": "python -m pre_commit run -a",
+        "status": "passed",
+        "exit_code": 0
+      }
+    ]
+  }
+}

--- a/tests/test_pr_quality_candidate_validation.py
+++ b/tests/test_pr_quality_candidate_validation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.pr_quality_candidate_validation import (
+    SCHEMA_VERSION,
+    build_validation_report,
+    main,
+    render_markdown,
+)
+
+FIXTURES = Path("tests/fixtures/pr_quality_candidate_visibility")
+SCENARIOS = [
+    FIXTURES / "formatting_candidate_verified.json",
+    FIXTURES / "broader_diff_review_first.json",
+]
+
+
+def test_controlled_validation_exercises_verified_and_review_first_states_without_authority() -> (
+    None
+):
+    report = build_validation_report(SCENARIOS)
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["status"] == "passed"
+    assert report["scenario_count"] == 2
+    assert report["passed_count"] == 2
+
+    rows = {row["scenario_id"]: row for row in report["scenarios"]}
+    assert rows["formatting_candidate_structurally_verified"]["observed_status"] == (
+        "candidate_structurally_verified"
+    )
+    assert rows["formatting_candidate_structurally_verified"]["observed_verifier_status"] == (
+        "structurally_verified_candidate"
+    )
+    assert rows["broader_diff_remains_review_first"]["observed_status"] == (
+        "candidate_review_first_after_verification"
+    )
+    assert rows["broader_diff_remains_review_first"]["observed_verifier_status"] == (
+        "blocked_review_first"
+    )
+    assert all(row["candidate_renderer_exercised"] is True for row in rows.values())
+    assert all(row["automation_allowed"] is False for row in rows.values())
+    assert all(row["merge_authorized"] is False for row in rows.values())
+
+    boundary = report["boundary"]
+    assert boundary["controlled_fixture_inputs_only"] is True
+    assert boundary["contributes_to_current_pr_decision"] is False
+    assert boundary["automation_allowed"] is False
+    assert boundary["merge_authorized"] is False
+    assert boundary["semantic_equivalence_proven"] is False
+
+
+def test_controlled_validation_markdown_marks_evidence_as_non_decision_input() -> None:
+    markdown = render_markdown(build_validation_report(SCENARIOS))
+
+    assert "Controlled read-only candidate evidence validation" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Validation status: `passed`" in markdown
+    assert "Scenarios passed: `2/2`" in markdown
+    assert "Automation allowed: `false`" in markdown
+    assert "Merge authorized: `false`" in markdown
+    assert "does not identify a remediation candidate in the current PR" in markdown
+
+
+def test_controlled_validation_cli_writes_report_artifacts(tmp_path: Path, capsys) -> None:
+    out_dir = tmp_path / "validation"
+    rc = main(
+        [
+            "--scenario",
+            str(SCENARIOS[0]),
+            "--scenario",
+            str(SCENARIOS[1]),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    report = json.loads((out_dir / "candidate-validation.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "candidate-validation.md").read_text(encoding="utf-8")
+
+    assert printed["status"] == "passed"
+    assert printed["scenario_count"] == 2
+    assert printed["passed_count"] == 2
+    assert printed["boundary"]["contributes_to_current_pr_decision"] is False
+    assert report["status"] == "passed"
+    assert "Current PR decision input: `false`" in markdown

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -569,3 +569,32 @@ def test_pr_quality_workflow_captures_required_pre_commit_candidate_proof() -> N
     )
     assert "--commit-safe-fixes" not in text
     assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_appends_controlled_candidate_validation_only_after_decision_render() -> (
+    None
+):
+    text = _workflow_text()
+
+    action_report = text.index("python -m sdetkit.pr_quality_action_report")
+    validation = text.index("python -m sdetkit.pr_quality_candidate_validation")
+    validation_append = text.index(
+        "cat build/pr-quality/candidate-validation/candidate-validation.md"
+    )
+    action_report_command = text[
+        action_report : text.index("> build/pr-quality/pr-comment-metadata.json", action_report)
+    ]
+
+    assert action_report < validation < validation_append
+    assert "candidate-validation" not in action_report_command
+    assert (
+        "--scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json"
+        in text
+    )
+    assert (
+        "--scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json"
+        in text
+    )
+    assert "build/pr-quality/candidate-validation/" in text
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text


### PR DESCRIPTION
## Summary
- Adds deterministic, read-only candidate-evidence validation to the PR Quality comment workflow.
- Exercises one narrow formatting-candidate scenario and one broader-diff review-first scenario through the accepted candidate visibility pipeline.
- Appends a clearly labelled validation section only after the current PR action report is rendered.
- Archives controlled-validation artifacts with the PR Quality evidence bundle.

## Why
PR #1437 made PatchScorer and ProtectedVerifier results visible for current remediation candidates, while explicitly retaining no automation or merge authority.

This PR performs the next required validation step: prove that the accepted read-only evidence chain renders both an eligible candidate state and a blocked broader-scope state in a deterministic workflow artifact, without creating a real failing PR or affecting the current PR decision.

## Decision isolation
The controlled section is evidence-only:

```text
controlled_fixture_inputs_only=true
contributes_to_current_pr_decision=false
current_pr_action_report_rendered_before_validation=true
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
repository_content_write_added=false
commit_or_push_path_added=false
automatic_dismissal_added=false
```

The real PR action report is generated before the controlled-validation module runs. The validation report is appended afterward as an explicitly labelled fixture result and is not supplied to the decision renderer.

## Controlled scenarios
- `formatting_candidate_structurally_verified`: proves the read-only candidate renderer reaches `candidate_structurally_verified` / `structurally_verified_candidate` while authority remains false.
- `broader_diff_remains_review_first`: proves a wider observed change inventory reaches `candidate_review_first_after_verification` / `blocked_review_first`.

## Scope
- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/pr_quality_candidate_validation.py`
- `tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json`
- `tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json`
- `tests/test_pr_quality_candidate_validation.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

`docs/roadmap/manifest.json` remains fresh and is not changed by this PR.

## Local validation
- Initial focused validation suite: `74 passed`.
- Post-freshness focused validation suite: `77 passed`.
- Full pytest suite: `3694 passed, 1 skipped`.
- PR-owned new Python security finding check: `0` warn/error findings.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- `git diff --cached --check`: passed.

## Risk
Low-to-medium. This changes the PR Quality comment evidence surface, but the output is explicitly controlled validation and is structurally isolated from the current PR decision path.

## Next
Use the controlled validation output in live CI to confirm artifact/comment visibility and human readability. Do not introduce automatic remediation authority based on fixture evidence.
