### PR TITLE
Add local read-only DiagnosticJob evidence worker

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -610,6 +610,44 @@ jobs:
             --out build/pr-quality/pr-comment-body.md \
             > build/pr-quality/pr-comment-metadata.json
 
+          mkdir -p build/pr-quality/diagnostic-job
+          diagnostic_job_rc=0
+          PYTHONPATH=src python -m sdetkit.diagnostic_job \
+            --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
+            --evidence-graph build/sdetkit/evidence-graph/evidence-graph.json \
+            --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
+            --security-review build/pr-quality/security-diagnosis/security-finding-diagnosis.json \
+            --repo "$REPOSITORY" \
+            --base-sha "$PR_BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --event-name pull_request \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --out-dir build/pr-quality/diagnostic-job \
+            --format json \
+            > build/pr-quality/diagnostic-job/diagnostic-job-cli.json \
+            || diagnostic_job_rc=$?
+          printf '%s\n' "$diagnostic_job_rc" \
+            > build/pr-quality/diagnostic-job/diagnostic-job-exit-code.txt
+
+          if [ "$diagnostic_job_rc" -ne 0 ] \
+            && [ ! -s build/pr-quality/diagnostic-job/diagnostic-job.md ]; then
+            {
+              printf '%s\n' \
+                '## Local diagnostic job evidence' \
+                '' \
+                '- Evidence type: `current_pr_read_only_worker_result`' \
+                '- Status: `collection_failed`' \
+                '- Current PR decision input: `false`' \
+                '- Proof commands executed by worker: `false`' \
+                '- Patch application allowed: `false`' \
+                '- Automation allowed: `false`' \
+                '- Merge authorized: `false`' \
+                '- Semantic equivalence proven: `false`' \
+                '' \
+                '- Interpretation: diagnostic worker artifact collection failed; the base PR decision and report remain authoritative, and this failed advisory collection grants no authority.'
+            } > build/pr-quality/diagnostic-job/diagnostic-job.md
+          fi
+
           mkdir -p build/pr-quality/candidate-validation
           PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
             --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
@@ -617,6 +655,11 @@ jobs:
             --out-dir build/pr-quality/candidate-validation \
             --format json \
             > build/pr-quality/candidate-validation/candidate-validation-cli.json
