### PR TITLE
Record diagnostic worker evidence as advisory trajectory

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -648,6 +648,49 @@ jobs:
             } > build/pr-quality/diagnostic-job/diagnostic-job.md
           fi
 
+          mkdir -p build/pr-quality/diagnostic-job/trajectory
+          diagnostic_worker_trajectory_rc=2
+          if [ "$diagnostic_job_rc" -eq 0 ] \
+            && [ -s build/pr-quality/diagnostic-job/diagnostic-job.json ] \
+            && [ -s build/pr-quality/diagnostic-job/diagnostic-worker-result.json ] \
+            && [ -s build/pr-quality/diagnostic-job/vector/diagnostic-vector.json ]; then
+            diagnostic_worker_trajectory_rc=0
+            PYTHONPATH=src python -m sdetkit.diagnostic_worker_trajectory \
+              --diagnostic-job build/pr-quality/diagnostic-job/diagnostic-job.json \
+              --diagnostic-worker-result build/pr-quality/diagnostic-job/diagnostic-worker-result.json \
+              --diagnostic-vector build/pr-quality/diagnostic-job/vector/diagnostic-vector.json \
+              --repo "$REPOSITORY" \
+              --branch "${{ github.event.pull_request.head.ref }}" \
+              --commit-sha "$HEAD_SHA" \
+              --pr-number "${{ github.event.pull_request.number }}" \
+              --out-dir build/pr-quality/diagnostic-job/trajectory \
+              --format json \
+              > build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory-cli.json \
+              || diagnostic_worker_trajectory_rc=$?
+          fi
+          printf '%s\n' "$diagnostic_worker_trajectory_rc" \
+            > build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory-exit-code.txt
+
+          if [ "$diagnostic_worker_trajectory_rc" -ne 0 ] \
+            && [ ! -s build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md ]; then
+            {
+              printf '%s\n' \
+                '## Local diagnostic worker trajectory handoff' \
+                '' \
+                '- Evidence type: `post_decision_reporting_only_trajectory`' \
+                '- Status: `collection_failed`' \
+                '- Reporting only: `true`' \
+                '- Current PR decision input: `false`' \
+                '- Proof commands executed: `false`' \
+                '- Patch application allowed: `false`' \
+                '- Automation allowed: `false`' \
+                '- Merge authorized: `false`' \
+                '- Semantic equivalence proven: `false`' \
+                '' \
+                '- Interpretation: advisory trajectory handoff failed; current-run candidate decisions and RepoMemory remain unchanged.'
+            } > build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md
+          fi
+
           mkdir -p build/pr-quality/candidate-validation
           PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
             --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
@@ -659,6 +702,11 @@ jobs:
           if [ -s build/pr-quality/diagnostic-job/diagnostic-job.md ]; then
             printf '\n' >> build/pr-quality/pr-comment-body.md
             cat build/pr-quality/diagnostic-job/diagnostic-job.md >> build/pr-quality/pr-comment-body.md
