### PR TITLE
Replay runtime guard worker evidence in benchmark harness

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -700,6 +700,15 @@ jobs:
             --format json \
             > build/pr-quality/candidate-validation/candidate-validation-cli.json
 
+          mkdir -p build/pr-quality/runtime-guard-benchmark
+          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
+            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_oracle.json \
+            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_nop.json \
+            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_unsafe.json \
+            --out-dir build/pr-quality/runtime-guard-benchmark \
+            --format json \
+            > build/pr-quality/runtime-guard-benchmark/runtime-guard-benchmark-cli.json
+
           if [ -s build/pr-quality/diagnostic-job/diagnostic-job.md ]; then
             printf '\n' >> build/pr-quality/pr-comment-body.md
             cat build/pr-quality/diagnostic-job/diagnostic-job.md >> build/pr-quality/pr-comment-body.md
@@ -717,6 +726,9 @@ jobs:
 
           printf '\n' >> build/pr-quality/pr-comment-body.md
           cat build/pr-quality/candidate-validation/candidate-validation.md >> build/pr-quality/pr-comment-body.md
+
+          printf '\n' >> build/pr-quality/pr-comment-body.md
+          cat build/pr-quality/runtime-guard-benchmark/benchmark-report.md >> build/pr-quality/pr-comment-body.md
 
       - name: Build verified operator evidence loop
         if: always()
@@ -781,6 +793,7 @@ jobs:
             build/pr-quality/diagnostic-job/
             build/pr-quality/candidate-visibility/
             build/pr-quality/candidate-validation/
+            build/pr-quality/runtime-guard-benchmark/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
             build/sdetkit/operator-loop/

--- a/src/sdetkit/replayable_benchmark_harness.py
+++ b/src/sdetkit/replayable_benchmark_harness.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import tempfile
 from collections import Counter
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from sdetkit.diagnostic_job import build_diagnostic_job, run_diagnostic_worker
+from sdetkit.diagnostic_worker_trajectory import build_worker_trajectory_records
 from sdetkit.git_inventory_collector import STAGED_WORKTREE
 from sdetkit.isolated_proof_runner import INVENTORY_CLAIM_MATCH, run_isolated_proof
 from sdetkit.network_boundary import NETWORK_ISOLATION_ENFORCED, NETWORK_ISOLATION_REQUIRED
@@ -29,6 +32,23 @@ ANTI_CHEAT_REJECTION_COUNT = "_".join(("anti", "cheat", "rejection", "count"))
 LIVE_EVIDENCE_SOURCE = "_".join(("git", "grounded", "isolated", "proof"))
 LIVE_EXECUTION_MODEL = "_".join(("git", "derived", "isolated", "proof", "evaluation"))
 VERIFICATION_EVIDENCE_SOURCE = "_".join(("verification", "evidence", "source"))
