### PR TITLE
Reject missing DiagnosticJob evidence inputs

### DIFF
--- a/src/sdetkit/diagnostic_job.py
+++ b/src/sdetkit/diagnostic_job.py
@@ -53,8 +53,10 @@ def _bool(value: Any) -> bool:
 
 
 def _read_json(path: Path | None) -> JsonObject:
-    if path is None or not path.exists():
+    if path is None:
         return {}
+    if not path.exists():
+        raise ValueError(f"declared diagnostic job evidence input is missing: {path}")
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"expected JSON object in {path}")

--- a/tests/test_diagnostic_job.py
+++ b/tests/test_diagnostic_job.py
@@ -157,3 +157,29 @@ def test_diagnostic_job_cli_writes_job_result_vector_and_comment_artifacts(
     assert (out_dir / "vector" / "diagnostic-vector.json").exists()
     assert (out_dir / "vector" / "failure-vector.json").exists()
     assert "does not execute proof, apply a patch, or authorize a merge" in markdown
+
+
+def test_diagnostic_job_cli_rejects_declared_missing_evidence_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "missing-check-intelligence.json"
+    out_dir = tmp_path / "job"
+
+    rc = main(
+        [
+            "--check-intelligence",
+            str(missing),
+            "--head-sha",
+            "head123",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 2
+    assert "declared diagnostic job evidence input is missing" in capsys.readouterr().out
+    assert not (out_dir / "diagnostic-worker-result.json").exists()
+    assert not (out_dir / "diagnostic-job.md").exists()


### PR DESCRIPTION
## Summary
- Rejects an explicitly supplied but missing `DiagnosticJob` evidence input instead of silently treating it as empty evidence.
- Adds regression coverage proving the CLI returns collection failure and does not emit misleading worker-result artifacts for a declared missing input.
- Completes the existing visible `collection_failed` fallback introduced in PR #1441.

## Why
PR #1441 correctly added a local read-only diagnostic worker and a non-blocking workflow fallback. Post-merge review found that `_read_json()` still returned an empty payload for a declared missing evidence path, allowing an incomplete evidence read to be reported as a completed diagnostic job.

This containment PR ensures a declared missing input reaches the existing visible advisory failure path.

## Safety boundary
```text
declared_missing_input=collection_failed
optional_unsupplied_input=permitted
base_pr_decision_remains_authoritative=true
current_pr_decision_input=false
proof_commands_executed=false
patch_application_allowed=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
repository_content_write_added=false
commit_or_push_path_added=false
```

## Scope
- `src/sdetkit/diagnostic_job.py`
- `tests/test_diagnostic_job.py`

`docs/roadmap/manifest.json` remains fresh and unchanged.

## Local validation
- Focused containment suite: `103 passed`.
- Post-manifest focused suite: `106 passed`.
- Full pytest suite: `3715 passed, 1 skipped`.
- Corrected Python file security finding check: `0` warn/error findings.
- The repository-wide security command remains non-zero only for existing baseline findings outside the corrected files.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- `git diff --cached --check`: passed.

## Risk
Low. The correction is limited to handling a declared missing advisory evidence file and its regression test. It does not modify workflow authority or the successful worker path.

## Next
After merge, verify accepted `main` and run a controlled missing-input invocation to prove it returns collection failure while the workflow fallback remains non-authorizing.
