### PR TITLE
Retain controlled candidate evidence in RepoMemory profile

### DIFF
--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -49,6 +49,7 @@ jobs:
             build/repo-memory-history/live-report \
             build/repo-memory-history/pattern-insights \
             build/repo-memory-history/flaky-test-registry \
+            build/repo-memory-history/candidate-validation \
             build/repo-memory-history/profile
 
           live_root="${RUNNER_TEMP}/sdetkit-repo-memory-history-live-repositories"
@@ -109,6 +110,13 @@ jobs:
           )
           PY
 
+          PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
+            --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
+            --scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json \
+            --out-dir build/repo-memory-history/candidate-validation \
+            --format json \
+            > build/repo-memory-history/candidate-validation-cli.json
+
           PYTHONPATH=src python -m sdetkit.trusted_flaky_test_registry_producer \
             --source-run-id "${GITHUB_RUN_ID}" \
             --source-head-sha "${GITHUB_SHA}" \
@@ -121,6 +129,7 @@ jobs:
             --benchmark-report build/repo-memory-history/fixture-report/benchmark-report.json \
             --live-benchmark-report build/repo-memory-history/live-report/benchmark-report.json \
             --flaky-test-registry-evidence build/repo-memory-history/flaky-test-registry/flaky-test-registry-evidence.json \
+            --controlled-candidate-validation-evidence build/repo-memory-history/candidate-validation/candidate-validation.json \
             --out-dir build/repo-memory-history/profile \
             --format json \
             > build/repo-memory-history/profile-cli.json
@@ -141,6 +150,15 @@ jobs:
           assert profile["proof_provenance"]["expected_failed_scenario_count"] == 5
           assert profile["proof_provenance"]["network_boundary_blocked_scenario_count"] == 1
           assert profile["proof_provenance"]["anti_cheat_rejection_scenario_count"] == 2
+
+          controlled = profile["controlled_candidate_validation"]
+          assert controlled["collection_status"] == "collected"
+          assert controlled["status"] == "controlled_validation_passed"
+          assert controlled["scenario_count"] == 2
+          assert controlled["passed_count"] == 2
+          assert controlled["current_pr_decision_input"] is False
+          assert controlled["decision_boundary"]["automation_allowed"] is False
+          assert controlled["decision_boundary"]["merge_authorized"] is False
 
           flaky = profile["flaky_test_registry"]
           assert flaky["collection_status"] == "collected"
@@ -419,6 +437,7 @@ jobs:
             build/repo-memory-history/fixture-report/
             build/repo-memory-history/pattern-insights/
             build/repo-memory-history/flaky-test-registry/
+            build/repo-memory-history/candidate-validation/
             build/repo-memory-history/security-reviewed-dispositions/
           if-no-files-found: error
           retention-days: 90

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -142,8 +142,12 @@ def _controlled_candidate_validation(evidence: Mapping[str, Any]) -> JsonObject:
     for scenario in scenarios:
         if not _bool(scenario.get("passed")):
             raise ValueError("controlled candidate validation contains a failing scenario")
