### PR TITLE
Promote controlled candidate evidence as advisory history

### DIFF
--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -285,12 +285,19 @@ jobs:
           assert summary["latest_record"]["source_head_sha"] == os.environ["GITHUB_SHA"]
           assert summary["latest_record"]["profile_status"] == "live_proof_supported_memory"
           assert summary["latest_record"]["live_contract_proven"] is True
+          assert summary["controlled_validation_record_count"] >= 1
+          assert summary["controlled_validation_scenario_count"] >= 2
+          assert summary["controlled_structurally_verified_count"] >= 1
+          assert summary["controlled_review_first_count"] >= 1
+          assert summary["latest_record"]["controlled_validation_status"] == "controlled_validation_passed"
+          assert summary["latest_record"]["controlled_current_pr_decision_input"] is False
 
           boundary = summary["decision_boundary"]
           assert boundary["automation_allowed"] is False
           assert boundary["merge_authorized"] is False
           assert boundary["semantic_equivalence_proven"] is False
           assert boundary["prior_history_is_read_only_input"] is True
+          assert boundary["controlled_validation_is_advisory_only"] is True
 
           print("Trusted-main RepoMemory history snapshot passed.")
           PY

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -20,6 +20,12 @@ PRIOR_HISTORY_READ_ONLY_INPUT = "_".join(("prior", "history", "is", "read", "onl
 PROOF_COMMANDS_EXECUTED_BY_READER = "_".join(("proof", "commands", "executed", "by", "reader"))
 TRUSTED_HISTORY_COLLECTION_STATUS = "_".join(("trusted", "history", "collection", "status"))
 TRUSTED_HISTORY_STATUS = "_".join(("trusted", "history", "status"))
+CONTROLLED_VALIDATION_RECORD_COUNT = "_".join(("controlled", "validation", "record", "count"))
+CONTROLLED_VALIDATION_SCENARIO_COUNT = "_".join(("controlled", "validation", "scenario", "count"))
+CONTROLLED_STRUCTURALLY_VERIFIED_COUNT = "_".join(
+    ("controlled", "structurally", "verified", "count")
+)
+CONTROLLED_REVIEW_FIRST_COUNT = "_".join(("controlled", "review", "first", "count"))
 TRUSTED_HISTORY_RECORD_COUNT = "_".join(("trusted", "history", "record", "count"))
 TRUSTED_HISTORY_BASE_ANCESTRY_VERIFIED = "_".join(
     ("trusted", "history", "base", "ancestry", "verified")
@@ -718,6 +724,34 @@ def _runtime_proof_artifact_lines(runtime_proof_artifacts: JsonObject | None) ->
                 (
                     "- Trusted history prior input read-only: "
                     f"`{str(bool(trusted_history.get(PRIOR_HISTORY_READ_ONLY_INPUT, False))).lower()}`"
+                ),
+                (
+                    "- Trusted history controlled validation records: "
+                    f"`{_int(trusted_history.get(CONTROLLED_VALIDATION_RECORD_COUNT))}`"
+                ),
+                (
+                    "- Trusted history controlled validation scenarios: "
+                    f"`{_int(trusted_history.get(CONTROLLED_VALIDATION_SCENARIO_COUNT))}`"
+                ),
+                (
+                    "- Trusted history controlled structurally verified scenarios: "
+                    f"`{_int(trusted_history.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT))}`"
+                ),
+                (
+                    "- Trusted history controlled review-first scenarios: "
+                    f"`{_int(trusted_history.get(CONTROLLED_REVIEW_FIRST_COUNT))}`"
+                ),
+                (
+                    "- Trusted history latest controlled validation status: "
+                    f"`{_string(trusted_history.get('latest_controlled_validation_status') or 'not_collected')}`"
+                ),
+                (
+                    "- Trusted history controlled validation reporting only: "
+                    f"`{str(bool(trusted_history.get('controlled_validation_reporting_only', False))).lower()}`"
+                ),
+                (
+                    "- Trusted history controlled validation authorizes current action: "
+                    f"`{str(bool(trusted_history.get('controlled_validation_authorizes_current_action', False))).lower()}`"
                 ),
                 (
                     "- Automation allowed by trusted history: "

--- a/src/sdetkit/pr_quality_runtime_proof_artifacts.py
+++ b/src/sdetkit/pr_quality_runtime_proof_artifacts.py
@@ -19,6 +19,12 @@ LIVE_PROVEN_RECORD_COUNT = "_".join(("live", "contract", "proven", "record", "co
 PRIOR_HISTORY_READ_ONLY_INPUT = "_".join(("prior", "history", "is", "read", "only", "input"))
 PROOF_COMMANDS_EXECUTED_BY_READER = "_".join(("proof", "commands", "executed", "by", "reader"))
 TRUSTED_HISTORY_STATUS = "_".join(("trusted", "history", "status"))
+CONTROLLED_VALIDATION_RECORD_COUNT = "_".join(("controlled", "validation", "record", "count"))
+CONTROLLED_VALIDATION_SCENARIO_COUNT = "_".join(("controlled", "validation", "scenario", "count"))
+CONTROLLED_STRUCTURALLY_VERIFIED_COUNT = "_".join(
+    ("controlled", "structurally", "verified", "count")
+)
+CONTROLLED_REVIEW_FIRST_COUNT = "_".join(("controlled", "review", "first", "count"))
 
 JsonObject = dict[str, Any]
 
@@ -171,7 +177,24 @@ def _trusted_history_summary(evidence: Mapping[str, Any]) -> JsonObject:
         "record_count": _int(history.get("record_count")),
         LIVE_PROVEN_RECORD_COUNT: _int(history.get(LIVE_PROVEN_RECORD_COUNT)),
         PRIOR_HISTORY_READ_ONLY_INPUT: _bool(history.get(PRIOR_HISTORY_READ_ONLY_INPUT)),
+        CONTROLLED_VALIDATION_RECORD_COUNT: _int(history.get(CONTROLLED_VALIDATION_RECORD_COUNT)),
+        CONTROLLED_VALIDATION_SCENARIO_COUNT: _int(
+            history.get(CONTROLLED_VALIDATION_SCENARIO_COUNT)
+        ),
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: _int(
+            history.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT)
+        ),
+        CONTROLLED_REVIEW_FIRST_COUNT: _int(history.get(CONTROLLED_REVIEW_FIRST_COUNT)),
+        "latest_controlled_validation_status": _string(
+            history.get("latest_controlled_validation_status") or "not_collected"
+        ),
+        "controlled_validation_reporting_only": _bool(
+            history.get("controlled_validation_reporting_only")
+        ),
         PROOF_COMMANDS_EXECUTED_BY_READER: _bool(boundary.get(PROOF_COMMANDS_EXECUTED_BY_READER)),
+        "controlled_validation_authorizes_current_action": _bool(
+            boundary.get("controlled_validation_authorizes_current_action")
+        ),
         "automation_allowed": _bool(boundary.get("automation_allowed")),
         "merge_authorized": _bool(boundary.get("merge_authorized")),
         "semantic_equivalence_proven": _bool(boundary.get("semantic_equivalence_proven")),
@@ -370,6 +393,34 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
                 (
                     "- Prior history is read-only input: "
                     f"`{str(_bool(trusted_history.get(PRIOR_HISTORY_READ_ONLY_INPUT))).lower()}`"
+                ),
+                (
+                    "- Controlled validation records: "
+                    f"`{_int(trusted_history.get(CONTROLLED_VALIDATION_RECORD_COUNT))}`"
+                ),
+                (
+                    "- Controlled validation scenario total: "
+                    f"`{_int(trusted_history.get(CONTROLLED_VALIDATION_SCENARIO_COUNT))}`"
+                ),
+                (
+                    "- Controlled structurally verified scenario total: "
+                    f"`{_int(trusted_history.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT))}`"
+                ),
+                (
+                    "- Controlled review-first scenario total: "
+                    f"`{_int(trusted_history.get(CONTROLLED_REVIEW_FIRST_COUNT))}`"
+                ),
+                (
+                    "- Latest controlled validation status: "
+                    f"`{_string(trusted_history.get('latest_controlled_validation_status'))}`"
+                ),
+                (
+                    "- Controlled validation reporting only: "
+                    f"`{str(_bool(trusted_history.get('controlled_validation_reporting_only'))).lower()}`"
+                ),
+                (
+                    "- Controlled validation authorizes current action: "
+                    f"`{str(_bool(trusted_history.get('controlled_validation_authorizes_current_action'))).lower()}`"
                 ),
                 (
                     "- Proof commands executed by trusted-history reader: "

--- a/src/sdetkit/repo_memory_profile_history.py
+++ b/src/sdetkit/repo_memory_profile_history.py
@@ -9,9 +9,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = ".".join(("sdetkit", "repo", "memory", "profile", "history", "v1"))
-RECORD_SCHEMA_VERSION = ".".join(
+SCHEMA_VERSION = ".".join(("sdetkit", "repo", "memory", "profile", "history", "v2"))
+LEGACY_RECORD_SCHEMA_VERSION = ".".join(
     ("sdetkit", "repo", "memory", "profile", "history", "record", "v1")
+)
+RECORD_SCHEMA_VERSION = ".".join(
+    ("sdetkit", "repo", "memory", "profile", "history", "record", "v2")
 )
 DEFAULT_OUT_DIR = Path("build") / "repo-memory-history"
 SUMMARY_JSON = "repo-memory-history-summary.json"
@@ -30,6 +33,18 @@ NETWORK_BOUNDARY_BLOCKED_SCENARIO_COUNT = "_".join(
     ("network", "boundary", "blocked", "scenario", "count")
 )
 ANTI_CHEAT_REJECTION_SCENARIO_COUNT = "_".join(("anti", "cheat", "rejection", "scenario", "count"))
+CONTROLLED_VALIDATION_PASSED = "_".join(("controlled", "validation", "passed"))
+CONTROLLED_VALIDATION_STATUS = "_".join(("controlled", "validation", "status"))
+CONTROLLED_VALIDATION_RECORD_COUNT = "_".join(("controlled", "validation", "record", "count"))
+CONTROLLED_VALIDATION_SCENARIO_COUNT = "_".join(("controlled", "validation", "scenario", "count"))
+CONTROLLED_VALIDATION_PASSED_COUNT = "_".join(("controlled", "validation", "passed", "count"))
+CONTROLLED_STRUCTURALLY_VERIFIED_COUNT = "_".join(
+    ("controlled", "structurally", "verified", "count")
+)
+CONTROLLED_REVIEW_FIRST_COUNT = "_".join(("controlled", "review", "first", "count"))
+CONTROLLED_CURRENT_PR_DECISION_INPUT = "_".join(
+    ("controlled", "current", "pr", "decision", "input")
+)
 
 JsonObject = dict[str, Any]
 
@@ -106,6 +121,50 @@ def _assert_no_authority(boundary: Mapping[str, Any], *, source: str) -> None:
         )
 
 
+def _controlled_validation_observation(profile: Mapping[str, Any]) -> JsonObject:
+    controlled = _as_dict(profile.get("controlled_candidate_validation"))
+    status = _text(controlled.get("status") or "not_collected")
+    empty = {
+        CONTROLLED_VALIDATION_STATUS: "not_collected",
+        CONTROLLED_VALIDATION_SCENARIO_COUNT: 0,
+        CONTROLLED_VALIDATION_PASSED_COUNT: 0,
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: 0,
+        CONTROLLED_REVIEW_FIRST_COUNT: 0,
+        CONTROLLED_CURRENT_PR_DECISION_INPUT: False,
+    }
+    if not controlled or status == "not_collected":
+        return empty
+    if status != CONTROLLED_VALIDATION_PASSED:
+        raise ValueError("controlled validation profile status is not supported")
+    if _bool(controlled.get("current_pr_decision_input")):
+        raise ValueError("controlled validation profile cannot influence a current PR decision")
+    _assert_no_authority(
+        _as_dict(controlled.get("decision_boundary")),
+        source="controlled validation profile evidence",
+    )
+
+    scenario_count = _int(controlled.get("scenario_count"))
+    passed_count = _int(controlled.get("passed_count"))
+    structurally_verified = _int(controlled.get("structurally_verified_count"))
+    review_first = _int(controlled.get("review_first_count"))
+    if (
+        scenario_count < 2
+        or passed_count != scenario_count
+        or structurally_verified < 1
+        or review_first < 1
+    ):
+        raise ValueError("controlled validation profile totals are inconsistent")
+
+    return {
+        CONTROLLED_VALIDATION_STATUS: CONTROLLED_VALIDATION_PASSED,
+        CONTROLLED_VALIDATION_SCENARIO_COUNT: scenario_count,
+        CONTROLLED_VALIDATION_PASSED_COUNT: passed_count,
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: structurally_verified,
+        CONTROLLED_REVIEW_FIRST_COUNT: review_first,
+        CONTROLLED_CURRENT_PR_DECISION_INPUT: False,
+    }
+
+
 def validate_profile(profile: Mapping[str, Any]) -> None:
     if _text(profile.get("memory_mode")) != READ_ONLY_PROFILE_MODE:
         raise ValueError("RepoMemory profile must use read_only_profile memory mode")
@@ -113,15 +172,61 @@ def validate_profile(profile: Mapping[str, Any]) -> None:
         _as_dict(profile.get("decision_boundary")),
         source="RepoMemory profile",
     )
+    _controlled_validation_observation(profile)
 
 
 def validate_record(record: Mapping[str, Any]) -> None:
-    if _text(record.get("schema_version")) != RECORD_SCHEMA_VERSION:
+    schema = _text(record.get("schema_version"))
+    if schema not in {LEGACY_RECORD_SCHEMA_VERSION, RECORD_SCHEMA_VERSION}:
         raise ValueError("history record schema is not supported")
     _assert_no_authority(
         _as_dict(record.get("decision_boundary")),
         source="RepoMemory history record",
     )
+
+    controlled_keys = {
+        CONTROLLED_VALIDATION_STATUS,
+        CONTROLLED_VALIDATION_SCENARIO_COUNT,
+        CONTROLLED_VALIDATION_PASSED_COUNT,
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
+        CONTROLLED_REVIEW_FIRST_COUNT,
+        CONTROLLED_CURRENT_PR_DECISION_INPUT,
+    }
+    if schema == LEGACY_RECORD_SCHEMA_VERSION:
+        if any(key in record for key in controlled_keys):
+            raise ValueError("legacy history record cannot carry controlled validation evidence")
+        return
+
+    status = _text(record.get(CONTROLLED_VALIDATION_STATUS) or "not_collected")
+    if status not in {"not_collected", CONTROLLED_VALIDATION_PASSED}:
+        raise ValueError("history record controlled validation status is not supported")
+    if _bool(record.get(CONTROLLED_CURRENT_PR_DECISION_INPUT)):
+        raise ValueError(
+            "history record controlled validation cannot influence a current PR decision"
+        )
+    if status == "not_collected":
+        if any(
+            _int(record.get(key))
+            for key in (
+                CONTROLLED_VALIDATION_SCENARIO_COUNT,
+                CONTROLLED_VALIDATION_PASSED_COUNT,
+                CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
+                CONTROLLED_REVIEW_FIRST_COUNT,
+            )
+        ):
+            raise ValueError(
+                "uncollected controlled validation record cannot carry scenario totals"
+            )
+        return
+
+    scenario_count = _int(record.get(CONTROLLED_VALIDATION_SCENARIO_COUNT))
+    if (
+        scenario_count < 2
+        or _int(record.get(CONTROLLED_VALIDATION_PASSED_COUNT)) != scenario_count
+        or _int(record.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT)) < 1
+        or _int(record.get(CONTROLLED_REVIEW_FIRST_COUNT)) < 1
+    ):
+        raise ValueError("history record controlled validation totals are inconsistent")
 
 
 def build_history_record(
@@ -141,6 +246,7 @@ def build_history_record(
         raise ValueError("source_head_sha is required")
 
     provenance = _as_dict(profile.get("proof_provenance"))
+    controlled = _controlled_validation_observation(profile)
     boundary = {
         AUTOMATION_ALLOWED: False,
         MERGE_AUTHORIZED: False,
@@ -161,6 +267,18 @@ def build_history_record(
         ANTI_CHEAT_REJECTION_SCENARIO_COUNT: _int(
             provenance.get(ANTI_CHEAT_REJECTION_SCENARIO_COUNT)
         ),
+        CONTROLLED_VALIDATION_STATUS: _text(controlled.get(CONTROLLED_VALIDATION_STATUS)),
+        CONTROLLED_VALIDATION_SCENARIO_COUNT: _int(
+            controlled.get(CONTROLLED_VALIDATION_SCENARIO_COUNT)
+        ),
+        CONTROLLED_VALIDATION_PASSED_COUNT: _int(
+            controlled.get(CONTROLLED_VALIDATION_PASSED_COUNT)
+        ),
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: _int(
+            controlled.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT)
+        ),
+        CONTROLLED_REVIEW_FIRST_COUNT: _int(controlled.get(CONTROLLED_REVIEW_FIRST_COUNT)),
+        CONTROLLED_CURRENT_PR_DECISION_INPUT: False,
         "decision_boundary": boundary,
     }
 
@@ -214,6 +332,11 @@ def build_history_summary(
     statuses = Counter(_text(item.get("profile_status")) for item in records)
     latest = dict(records[-1]) if records else {}
     live_records = [item for item in records if _bool(item.get(LIVE_CONTRACT_PROVEN))]
+    controlled_records = [
+        item
+        for item in records
+        if _text(item.get(CONTROLLED_VALIDATION_STATUS)) == CONTROLLED_VALIDATION_PASSED
+    ]
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -224,6 +347,16 @@ def build_history_summary(
         "appended": appended,
         "record_count": len(records),
         "live_contract_proven_record_count": len(live_records),
+        CONTROLLED_VALIDATION_RECORD_COUNT: len(controlled_records),
+        CONTROLLED_VALIDATION_SCENARIO_COUNT: sum(
+            _int(item.get(CONTROLLED_VALIDATION_SCENARIO_COUNT)) for item in controlled_records
+        ),
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: sum(
+            _int(item.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT)) for item in controlled_records
+        ),
+        CONTROLLED_REVIEW_FIRST_COUNT: sum(
+            _int(item.get(CONTROLLED_REVIEW_FIRST_COUNT)) for item in controlled_records
+        ),
         "profile_status_counts": dict(sorted(statuses.items())),
         "known_safe_candidate_total": sum(
             _int(item.get("known_safe_candidate_count")) for item in records
@@ -240,12 +373,22 @@ def build_history_summary(
             "source_head_sha": _text(latest.get("source_head_sha")),
             "profile_status": _text(latest.get("profile_status")),
             LIVE_CONTRACT_PROVEN: _bool(latest.get(LIVE_CONTRACT_PROVEN)),
+            CONTROLLED_VALIDATION_STATUS: _text(
+                latest.get(CONTROLLED_VALIDATION_STATUS) or "not_collected"
+            ),
+            CONTROLLED_VALIDATION_SCENARIO_COUNT: _int(
+                latest.get(CONTROLLED_VALIDATION_SCENARIO_COUNT)
+            ),
+            CONTROLLED_CURRENT_PR_DECISION_INPUT: _bool(
+                latest.get(CONTROLLED_CURRENT_PR_DECISION_INPUT)
+            ),
         },
         "decision_boundary": {
             AUTOMATION_ALLOWED: False,
             MERGE_AUTHORIZED: False,
             SEMANTIC_EQUIVALENCE_PROVEN: False,
             "prior_history_is_read_only_input": True,
+            "controlled_validation_is_advisory_only": True,
             "reason": (
                 "RepoMemory profile history records proven read-only outcomes only; "
                 "it does not authorize remediation."
@@ -276,6 +419,22 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
             "- Anti-cheat rejection scenario total: "
             f"`{_int(summary.get(ANTI_CHEAT_REJECTION_SCENARIO_COUNT))}`"
         ),
+        (
+            "- Controlled validation records: "
+            f"`{_int(summary.get(CONTROLLED_VALIDATION_RECORD_COUNT))}`"
+        ),
+        (
+            "- Controlled validation scenario total: "
+            f"`{_int(summary.get(CONTROLLED_VALIDATION_SCENARIO_COUNT))}`"
+        ),
+        (
+            "- Controlled structurally verified scenario total: "
+            f"`{_int(summary.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT))}`"
+        ),
+        (
+            "- Controlled review-first scenario total: "
+            f"`{_int(summary.get(CONTROLLED_REVIEW_FIRST_COUNT))}`"
+        ),
         "",
         "## Latest record",
         "",
@@ -284,6 +443,18 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
         f"- Source head sha: `{_text(latest.get('source_head_sha'))}`",
         f"- Profile status: `{_text(latest.get('profile_status'))}`",
         (f"- Live contract proven: `{str(_bool(latest.get(LIVE_CONTRACT_PROVEN))).lower()}`"),
+        (
+            "- Controlled validation status: "
+            f"`{_text(latest.get(CONTROLLED_VALIDATION_STATUS) or 'not_collected')}`"
+        ),
+        (
+            "- Controlled validation scenarios: "
+            f"`{_int(latest.get(CONTROLLED_VALIDATION_SCENARIO_COUNT))}`"
+        ),
+        (
+            "- Controlled validation current PR decision input: "
+            f"`{str(_bool(latest.get(CONTROLLED_CURRENT_PR_DECISION_INPUT))).lower()}`"
+        ),
         "",
         "## Boundary",
         "",
@@ -296,6 +467,10 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
         (
             "- Prior history is read-only input: "
             f"`{str(_bool(boundary.get('prior_history_is_read_only_input'))).lower()}`"
+        ),
+        (
+            "- Controlled validation is advisory only: "
+            f"`{str(_bool(boundary.get('controlled_validation_is_advisory_only'))).lower()}`"
         ),
         "- History executes proof commands: `false`",
         "",

--- a/src/sdetkit/trusted_history_evidence.py
+++ b/src/sdetkit/trusted_history_evidence.py
@@ -9,13 +9,19 @@ from typing import Any
 
 from sdetkit.repo_memory_profile_history import (
     AUTOMATION_ALLOWED,
+    CONTROLLED_REVIEW_FIRST_COUNT,
+    CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
+    CONTROLLED_VALIDATION_PASSED,
+    CONTROLLED_VALIDATION_RECORD_COUNT,
+    CONTROLLED_VALIDATION_SCENARIO_COUNT,
+    CONTROLLED_VALIDATION_STATUS,
     LIVE_CONTRACT_PROVEN,
     MERGE_AUTHORIZED,
     SEMANTIC_EQUIVALENCE_PROVEN,
     validate_record,
 )
 
-SCHEMA_VERSION = ".".join(("sdetkit", "trusted", "history", "evidence", "v1"))
+SCHEMA_VERSION = ".".join(("sdetkit", "trusted", "history", "evidence", "v2"))
 DEFAULT_OUT_DIR = Path("build") / "pr-quality" / "trusted-history"
 EVIDENCE_JSON = "trusted-history-evidence.json"
 EVIDENCE_MD = "trusted-history-evidence.md"
@@ -165,6 +171,37 @@ def build_trusted_history_evidence(
     if not _bool(latest.get(LIVE_CONTRACT_PROVEN)):
         raise ValueError("trusted history latest record lacks live-contract proof")
 
+    latest_controlled_status = _string(latest.get(CONTROLLED_VALIDATION_STATUS) or "not_collected")
+    record_controlled_status = _string(last.get(CONTROLLED_VALIDATION_STATUS) or "not_collected")
+    if latest_controlled_status != record_controlled_status:
+        raise ValueError(
+            "trusted history latest controlled validation status does not match JSONL record"
+        )
+
+    controlled_records = [
+        record
+        for record in records
+        if _string(record.get(CONTROLLED_VALIDATION_STATUS)) == CONTROLLED_VALIDATION_PASSED
+    ]
+    controlled_expectations = {
+        CONTROLLED_VALIDATION_RECORD_COUNT: len(controlled_records),
+        CONTROLLED_VALIDATION_SCENARIO_COUNT: sum(
+            _int(record.get(CONTROLLED_VALIDATION_SCENARIO_COUNT)) for record in controlled_records
+        ),
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: sum(
+            _int(record.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT))
+            for record in controlled_records
+        ),
+        CONTROLLED_REVIEW_FIRST_COUNT: sum(
+            _int(record.get(CONTROLLED_REVIEW_FIRST_COUNT)) for record in controlled_records
+        ),
+    }
+    for key, expected in controlled_expectations.items():
+        if _int(payload.get(key)) != expected:
+            raise ValueError("trusted history controlled validation summary does not match records")
+    if controlled_records and not _bool(boundary.get("controlled_validation_is_advisory_only")):
+        raise ValueError("trusted history controlled validation is not marked advisory only")
+
     return {
         "schema_version": SCHEMA_VERSION,
         "collection_status": COLLECTED,
@@ -183,6 +220,18 @@ def build_trusted_history_evidence(
             "latest_accepted_main_head": selected_head,
             "latest_live_contract_proven": True,
             "prior_history_is_read_only_input": True,
+            CONTROLLED_VALIDATION_RECORD_COUNT: controlled_expectations[
+                CONTROLLED_VALIDATION_RECORD_COUNT
+            ],
+            CONTROLLED_VALIDATION_SCENARIO_COUNT: controlled_expectations[
+                CONTROLLED_VALIDATION_SCENARIO_COUNT
+            ],
+            CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: controlled_expectations[
+                CONTROLLED_STRUCTURALLY_VERIFIED_COUNT
+            ],
+            CONTROLLED_REVIEW_FIRST_COUNT: controlled_expectations[CONTROLLED_REVIEW_FIRST_COUNT],
+            "latest_controlled_validation_status": record_controlled_status,
+            "controlled_validation_reporting_only": True,
         },
         "decision_boundary": {
             "reporting_only": True,
@@ -190,6 +239,7 @@ def build_trusted_history_evidence(
             AUTOMATION_ALLOWED: False,
             MERGE_AUTHORIZED: False,
             SEMANTIC_EQUIVALENCE_PROVEN: False,
+            "controlled_validation_authorizes_current_action": False,
         },
     }
 
@@ -220,6 +270,30 @@ def render_markdown(evidence: Mapping[str, Any]) -> str:
                 "- Prior history is read-only input: "
                 f"`{str(_bool(history.get('prior_history_is_read_only_input'))).lower()}`"
             ),
+            (
+                "- Controlled validation records: "
+                f"`{_int(history.get(CONTROLLED_VALIDATION_RECORD_COUNT))}`"
+            ),
+            (
+                "- Controlled validation scenario total: "
+                f"`{_int(history.get(CONTROLLED_VALIDATION_SCENARIO_COUNT))}`"
+            ),
+            (
+                "- Controlled structurally verified scenario total: "
+                f"`{_int(history.get(CONTROLLED_STRUCTURALLY_VERIFIED_COUNT))}`"
+            ),
+            (
+                "- Controlled review-first scenario total: "
+                f"`{_int(history.get(CONTROLLED_REVIEW_FIRST_COUNT))}`"
+            ),
+            (
+                "- Latest controlled validation status: "
+                f"`{_string(history.get('latest_controlled_validation_status') or 'not_collected')}`"
+            ),
+            (
+                "- Controlled validation reporting only: "
+                f"`{str(_bool(history.get('controlled_validation_reporting_only'))).lower()}`"
+            ),
             "",
             "## Boundary",
             "",
@@ -232,6 +306,10 @@ def render_markdown(evidence: Mapping[str, Any]) -> str:
             (
                 "- Semantic equivalence proven: "
                 f"`{str(_bool(boundary.get(SEMANTIC_EQUIVALENCE_PROVEN))).lower()}`"
+            ),
+            (
+                "- Controlled validation authorizes current action: "
+                f"`{str(_bool(boundary.get('controlled_validation_authorizes_current_action'))).lower()}`"
             ),
             "",
         ]

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2079,3 +2079,44 @@ def test_action_report_renders_verified_prior_disposition_as_advisory_only() -> 
     assert "Latest prior reviewed reason: `false positive`" in body
     assert "Prior disposition is advisory evidence only; current action remains manual." in body
     assert "Human review required: `true`" in body
+
+
+def test_action_report_runtime_lines_render_controlled_history_as_advisory_only() -> None:
+    from sdetkit import pr_quality_action_report as report
+
+    lines = report._runtime_proof_artifact_lines(
+        {
+            "trusted_history": {
+                "collection_status": "collected",
+                "status": "trusted_history_verified",
+                "controlled_validation_record_count": 1,
+                "controlled_validation_scenario_count": 2,
+                "controlled_structurally_verified_count": 1,
+                "controlled_review_first_count": 1,
+                "latest_controlled_validation_status": "controlled_validation_passed",
+                "controlled_validation_reporting_only": True,
+                "controlled_validation_authorizes_current_action": False,
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+            "decision_boundary": {
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        }
+    )
+    body = "\n".join(lines)
+
+    assert "Trusted history controlled validation records: `1`" in body
+    assert "Trusted history controlled validation scenarios: `2`" in body
+    assert (
+        "Trusted history latest controlled validation status: `controlled_validation_passed`"
+        in body
+    )
+    assert "Trusted history controlled validation reporting only: `true`" in body
+    assert "Trusted history controlled validation authorizes current action: `false`" in body
+    assert "Automation allowed by trusted history: `false`" in body
+    assert "Merge authorized by trusted history: `false`" in body
+    assert "Semantic equivalence proven by trusted history: `false`" in body

--- a/tests/test_pr_quality_runtime_proof_artifacts.py
+++ b/tests/test_pr_quality_runtime_proof_artifacts.py
@@ -6,6 +6,10 @@ from pathlib import Path
 from sdetkit.pr_quality_runtime_proof_artifacts import (
     BASE_ANCESTRY_VERIFIED,
     COLLECTED,
+    CONTROLLED_REVIEW_FIRST_COUNT,
+    CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
+    CONTROLLED_VALIDATION_RECORD_COUNT,
+    CONTROLLED_VALIDATION_SCENARIO_COUNT,
     LIVE_PROVEN_RECORD_COUNT,
     NOT_COLLECTED,
     PRIOR_HISTORY_READ_ONLY_INPUT,
@@ -226,12 +230,19 @@ def _trusted_history_evidence() -> dict:
             LIVE_PROVEN_RECORD_COUNT: 1,
             "latest_accepted_main_head": "accepted-main-head",
             PRIOR_HISTORY_READ_ONLY_INPUT: True,
+            CONTROLLED_VALIDATION_RECORD_COUNT: 1,
+            CONTROLLED_VALIDATION_SCENARIO_COUNT: 2,
+            CONTROLLED_STRUCTURALLY_VERIFIED_COUNT: 1,
+            CONTROLLED_REVIEW_FIRST_COUNT: 1,
+            "latest_controlled_validation_status": "controlled_validation_passed",
+            "controlled_validation_reporting_only": True,
         },
         "decision_boundary": {
             PROOF_COMMANDS_EXECUTED_BY_READER: False,
             "automation_allowed": False,
             "merge_authorized": False,
             "semantic_equivalence_proven": False,
+            "controlled_validation_authorizes_current_action": False,
         },
     }
 
@@ -250,6 +261,12 @@ def test_runtime_proof_summary_renders_validated_trusted_main_history() -> None:
     assert trusted["record_count"] == 1
     assert trusted[LIVE_PROVEN_RECORD_COUNT] == 1
     assert trusted[PRIOR_HISTORY_READ_ONLY_INPUT] is True
+    assert trusted[CONTROLLED_VALIDATION_RECORD_COUNT] == 1
+    assert trusted[CONTROLLED_VALIDATION_SCENARIO_COUNT] == 2
+    assert trusted[CONTROLLED_STRUCTURALLY_VERIFIED_COUNT] == 1
+    assert trusted[CONTROLLED_REVIEW_FIRST_COUNT] == 1
+    assert trusted["controlled_validation_reporting_only"] is True
+    assert trusted["controlled_validation_authorizes_current_action"] is False
     assert trusted[PROOF_COMMANDS_EXECUTED_BY_READER] is False
     assert trusted["automation_allowed"] is False
     assert trusted["merge_authorized"] is False
@@ -262,6 +279,9 @@ def test_runtime_proof_summary_renders_validated_trusted_main_history() -> None:
     assert "Records: `1`" in markdown
     assert "Live-contract-proven records: `1`" in markdown
     assert "Prior history is read-only input: `true`" in markdown
+    assert "Controlled validation records: `1`" in markdown
+    assert "Controlled validation reporting only: `true`" in markdown
+    assert "Controlled validation authorizes current action: `false`" in markdown
     assert "Automation allowed by trusted history: `false`" in markdown
     assert "Merge authorized by trusted history: `false`" in markdown
 

--- a/tests/test_repo_memory_profile_history.py
+++ b/tests/test_repo_memory_profile_history.py
@@ -8,7 +8,15 @@ import pytest
 from sdetkit.repo_memory_profile_history import (
     ANTI_CHEAT_REJECTION_SCENARIO_COUNT,
     AUTOMATION_ALLOWED,
+    CONTROLLED_CURRENT_PR_DECISION_INPUT,
+    CONTROLLED_REVIEW_FIRST_COUNT,
+    CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
+    CONTROLLED_VALIDATION_PASSED,
+    CONTROLLED_VALIDATION_RECORD_COUNT,
+    CONTROLLED_VALIDATION_SCENARIO_COUNT,
+    CONTROLLED_VALIDATION_STATUS,
     HISTORY_JSONL,
+    LEGACY_RECORD_SCHEMA_VERSION,
     LIVE_CONTRACT_PROVEN,
     LIVE_PROFILE_STATUS,
     MERGE_AUTHORIZED,
@@ -229,3 +237,102 @@ def test_history_cli_rejects_missing_declared_prior_input(
 
     assert rc == 2
     assert "prior history input does not exist" in capsys.readouterr().out
+
+
+def _controlled_profile() -> dict:
+    profile = _profile()
+    profile["controlled_candidate_validation"] = {
+        "collection_status": "collected",
+        "status": CONTROLLED_VALIDATION_PASSED,
+        "scenario_count": 2,
+        "passed_count": 2,
+        "structurally_verified_count": 1,
+        "review_first_count": 1,
+        "current_pr_decision_input": False,
+        "decision_boundary": {
+            AUTOMATION_ALLOWED: False,
+            MERGE_AUTHORIZED: False,
+            SEMANTIC_EQUIVALENCE_PROVEN: False,
+        },
+    }
+    return profile
+
+
+def test_history_promotes_controlled_validation_as_advisory_record_data(tmp_path: Path) -> None:
+    record = build_history_record(
+        _controlled_profile(),
+        source_run_id="run-controlled",
+        source_head_sha="controlled123",
+        recorded_at_utc="2026-05-27T00:00:00Z",
+    )
+    history_path = write_history_jsonl([record], out_dir=tmp_path)
+    summary = build_history_summary(
+        [record],
+        appended=True,
+        history_path=history_path,
+        prior_history_collected=False,
+        prior_record_count=0,
+    )
+
+    assert record[CONTROLLED_VALIDATION_STATUS] == CONTROLLED_VALIDATION_PASSED
+    assert record[CONTROLLED_VALIDATION_SCENARIO_COUNT] == 2
+    assert record[CONTROLLED_STRUCTURALLY_VERIFIED_COUNT] == 1
+    assert record[CONTROLLED_REVIEW_FIRST_COUNT] == 1
+    assert record[CONTROLLED_CURRENT_PR_DECISION_INPUT] is False
+    assert summary[CONTROLLED_VALIDATION_RECORD_COUNT] == 1
+    assert summary[CONTROLLED_VALIDATION_SCENARIO_COUNT] == 2
+    assert summary["latest_record"][CONTROLLED_VALIDATION_STATUS] == CONTROLLED_VALIDATION_PASSED
+    assert summary["decision_boundary"]["controlled_validation_is_advisory_only"] is True
+    assert summary["decision_boundary"][AUTOMATION_ALLOWED] is False
+
+    markdown = render_markdown(summary)
+    assert "Controlled validation records: `1`" in markdown
+    assert "Controlled validation status: `controlled_validation_passed`" in markdown
+    assert "Controlled validation is advisory only: `true`" in markdown
+
+
+def test_history_imports_legacy_record_as_zero_controlled_validation_evidence(
+    tmp_path: Path,
+) -> None:
+    legacy = _record("run-legacy", "legacy123")
+    legacy["schema_version"] = LEGACY_RECORD_SCHEMA_VERSION
+    for key in (
+        CONTROLLED_VALIDATION_STATUS,
+        CONTROLLED_VALIDATION_SCENARIO_COUNT,
+        "controlled_validation_passed_count",
+        CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
+        CONTROLLED_REVIEW_FIRST_COUNT,
+        CONTROLLED_CURRENT_PR_DECISION_INPUT,
+    ):
+        legacy.pop(key, None)
+
+    current = build_history_record(
+        _controlled_profile(),
+        source_run_id="run-current",
+        source_head_sha="current123",
+    )
+    records, appended = merge_history_records([legacy], current)
+    history_path = write_history_jsonl(records, out_dir=tmp_path)
+    summary = build_history_summary(
+        records,
+        appended=appended,
+        history_path=history_path,
+        prior_history_collected=True,
+        prior_record_count=1,
+    )
+
+    assert summary["record_count"] == 2
+    assert summary[CONTROLLED_VALIDATION_RECORD_COUNT] == 1
+    assert summary[CONTROLLED_VALIDATION_SCENARIO_COUNT] == 2
+
+
+def test_history_rejects_controlled_profile_that_claims_current_pr_influence() -> None:
+    profile = _controlled_profile()
+    profile["controlled_candidate_validation"]["current_pr_decision_input"] = True
+
+    with pytest.raises(ValueError, match="cannot influence a current PR decision"):
+        build_history_record(
+            profile,
+            source_run_id="run-bad",
+            source_head_sha="bad123",
+        )

--- a/tests/test_repo_memory_profile_history_workflow.py
+++ b/tests/test_repo_memory_profile_history_workflow.py
@@ -180,3 +180,22 @@ def test_repo_memory_history_retains_controlled_candidate_validation_as_read_onl
     assert "build/repo-memory-history/candidate-validation/" in text
     assert "contents: write" not in text.split("jobs:", 1)[0]
     assert "git push " not in text
+
+
+def test_repo_memory_history_promotes_controlled_validation_as_advisory_counts_only() -> None:
+    text = _workflow_text()
+
+    assert 'assert summary["controlled_validation_record_count"] >= 1' in text
+    assert 'assert summary["controlled_validation_scenario_count"] >= 2' in text
+    assert 'assert summary["controlled_structurally_verified_count"] >= 1' in text
+    assert 'assert summary["controlled_review_first_count"] >= 1' in text
+    assert (
+        'assert summary["latest_record"]["controlled_validation_status"] == "controlled_validation_passed"'
+        in text
+    )
+    assert (
+        'assert summary["latest_record"]["controlled_current_pr_decision_input"] is False' in text
+    )
+    assert 'assert boundary["controlled_validation_is_advisory_only"] is True' in text
+    assert "contents: write" not in text.split("jobs:", 1)[0]
+    assert "git push " not in text

--- a/tests/test_trusted_history_evidence.py
+++ b/tests/test_trusted_history_evidence.py
@@ -8,6 +8,12 @@ import pytest
 
 from sdetkit.repo_memory_profile_history import (
     AUTOMATION_ALLOWED,
+    CONTROLLED_REVIEW_FIRST_COUNT,
+    CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
+    CONTROLLED_VALIDATION_PASSED,
+    CONTROLLED_VALIDATION_RECORD_COUNT,
+    CONTROLLED_VALIDATION_SCENARIO_COUNT,
+    CONTROLLED_VALIDATION_STATUS,
     LIVE_CONTRACT_PROVEN,
     LIVE_PROFILE_STATUS,
     MERGE_AUTHORIZED,
@@ -254,3 +260,151 @@ def test_trusted_history_markdown_preserves_advisory_boundary(tmp_path: Path) ->
     assert "Proof commands executed by reader: `false`" in markdown
     assert "Merge authorized: `false`" in markdown
     assert "Semantic equivalence proven: `false`" in markdown
+
+
+def _controlled_profile() -> dict:
+    profile = _profile()
+    profile["controlled_candidate_validation"] = {
+        "status": CONTROLLED_VALIDATION_PASSED,
+        "scenario_count": 2,
+        "passed_count": 2,
+        "structurally_verified_count": 1,
+        "review_first_count": 1,
+        "current_pr_decision_input": False,
+        "decision_boundary": {
+            AUTOMATION_ALLOWED: False,
+            MERGE_AUTHORIZED: False,
+            SEMANTIC_EQUIVALENCE_PROVEN: False,
+        },
+    }
+    return profile
+
+
+def test_trusted_history_reports_controlled_validation_as_advisory_only(tmp_path: Path) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    record = build_history_record(
+        _controlled_profile(),
+        source_run_id="trusted-controlled",
+        source_head_sha=accepted_head,
+    )
+    history_path = write_history_jsonl([record], out_dir=tmp_path)
+    summary = build_history_summary(
+        [record],
+        appended=True,
+        history_path=history_path,
+        prior_history_collected=False,
+        prior_record_count=0,
+    )
+
+    evidence = build_trusted_history_evidence(
+        summary=summary,
+        records=[record],
+        selected_run_id="trusted-controlled",
+        selected_head_sha=accepted_head,
+        base_sha=base_head,
+        base_ancestry_verified=True,
+    )
+
+    history = evidence["history"]
+    assert history[CONTROLLED_VALIDATION_RECORD_COUNT] == 1
+    assert history[CONTROLLED_VALIDATION_SCENARIO_COUNT] == 2
+    assert history[CONTROLLED_STRUCTURALLY_VERIFIED_COUNT] == 1
+    assert history[CONTROLLED_REVIEW_FIRST_COUNT] == 1
+    assert history["latest_controlled_validation_status"] == CONTROLLED_VALIDATION_PASSED
+    assert history["controlled_validation_reporting_only"] is True
+    assert evidence["decision_boundary"]["controlled_validation_authorizes_current_action"] is False
+
+    markdown = render_markdown(evidence)
+    assert "Controlled validation records: `1`" in markdown
+    assert "Controlled validation reporting only: `true`" in markdown
+    assert "Controlled validation authorizes current action: `false`" in markdown
+
+
+def test_trusted_history_rejects_forged_controlled_validation_summary(tmp_path: Path) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    record = build_history_record(
+        _controlled_profile(),
+        source_run_id="trusted-controlled",
+        source_head_sha=accepted_head,
+    )
+    history_path = write_history_jsonl([record], out_dir=tmp_path)
+    summary = build_history_summary(
+        [record],
+        appended=True,
+        history_path=history_path,
+        prior_history_collected=False,
+        prior_record_count=0,
+    )
+    summary[CONTROLLED_VALIDATION_RECORD_COUNT] = 99
+
+    with pytest.raises(ValueError, match="controlled validation summary does not match records"):
+        build_trusted_history_evidence(
+            summary=summary,
+            records=[record],
+            selected_run_id="trusted-controlled",
+            selected_head_sha=accepted_head,
+            base_sha=base_head,
+            base_ancestry_verified=True,
+        )
+
+
+def test_trusted_history_rejects_controlled_summary_not_marked_advisory_only(
+    tmp_path: Path,
+) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    record = build_history_record(
+        _controlled_profile(),
+        source_run_id="trusted-controlled",
+        source_head_sha=accepted_head,
+    )
+    history_path = write_history_jsonl([record], out_dir=tmp_path)
+    summary = build_history_summary(
+        [record],
+        appended=True,
+        history_path=history_path,
+        prior_history_collected=False,
+        prior_record_count=0,
+    )
+    summary["decision_boundary"]["controlled_validation_is_advisory_only"] = False
+
+    with pytest.raises(ValueError, match="not marked advisory only"):
+        build_trusted_history_evidence(
+            summary=summary,
+            records=[record],
+            selected_run_id="trusted-controlled",
+            selected_head_sha=accepted_head,
+            base_sha=base_head,
+            base_ancestry_verified=True,
+        )
+
+
+def test_trusted_history_rejects_forged_latest_controlled_validation_status(
+    tmp_path: Path,
+) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    record = build_history_record(
+        _controlled_profile(),
+        source_run_id="trusted-controlled",
+        source_head_sha=accepted_head,
+    )
+    history_path = write_history_jsonl([record], out_dir=tmp_path)
+    summary = build_history_summary(
+        [record],
+        appended=True,
+        history_path=history_path,
+        prior_history_collected=False,
+        prior_record_count=0,
+    )
+    summary["latest_record"][CONTROLLED_VALIDATION_STATUS] = "not_collected"
+
+    with pytest.raises(
+        ValueError, match="latest controlled validation status does not match JSONL record"
+    ):
+        build_trusted_history_evidence(
+            summary=summary,
+            records=[record],
+            selected_run_id="trusted-controlled",
+            selected_head_sha=accepted_head,
+            base_sha=base_head,
+            base_ancestry_verified=True,
+        )


### PR DESCRIPTION
## Summary
- Promotes accepted-main controlled candidate-validation observations into persistent RepoMemory history as advisory-only fields.
- Extends the trusted-history reader and PR Quality runtime/comment rendering so operators can see retained controlled-validation counts and latest status.
- Preserves compatibility with existing v1 history records by treating them as zero controlled-validation observations.
- Validates controlled-history totals and latest status against the JSONL records before displaying them.

## Why
PR #1439 proved that accepted-main RepoMemory profile artifacts retain the controlled candidate-validation report, while deliberately excluding it from cumulative history.

This PR performs the next reviewed step: retain an advisory history summary for that already-proven observation path so PR Quality can show whether accepted main has repeatedly observed both:
- a structurally verified formatting candidate; and
- a broader-diff review-first denial.

The history remains reporting-only. It does not authorize remediation or merge decisions.

## Safety boundary
```text
controlled_validation_reporting_only=true
controlled_validation_authorizes_current_action=false
controlled_current_pr_decision_input=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
repository_content_write_added=false
commit_or_push_path_added=false
automatic_remediation_added=false
```

## Integrity contracts
- New history records use the additive v2 record schema.
- Existing v1 history records remain accepted and contribute zero controlled-validation observations.
- Controlled-validation totals displayed by trusted history are recomputed from validated JSONL records.
- The latest controlled-validation status displayed by trusted history is cross-checked against, and rendered from, the latest validated JSONL record.
- Controlled-history reporting is rejected unless the summary explicitly preserves the advisory-only boundary.

## Scope
- `.github/workflows/repo-memory-history.yml`
- `src/sdetkit/repo_memory_profile_history.py`
- `src/sdetkit/trusted_history_evidence.py`
- `src/sdetkit/pr_quality_runtime_proof_artifacts.py`
- `src/sdetkit/pr_quality_action_report.py`
- `tests/test_repo_memory_profile_history.py`
- `tests/test_trusted_history_evidence.py`
- `tests/test_pr_quality_runtime_proof_artifacts.py`
- `tests/test_pr_quality_action_report.py`
- `tests/test_repo_memory_profile_history_workflow.py`

`docs/roadmap/manifest.json` remains fresh and is unchanged.

## Local validation
- Initial focused reporting-chain suite: `140 passed`.
- Post-generated-artifact focused suite: `143 passed`.
- Integrity-corrected focused suite: `141 passed`, then `144 passed`.
- Full pytest suite after latest-status integrity correction: `3708 passed, 1 skipped`.
- Modified Python file security finding check: `0` warn/error findings.
- The repository-wide security command returns non-zero only because of existing baseline findings outside the modified Python files.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- `git diff --cached --check`: passed.

## Risk
Medium. This expands persistent accepted-main reporting schemas and PR Quality visibility, but not action eligibility. Backward-compatible import and anti-forgery validation are covered by tests.

## Next
Validate the new accepted-main history artifact and PR Quality rendering on the merged workflow run. Do not use controlled fixture history to authorize automatic remediation.
