### PR TITLE
Diagnose runtime guard evidence in local worker

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -617,6 +617,7 @@ jobs:
             --evidence-graph build/sdetkit/evidence-graph/evidence-graph.json \
             --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
             --security-review build/pr-quality/security-diagnosis/security-finding-diagnosis.json \
+            --runtime-proof-artifacts build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json \
             --repo "$REPOSITORY" \
             --base-sha "$PR_BASE_SHA" \
             --head-sha "$HEAD_SHA" \

--- a/src/sdetkit/diagnostic_job.py
+++ b/src/sdetkit/diagnostic_job.py
@@ -200,6 +200,7 @@ def run_diagnostic_worker(
     evidence_graph: Mapping[str, Any] | None = None,
     pr_quality_action_report: Mapping[str, Any] | None = None,
     security_review: Mapping[str, Any] | None = None,
+    runtime_proof_artifacts: Mapping[str, Any] | None = None,
     out_dir: Path,
 ) -> JsonObject:
     validate_job(job)
@@ -208,6 +209,7 @@ def run_diagnostic_worker(
         evidence_graph=evidence_graph,
         pr_quality_action_report=pr_quality_action_report,
         security_review=security_review,
+        runtime_proof_artifacts=runtime_proof_artifacts,
         generated_at=_string(job.get("created_at")) or DEFAULT_GENERATED_AT,
     )
     vector_artifacts = write_diagnostic_vector(vector, out_dir / VECTOR_DIR)
@@ -319,6 +321,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--evidence-graph", type=Path)
     parser.add_argument("--pr-quality-action-report", type=Path)
     parser.add_argument("--security-review", type=Path)
+    parser.add_argument("--runtime-proof-artifacts", type=Path)
     parser.add_argument("--repo", default="")
     parser.add_argument("--base-sha", default="")
     parser.add_argument("--head-sha", required=True)
@@ -337,6 +340,7 @@ def main(argv: list[str] | None = None) -> int:
         "evidence_graph": str(args.evidence_graph or ""),
         "pr_quality_action_report": str(args.pr_quality_action_report or ""),
         "security_review": str(args.security_review or ""),
+        "runtime_proof_artifacts": str(args.runtime_proof_artifacts or ""),
     }
     try:
         job = build_diagnostic_job(
@@ -354,6 +358,7 @@ def main(argv: list[str] | None = None) -> int:
             evidence_graph=_read_json(args.evidence_graph),
             pr_quality_action_report=_read_json(args.pr_quality_action_report),
             security_review=_read_json(args.security_review),
+            runtime_proof_artifacts=_read_json(args.runtime_proof_artifacts),
             out_dir=args.out_dir,
         )
         artifacts = write_artifacts(job, result, out_dir=args.out_dir)