+DIAGNOSTIC_WORKER_REPORT_SCHEMA_VERSION = (
+    "sdetkit.replayable_benchmark_harness.diagnostic_worker.v1"
+)
+DIAGNOSTIC_WORKER_REPORT_MODE = "diagnostic_worker_runtime_guard_fixture"
+RUNTIME_GUARD_WORKER_ORACLE_PASS = "runtime_guard_worker_oracle_pass"
+RUNTIME_GUARD_WORKER_NOP_PASS = "runtime_guard_worker_nop_pass"
+RUNTIME_GUARD_WORKER_AUTHORITY_FAIL = "runtime_guard_worker_authority_fail"
+DIAGNOSTIC_WORKER_SCENARIO_TYPES = {
+    RUNTIME_GUARD_WORKER_ORACLE_PASS,
+    RUNTIME_GUARD_WORKER_NOP_PASS,
+    RUNTIME_GUARD_WORKER_AUTHORITY_FAIL,
+}
+DIAGNOSTIC_WORKER_REQUIRED_SCENARIO_TYPES = (
+    RUNTIME_GUARD_WORKER_ORACLE_PASS,
+    RUNTIME_GUARD_WORKER_NOP_PASS,
+    RUNTIME_GUARD_WORKER_AUTHORITY_FAIL,
+)
 
 SCENARIO_TYPES = {
     "nop_fail",
@@ -113,6 +133,30 @@ def load_scenarios(paths: list[Path]) -> list[JsonObject]:
             msg = f"unsupported scenario_type for {scenario_id}: {scenario_type}"
             raise ValueError(msg)
 
+        identifiers.add(scenario_id)
+        scenarios.append(scenario)
+
+    return scenarios
+
+
+def load_diagnostic_worker_scenarios(paths: list[Path]) -> list[JsonObject]:
+    scenarios: list[JsonObject] = []
+    identifiers: set[str] = set()
+
+    for path in paths:
+        scenario = _read_json_object(path)
+        scenario_id = _string(scenario.get("scenario_id"))
+        scenario_type = _string(scenario.get("scenario_type"))
+        if not scenario_id:
+            raise ValueError(f"scenario_id is required in {path}")
+        if scenario_id in identifiers:
+            raise ValueError(f"duplicate scenario_id: {scenario_id}")
+        if scenario_type not in DIAGNOSTIC_WORKER_SCENARIO_TYPES:
+            raise ValueError(
+                f"unsupported diagnostic worker scenario_type for {scenario_id}: {scenario_type}"
+            )
+        if not _as_dict(scenario.get("runtime_proof_artifacts")):
+            raise ValueError(f"runtime_proof_artifacts is required in {path}")
         identifiers.add(scenario_id)
         scenarios.append(scenario)
 
@@ -676,6 +720,256 @@ def build_isolated_evidence_report(
     }
 
 
+def _run_diagnostic_worker_fixture(
+    scenario: Mapping[str, Any],
+) -> tuple[JsonObject, JsonObject, JsonObject]:
+    scenario_id = _string(scenario.get("scenario_id"))
+    job = build_diagnostic_job(
+        repo="controlled-fixture/replayable-benchmark",
+        base_sha="fixture-base",
+        head_sha=f"fixture-head-{scenario_id}",
+        event_name="replayable_benchmark",
+        pr_number=0,
+        input_artifacts={"runtime_proof_artifacts": f"fixture:{scenario_id}"},
+    )
+    with tempfile.TemporaryDirectory(prefix="sdetkit-runtime-worker-benchmark-") as temp_dir:
+        worker_dir = Path(temp_dir) / "worker"
+        result = run_diagnostic_worker(
+            job,
+            runtime_proof_artifacts=_as_dict(scenario.get("runtime_proof_artifacts")),
+            out_dir=worker_dir,
+        )
+        vector = _read_json_object(worker_dir / "vector" / "diagnostic-vector.json")
+    return job, result, vector
+
+
+def evaluate_diagnostic_worker_scenario(scenario: Mapping[str, Any]) -> JsonObject:
+    scenario_id = _string(scenario.get("scenario_id"))
+    scenario_type = _string(scenario.get("scenario_type"))
+    if scenario_type not in DIAGNOSTIC_WORKER_SCENARIO_TYPES:
+        raise ValueError(f"unsupported diagnostic worker scenario_type: {scenario_type}")
+
+    job, worker_result, diagnostic_vector = _run_diagnostic_worker_fixture(scenario)
+    result_summary = _as_dict(worker_result.get("summary"))
+    primary = _as_dict(worker_result.get("primary_diagnosis"))
+    boundary = _as_dict(worker_result.get("decision_boundary"))
+    expected = _as_dict(scenario.get("expected"))
+    diagnoses = [_as_dict(item) for item in _as_list(diagnostic_vector.get("diagnoses"))]
+    failure_vector = _as_dict(diagnoses[0].get("failure_vector")) if diagnoses else {}
+    checks: list[JsonObject] = [
+        _check(
+            name="worker_automation_boundary",
+            passed=not _bool(boundary.get("automation_allowed")),
+            expected=False,
+            actual=_bool(boundary.get("automation_allowed")),
+        ),
+        _check(
+            name="worker_merge_boundary",
+            passed=not _bool(boundary.get("merge_authorized")),
+            expected=False,
+            actual=_bool(boundary.get("merge_authorized")),
+        ),
+        _check(
+            name="worker_semantic_boundary",
+            passed=not _bool(boundary.get("semantic_equivalence_proven")),
+            expected=False,
+            actual=_bool(boundary.get("semantic_equivalence_proven")),
+        ),
+    ]
+    trajectory_records: list[JsonObject] = []
+    observed_error = ""
+
+    if scenario_type == RUNTIME_GUARD_WORKER_ORACLE_PASS:
+        trajectory_records = build_worker_trajectory_records(
+            job=job,
+            worker_result=worker_result,
+            diagnostic_vector=diagnostic_vector,
+            repo="controlled-fixture/replayable-benchmark",
+            branch="fixture",
+            commit_sha="fixture-runtime-worker-oracle",
+        )
+        record = _as_dict(trajectory_records[0]) if trajectory_records else {}
+        decision = _as_dict(record.get("decision"))
+        proof = _as_dict(record.get("proof"))
+        worker_evidence = _as_dict(record.get("worker_evidence"))
+        checks.extend(
+            [
+                _check(
+                    name="runtime_guard_failure_class",
+                    passed=_string(failure_vector.get("failure_class"))
+                    == _string(expected.get("failure_class")),
+                    expected=_string(expected.get("failure_class")),
+                    actual=_string(failure_vector.get("failure_class")),
+                ),
+                _check(
+                    name="runtime_guard_surface",
+                    passed=_string(primary.get("failure_surface"))
+                    == _string(expected.get("primary_surface")),
+                    expected=_string(expected.get("primary_surface")),
+                    actual=_string(primary.get("failure_surface")),
+                ),
+                _check(
+                    name="runtime_guard_action",
+                    passed=_string(result_summary.get("primary_action"))
+                    == _string(expected.get("primary_action")),
+                    expected=_string(expected.get("primary_action")),
+                    actual=_string(result_summary.get("primary_action")),
+                ),
+                _check(
+                    name="runtime_guard_review_first",
+                    passed=_bool(primary.get("review_first"))
+                    and not _bool(primary.get("safe_fix_candidate")),
+                    expected=True,
+                    actual=_bool(primary.get("review_first"))
+                    and not _bool(primary.get("safe_fix_candidate")),
+                ),
+                _check(
+                    name="runtime_guard_advisory_trajectory",
+                    passed=len(trajectory_records) == 1
+                    and _bool(decision.get("review_first"))
+                    and not _bool(decision.get("auto_fix_allowed"))
+                    and _as_list(proof.get("commands")) == []
+                    and _bool(worker_evidence.get("reporting_only")),
+                    expected=True,
+                    actual=len(trajectory_records) == 1
+                    and _bool(decision.get("review_first"))
+                    and not _bool(decision.get("auto_fix_allowed"))
+                    and _as_list(proof.get("commands")) == []
+                    and _bool(worker_evidence.get("reporting_only")),
+                ),
+            ]
+        )
+    elif scenario_type == RUNTIME_GUARD_WORKER_NOP_PASS:
+        trajectory_records = build_worker_trajectory_records(
+            job=job,
+            worker_result=worker_result,
+            diagnostic_vector=diagnostic_vector,
+            repo="controlled-fixture/replayable-benchmark",
+            branch="fixture",
+            commit_sha="fixture-runtime-worker-nop",
+        )
+        checks.extend(
+            [
+                _check(
+                    name="passing_guard_emits_no_diagnosis",
+                    passed=_int(result_summary.get("diagnosis_count")) == 0 and not diagnoses,
+                    expected=True,
+                    actual=_int(result_summary.get("diagnosis_count")) == 0 and not diagnoses,
+                ),
+                _check(
+                    name="passing_guard_emits_no_trajectory",
+                    passed=trajectory_records == [],
+                    expected=[],
+                    actual=trajectory_records,
+                ),
+            ]
+        )
+    else:
+        forged = json.loads(json.dumps(worker_result))
+        forged_boundary = _as_dict(scenario.get("forged_worker_boundary"))
+        _as_dict(forged.get("decision_boundary")).update(forged_boundary)
+        expected_error = _string(scenario.get("expected_error"))
+        rejected = False
+        try:
+            build_worker_trajectory_records(
+                job=job,
+                worker_result=forged,
+                diagnostic_vector=diagnostic_vector,
+                repo="controlled-fixture/replayable-benchmark",
+                branch="fixture",
+                commit_sha="fixture-runtime-worker-unsafe",
+            )
+        except ValueError as exc:
+            observed_error = str(exc)
+            rejected = expected_error in observed_error
+        checks.extend(
+            [
+                _check(
+                    name="forged_worker_authority_rejected",
+                    passed=rejected,
+                    expected=expected_error,
+                    actual=observed_error,
+                ),
+                _check(
+                    name="forged_worker_emits_no_trajectory",
+                    passed=trajectory_records == [],
+                    expected=[],
+                    actual=trajectory_records,
+                ),
+            ]
+        )
+
+    passed = all(_bool(item.get("passed")) for item in checks)
+    return {
+        "scenario_id": scenario_id,
+        "scenario_type": scenario_type,
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "attempt_scored": False,
+        "attempt_score": 0,
+        "checks": checks,
+        "diagnosis_count": _int(result_summary.get("diagnosis_count")),
+        "trajectory_record_count": len(trajectory_records),
+        "observed_error": observed_error,
+    }
+
+
+def build_diagnostic_worker_benchmark_report(scenarios: list[Mapping[str, Any]]) -> JsonObject:
+    results = [evaluate_diagnostic_worker_scenario(scenario) for scenario in scenarios]
+    type_counts = Counter(_string(item.get("scenario_type")) for item in results)
+    required_present = all(
+        type_counts.get(item, 0) >= 1 for item in DIAGNOSTIC_WORKER_REQUIRED_SCENARIO_TYPES
+    )
+    required_passed = all(
+        any(
+            result.get("scenario_type") == scenario_type and result.get("passed") is True
+            for result in results
+        )
+        for scenario_type in DIAGNOSTIC_WORKER_REQUIRED_SCENARIO_TYPES
+    )
+    passed_count = sum(1 for item in results if item.get("passed") is True)
+    boundary = {
+        "execution_model": "_".join(
+            ("read", "only", "diagnostic", "worker", "fixture", "evaluation")
+        ),
+        "automation_allowed_count": 0,
+        "merge_authorized_count": 0,
+        "semantic_equivalence_claimed_count": 0,
+        "preserved": True,
+        "contributes_to_current_pr_decision": False,
+        "feeds_repo_memory": False,
+        "executes_patch": False,
+        "protected_verifier_semantics_expanded": False,
+    }
+    passed = bool(results) and passed_count == len(results) and required_present and required_passed
+    return {
+        "schema_version": DIAGNOSTIC_WORKER_REPORT_SCHEMA_VERSION,
+        "report_mode": DIAGNOSTIC_WORKER_REPORT_MODE,
+        "status": "passed" if passed else "failed",
+        "scenario_count": len(results),
+        "passed_count": passed_count,
+        "failed_count": len(results) - passed_count,
+        "scenario_type_counts": dict(sorted(type_counts.items())),
+        "required_contract": {
+            "required_scenario_types": list(DIAGNOSTIC_WORKER_REQUIRED_SCENARIO_TYPES),
+            "all_required_present": required_present,
+            "all_required_passed": required_passed,
+            "oracle_pass_rate": _type_rate(results, RUNTIME_GUARD_WORKER_ORACLE_PASS),
+            "nop_pass_rate": _type_rate(results, RUNTIME_GUARD_WORKER_NOP_PASS),
+            "unsafe_authority_rejection_rate": _type_rate(
+                results, RUNTIME_GUARD_WORKER_AUTHORITY_FAIL
+            ),
+        },
+        "safety_boundary": boundary,
+        "attempt_scored_count": 0,
+        "scenarios": results,
+        "next_boundary": (
+            "Keep runtime-guard worker benchmark evidence non-authorizing; "
+            "do not add remediation authority."
+        ),
+    }
+
+
 def render_markdown(report: Mapping[str, Any]) -> str:
     required = _as_dict(report.get("required_contract"))
     boundary = _as_dict(report.get("safety_boundary"))
@@ -683,6 +977,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     scenarios = [_as_dict(item) for item in _as_list(report.get("scenarios"))]
     report_mode = _string(report.get("report_mode") or "fixture_declared")
     is_live = report_mode == LIVE_EVIDENCE_SOURCE
+    is_diagnostic_worker = report_mode == DIAGNOSTIC_WORKER_REPORT_MODE
 
     lines = [
         "# Replayable Benchmark Harness report",
@@ -696,7 +991,41 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         "",
     ]
 
-    if is_live:
+    if is_diagnostic_worker:
+        lines.extend(
+            [
+                "## Required runtime-guard worker replay contract",
+                "",
+                (
+                    "- All required scenarios present: "
+                    f"`{str(_bool(required.get('all_required_present'))).lower()}`"
+                ),
+                (
+                    "- All required scenarios passed: "
+                    f"`{str(_bool(required.get('all_required_passed'))).lower()}`"
+                ),
+                (
+                    "- Oracle pass rate: "
+                    f"`{float(required.get('oracle_pass_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (f"- NOP pass rate: `{float(required.get('nop_pass_rate', 0.0) or 0.0):.4f}`"),
+                (
+                    "- Unsafe authority rejection rate: "
+                    f"`{float(required.get('unsafe_authority_rejection_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (
+                    "- Current PR decision input: "
+                    f"`{str(_bool(boundary.get('contributes_to_current_pr_decision'))).lower()}`"
+                ),
+                f"- Feeds RepoMemory: `{str(_bool(boundary.get('feeds_repo_memory'))).lower()}`",
+                (
+                    "- ProtectedVerifier semantics expanded: "
+                    f"`{str(_bool(boundary.get('protected_verifier_semantics_expanded'))).lower()}`"
+                ),
+                "",
+            ]
+        )
+    elif is_live:
         lines.extend(
             [
                 "## Required Git-grounded live-evidence contract",
@@ -816,7 +1145,16 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         )
 
     lines.extend(["", "## Boundary", ""])
-    if is_live:
+    if is_diagnostic_worker:
+        lines.extend(
+            [
+                "- This harness replays runtime-guard DiagnosticWorker behavior through controlled fixture inputs.",
+                "- It records oracle, NOP, and unsafe-authority outcomes without applying patches.",
+                "- It does not feed current PR decisions or RepoMemory.",
+                "- It does not expand ProtectedVerifier semantic claims or authorize automation.",
+            ]
+        )
+    elif is_live:
         lines.extend(
             [
                 "- This harness executes allowlisted proof profiles in disposable workspace copies.",
@@ -860,6 +1198,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fixture-backed benchmark scenario JSON. May be supplied more than once.",
     )
     parser.add_argument(
+        "--diagnostic-worker-scenario",
+        type=Path,
+        action="append",
+        default=[],
+        help="Controlled DiagnosticWorker runtime-guard scenario JSON.",
+    )
+    parser.add_argument(
         "--isolated-scenario",
         type=Path,
         action="append",
@@ -882,7 +1227,15 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        if args.isolated_scenario:
+        if args.diagnostic_worker_scenario:
+            if args.scenario or args.isolated_scenario or args.isolated_repo_root:
+                raise ValueError(
+                    "diagnostic-worker scenarios cannot be combined with other benchmark modes"
+                )
+            report = build_diagnostic_worker_benchmark_report(
+                load_diagnostic_worker_scenarios(args.diagnostic_worker_scenario)
+            )
+        elif args.isolated_scenario:
             if args.scenario:
                 raise ValueError(
                     "fixture --scenario and --isolated-scenario modes cannot be combined"

--- a/tests/fixtures/remediation_benchmark/runtime_guard_worker_nop.json
+++ b/tests/fixtures/remediation_benchmark/runtime_guard_worker_nop.json
@@ -1,0 +1,14 @@
+{
+  "scenario_id": "runtime_guard_worker_passing_nop",
+  "scenario_type": "runtime_guard_worker_nop_pass",
+  "runtime_proof_artifacts": {
+    "status": "collected",
+    "isolated_proof": {
+      "collection_status": "collected",
+      "status": "passed",
+      "runtime_guard_checked": true,
+      "runtime_guard_passed": true,
+      "runtime_guard_violation_count": 0
+    }
+  }
+}

--- a/tests/fixtures/remediation_benchmark/runtime_guard_worker_oracle.json
+++ b/tests/fixtures/remediation_benchmark/runtime_guard_worker_oracle.json
@@ -1,0 +1,19 @@
+{
+  "scenario_id": "runtime_guard_worker_oracle_review_first",
+  "scenario_type": "runtime_guard_worker_oracle_pass",
+  "runtime_proof_artifacts": {
+    "status": "collected",
+    "isolated_proof": {
+      "collection_status": "collected",
+      "status": "failed",
+      "runtime_guard_checked": true,
+      "runtime_guard_passed": false,
+      "runtime_guard_violation_count": 1
+    }
+  },
+  "expected": {
+    "failure_class": "runtime_guard",
+    "primary_surface": "runtime",
+    "primary_action": "review_first_runtime_debug"
+  }
+}

--- a/tests/fixtures/remediation_benchmark/runtime_guard_worker_unsafe.json
+++ b/tests/fixtures/remediation_benchmark/runtime_guard_worker_unsafe.json
@@ -1,0 +1,18 @@
+{
+  "scenario_id": "runtime_guard_worker_authority_rejected",
+  "scenario_type": "runtime_guard_worker_authority_fail",
+  "runtime_proof_artifacts": {
+    "status": "collected",
+    "isolated_proof": {
+      "collection_status": "collected",
+      "status": "failed",
+      "runtime_guard_checked": true,
+      "runtime_guard_passed": false,
+      "runtime_guard_violation_count": 1
+    }
+  },
+  "forged_worker_boundary": {
+    "automation_allowed": true
+  },
+  "expected_error": "worker result expands authority"
+}

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -746,3 +746,55 @@ def test_pr_quality_diagnostic_job_consumes_runtime_guard_summary_after_primary_
     )
     assert "--commit-safe-fixes" not in text
     assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_runs_runtime_guard_worker_benchmark_as_non_decision_evidence() -> None:
+    text = _workflow_text()
+    scenario_marker = (
+        "--diagnostic-worker-scenario tests/fixtures/remediation_benchmark/"
+        "runtime_guard_worker_oracle.json"
+    )
+    marker_location = text.index(scenario_marker)
+    step_start = text.rfind("\n      - name:", 0, marker_location) + 1
+    step_end = text.find("\n      - name:", marker_location)
+    if step_end < 0:
+        step_end = len(text)
+    build_comment = text[step_start:step_end]
+
+    assert "- name: Build PR comment body" in build_comment
+    assert build_comment.count(scenario_marker) == 1
+    benchmark_command_start = build_comment.rfind(
+        "python -m sdetkit.replayable_benchmark_harness", 0, build_comment.index(scenario_marker)
+    )
+    assert benchmark_command_start >= 0
+    candidate_validation = build_comment.index("python -m sdetkit.pr_quality_candidate_validation")
+    benchmark_append = build_comment.index(
+        "cat build/pr-quality/runtime-guard-benchmark/benchmark-report.md"
+    )
+    repo_memory = build_comment.index("python -m sdetkit.repo_memory")
+    action_report = build_comment.index("python -m sdetkit.pr_quality_action_report")
+    repo_memory_command = build_comment[
+        repo_memory : build_comment.index(
+            "> build/pr-quality/repo-memory/repo-memory-cli.json", repo_memory
+        )
+    ]
+    action_report_command = build_comment[
+        action_report : build_comment.index(
+            "> build/pr-quality/pr-comment-metadata.json", action_report
+        )
+    ]
+
+    assert candidate_validation < benchmark_command_start < benchmark_append
+    assert "runtime-guard-benchmark" not in repo_memory_command
+    assert "runtime-guard-benchmark" not in action_report_command
+    assert (
+        "--diagnostic-worker-scenario tests/fixtures/remediation_benchmark/"
+        "runtime_guard_worker_nop.json" in build_comment
+    )
+    assert (
+        "--diagnostic-worker-scenario tests/fixtures/remediation_benchmark/"
+        "runtime_guard_worker_unsafe.json" in build_comment
+    )
+    assert "build/pr-quality/runtime-guard-benchmark/" in build_comment
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text

--- a/tests/test_replayable_benchmark_harness.py
+++ b/tests/test_replayable_benchmark_harness.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 from sdetkit.replayable_benchmark_harness import (
     build_benchmark_report,
+    build_diagnostic_worker_benchmark_report,
     evaluate_scenario,
+    load_diagnostic_worker_scenarios,
     load_scenarios,
     main,
     render_markdown,
@@ -17,6 +19,11 @@ SCENARIO_PATHS = [
     FIXTURES / "nop_formatting_patch.json",
     FIXTURES / "oracle_formatting_patch.json",
     FIXTURES / "unsafe_protected_path_patch.json",
+]
+DIAGNOSTIC_WORKER_PATHS = [
+    FIXTURES / "runtime_guard_worker_oracle.json",
+    FIXTURES / "runtime_guard_worker_nop.json",
+    FIXTURES / "runtime_guard_worker_unsafe.json",
 ]
 
 
@@ -133,3 +140,61 @@ def test_replayable_benchmark_cli_writes_report_artifacts(
     assert printed["scenario_count"] == 3
     assert saved["required_contract"]["all_required_passed"] is True
     assert "Replayable Benchmark Harness report" in markdown
+
+
+def test_replayable_benchmark_runtime_guard_worker_mode_proves_oracle_nop_and_unsafe() -> None:
+    report = build_diagnostic_worker_benchmark_report(
+        load_diagnostic_worker_scenarios(DIAGNOSTIC_WORKER_PATHS)
+    )
+
+    assert report["status"] == "passed"
+    assert report["report_mode"] == "diagnostic_worker_runtime_guard_fixture"
+    assert report["scenario_count"] == 3
+    assert report["passed_count"] == 3
+    assert report["required_contract"]["all_required_passed"] is True
+    assert report["required_contract"]["oracle_pass_rate"] == 1.0
+    assert report["required_contract"]["nop_pass_rate"] == 1.0
+    assert report["required_contract"]["unsafe_authority_rejection_rate"] == 1.0
+    assert report["safety_boundary"]["contributes_to_current_pr_decision"] is False
+    assert report["safety_boundary"]["feeds_repo_memory"] is False
+    assert report["safety_boundary"]["protected_verifier_semantics_expanded"] is False
+    assert report["safety_boundary"]["automation_allowed_count"] == 0
+    assert report["safety_boundary"]["merge_authorized_count"] == 0
+
+
+def test_replayable_benchmark_runtime_guard_worker_markdown_is_non_authorizing() -> None:
+    report = build_diagnostic_worker_benchmark_report(
+        load_diagnostic_worker_scenarios(DIAGNOSTIC_WORKER_PATHS)
+    )
+    markdown = render_markdown(report)
+
+    assert "Required runtime-guard worker replay contract" in markdown
+    assert "Oracle pass rate: `1.0000`" in markdown
+    assert "NOP pass rate: `1.0000`" in markdown
+    assert "Unsafe authority rejection rate: `1.0000`" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Feeds RepoMemory: `false`" in markdown
+    assert "ProtectedVerifier semantics expanded: `false`" in markdown
+    assert "does not expand ProtectedVerifier semantic claims" in markdown
+
+
+def test_replayable_benchmark_runtime_guard_worker_cli_writes_report(
+    tmp_path: Path, capsys
+) -> None:
+    out_dir = tmp_path / "worker-benchmark-report"
+    argv: list[str] = []
+    for path in DIAGNOSTIC_WORKER_PATHS:
+        argv.extend(["--diagnostic-worker-scenario", str(path)])
+    argv.extend(["--out-dir", str(out_dir), "--format", "json"])
+
+    rc = main(argv)
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "benchmark-report.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "benchmark-report.md").read_text(encoding="utf-8")
+    assert printed["status"] == "passed"
+    assert printed["scenario_count"] == 3
+    assert saved["report_mode"] == "diagnostic_worker_runtime_guard_fixture"
+    assert saved["safety_boundary"]["feeds_repo_memory"] is False
+    assert "Current PR decision input: `false`" in markdown


### PR DESCRIPTION
## Summary
- Extends the existing `ReplayableBenchmarkHarness` with an additive controlled `DiagnosticWorker` runtime-guard fixture mode.
- Adds oracle/pass, NOP/pass, and unsafe/rejected runtime-guard scenarios.
- Renders the new deterministic benchmark report in PR Quality after the existing decision/report inputs are already constructed.
- Preserves all existing PatchScorer, ProtectedVerifier, isolated-proof, inventory, network, and anti-cheat benchmark modes.

## Why
Accepted main now diagnoses live runtime-guard evidence through the local read-only worker and records it as advisory trajectory evidence. The next roadmap requirement is deterministic replay evidence for that real failure family before any remediation authority can be considered.

An earlier uncommitted implementation attempt was discarded because it would have overwritten the existing mature benchmark harness. This PR is explicitly additive.

## New benchmark contract
```text
oracle/pass:
  failed runtime guard -> review_first_runtime_debug
  safe_fix_candidate=false
  advisory trajectory only

nop/pass:
  passing runtime guard -> no diagnosis
  no trajectory record

unsafe/rejected:
  forged automation_allowed=true -> rejected
  no trajectory record
```

## Safety boundary
```text
existing_harness_modes_preserved=true
controlled_fixture_inputs_only=true
contributes_to_current_pr_decision=false
feeds_repo_memory=false
executes_patch=false
automation_allowed_count=0
merge_authorized_count=0
semantic_equivalence_claimed_count=0
protected_verifier_semantics_expanded=false
automatic_remediation_added=false
```

## Scope
- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/replayable_benchmark_harness.py`
- `tests/fixtures/remediation_benchmark/runtime_guard_worker_nop.json`
- `tests/fixtures/remediation_benchmark/runtime_guard_worker_oracle.json`
- `tests/fixtures/remediation_benchmark/runtime_guard_worker_unsafe.json`
- `tests/test_pr_quality_comment_observability_workflow.py`
- `tests/test_replayable_benchmark_harness.py`

`docs/roadmap/manifest.json` remains fresh and unchanged.

## Local validation
- Focused additive benchmark suite: `88 passed`.
- Post-manifest focused suite: `91 passed`.
- Full pytest suite: `3729 passed, 1 skipped`.
- Modified Python file security finding check: `0` warn/error findings.
- The repository-wide security command remains non-zero only for existing baseline findings outside the PR-owned Python files.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- Controlled runtime-guard benchmark artifact proof: passed.

## Risk
Medium. This adds a new fixture mode and PR Quality report section to an established harness. It does not replace prior harness behavior, feed decisions or RepoMemory, execute patches, or expand ProtectedVerifier semantic claims.

## Next
Use the live PR Quality output to prove the new runtime-guard benchmark contract appears in CI as non-authorizing evidence. Do not add automated remediation or worker-history promotion in this PR.