+
+          if [ -s build/pr-quality/diagnostic-job/diagnostic-job.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/diagnostic-job/diagnostic-job.md >> build/pr-quality/pr-comment-body.md
+          fi
 
           if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then
             printf '\n' >> build/pr-quality/pr-comment-body.md
@@ -686,6 +729,7 @@ jobs:
             build/pr-quality/repo-memory/
             build/pr-quality/trusted-history/
             build/pr-quality/runtime-proof/
+            build/pr-quality/diagnostic-job/
             build/pr-quality/candidate-visibility/
             build/pr-quality/candidate-validation/
             build/pr-quality/pr-evidence-narrative.md

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -396,7 +396,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.expansion",
         "module_path": "src/sdetkit/expansion.py",
-        "tests_referencing_module": 26
+        "tests_referencing_module": 27
       },
       {
         "contract_script_paths": [
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 118
+        "tests_referencing_module": 119
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/diagnostic_job.py
+++ b/src/sdetkit/diagnostic_job.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.diagnostic_vector_engine import (
+    ACTUAL_FAILURE,
+    DEFAULT_GENERATED_AT,
+    DIAGNOSIS_ID,
+    FAILURE_SURFACE,
+    HEADLINE_FAILURE,
+    RECOMMENDED_NEXT_ACTION,
+    REVIEW_FIRST,
+    SAFE_FIX_CANDIDATE,
+    build_diagnostic_vector,
+    write_diagnostic_vector,
+)
+
+SCHEMA_VERSION = "sdetkit.diagnostic_job.v1"
+WORKER_RESULT_SCHEMA_VERSION = "sdetkit.diagnostic_worker_result.v1"
+JOB_TYPE = "diagnostic_vector"
+WORKER_NAME = "diagnostic_worker"
+EXECUTION_MODE = "local_read_only"
+JOB_JSON = "diagnostic-job.json"
+RESULT_JSON = "diagnostic-worker-result.json"
+REPORT_MD = "diagnostic-job.md"
+VECTOR_DIR = "vector"
+DEFAULT_OUT_DIR = Path("build") / "diagnostic-job"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _boundary() -> JsonObject:
+    return {
+        "current_pr_decision_input": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "patch_application_allowed": False,
+        "proof_commands_executed": False,
+    }
+
+
+def _job_id(*, repo: str, head_sha: str, event_name: str, pr_number: int) -> str:
+    basis = "|".join((repo, head_sha, event_name, str(pr_number), JOB_TYPE))
+    digest = hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+    return f"diagnostic-job-{digest}"
+
+
+def build_diagnostic_job(
+    *,
+    repo: str,
+    base_sha: str,
+    head_sha: str,
+    event_name: str,
+    pr_number: int,
+    input_artifacts: Mapping[str, str],
+    generated_at: str = DEFAULT_GENERATED_AT,
+) -> JsonObject:
+    normalized_inputs = {
+        _string(name): _string(path)
+        for name, path in sorted(input_artifacts.items())
+        if _string(name) and _string(path)
+    }
+    if not _string(head_sha):
+        raise ValueError("diagnostic job requires a head SHA")
+    if not normalized_inputs:
+        raise ValueError("diagnostic job requires at least one evidence input artifact")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "job_id": _job_id(
+            repo=_string(repo),
+            head_sha=_string(head_sha),
+            event_name=_string(event_name),
+            pr_number=pr_number,
+        ),
+        "job_type": JOB_TYPE,
+        "created_at": generated_at,
+        "execution_mode": EXECUTION_MODE,
+        "event": {
+            "repo": _string(repo),
+            "base_sha": _string(base_sha),
+            "head_sha": _string(head_sha),
+            "event_name": _string(event_name),
+            "pr_number": pr_number,
+        },
+        "input_artifacts": normalized_inputs,
+        "worker_contract": {
+            "worker": WORKER_NAME,
+            "reads_current_pr_evidence": True,
+            "writes_artifacts_only": True,
+            "runs_proof_commands": False,
+            "applies_patch": False,
+            "publishes_decision": False,
+        },
+        "decision_boundary": _boundary(),
+    }
+
+
+def validate_job(job: Mapping[str, Any]) -> None:
+    if _string(job.get("schema_version")) != SCHEMA_VERSION:
+        raise ValueError("diagnostic job schema is not supported")
+    if _string(job.get("job_type")) != JOB_TYPE:
+        raise ValueError("diagnostic job type is not supported")
+    if _string(job.get("execution_mode")) != EXECUTION_MODE:
+        raise ValueError("diagnostic job execution mode must be local read-only")
+    if not _string(job.get("job_id")):
+        raise ValueError("diagnostic job id is required")
+    if not _as_dict(job.get("input_artifacts")):
+        raise ValueError("diagnostic job input artifacts are required")
+
+    boundary = _as_dict(job.get("decision_boundary"))
+    denied = (
+        "current_pr_decision_input",
+        "automation_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "patch_application_allowed",
+        "proof_commands_executed",
+    )
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    if expanded:
+        raise ValueError("diagnostic job expands authority: " + ", ".join(expanded))
+
+    contract = _as_dict(job.get("worker_contract"))
+    if _string(contract.get("worker")) != WORKER_NAME:
+        raise ValueError("diagnostic job worker is not supported")
+    if not _bool(contract.get("reads_current_pr_evidence")):
+        raise ValueError("diagnostic worker must consume current PR evidence")
+    if not _bool(contract.get("writes_artifacts_only")):
+        raise ValueError("diagnostic worker must be artifact-only")
+    prohibited = [
+        key
+        for key in ("runs_proof_commands", "applies_patch", "publishes_decision")
+        if _bool(contract.get(key))
+    ]
+    if prohibited:
+        raise ValueError("diagnostic worker contract expands authority: " + ", ".join(prohibited))
+
+
+def _primary_diagnosis(payload: Mapping[str, Any]) -> JsonObject:
+    rows = [_as_dict(item) for item in _as_list(payload.get("diagnoses")) if _as_dict(item)]
+    if not rows:
+        return {}
+    row = rows[0]
+    return {
+        DIAGNOSIS_ID: _string(row.get(DIAGNOSIS_ID)),
+        FAILURE_SURFACE: _string(row.get(FAILURE_SURFACE)),
+        HEADLINE_FAILURE: _string(row.get(HEADLINE_FAILURE)),
+        ACTUAL_FAILURE: _string(row.get(ACTUAL_FAILURE)),
+        RECOMMENDED_NEXT_ACTION: _string(row.get(RECOMMENDED_NEXT_ACTION)),
+        REVIEW_FIRST: _bool(row.get(REVIEW_FIRST)),
+        SAFE_FIX_CANDIDATE: _bool(row.get(SAFE_FIX_CANDIDATE)),
+    }
+
+
+def run_diagnostic_worker(
+    job: Mapping[str, Any],
+    *,
+    check_intelligence: Mapping[str, Any] | None = None,
+    evidence_graph: Mapping[str, Any] | None = None,
+    pr_quality_action_report: Mapping[str, Any] | None = None,
+    security_review: Mapping[str, Any] | None = None,
+    out_dir: Path,
+) -> JsonObject:
+    validate_job(job)
+    vector = build_diagnostic_vector(
+        check_intelligence=check_intelligence,
+        evidence_graph=evidence_graph,
+        pr_quality_action_report=pr_quality_action_report,
+        security_review=security_review,
+        generated_at=_string(job.get("created_at")) or DEFAULT_GENERATED_AT,
+    )
+    vector_artifacts = write_diagnostic_vector(vector, out_dir / VECTOR_DIR)
+    return {
+        "schema_version": WORKER_RESULT_SCHEMA_VERSION,
+        "job_id": _string(job.get("job_id")),
+        "job_type": JOB_TYPE,
+        "worker": WORKER_NAME,
+        "status": "completed",
+        "execution_mode": EXECUTION_MODE,
+        "summary": _as_dict(vector.get("summary")),
+        "primary_diagnosis": _primary_diagnosis(vector),
+        "output_artifacts": vector_artifacts,
+        "decision_boundary": _boundary(),
+        "execution": {
+            "proof_commands_executed": False,
+            "patch_attempted": False,
+            "repository_write_attempted": False,
+        },
+    }
+
+
+def render_markdown(job: Mapping[str, Any], result: Mapping[str, Any]) -> str:
+    summary = _as_dict(result.get("summary"))
+    primary = _as_dict(result.get("primary_diagnosis"))
+    boundary = _as_dict(result.get("decision_boundary"))
+    lines = [
+        "## Local diagnostic job evidence",
+        "",
+        "- Evidence type: `current_pr_read_only_worker_result`",
+        f"- Job ID: `{_string(job.get('job_id'))}`",
+        f"- Job type: `{_string(job.get('job_type'))}`",
+        f"- Worker: `{_string(result.get('worker'))}`",
+        f"- Execution mode: `{_string(result.get('execution_mode'))}`",
+        f"- Status: `{_string(result.get('status'))}`",
+        f"- Diagnoses emitted: `{int(summary.get('diagnosis_count', 0) or 0)}`",
+        f"- Review-first diagnoses: `{int(summary.get('review_first_count', 0) or 0)}`",
+        f"- Safe-fix candidates observed: `{int(summary.get('safe_fix_candidate_count', 0) or 0)}`",
+        f"- Primary surface: `{_string(summary.get('primary_surface') or 'none')}`",
+        f"- Primary action: `{_string(summary.get('primary_action') or 'none')}`",
+        (
+            "- Current PR decision input: "
+            f"`{str(_bool(boundary.get('current_pr_decision_input'))).lower()}`"
+        ),
+        (
+            "- Proof commands executed by worker: "
+            f"`{str(_bool(boundary.get('proof_commands_executed'))).lower()}`"
+        ),
+        (
+            "- Patch application allowed: "
+            f"`{str(_bool(boundary.get('patch_application_allowed'))).lower()}`"
+        ),
+        (f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`"),
+        (f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`"),
+        (
+            "- Semantic equivalence proven: "
+            f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+        ),
+    ]
+    if primary:
+        lines.extend(
+            [
+                "",
+                "### Primary observed diagnosis",
+                "",
+                f"- Surface: `{_string(primary.get(FAILURE_SURFACE) or 'unknown')}`",
+                f"- Headline: {_string(primary.get(HEADLINE_FAILURE) or 'none')}",
+                f"- Actual failure: `{_string(primary.get(ACTUAL_FAILURE) or 'none')}`",
+                (
+                    "- Recommended next action: "
+                    f"`{_string(primary.get(RECOMMENDED_NEXT_ACTION) or 'none')}`"
+                ),
+                f"- Review first: `{str(_bool(primary.get(REVIEW_FIRST))).lower()}`",
+                (
+                    "- Safe-fix candidate observed: "
+                    f"`{str(_bool(primary.get(SAFE_FIX_CANDIDATE))).lower()}`"
+                ),
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "- Interpretation: this local worker reports current PR diagnosis evidence through the existing diagnostic-vector engine; it does not execute proof, apply a patch, or authorize a merge.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_artifacts(
+    job: Mapping[str, Any], result: Mapping[str, Any], *, out_dir: Path
+) -> JsonObject:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    job_path = out_dir / JOB_JSON
+    result_path = out_dir / RESULT_JSON
+    markdown_path = out_dir / REPORT_MD
+    _write_json(job_path, job)
+    _write_json(result_path, result)
+    markdown_path.write_text(render_markdown(job, result), encoding="utf-8")
+    return {
+        "diagnostic_job_json": job_path.as_posix(),
+        "diagnostic_worker_result_json": result_path.as_posix(),
+        "diagnostic_job_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.diagnostic_job")
+    parser.add_argument("--check-intelligence", type=Path)
+    parser.add_argument("--evidence-graph", type=Path)
+    parser.add_argument("--pr-quality-action-report", type=Path)
+    parser.add_argument("--security-review", type=Path)
+    parser.add_argument("--repo", default="")
+    parser.add_argument("--base-sha", default="")
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--event-name", default="local")
+    parser.add_argument("--pr-number", type=int, default=0)
+    parser.add_argument("--generated-at", default=DEFAULT_GENERATED_AT)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    inputs = {
+        "check_intelligence": str(args.check_intelligence or ""),
+        "evidence_graph": str(args.evidence_graph or ""),
+        "pr_quality_action_report": str(args.pr_quality_action_report or ""),
+        "security_review": str(args.security_review or ""),
+    }
+    try:
+        job = build_diagnostic_job(
+            repo=args.repo,
+            base_sha=args.base_sha,
+            head_sha=args.head_sha,
+            event_name=args.event_name,
+            pr_number=args.pr_number,
+            input_artifacts=inputs,
+            generated_at=args.generated_at,
+        )
+        result = run_diagnostic_worker(
+            job,
+            check_intelligence=_read_json(args.check_intelligence),
+            evidence_graph=_read_json(args.evidence_graph),
+            pr_quality_action_report=_read_json(args.pr_quality_action_report),
+            security_review=_read_json(args.security_review),
+            out_dir=args.out_dir,
+        )
+        artifacts = write_artifacts(job, result, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "artifacts": artifacts,
+                    "job_id": job["job_id"],
+                    "summary": result["summary"],
+                    "decision_boundary": result["decision_boundary"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"diagnostic_job_json: {artifacts['diagnostic_job_json']}")
+        print(f"diagnostic_worker_result_json: {artifacts['diagnostic_worker_result_json']}")
+        print(f"diagnostic_job_markdown: {artifacts['diagnostic_job_markdown']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_diagnostic_job.py
+++ b/tests/test_diagnostic_job.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.diagnostic_job import (
+    SCHEMA_VERSION,
+    WORKER_RESULT_SCHEMA_VERSION,
+    build_diagnostic_job,
+    main,
+    render_markdown,
+    run_diagnostic_worker,
+    validate_job,
+)
+
+
+def _job() -> dict:
+    return build_diagnostic_job(
+        repo="sherif69-sa/DevS69-sdetkit",
+        base_sha="base123",
+        head_sha="head123",
+        event_name="pull_request",
+        pr_number=1441,
+        input_artifacts={"check_intelligence": "build/check-intelligence.json"},
+        generated_at="2026-05-27T00:00:00Z",
+    )
+
+
+def _formatting_intelligence() -> dict:
+    return {
+        "failed_checks": [
+            {
+                "name": "PR Quality local quality gate",
+                "surface": "formatting",
+                "command": "python -m pre_commit run -a",
+                "scope": "pr_owned_only",
+                "diagnosis": {"title": "Pre-commit formatting drift", "surface": "formatting"},
+                "first_failure": {
+                    "line": "ruff format..............................Failed",
+                    "line_number": 30,
+                    "tool": "ruff",
+                    "kind": "format_drift",
+                },
+                "safe_to_auto_fix": True,
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "affected_files": ["src/sdetkit/example.py"],
+                },
+                "affected_files": ["src/sdetkit/example.py"],
+            }
+        ]
+    }
+
+
+def test_diagnostic_job_is_deterministic_and_read_only() -> None:
+    first = _job()
+    second = _job()
+
+    assert first == second
+    assert first["schema_version"] == SCHEMA_VERSION
+    assert first["job_type"] == "diagnostic_vector"
+    assert first["execution_mode"] == "local_read_only"
+    assert first["worker_contract"]["writes_artifacts_only"] is True
+    assert first["worker_contract"]["runs_proof_commands"] is False
+    assert first["worker_contract"]["applies_patch"] is False
+    assert first["worker_contract"]["publishes_decision"] is False
+    assert first["decision_boundary"]["current_pr_decision_input"] is False
+    assert first["decision_boundary"]["automation_allowed"] is False
+    assert first["decision_boundary"]["merge_authorized"] is False
+
+
+def test_diagnostic_worker_executes_existing_vector_engine_without_authority(
+    tmp_path: Path,
+) -> None:
+    job = _job()
+    result = run_diagnostic_worker(
+        job,
+        check_intelligence=_formatting_intelligence(),
+        out_dir=tmp_path,
+    )
+
+    assert result["schema_version"] == WORKER_RESULT_SCHEMA_VERSION
+    assert result["status"] == "completed"
+    assert result["summary"]["diagnosis_count"] == 1
+    assert result["summary"]["safe_fix_candidate_count"] == 1
+    assert result["primary_diagnosis"]["failure_surface"] == "formatting"
+    assert result["primary_diagnosis"]["safe_fix_candidate"] is True
+    assert result["decision_boundary"]["current_pr_decision_input"] is False
+    assert result["decision_boundary"]["proof_commands_executed"] is False
+    assert result["decision_boundary"]["patch_application_allowed"] is False
+    assert result["decision_boundary"]["automation_allowed"] is False
+    assert result["execution"]["patch_attempted"] is False
+    assert (tmp_path / "vector" / "failure-vector.json").exists()
+
+    markdown = render_markdown(job, result)
+    assert "Local diagnostic job evidence" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Safe-fix candidates observed: `1`" in markdown
+    assert "Patch application allowed: `false`" in markdown
+
+
+def test_diagnostic_job_rejects_worker_authority_expansion() -> None:
+    job = _job()
+    job["worker_contract"]["applies_patch"] = True
+
+    with pytest.raises(ValueError, match="expands authority"):
+        validate_job(job)
+
+    job = _job()
+    job["decision_boundary"]["semantic_equivalence_proven"] = True
+
+    with pytest.raises(ValueError, match="expands authority"):
+        validate_job(job)
+
+
+def test_diagnostic_job_cli_writes_job_result_vector_and_comment_artifacts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    check_path = tmp_path / "check-intelligence.json"
+    check_path.write_text(json.dumps(_formatting_intelligence()), encoding="utf-8")
+    out_dir = tmp_path / "job"
+
+    rc = main(
+        [
+            "--check-intelligence",
+            str(check_path),
+            "--repo",
+            "sherif69-sa/DevS69-sdetkit",
+            "--base-sha",
+            "base123",
+            "--head-sha",
+            "head123",
+            "--event-name",
+            "pull_request",
+            "--pr-number",
+            "1441",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    stdout = json.loads(capsys.readouterr().out)
+    job = json.loads((out_dir / "diagnostic-job.json").read_text(encoding="utf-8"))
+    result = json.loads((out_dir / "diagnostic-worker-result.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "diagnostic-job.md").read_text(encoding="utf-8")
+
+    assert stdout["decision_boundary"]["automation_allowed"] is False
+    assert job["event"]["head_sha"] == "head123"
+    assert result["summary"]["diagnosis_count"] == 1
+    assert (out_dir / "vector" / "diagnostic-vector.json").exists()
+    assert (out_dir / "vector" / "failure-vector.json").exists()
+    assert "does not execute proof, apply a patch, or authorize a merge" in markdown

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -598,3 +598,55 @@ def test_pr_quality_workflow_appends_controlled_candidate_validation_only_after_
     assert "build/pr-quality/candidate-validation/" in text
     assert "--commit-safe-fixes" not in text
     assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_runs_local_diagnostic_job_as_post_decision_read_only_evidence() -> (
+    None
+):
+    text = _workflow_text()
+
+    action_report = text.index("python -m sdetkit.pr_quality_action_report")
+    job = text.index("python -m sdetkit.diagnostic_job")
+    job_append = text.index("cat build/pr-quality/diagnostic-job/diagnostic-job.md")
+    action_report_command = text[
+        action_report : text.index("> build/pr-quality/pr-comment-metadata.json", action_report)
+    ]
+
+    assert action_report < job < job_append
+    assert "diagnostic-job" not in action_report_command
+    assert (
+        "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in text
+    )
+    assert "--evidence-graph build/sdetkit/evidence-graph/evidence-graph.json" in text
+    assert (
+        "--pr-quality-action-report build/pr-quality/check-intelligence/action-report.json" in text
+    )
+    assert (
+        "--security-review build/pr-quality/security-diagnosis/security-finding-diagnosis.json"
+        in text
+    )
+    assert '--base-sha "$PR_BASE_SHA"' in text
+    assert '--head-sha "$HEAD_SHA"' in text
+    assert "build/pr-quality/diagnostic-job/" in text
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_keeps_failed_diagnostic_job_advisory_and_visible() -> None:
+    text = _workflow_text()
+    build_comment = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build verified operator evidence loop"
+        )
+    ]
+
+    assert "diagnostic_job_rc=0" in build_comment
+    assert "|| diagnostic_job_rc=$?" in build_comment
+    assert "diagnostic-job-exit-code.txt" in build_comment
+    assert 'if [ "$diagnostic_job_rc" -ne 0 ]' in build_comment
+    assert "Status: `collection_failed`" in build_comment
+    assert "Current PR decision input: `false`" in build_comment
+    assert "Patch application allowed: `false`" in build_comment
+    assert "Automation allowed: `false`" in build_comment
+    assert "Merge authorized: `false`" in build_comment
+    assert "base PR decision and report remain authoritative" in build_comment


### PR DESCRIPTION
## Summary
- Introduces a deterministic, local-only `DiagnosticJob` artifact and `DiagnosticWorkerResult` artifact.
- Executes the existing `diagnostic_vector_engine` from current PR Quality evidence instead of creating a parallel diagnosis model.
- Appends the worker result as an explicitly advisory PR Quality evidence section after the primary action report has already been rendered.
- Degrades visibly to a non-authorizing `collection_failed` section if advisory worker collection fails, preserving the base PR report.

## Why
Accepted main now extracts exact failure evidence, verifies read-only remediation candidates, retains controlled observations in RepoMemory, and reports advisory trusted history.

This PR begins Wave G with the missing local execution contract:

```text
current PR evidence
→ DiagnosticJob artifact
→ local read-only DiagnosticWorkerResult
→ existing DiagnosticVector / FailureVector artifacts
→ advisory PR Quality visibility
```

It does not add queueing, cloud infrastructure, proof execution, patch application, automatic remediation, or merge authorization.

## Safety boundary
```text
execution_mode=local_read_only
current_pr_decision_input=false
proof_commands_executed=false
patch_application_allowed=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
repository_content_write_added=false
commit_or_push_path_added=false
automatic_remediation_added=false
```

## Reliability boundary
The diagnostic worker is advisory. If worker artifact collection fails:
- its exit code is retained in `diagnostic-job-exit-code.txt`;
- PR Quality appends a visible `collection_failed` advisory section;
- the already-built base PR action report remains authoritative;
- the failed advisory collection grants no authority.

## Scope
- `.github/workflows/pr-quality-comment.yml`
- `docs/roadmap/manifest.json`
- `src/sdetkit/diagnostic_job.py`
- `tests/test_diagnostic_job.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

The manifest delta is the generated registry update required by the added module and tests.

## Local validation
- Initial focused DiagnosticJob suite: `101 passed`.
- Post-manifest focused suite: `104 passed`.
- YAML-safe advisory-failure focused suite: `102 passed`, then `105 passed`.
- Full pytest suite after YAML-safe advisory fallback correction: `3714 passed, 1 skipped`.
- Modified Python file security finding check: `0` warn/error findings.
- The repository-wide security command remains non-zero only for existing baseline findings outside these PR-owned Python files.
- Workflow YAML parse validation: passed.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- `git diff --cached --check`: passed.

## Risk
Medium. This introduces a new live PR Quality artifact and rendering section. The implementation keeps it post-decision and advisory-only, with explicit non-blocking failure behavior and no repository-write authority.

## Next
Use the live PR Quality run for this PR to prove that `Local diagnostic job evidence` is visible and non-authorizing in CI. Do not introduce automated patch execution or job queues yet.