--- a/src/sdetkit/diagnostic_vector_engine.py
+++ b/src/sdetkit/diagnostic_vector_engine.py
@@ -364,6 +364,7 @@ def _failure_class(
         "lint",
         "type",
         "test",
+        "runtime_guard",
         "dependency",
         "merge_conflict",
         "flaky",
@@ -399,6 +400,8 @@ def _failure_class(
         return "formatter_only"
     if surface == "type_contract" or "mypy" in haystack:
         return "type"
+    if "runtime_guard" in haystack or "runtime guard" in haystack:
+        return "runtime_guard"
     if surface in {"test", "runtime"} or "pytest" in haystack or "assertion" in haystack:
         return "test"
     if surface == "quality" and "coverage" in haystack:
@@ -676,6 +679,52 @@ def _vectors_from_security_review(
     return vectors
 
 
+def _vectors_from_runtime_proof_artifacts(
+    payload: Mapping[str, Any],
+    *,
+    safe_fix_history: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    isolated = _as_dict(payload.get("isolated_proof"))
+    if not isolated:
+        return []
+    if not _bool(isolated.get("runtime_guard_checked")):
+        return []
+    if _bool(isolated.get("runtime_guard_passed")):
+        return []
+
+    violation_count = int(isolated.get("runtime_guard_violation_count", 0) or 0)
+    first_line = f"runtime_guard_passed=false; runtime_guard_violation_count={violation_count}"
+    adapted = {
+        "name": "Isolated runtime proof guard",
+        "title": "Runtime guard violation observed",
+        "surface": "runtime",
+        "classification": "runtime_guard",
+        "actual_failure": first_line,
+        "first_failure_line": first_line,
+        "tool": "runtime_guard",
+        "kind": "runtime_guard_violation",
+        "review_first": True,
+        "safe_to_auto_fix": False,
+        "scope": "proof_boundary",
+        "environment": "github_actions",
+        "safe_remediation": {
+            "strategy": "review_first",
+            "reason": "runtime guard violations require human review and focused proof",
+        },
+        "proof_commands": [
+            "python -m pytest -q tests/test_protected_verifier.py tests/test_pr_quality_runtime_proof_artifacts.py -o addopts="
+        ],
+        "evidence_sources": ["runtime_proof_artifacts"],
+    }
+    return [
+        _vector_from_record(
+            adapted,
+            source="runtime_proof_artifacts",
+            safe_fix_history=safe_fix_history,
+        )
+    ]
+
+
 def _vectors_from_action_report(
     payload: Mapping[str, Any],
     *,
@@ -736,6 +785,7 @@ def build_diagnostic_vector(
     test_failure_bundle: Mapping[str, Any] | None = None,
     evidence_graph: Mapping[str, Any] | None = None,
     pr_quality_action_report: Mapping[str, Any] | None = None,
+    runtime_proof_artifacts: Mapping[str, Any] | None = None,
     operator_loop: Mapping[str, Any] | None = None,
     generated_at: str = DEFAULT_GENERATED_AT,
 ) -> dict[str, Any]:
@@ -768,6 +818,12 @@ def build_diagnostic_vector(
     vectors.extend(
         _vectors_from_action_report(
             _as_dict(pr_quality_action_report),
+            safe_fix_history=safe_fix_history,
+        )
+    )
+    vectors.extend(
+        _vectors_from_runtime_proof_artifacts(
+            _as_dict(runtime_proof_artifacts),
             safe_fix_history=safe_fix_history,
         )
     )
@@ -831,6 +887,7 @@ def build_diagnostic_vector(
             "test_failure_bundle": bool(test_failure_bundle),
             "evidence_graph": bool(evidence_graph),
             "pr_quality_action_report": bool(pr_quality_action_report),
+            "runtime_proof_artifacts": bool(runtime_proof_artifacts),
             "operator_loop": bool(operator_loop),
         },
     }
@@ -919,6 +976,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--test-failure-bundle", default="")
     parser.add_argument("--evidence-graph", default="")
     parser.add_argument("--pr-quality-action-report", default="")
+    parser.add_argument("--runtime-proof-artifacts", default="")
     parser.add_argument("--operator-loop", default="")
     parser.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
     parser.add_argument("--generated-at", default=DEFAULT_GENERATED_AT)
@@ -946,6 +1004,7 @@ def main(argv: list[str] | None = None) -> int:
             test_failure_bundle=_read_json(_optional_path(args.test_failure_bundle)),
             evidence_graph=_read_json(_optional_path(args.evidence_graph)),
             pr_quality_action_report=_read_json(_optional_path(args.pr_quality_action_report)),
+            runtime_proof_artifacts=_read_json(_optional_path(args.runtime_proof_artifacts)),
             operator_loop=_read_json(_optional_path(args.operator_loop)),
             generated_at=args.generated_at,
         )

--- a/tests/test_diagnostic_job.py
+++ b/tests/test_diagnostic_job.py
@@ -183,3 +183,37 @@ def test_diagnostic_job_cli_rejects_declared_missing_evidence_input(
     assert "declared diagnostic job evidence input is missing" in capsys.readouterr().out
     assert not (out_dir / "diagnostic-worker-result.json").exists()
     assert not (out_dir / "diagnostic-job.md").exists()
+
+
+def test_diagnostic_worker_surfaces_runtime_guard_violation_as_read_only_review_first_evidence(
+    tmp_path: Path,
+) -> None:
+    result = run_diagnostic_worker(
+        _job(),
+        runtime_proof_artifacts={
+            "isolated_proof": {
+                "collection_status": "collected",
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": False,
+                "runtime_guard_violation_count": 1,
+            }
+        },
+        out_dir=tmp_path,
+    )
+
+    assert result["summary"]["diagnosis_count"] == 1
+    assert result["summary"]["primary_surface"] == "runtime"
+    assert result["summary"]["primary_action"] == "review_first_runtime_debug"
+    assert result["primary_diagnosis"]["actual_failure"] == (
+        "runtime_guard_passed=false; runtime_guard_violation_count=1"
+    )
+    assert result["primary_diagnosis"]["review_first"] is True
+    assert result["primary_diagnosis"]["safe_fix_candidate"] is False
+    assert result["decision_boundary"]["current_pr_decision_input"] is False
+    assert result["decision_boundary"]["automation_allowed"] is False
+    assert result["decision_boundary"]["merge_authorized"] is False
+
+    markdown = render_markdown(_job(), result)
+    assert "Primary surface: `runtime`" in markdown
+    assert "Primary action: `review_first_runtime_debug`" in markdown
+    assert "Runtime guard violation observed" in markdown

--- a/tests/test_diagnostic_vector_engine.py
+++ b/tests/test_diagnostic_vector_engine.py
@@ -283,3 +283,51 @@ def test_diagnostic_vector_cli_writes_failure_vector_json(tmp_path: Path, capsys
     assert failure_vector_doc["summary"]["failure_vector_count"] == 1
     assert failure_vector_doc["failure_vectors"][0]["failure_class"] == "formatter_only"
     assert failure_vector_doc["failure_vectors"][0]["safe_fix_candidate"] is True
+
+
+def test_diagnostic_vector_emits_review_first_runtime_guard_violation_from_runtime_proof_artifacts() -> (
+    None
+):
+    payload = build_diagnostic_vector(
+        runtime_proof_artifacts={
+            "isolated_proof": {
+                "collection_status": "collected",
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": False,
+                "runtime_guard_violation_count": 1,
+            }
+        }
+    )
+
+    diagnosis = payload["diagnoses"][0]
+    vector = diagnosis["failure_vector"]
+    assert payload["summary"]["diagnosis_count"] == 1
+    assert payload["summary"]["review_first_count"] == 1
+    assert payload["source_status"]["runtime_proof_artifacts"] is True
+    assert diagnosis[FAILURE_SURFACE] == "runtime"
+    assert (
+        diagnosis[ACTUAL_FAILURE] == "runtime_guard_passed=false; runtime_guard_violation_count=1"
+    )
+    assert diagnosis[REVIEW_FIRST] is True
+    assert diagnosis[SAFE_FIX_CANDIDATE] is False
+    assert diagnosis[RECOMMENDED_NEXT_ACTION] == "review_first_runtime_debug"
+    assert vector["source"] == "runtime_proof_artifacts"
+    assert vector["failure_class"] == "runtime_guard"
+    assert vector["scope"] == "proof_boundary"
+
+
+def test_diagnostic_vector_does_not_emit_runtime_guard_diagnosis_when_guard_passes() -> None:
+    payload = build_diagnostic_vector(
+        runtime_proof_artifacts={
+            "isolated_proof": {
+                "collection_status": "collected",
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": True,
+                "runtime_guard_violation_count": 0,
+            }
+        }
+    )
+
+    assert payload["diagnoses"] == []
+    assert payload["summary"]["diagnosis_count"] == 0
+    assert payload["source_status"]["runtime_proof_artifacts"] is True

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -717,3 +717,32 @@ def test_pr_quality_workflow_keeps_failed_diagnostic_worker_trajectory_visible_a
     assert "Automation allowed: `false`" in build_comment
     assert "Merge authorized: `false`" in build_comment
     assert "current-run candidate decisions and RepoMemory remain unchanged" in build_comment
+
+
+def test_pr_quality_diagnostic_job_consumes_runtime_guard_summary_after_primary_decision_render() -> (
+    None
+):
+    text = _workflow_text()
+
+    action_report = text.index("python -m sdetkit.pr_quality_action_report")
+    diagnostic_job = text.index("python -m sdetkit.diagnostic_job")
+    diagnostic_job_command = text[
+        diagnostic_job : text.index(
+            "> build/pr-quality/diagnostic-job/diagnostic-job-cli.json", diagnostic_job
+        )
+    ]
+    action_report_command = text[
+        action_report : text.index("> build/pr-quality/pr-comment-metadata.json", action_report)
+    ]
+
+    assert action_report < diagnostic_job
+    assert (
+        "--runtime-proof-artifacts build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json"
+        in diagnostic_job_command
+    )
+    assert (
+        "--runtime-proof-artifacts build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json"
+        in action_report_command
+    )
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text


### PR DESCRIPTION
## Summary
- Wires the existing PR Quality runtime-proof summary into the post-decision local DiagnosticJob worker.
- Adds a `runtime_guard` failure-vector classification for runtime guard violations.
- Emits review-first runtime diagnosis evidence when `runtime_guard_passed=false`.
- Preserves the advisory trajectory and all no-authority boundaries.

## Why
The live advisory-trajectory PR reported `Runtime guard passed: false` with one violation, but the local DiagnosticJob worker did not consume `runtime-proof-artifacts.json`. This PR closes that real diagnosis gap without changing action eligibility.

## Diagnosis contract
```text
failure_surface=runtime
failure_class=runtime_guard
actual_failure=runtime_guard_passed=false; runtime_guard_violation_count=1
recommended_next_action=review_first_runtime_debug
safe_fix_candidate=false
review_first=true
```

## Safety boundary
```text
worker_runs_post_decision=true
current_pr_decision_input=false
patch_application_allowed=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
diagnostic_worker_trajectory_reporting_only=true
repo_memory_inputs_unchanged=true
automatic_remediation_added=false
```

## Scope
- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/diagnostic_job.py`
- `src/sdetkit/diagnostic_vector_engine.py`
- `tests/test_diagnostic_job.py`
- `tests/test_diagnostic_vector_engine.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

`docs/roadmap/manifest.json` remains fresh and unchanged.

## Local validation
- Focused runtime-guard diagnosis suite: `111 passed`.
- Post-manifest focused suite: `114 passed`.
- Full pytest suite: `3725 passed, 1 skipped`.
- Modified Python file security finding check: `0` warn/error findings.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- Controlled runtime-guard DiagnosticJob to advisory-trajectory proof: passed.

## Next
Use the live PR Quality run to confirm the worker surfaces runtime-guard evidence as review-first and the derived trajectory remains reporting-only.