-        if _bool(scenario.get("automation_allowed")) or _bool(scenario.get("merge_authorized")):
-            raise ValueError("controlled candidate validation scenario expands authority")
+        scenario_expanded = [key for key in denied if _bool(scenario.get(key))]
+        if scenario_expanded:
+            raise ValueError(
+                "controlled candidate validation scenario expands authority: "
+                + ", ".join(scenario_expanded)
+            )
         observed_states.add(
             (
                 _string(scenario.get("observed_status")),

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -18,7 +18,7 @@ from sdetkit.replayable_benchmark_harness import (
     VERIFICATION_EVIDENCE_SOURCE,
 )
 
-SCHEMA_VERSION = "sdetkit.repo_memory.v5"
+SCHEMA_VERSION = "sdetkit.repo_memory.v6"
 DEFAULT_OUT_DIR = Path("build") / "repo-memory"
 PROFILE_JSON = "repo-memory-profile.json"
 PROFILE_MD = "repo-memory-profile.md"
@@ -28,6 +28,8 @@ LIVE_PROFILE_STATUS = "_".join(("live", "proof", "supported", "memory"))
 LIVE_PROOF_STATE = "_".join(("live", "proof", "supported", "candidate"))
 GIT_INVENTORY_VERIFIED = "_".join(("git", "inventory", "verified"))
 EXPECTED_FAILED_EVIDENCE_COUNT = "_".join(("expected", "failed", "evidence", "count"))
+CONTROLLED_VALIDATION_SCHEMA = "sdetkit.pr_quality.candidate_validation.v1"
+CONTROLLED_VALIDATION_STATUS = "_".join(("controlled", "validation", "passed"))
 
 JsonObject = dict[str, Any]
 
@@ -87,6 +89,91 @@ def _live_contract_proven(live_benchmark_report: Mapping[str, Any]) -> bool:
     return _string(
         live_benchmark_report.get("report_mode")
     ) == LIVE_EVIDENCE_SOURCE and _benchmark_contract_proven(live_benchmark_report)
+
+
+def _controlled_candidate_validation(evidence: Mapping[str, Any]) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    payload = _as_dict(evidence)
+    if not payload:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "scenario_count": 0,
+            "passed_count": 0,
+            "structurally_verified_count": 0,
+            "review_first_count": 0,
+            "current_pr_decision_input": False,
+            "decision_boundary": denied,
+        }
+
+    if _string(payload.get("schema_version")) != CONTROLLED_VALIDATION_SCHEMA:
+        raise ValueError("controlled candidate validation schema is not supported")
+    if _string(payload.get("status")) != "passed":
+        raise ValueError("controlled candidate validation must have passed before ingestion")
+
+    boundary = _as_dict(payload.get("boundary"))
+    if not _bool(boundary.get("controlled_fixture_inputs_only")):
+        raise ValueError("controlled candidate validation must use fixture inputs only")
+    if _bool(boundary.get("contributes_to_current_pr_decision")):
+        raise ValueError(
+            "controlled candidate validation cannot contribute to a current PR decision"
+        )
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    if expanded:
+        raise ValueError(
+            "controlled candidate validation expands authority: " + ", ".join(expanded)
+        )
+
+    scenarios = [_as_dict(item) for item in _as_list(payload.get("scenarios")) if _as_dict(item)]
+    scenario_count = _int(payload.get("scenario_count"))
+    passed_count = _int(payload.get("passed_count"))
+    if scenario_count != len(scenarios) or passed_count != scenario_count or scenario_count < 2:
+        raise ValueError("controlled candidate validation scenario totals are inconsistent")
+
+    expected_states = {
+        ("candidate_structurally_verified", "structurally_verified_candidate"),
+        ("candidate_review_first_after_verification", "blocked_review_first"),
+    }
+    observed_states: set[tuple[str, str]] = set()
+    for scenario in scenarios:
+        if not _bool(scenario.get("passed")):
+            raise ValueError("controlled candidate validation contains a failing scenario")
+        if _bool(scenario.get("automation_allowed")) or _bool(scenario.get("merge_authorized")):
+            raise ValueError("controlled candidate validation scenario expands authority")
+        observed_states.add(
+            (
+                _string(scenario.get("observed_status")),
+                _string(scenario.get("observed_verifier_status")),
+            )
+        )
+    if not expected_states.issubset(observed_states):
+        raise ValueError("controlled candidate validation does not prove both boundary states")
+
+    return {
+        "collection_status": "collected",
+        "status": CONTROLLED_VALIDATION_STATUS,
+        "evidence_type": "deterministic_fixture_validation",
+        "scenario_count": scenario_count,
+        "passed_count": passed_count,
+        "structurally_verified_count": sum(
+            1
+            for state, verifier in observed_states
+            if state == "candidate_structurally_verified"
+            and verifier == "structurally_verified_candidate"
+        ),
+        "review_first_count": sum(
+            1
+            for state, verifier in observed_states
+            if state == "candidate_review_first_after_verification"
+            and verifier == "blocked_review_first"
+        ),
+        "current_pr_decision_input": False,
+        "decision_boundary": denied,
+    }
 
 
 def _proof_commands(benchmark_report: Mapping[str, Any]) -> list[str]:
@@ -501,9 +588,13 @@ def build_repo_memory_profile(
     benchmark_report: Mapping[str, Any],
     live_benchmark_report: Mapping[str, Any] | None = None,
     flaky_test_registry_evidence: Mapping[str, Any] | None = None,
+    controlled_candidate_validation_evidence: Mapping[str, Any] | None = None,
 ) -> JsonObject:
     live_report = dict(live_benchmark_report or {})
     flaky_registry = _flaky_test_registry(flaky_test_registry_evidence or {})
+    controlled_validation = _controlled_candidate_validation(
+        controlled_candidate_validation_evidence or {}
+    )
     benchmark_proven = _benchmark_contract_proven(benchmark_report)
     live_proven = _live_contract_proven(live_report)
     safe_fix_history = _safe_fix_history(
@@ -596,6 +687,7 @@ def build_repo_memory_profile(
         "safe_fix_history": safe_fix_history,
         "known_safe_candidate_count": len(supported_candidates),
         "live_safe_candidate_count": len(live_supported_candidates),
+        "controlled_candidate_validation": controlled_validation,
         "flaky_test_registry": flaky_registry,
         "escalation_rules": _escalation_rules(),
         "unproven_boundaries": unproven_boundaries,
@@ -621,6 +713,7 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
     commands = _as_dict(profile.get("command_profile"))
     provenance = _as_dict(profile.get("proof_provenance"))
     failure_patterns = _as_dict(profile.get("failure_patterns"))
+    controlled = _as_dict(profile.get("controlled_candidate_validation"))
     flaky = _as_dict(profile.get("flaky_test_registry"))
     flaky_source = _as_dict(flaky.get("source"))
     boundary = _as_dict(profile.get("decision_boundary"))
@@ -729,6 +822,34 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
     lines.extend(
         [
             "",
+            "## Controlled candidate validation evidence",
+            "",
+            f"- Collection status: `{_string(controlled.get('collection_status'))}`",
+            f"- Status: `{_string(controlled.get('status'))}`",
+            f"- Scenarios passed: `{_int(controlled.get('passed_count'))}/{_int(controlled.get('scenario_count'))}`",
+            (
+                "- Structurally verified scenarios: "
+                f"`{_int(controlled.get('structurally_verified_count'))}`"
+            ),
+            f"- Review-first scenarios: `{_int(controlled.get('review_first_count'))}`",
+            (
+                "- Current PR decision input: "
+                f"`{str(_bool(controlled.get('current_pr_decision_input'))).lower()}`"
+            ),
+            (
+                "- Automation allowed by controlled validation: "
+                f"`{str(_bool(_as_dict(controlled.get('decision_boundary')).get('automation_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by controlled validation: "
+                f"`{str(_bool(_as_dict(controlled.get('decision_boundary')).get('merge_authorized'))).lower()}`"
+            ),
+        ]
+    )
+
+    lines.extend(
+        [
+            "",
             "## Flaky test registry",
             "",
             f"- Collection status: `{_string(flaky.get('collection_status'))}`",
@@ -803,6 +924,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--benchmark-report", type=Path, required=True)
     parser.add_argument("--live-benchmark-report", type=Path)
     parser.add_argument("--flaky-test-registry-evidence", type=Path)
+    parser.add_argument("--controlled-candidate-validation-evidence", type=Path)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--format", choices=["text", "json"], default="text")
     return parser
@@ -823,6 +945,11 @@ def main(argv: list[str] | None = None) -> int:
                 if args.flaky_test_registry_evidence
                 else None
             ),
+            controlled_candidate_validation_evidence=(
+                _read_json(args.controlled_candidate_validation_evidence)
+                if args.controlled_candidate_validation_evidence
+                else None
+            ),
         )
         artifacts = write_profile(profile, out_dir=args.out_dir)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
@@ -837,6 +964,9 @@ def main(argv: list[str] | None = None) -> int:
                     "artifacts": artifacts,
                     "known_safe_candidate_count": profile["known_safe_candidate_count"],
                     "live_safe_candidate_count": profile["live_safe_candidate_count"],
+                    "controlled_candidate_validation_status": profile[
+                        "controlled_candidate_validation"
+                    ]["status"],
                 },
                 indent=2,
                 sort_keys=True,

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -735,3 +735,19 @@ def test_repo_memory_cli_accepts_controlled_validation_without_promotion(
     assert (
         saved["controlled_candidate_validation"]["decision_boundary"]["automation_allowed"] is False
     )
+
+
+def test_repo_memory_rejects_controlled_scenario_semantic_equivalence_claim() -> None:
+    evidence = _candidate_validation_report()
+    evidence["scenarios"][0]["semantic_equivalence_proven"] = True
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            controlled_candidate_validation_evidence=evidence,
+        )
+    except ValueError as exc:
+        assert "scenario expands authority" in str(exc)
+    else:
+        raise AssertionError("expected semantic-equivalence-claiming scenario to be rejected")

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -4,6 +4,7 @@ import copy
 import json
 from pathlib import Path
 
+from sdetkit.pr_quality_candidate_validation import build_validation_report
 from sdetkit.replayable_benchmark_harness import (
     EVIDENCE_SHADOW_FAIL,
     INVENTORY_CLAIM_MISMATCH_FAIL,
@@ -33,6 +34,15 @@ SCENARIOS = [
     FIXTURES / "oracle_formatting_patch.json",
     FIXTURES / "unsafe_protected_path_patch.json",
 ]
+CANDIDATE_FIXTURES = Path("tests/fixtures/pr_quality_candidate_visibility")
+CANDIDATE_SCENARIOS = [
+    CANDIDATE_FIXTURES / "formatting_candidate_verified.json",
+    CANDIDATE_FIXTURES / "broader_diff_review_first.json",
+]
+
+
+def _candidate_validation_report() -> dict:
+    return build_validation_report(CANDIDATE_SCENARIOS)
 
 
 def _benchmark_report() -> dict:
@@ -218,7 +228,7 @@ def test_repo_memory_records_benchmark_supported_candidate_without_automation() 
         benchmark_report=_benchmark_report(),
     )
 
-    assert profile["schema_version"] == "sdetkit.repo_memory.v5"
+    assert profile["schema_version"] == "sdetkit.repo_memory.v6"
     assert profile["profile_status"] == "benchmark_supported_memory"
     assert profile["memory_mode"] == "read_only_profile"
     assert profile["inputs"]["benchmark_contract_proven"] is True
@@ -643,3 +653,85 @@ def test_repo_memory_markdown_renders_trusted_no_observation_status() -> None:
     assert "Observation status: `no_test_observations_available`" in markdown
     assert "Entries: `0`" in markdown
     assert "Automation allowed by flaky-test history: `false`" in markdown
+
+
+def test_repo_memory_retains_controlled_candidate_validation_as_advisory_only() -> None:
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=_benchmark_report(),
+        live_benchmark_report=_live_benchmark_report(),
+        controlled_candidate_validation_evidence=_candidate_validation_report(),
+    )
+
+    controlled = profile["controlled_candidate_validation"]
+    assert controlled["collection_status"] == "collected"
+    assert controlled["status"] == "controlled_validation_passed"
+    assert controlled["scenario_count"] == 2
+    assert controlled["passed_count"] == 2
+    assert controlled["structurally_verified_count"] == 1
+    assert controlled["review_first_count"] == 1
+    assert controlled["current_pr_decision_input"] is False
+    assert controlled["decision_boundary"]["automation_allowed"] is False
+    assert controlled["decision_boundary"]["merge_authorized"] is False
+    assert profile["live_safe_candidate_count"] == 1
+    assert profile["decision_boundary"]["automation_allowed"] is False
+
+    markdown = render_markdown(profile)
+    assert "Controlled candidate validation evidence" in markdown
+    assert "Status: `controlled_validation_passed`" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Automation allowed by controlled validation: `false`" in markdown
+
+
+def test_repo_memory_rejects_controlled_validation_that_can_influence_current_pr() -> None:
+    evidence = _candidate_validation_report()
+    evidence["boundary"]["contributes_to_current_pr_decision"] = True
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=_pattern_insights(),
+            benchmark_report=_benchmark_report(),
+            controlled_candidate_validation_evidence=evidence,
+        )
+    except ValueError as exc:
+        assert "cannot contribute to a current PR decision" in str(exc)
+    else:
+        raise AssertionError("expected decision-influencing controlled validation to be rejected")
+
+
+def test_repo_memory_cli_accepts_controlled_validation_without_promotion(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    controlled_path = tmp_path / "candidate-validation.json"
+    out_dir = tmp_path / "repo-memory-controlled-validation"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+    controlled_path.write_text(json.dumps(_candidate_validation_report()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--controlled-candidate-validation-evidence",
+            str(controlled_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "repo-memory-profile.json").read_text(encoding="utf-8"))
+    assert printed["controlled_candidate_validation_status"] == "controlled_validation_passed"
+    assert saved["controlled_candidate_validation"]["current_pr_decision_input"] is False
+    assert (
+        saved["controlled_candidate_validation"]["decision_boundary"]["automation_allowed"] is False
+    )

--- a/tests/test_repo_memory_profile_history_workflow.py
+++ b/tests/test_repo_memory_profile_history_workflow.py
@@ -150,3 +150,33 @@ def test_repo_memory_history_filters_dismissed_security_evidence_to_merged_pr_ch
     )
     assert 'assert summary["latest_record"]["alerts_excluded_outside_changed_paths"] >= 0' in text
     assert "gh api --paginate" in text
+
+
+def test_repo_memory_history_retains_controlled_candidate_validation_as_read_only_profile_evidence() -> (
+    None
+):
+    text = _workflow_text()
+
+    validation = text.index("python -m sdetkit.pr_quality_candidate_validation")
+    profile = text.index("python -m sdetkit.repo_memory")
+
+    assert validation < profile
+    assert (
+        "--scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json"
+        in text
+    )
+    assert (
+        "--scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json"
+        in text
+    )
+    assert (
+        "--controlled-candidate-validation-evidence build/repo-memory-history/candidate-validation/candidate-validation.json"
+        in text
+    )
+    assert 'assert controlled["status"] == "controlled_validation_passed"' in text
+    assert 'assert controlled["current_pr_decision_input"] is False' in text
+    assert 'assert controlled["decision_boundary"]["automation_allowed"] is False' in text
+    assert 'assert controlled["decision_boundary"]["merge_authorized"] is False' in text
+    assert "build/repo-memory-history/candidate-validation/" in text
+    assert "contents: write" not in text.split("jobs:", 1)[0]
+    assert "git push " not in text


### PR DESCRIPTION
## Summary
- Adds controlled candidate-validation evidence as advisory data in the trusted-main RepoMemory profile artifact.
- Updates `RepoMemory` to schema `sdetkit.repo_memory.v6` with strict ingestion checks for deterministic fixture validation.
- Runs the accepted controlled candidate scenarios in the `RepoMemory Profile History` workflow and supplies the validated report to the profile builder.
- Adds tests proving that the retained evidence cannot influence a current PR decision or authorize action.

## Why
PR #1438 proved that controlled formatting-candidate and broader-diff review-first evidence can be rendered in PR Quality without influencing the current PR decision. That evidence was visible in the PR artifact, but it was not retained in the trusted-main RepoMemory profile artifact after merge.

This PR closes that retention gap without promoting the evidence into cumulative history records and without introducing remediation authority.

## Safety boundary
```text
controlled_fixture_inputs_only=true
controlled_validation_retained_in_profile_artifact=true
controlled_validation_promoted_to_cumulative_history=false
contributes_to_current_pr_decision=false
known_safe_candidate_count_changed_by_controlled_evidence=false
live_safe_candidate_count_changed_by_controlled_evidence=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
repository_content_write_added=false
commit_or_push_path_added=false
```

## Retained evidence contract
`RepoMemory` accepts controlled candidate-validation evidence only when:
- its schema matches the accepted candidate-validation report schema;
- the validation status is passed;
- fixture-only inputs are asserted;
- both structurally verified and review-first boundary scenarios are present;
- the report and every scenario preserve no-authority boundaries.

The retained field is advisory profile evidence only. It does not alter safe-candidate promotion or action decisions.

## Scope
- `.github/workflows/repo-memory-history.yml`
- `src/sdetkit/repo_memory.py`
- `tests/test_repo_memory.py`
- `tests/test_repo_memory_profile_history_workflow.py`

`docs/roadmap/manifest.json` remains fresh and is unchanged.

## Local validation
- Initial focused retention suite: `78 passed`.
- Post-freshness focused retention suite: `81 passed`.
- Full pytest suite: `3698 passed, 1 skipped`.
- Modified Python file security finding check: `0` warn/error findings.
- The repository-wide security command still returns non-zero only because of existing baseline findings outside the modified Python files.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- `git diff --cached --check`: passed.

## Risk
Low-to-medium. This changes a trusted-main evidence artifact and workflow, but it remains read-only, fixture-backed, and explicitly non-authorizing.

## Next
After accepted-main retention is proven in the workflow artifact, consider a separate reviewed PR to carry a minimal advisory count into cumulative history. Do not use controlled fixture evidence to authorize remediation.