+          fi
+
+          if [ -s build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md >> build/pr-quality/pr-comment-body.md
           fi
 
           if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 119
+        "tests_referencing_module": 120
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/diagnostic_worker_trajectory.py
+++ b/src/sdetkit/diagnostic_worker_trajectory.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.diagnostic_job import (
+    EXECUTION_MODE,
+    JOB_TYPE,
+    WORKER_NAME,
+    WORKER_RESULT_SCHEMA_VERSION,
+    validate_job,
+)
+from sdetkit.diagnostic_job import (
+    SCHEMA_VERSION as JOB_SCHEMA_VERSION,
+)
+from sdetkit.trajectory_store import (
+    DEFAULT_GENERATED_AT,
+    build_trajectory_records,
+    write_trajectory_records,
+)
+from sdetkit.trajectory_store import (
+    SCHEMA_VERSION as TRAJECTORY_SCHEMA_VERSION,
+)
+
+SCHEMA_VERSION = "sdetkit.diagnostic_worker_trajectory.v1"
+OUT_JSONL = "diagnostic-worker-trajectory.jsonl"
+SUMMARY_JSON = "diagnostic-worker-trajectory-summary.json"
+REPORT_MD = "diagnostic-worker-trajectory.md"
+DEFAULT_OUT_DIR = Path("build") / "diagnostic-worker-trajectory"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_required_json(path: Path) -> JsonObject:
+    if not path.exists():
+        raise ValueError(f"declared diagnostic worker trajectory input is missing: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _assert_false_fields(payload: Mapping[str, Any], *, source: str) -> None:
+    denied = (
+        "current_pr_decision_input",
+        "proof_commands_executed",
+        "patch_application_allowed",
+        "automation_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+    )
+    expanded = [key for key in denied if _bool(payload.get(key))]
+    if expanded:
+        raise ValueError(f"{source} expands authority: " + ", ".join(expanded))
+
+
+def _summary_projection(payload: Mapping[str, Any]) -> JsonObject:
+    return {
+        "diagnosis_count": _int(payload.get("diagnosis_count")),
+        "review_first_count": _int(payload.get("review_first_count")),
+        "safe_fix_candidate_count": _int(payload.get("safe_fix_candidate_count")),
+        "primary_surface": _string(payload.get("primary_surface")),
+        "primary_action": _string(payload.get("primary_action")),
+    }
+
+
+def validate_worker_handoff(
+    *,
+    job: Mapping[str, Any],
+    worker_result: Mapping[str, Any],
+    diagnostic_vector: Mapping[str, Any],
+) -> None:
+    validate_job(job)
+    if _string(job.get("schema_version")) != JOB_SCHEMA_VERSION:
+        raise ValueError("diagnostic job schema is not supported for trajectory handoff")
+    if _string(worker_result.get("schema_version")) != WORKER_RESULT_SCHEMA_VERSION:
+        raise ValueError("diagnostic worker result schema is not supported")
+    if _string(worker_result.get("job_id")) != _string(job.get("job_id")):
+        raise ValueError("diagnostic worker result job id does not match job")
+    if _string(worker_result.get("job_type")) != JOB_TYPE:
+        raise ValueError("diagnostic worker result job type is not supported")
+    if _string(worker_result.get("worker")) != WORKER_NAME:
+        raise ValueError("diagnostic worker result worker is not supported")
+    if _string(worker_result.get("status")) != "completed":
+        raise ValueError("diagnostic worker result must be completed before trajectory handoff")
+    if _string(worker_result.get("execution_mode")) != EXECUTION_MODE:
+        raise ValueError("diagnostic worker result execution mode must be local read-only")
+
+    _assert_false_fields(_as_dict(worker_result.get("decision_boundary")), source="worker result")
+    execution = _as_dict(worker_result.get("execution"))
+    execution_expanded = [
+        key
+        for key in ("proof_commands_executed", "patch_attempted", "repository_write_attempted")
+        if _bool(execution.get(key))
+    ]
+    if execution_expanded:
+        raise ValueError(
+            "diagnostic worker execution expands authority: " + ", ".join(execution_expanded)
+        )
+
+    result_summary = _summary_projection(_as_dict(worker_result.get("summary")))
+    vector_summary = _summary_projection(_as_dict(diagnostic_vector.get("summary")))
+    if result_summary != vector_summary:
+        raise ValueError("diagnostic worker result summary does not match diagnostic vector")
+
+    vector_diagnoses = [
+        _as_dict(row) for row in _as_list(diagnostic_vector.get("diagnoses")) if _as_dict(row)
+    ]
+    result_primary = _as_dict(worker_result.get("primary_diagnosis"))
+    if vector_diagnoses:
+        vector_primary = vector_diagnoses[0]
+        for key in ("diagnosis_id", "failure_surface", "headline_failure", "actual_failure"):
+            if _string(result_primary.get(key)) != _string(vector_primary.get(key)):
+                raise ValueError(
+                    "diagnostic worker primary diagnosis does not match diagnostic vector"
+                )
+
+
+def build_worker_trajectory_records(
+    *,
+    job: Mapping[str, Any],
+    worker_result: Mapping[str, Any],
+    diagnostic_vector: Mapping[str, Any],
+    repo: str = "",
+    branch: str = "",
+    commit_sha: str = "",
+    pr_number: int = 0,
+    generated_at: str = DEFAULT_GENERATED_AT,
+) -> list[JsonObject]:
+    validate_worker_handoff(
+        job=job,
+        worker_result=worker_result,
+        diagnostic_vector=diagnostic_vector,
+    )
+    base_records = build_trajectory_records(
+        diagnostic_vector=diagnostic_vector,
+        repo=repo,
+        branch=branch,
+        commit_sha=commit_sha,
+        pr_number=pr_number,
+        generated_at=generated_at,
+    )
+
+    records: list[JsonObject] = []
+    for base_record in base_records:
+        record = copy.deepcopy(base_record)
+        observed_decision = _as_dict(record.get("decision"))
+        observed_fix = _as_dict(record.get("fix"))
+        original_id = _string(record.get("trajectory_id"))
+        record["trajectory_id"] = f"{original_id}-diagnostic-worker-observation"
+        record["environment"] = {
+            "runner": "github_actions",
+            "source": "diagnostic_worker_result",
+            "worker": WORKER_NAME,
+            "execution_mode": EXECUTION_MODE,
+        }
+        record["action"] = "record_diagnostic_worker_observation"
+        record["command"] = "none"
+        response = _as_dict(record.get("response"))
+        response["response_type"] = "diagnostic_worker_observation"
+        record["response"] = response
+        record["decision"] = {
+            "review_first": True,
+            "auto_fix_allowed": False,
+            "reason": "diagnostic worker trajectory is reporting-only evidence",
+        }
+        record["fix"] = {
+            "allowed_strategy": "none",
+            "patch_files": [],
+            "blocked_reason": "diagnostic worker trajectory is reporting-only evidence",
+        }
+        record["proof"] = {
+            "commands": [],
+            "focused_proof": "not_run",
+            "quality_proof": "not_run",
+            "verifier_result": "not_run",
+        }
+        record["final_result"] = "advisory_observation_recorded"
+        record["learned_pattern"] = "diagnostic_worker_observation"
+        record["worker_evidence"] = {
+            "job_id": _string(job.get("job_id")),
+            "worker_result_status": _string(worker_result.get("status")),
+            "observed_safe_fix_candidate": _bool(observed_decision.get("auto_fix_allowed"))
+            or bool(_as_list(observed_fix.get("patch_files"))),
+            "reporting_only": True,
+            "current_pr_decision_input": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        }
+        records.append(record)
+    return records
+
+
+def build_summary(
+    records: list[Mapping[str, Any]],
+    *,
+    worker_result: Mapping[str, Any],
+    trajectory_jsonl: str,
+) -> JsonObject:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "trajectory_schema_version": TRAJECTORY_SCHEMA_VERSION,
+        "status": "recorded",
+        "record_count": len(records),
+        "review_first_count": sum(
+            1 for row in records if _as_dict(row.get("decision")).get("review_first") is True
+        ),
+        "observed_safe_fix_candidate_count": sum(
+            1
+            for row in records
+            if _as_dict(row.get("worker_evidence")).get("observed_safe_fix_candidate") is True
+        ),
+        "worker_result_status": _string(worker_result.get("status")),
+        "trajectory_jsonl": trajectory_jsonl,
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def render_markdown(summary: Mapping[str, Any]) -> str:
+    lines = [
+        "## Local diagnostic worker trajectory handoff",
+        "",
+        "- Evidence type: `post_decision_reporting_only_trajectory`",
+        f"- Status: `{_string(summary.get('status'))}`",
+        f"- Records written: `{_int(summary.get('record_count'))}`",
+        f"- Review-first records: `{_int(summary.get('review_first_count'))}`",
+        (
+            "- Observed safe-fix candidates retained as advisory only: "
+            f"`{_int(summary.get('observed_safe_fix_candidate_count'))}`"
+        ),
+        f"- Reporting only: `{str(_bool(summary.get('reporting_only'))).lower()}`",
+        (
+            "- Current PR decision input: "
+            f"`{str(_bool(summary.get('current_pr_decision_input'))).lower()}`"
+        ),
+        (
+            "- Proof commands executed: "
+            f"`{str(_bool(summary.get('proof_commands_executed'))).lower()}`"
+        ),
+        (
+            "- Patch application allowed: "
+            f"`{str(_bool(summary.get('patch_application_allowed'))).lower()}`"
+        ),
+        f"- Automation allowed: `{str(_bool(summary.get('automation_allowed'))).lower()}`",
+        f"- Merge authorized: `{str(_bool(summary.get('merge_authorized'))).lower()}`",
+        (
+            "- Semantic equivalence proven: "
+            f"`{str(_bool(summary.get('semantic_equivalence_proven'))).lower()}`"
+        ),
+        "",
+        "- Interpretation: this separate trajectory records the DiagnosticWorkerResult for observation only; it is not consumed by current-run candidate decisions or RepoMemory.",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_artifacts(
+    records: list[Mapping[str, Any]],
+    *,
+    worker_result: Mapping[str, Any],
+    out_dir: Path,
+) -> JsonObject:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = out_dir / OUT_JSONL
+    write_trajectory_records(records, jsonl_path)
+    summary = build_summary(
+        records,
+        worker_result=worker_result,
+        trajectory_jsonl=jsonl_path.as_posix(),
+    )
+    summary_path = out_dir / SUMMARY_JSON
+    markdown_path = out_dir / REPORT_MD
+    _write_json(summary_path, summary)
+    markdown_path.write_text(render_markdown(summary), encoding="utf-8")
+    return {
+        "summary": summary,
+        "artifacts": {
+            "diagnostic_worker_trajectory_jsonl": jsonl_path.as_posix(),
+            "diagnostic_worker_trajectory_summary_json": summary_path.as_posix(),
+            "diagnostic_worker_trajectory_markdown": markdown_path.as_posix(),
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.diagnostic_worker_trajectory")
+    parser.add_argument("--diagnostic-job", type=Path, required=True)
+    parser.add_argument("--diagnostic-worker-result", type=Path, required=True)
+    parser.add_argument("--diagnostic-vector", type=Path, required=True)
+    parser.add_argument("--repo", default="")
+    parser.add_argument("--branch", default="")
+    parser.add_argument("--commit-sha", default="")
+    parser.add_argument("--pr-number", type=int, default=0)
+    parser.add_argument("--generated-at", default=DEFAULT_GENERATED_AT)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        job = _read_required_json(args.diagnostic_job)
+        worker_result = _read_required_json(args.diagnostic_worker_result)
+        diagnostic_vector = _read_required_json(args.diagnostic_vector)
+        records = build_worker_trajectory_records(
+            job=job,
+            worker_result=worker_result,
+            diagnostic_vector=diagnostic_vector,
+            repo=args.repo,
+            branch=args.branch,
+            commit_sha=args.commit_sha,
+            pr_number=args.pr_number,
+            generated_at=args.generated_at,
+        )
+        payload = write_artifacts(records, worker_result=worker_result, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            "diagnostic_worker_trajectory_jsonl: "
+            + payload["artifacts"]["diagnostic_worker_trajectory_jsonl"]
+        )
+        print(f"record_count: {payload['summary']['record_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_diagnostic_worker_trajectory.py
+++ b/tests/test_diagnostic_worker_trajectory.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.diagnostic_job import build_diagnostic_job, run_diagnostic_worker, write_artifacts
+from sdetkit.diagnostic_worker_trajectory import (
+    SCHEMA_VERSION,
+    build_worker_trajectory_records,
+    main,
+    render_markdown,
+)
+from sdetkit.diagnostic_worker_trajectory import (
+    write_artifacts as write_trajectory_artifacts,
+)
+
+
+def _job() -> dict:
+    return build_diagnostic_job(
+        repo="sherif69-sa/DevS69-sdetkit",
+        base_sha="base123",
+        head_sha="head123",
+        event_name="pull_request",
+        pr_number=1443,
+        input_artifacts={"check_intelligence": "build/check-intelligence.json"},
+        generated_at="2026-05-27T00:00:00Z",
+    )
+
+
+def _formatting_intelligence() -> dict:
+    return {
+        "failed_checks": [
+            {
+                "name": "PR Quality local quality gate",
+                "surface": "formatting",
+                "command": "python -m pre_commit run -a",
+                "scope": "pr_owned_only",
+                "diagnosis": {"title": "Pre-commit formatting drift", "surface": "formatting"},
+                "first_failure": {
+                    "line": "ruff format..............................Failed",
+                    "line_number": 30,
+                    "tool": "ruff",
+                    "kind": "format_drift",
+                },
+                "safe_to_auto_fix": True,
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "affected_files": ["src/sdetkit/example.py"],
+                },
+                "affected_files": ["src/sdetkit/example.py"],
+            }
+        ]
+    }
+
+
+def _worker_payloads(tmp_path: Path) -> tuple[dict, dict, dict]:
+    job = _job()
+    result = run_diagnostic_worker(
+        job,
+        check_intelligence=_formatting_intelligence(),
+        out_dir=tmp_path / "worker",
+    )
+    vector = json.loads(
+        (tmp_path / "worker" / "vector" / "diagnostic-vector.json").read_text(encoding="utf-8")
+    )
+    return job, result, vector
+
+
+def test_worker_trajectory_records_observed_candidates_as_advisory_only(tmp_path: Path) -> None:
+    job, result, vector = _worker_payloads(tmp_path)
+    records = build_worker_trajectory_records(
+        job=job,
+        worker_result=result,
+        diagnostic_vector=vector,
+        repo="sherif69-sa/DevS69-sdetkit",
+        branch="feature/diagnostic-worker-advisory-trajectory",
+        commit_sha="head123",
+        pr_number=1443,
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["environment"]["source"] == "diagnostic_worker_result"
+    assert record["action"] == "record_diagnostic_worker_observation"
+    assert record["decision"]["review_first"] is True
+    assert record["decision"]["auto_fix_allowed"] is False
+    assert record["fix"]["patch_files"] == []
+    assert record["proof"]["commands"] == []
+    assert record["final_result"] == "advisory_observation_recorded"
+    assert record["worker_evidence"]["observed_safe_fix_candidate"] is True
+    assert record["worker_evidence"]["reporting_only"] is True
+    assert record["worker_evidence"]["current_pr_decision_input"] is False
+    assert record["worker_evidence"]["automation_allowed"] is False
+    assert record["worker_evidence"]["merge_authorized"] is False
+
+
+def test_worker_trajectory_rejects_result_authority_or_mismatched_vector(tmp_path: Path) -> None:
+    job, result, vector = _worker_payloads(tmp_path)
+
+    result["decision_boundary"]["automation_allowed"] = True
+    with pytest.raises(ValueError, match="worker result expands authority"):
+        build_worker_trajectory_records(
+            job=job,
+            worker_result=result,
+            diagnostic_vector=vector,
+        )
+
+    job, result, vector = _worker_payloads(tmp_path / "second")
+    vector["summary"]["diagnosis_count"] = 99
+    with pytest.raises(ValueError, match="summary does not match diagnostic vector"):
+        build_worker_trajectory_records(
+            job=job,
+            worker_result=result,
+            diagnostic_vector=vector,
+        )
+
+
+def test_worker_trajectory_artifacts_render_reporting_only_boundary(tmp_path: Path) -> None:
+    job, result, vector = _worker_payloads(tmp_path)
+    records = build_worker_trajectory_records(
+        job=job,
+        worker_result=result,
+        diagnostic_vector=vector,
+    )
+    payload = write_trajectory_artifacts(
+        records,
+        worker_result=result,
+        out_dir=tmp_path / "trajectory",
+    )
+    summary = payload["summary"]
+
+    assert summary["schema_version"] == SCHEMA_VERSION
+    assert summary["record_count"] == 1
+    assert summary["observed_safe_fix_candidate_count"] == 1
+    assert summary["reporting_only"] is True
+    assert summary["current_pr_decision_input"] is False
+    assert summary["patch_application_allowed"] is False
+    assert summary["automation_allowed"] is False
+    assert summary["merge_authorized"] is False
+
+    markdown = render_markdown(summary)
+    assert "Local diagnostic worker trajectory handoff" in markdown
+    assert "Reporting only: `true`" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "not consumed by current-run candidate decisions or RepoMemory" in markdown
+
+
+def test_worker_trajectory_cli_writes_separate_jsonl_without_decision_authority(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    job, result, vector = _worker_payloads(tmp_path)
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    write_artifacts(job, result, out_dir=input_dir)
+    vector_path = tmp_path / "worker" / "vector" / "diagnostic-vector.json"
+    out_dir = tmp_path / "trajectory-out"
+
+    rc = main(
+        [
+            "--diagnostic-job",
+            str(input_dir / "diagnostic-job.json"),
+            "--diagnostic-worker-result",
+            str(input_dir / "diagnostic-worker-result.json"),
+            "--diagnostic-vector",
+            str(vector_path),
+            "--repo",
+            "sherif69-sa/DevS69-sdetkit",
+            "--branch",
+            "feature/diagnostic-worker-advisory-trajectory",
+            "--commit-sha",
+            "head123",
+            "--pr-number",
+            "1443",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["summary"]["reporting_only"] is True
+    assert printed["summary"]["automation_allowed"] is False
+    record = json.loads(
+        (out_dir / "diagnostic-worker-trajectory.jsonl").read_text(encoding="utf-8")
+    )
+    assert record["decision"]["auto_fix_allowed"] is False
+    assert (out_dir / "diagnostic-worker-trajectory-summary.json").exists()
+    assert (out_dir / "diagnostic-worker-trajectory.md").exists()

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -650,3 +650,70 @@ def test_pr_quality_workflow_keeps_failed_diagnostic_job_advisory_and_visible() 
     assert "Automation allowed: `false`" in build_comment
     assert "Merge authorized: `false`" in build_comment
     assert "base PR decision and report remain authoritative" in build_comment
+
+
+def test_pr_quality_workflow_records_diagnostic_worker_trajectory_as_post_decision_advisory_only() -> (
+    None
+):
+    text = _workflow_text()
+
+    pattern_insights = text.index("python -m sdetkit.trajectory_pattern_insights")
+    repo_memory = text.index("python -m sdetkit.repo_memory")
+    action_report = text.index("python -m sdetkit.pr_quality_action_report")
+    diagnostic_job = text.index("python -m sdetkit.diagnostic_job")
+    trajectory = text.index("python -m sdetkit.diagnostic_worker_trajectory")
+    trajectory_append = text.index(
+        "cat build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md"
+    )
+    action_report_command = text[
+        action_report : text.index("> build/pr-quality/pr-comment-metadata.json", action_report)
+    ]
+    repo_memory_command = text[
+        repo_memory : text.index("> build/pr-quality/repo-memory/repo-memory-cli.json", repo_memory)
+    ]
+
+    assert (
+        pattern_insights
+        < repo_memory
+        < action_report
+        < diagnostic_job
+        < trajectory
+        < trajectory_append
+    )
+    assert "diagnostic-worker-trajectory" not in action_report_command
+    assert "diagnostic-worker-trajectory" not in repo_memory_command
+    assert "--diagnostic-job build/pr-quality/diagnostic-job/diagnostic-job.json" in text
+    assert (
+        "--diagnostic-worker-result build/pr-quality/diagnostic-job/diagnostic-worker-result.json"
+        in text
+    )
+    assert (
+        "--diagnostic-vector build/pr-quality/diagnostic-job/vector/diagnostic-vector.json" in text
+    )
+    assert "build/pr-quality/diagnostic-job/trajectory/" in text
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_keeps_failed_diagnostic_worker_trajectory_visible_and_non_authorizing() -> (
+    None
+):
+    text = _workflow_text()
+    build_comment = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build verified operator evidence loop"
+        )
+    ]
+
+    assert "diagnostic_worker_trajectory_rc=2" in build_comment
+    assert "|| diagnostic_worker_trajectory_rc=$?" in build_comment
+    assert "diagnostic-worker-trajectory-exit-code.txt" in build_comment
+    assert "Local diagnostic worker trajectory handoff" in build_comment
+    assert "post_decision_reporting_only_trajectory" in build_comment
+    assert "Status: `collection_failed`" in build_comment
+    assert "Reporting only: `true`" in build_comment
+    assert "Current PR decision input: `false`" in build_comment
+    assert "Patch application allowed: `false`" in build_comment
+    assert "Automation allowed: `false`" in build_comment
+    assert "Merge authorized: `false`" in build_comment
+    assert "current-run candidate decisions and RepoMemory remain unchanged" in build_comment


### PR DESCRIPTION
## Summary
- Adds a separate `diagnostic_worker_trajectory` artifact handoff for completed local DiagnosticJob worker results.
- Validates the job, worker result, and diagnostic vector before writing a trajectory artifact.
- Converts any observed safe-fix candidate into a review-first, reporting-only trajectory record.
- Renders the advisory trajectory handoff in PR Quality after existing action-report and RepoMemory decisions are already built.
- Degrades visibly and non-blockingly if the advisory trajectory handoff cannot be collected.

## Why
Accepted main now proves the local read-only DiagnosticJob worker and its missing-input containment. The remaining gap is that a DiagnosticWorkerResult is visible in the PR comment and uploaded artifact bundle, but is not represented as an explicit trajectory handoff artifact.

This PR connects that output to a dedicated advisory trajectory without allowing it to affect current-run candidate decisions or RepoMemory.

## Data flow
```text
existing PR Quality decisions and RepoMemory
→ DiagnosticJob / DiagnosticWorkerResult
→ validated DiagnosticWorkerResult + DiagnosticVector handoff
→ separate advisory diagnostic-worker trajectory artifact
→ appended PR Quality reporting-only section
```

## Safety boundary
```text
reporting_only=true
current_pr_decision_input=false
proof_commands_executed=false
patch_application_allowed=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
current_run_candidate_decisions_unchanged=true
repo_memory_inputs_unchanged=true
repository_content_write_added=false
automatic_remediation_added=false
```

## Scope
- `.github/workflows/pr-quality-comment.yml`
- `docs/roadmap/manifest.json`
- `src/sdetkit/diagnostic_worker_trajectory.py`
- `tests/test_diagnostic_worker_trajectory.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

The manifest update is generated evidence required by the new module and tests.

## Local validation
- Focused advisory trajectory suite: `109 passed`.
- Post-manifest focused suite: `112 passed`.
- Full pytest suite: `3721 passed, 1 skipped`.
- New/modified Python file security finding check: `0` warn/error findings.
- The repository-wide security command remains non-zero only for existing baseline findings outside the PR-owned Python files.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- `git diff --cached --check`: passed.

## Reliability behavior
If the advisory trajectory handoff fails, PR Quality appends a visible `collection_failed` section stating that current-run candidate decisions and RepoMemory remain unchanged. The handoff cannot suppress the authoritative report or grant action authority.

## Risk
Medium. This adds a new workflow-generated reporting artifact and comment section. It is explicitly post-decision, separate from current-run memory/candidate inputs, and defended by no-authority and failure-visibility tests.

## Next
Use the live PR Quality run to prove the new advisory trajectory section is rendered as non-authorizing. Do not feed this trajectory into trusted history or automated actions in the same step.
