### PR TITLE
Respect security evidence freshness in diagnostic worker

### DIFF
--- a/src/sdetkit/diagnostic_vector_engine.py
+++ b/src/sdetkit/diagnostic_vector_engine.py
@@ -657,16 +657,38 @@ def _vectors_from_security_review(
     *,
     safe_fix_history: Mapping[str, Any] | None,
 ) -> list[dict[str, Any]]:
+    records = _as_list(payload.get("diagnoses"))
+    if not records:
+        records = _as_list(payload.get("findings"))
+
     vectors = []
-    for finding in _as_list(payload.get("findings")):
+    for finding in records:
         row = _as_dict(finding)
         if not row:
             continue
+        if _string(row.get("freshness")).lower() == "stale":
+            continue
+
         adapted = dict(row)
+        path = _string(row.get("path"))
         adapted["surface"] = "security"
         adapted["title"] = _first_text(
-            row.get("title"), row.get("summary"), "Security review finding"
+            row.get("title"),
+            row.get("summary"),
+            row.get("classification"),
+            row.get("rule_id"),
+            "Security review finding",
         )
+        adapted["first_failure_line"] = _first_text(
+            row.get("first_failure_line"),
+            row.get("diagnosis"),
+            row.get("summary"),
+            row.get("classification"),
+        )
+        adapted["affected_files"] = _string_list(row.get("affected_files")) or (
+            [path] if path else []
+        )
+        adapted["kind"] = _first_text(row.get("classification"), "security_finding")
         adapted["review_first"] = True
         adapted["safe_to_auto_fix"] = False
         vectors.append(

--- a/tests/test_diagnostic_job.py
+++ b/tests/test_diagnostic_job.py
@@ -217,3 +217,85 @@ def test_diagnostic_worker_surfaces_runtime_guard_violation_as_read_only_review_
     assert "Primary surface: `runtime`" in markdown
     assert "Primary action: `review_first_runtime_debug`" in markdown
     assert "Runtime guard violation observed" in markdown
+
+
+def test_diagnostic_worker_does_not_promote_stale_security_evidence_over_current_runtime_guard(
+    tmp_path: Path,
+) -> None:
+    result = run_diagnostic_worker(
+        _job(),
+        security_review={
+            "diagnoses": [
+                {
+                    "tool": "sdetkit-security-gate",
+                    "rule_id": "SEC_HIGH_ENTROPY_STRING",
+                    "path": "src/sdetkit/flaky_test_registry_evidence.py",
+                    "line": 218,
+                    "freshness": "stale",
+                    "classification": "stale_or_outdated_alert",
+                    "diagnosis": "The alert does not point at the current PR head.",
+                    "recommended_action": "wait_for_code_scanning_refresh",
+                    "safe_to_auto_fix": False,
+                    "automation_allowed": False,
+                }
+            ]
+        },
+        runtime_proof_artifacts={
+            "isolated_proof": {
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": False,
+                "runtime_guard_violation_count": 1,
+            }
+        },
+        out_dir=tmp_path,
+    )
+
+    assert result["summary"]["diagnosis_count"] == 1
+    assert result["summary"]["primary_surface"] == "runtime"
+    assert result["summary"]["primary_action"] == "review_first_runtime_debug"
+    assert result["decision_boundary"]["automation_allowed"] is False
+    assert result["decision_boundary"]["merge_authorized"] is False
+
+
+def test_diagnostic_worker_promotes_current_security_evidence_as_non_authorizing_primary(
+    tmp_path: Path,
+) -> None:
+    result = run_diagnostic_worker(
+        _job(),
+        security_review={
+            "diagnoses": [
+                {
+                    "tool": "CodeQL",
+                    "rule_id": "py/credential-exposure",
+                    "path": "src/sdetkit/current_security.py",
+                    "line": 7,
+                    "freshness": "current",
+                    "classification": "codeql_security_review_required",
+                    "diagnosis": "A current CodeQL finding requires rule-specific human security review.",
+                    "recommended_action": "review_codeql_finding",
+                    "safe_to_auto_fix": False,
+                    "automation_allowed": False,
+                }
+            ]
+        },
+        runtime_proof_artifacts={
+            "isolated_proof": {
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": False,
+                "runtime_guard_violation_count": 1,
+            }
+        },
+        out_dir=tmp_path,
+    )
+
+    assert result["summary"]["diagnosis_count"] == 2
+    assert result["summary"]["primary_surface"] == "security"
+    assert result["summary"]["primary_action"] == "review_first_security_review"
+    vector = json.loads(
+        (tmp_path / "vector" / "diagnostic-vector.json").read_text(encoding="utf-8")
+    )
+    assert vector["diagnoses"][0]["failure_vector"]["failure_class"] == "security"
+    assert result["primary_diagnosis"]["safe_fix_candidate"] is False
+    assert result["decision_boundary"]["current_pr_decision_input"] is False
+    assert result["decision_boundary"]["automation_allowed"] is False
+    assert result["decision_boundary"]["merge_authorized"] is False

--- a/tests/test_diagnostic_vector_engine.py
+++ b/tests/test_diagnostic_vector_engine.py
@@ -13,6 +13,7 @@ from sdetkit.diagnostic_vector_engine import (
     RECOMMENDED_NEXT_ACTION,
     REVIEW_FIRST,
     SAFE_FIX_CANDIDATE,
+    STALE_OR_CURRENT_SIGNAL,
     build_diagnostic_vector,
     main,
 )
@@ -331,3 +332,108 @@ def test_diagnostic_vector_does_not_emit_runtime_guard_diagnosis_when_guard_pass
     assert payload["diagnoses"] == []
     assert payload["summary"]["diagnosis_count"] == 0
     assert payload["source_status"]["runtime_proof_artifacts"] is True
+
+
+def test_diagnostic_vector_does_not_promote_stale_security_diagnosis_over_current_runtime_guard() -> (
+    None
+):
+    payload = build_diagnostic_vector(
+        security_review={
+            "diagnoses": [
+                {
+                    "tool": "sdetkit-security-gate",
+                    "rule_id": "SEC_HIGH_ENTROPY_STRING",
+                    "path": "src/sdetkit/flaky_test_registry_evidence.py",
+                    "line": 218,
+                    "freshness": "stale",
+                    "classification": "stale_or_outdated_alert",
+                    "diagnosis": "The alert does not point at the current PR head.",
+                    "recommended_action": "wait_for_code_scanning_refresh",
+                    "safe_to_auto_fix": False,
+                    "automation_allowed": False,
+                }
+            ]
+        },
+        runtime_proof_artifacts={
+            "isolated_proof": {
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": False,
+                "runtime_guard_violation_count": 1,
+            }
+        },
+    )
+
+    assert payload["source_status"]["security_review"] is True
+    assert payload["summary"]["diagnosis_count"] == 1
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis[FAILURE_SURFACE] == "runtime"
+    assert diagnosis[RECOMMENDED_NEXT_ACTION] == "review_first_runtime_debug"
+    assert diagnosis["failure_vector"]["failure_class"] == "runtime_guard"
+
+
+def test_diagnostic_vector_consumes_current_security_diagnosis_as_review_first_primary() -> None:
+    payload = build_diagnostic_vector(
+        security_review={
+            "diagnoses": [
+                {
+                    "tool": "CodeQL",
+                    "rule_id": "py/credential-exposure",
+                    "path": "src/sdetkit/current_security.py",
+                    "line": 7,
+                    "freshness": "current",
+                    "classification": "codeql_security_review_required",
+                    "diagnosis": "A current CodeQL finding requires rule-specific human security review.",
+                    "recommended_action": "review_codeql_finding",
+                    "safe_to_auto_fix": False,
+                    "automation_allowed": False,
+                }
+            ]
+        },
+        runtime_proof_artifacts={
+            "isolated_proof": {
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": False,
+                "runtime_guard_violation_count": 1,
+            }
+        },
+    )
+
+    assert payload["summary"]["diagnosis_count"] == 2
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis[FAILURE_SURFACE] == "security"
+    assert diagnosis[STALE_OR_CURRENT_SIGNAL] == "current"
+    assert diagnosis[REVIEW_FIRST] is True
+    assert diagnosis[SAFE_FIX_CANDIDATE] is False
+    assert diagnosis[RECOMMENDED_NEXT_ACTION] == "review_first_security_review"
+    assert diagnosis[AFFECTED_FILES] == ["src/sdetkit/current_security.py"]
+    assert diagnosis["failure_vector"]["source"] == "security_review"
+    assert diagnosis["failure_vector"]["failure_class"] == "security"
+
+
+def test_diagnostic_vector_preserves_legacy_security_findings_key_as_review_first() -> None:
+    payload = build_diagnostic_vector(
+        security_review={
+            "findings": [
+                {
+                    "tool": "sdetkit-security-gate",
+                    "rule_id": "SEC_SECRET_PATTERN",
+                    "path": "src/sdetkit/legacy_security.py",
+                    "line": 4,
+                    "freshness": "current",
+                    "classification": "security",
+                    "diagnosis": "Legacy security evidence requires review.",
+                    "safe_to_auto_fix": False,
+                    "automation_allowed": False,
+                }
+            ]
+        }
+    )
+
+    assert payload["summary"]["diagnosis_count"] == 1
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis[FAILURE_SURFACE] == "security"
+    assert diagnosis[REVIEW_FIRST] is True
+    assert diagnosis[SAFE_FIX_CANDIDATE] is False
+    assert diagnosis[AFFECTED_FILES] == ["src/sdetkit/legacy_security.py"]
+    assert diagnosis["failure_vector"]["source"] == "security_review"
+    assert diagnosis["failure_vector"]["failure_class"] == "security"


### PR DESCRIPTION
## Summary
- Fixes the DiagnosticWorker security adapter to consume the `diagnoses` array emitted by `security_finding_diagnosis`, while preserving the legacy `findings` fallback.
- Filters `freshness=stale` security diagnoses out of current worker failure vectors.
- Preserves current security findings as review-first, non-fixable diagnostic blockers.
- Adds deterministic tests proving stale security evidence does not outrank a current runtime-guard diagnosis.

## Why
Live PR Quality evidence already renders stale/current security classification correctly, and the workflow already passes the security diagnosis artifact into `DiagnosticJob`. However, the worker adapter read `findings` while the producer emits `diagnoses`, so the worker plane did not consume that evidence correctly.

Simply ingesting every emitted diagnosis would be unsafe because stale alerts have higher surface priority than runtime failures. This patch consumes the real schema while explicitly excluding stale alerts from current blocker ranking.

## Behavior
```text
stale security evidence + current runtime violation:
  security artifact is received
  stale security is not emitted as a current worker diagnosis
  runtime remains primary

current security evidence + current runtime violation:
  security becomes primary
  review_first=true
  safe_fix_candidate=false
  automation_allowed=false
  merge_authorized=false
```

## Safety boundary
```text
legacy_findings_fallback_preserved=true
current_pr_decision_input=false
automatic_security_fix_allowed=false
automatic_remediation_authorized=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
workflow_write_authority_added=false
```

## Scope
- `src/sdetkit/diagnostic_vector_engine.py`
- `tests/test_diagnostic_vector_engine.py`
- `tests/test_diagnostic_job.py`

`docs/roadmap/manifest.json` remains fresh and unchanged.

## Local validation
- Focused security-freshness correctness suite: `79 passed`.
- Post-manifest focused suite: `82 passed`.
- Full pytest suite: `3734 passed, 1 skipped`.
- Modified Python file security finding check: `0` warn/error findings.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- File-backed stale/current DiagnosticJob proof: passed.

## Risk
Low to medium. This changes which security diagnosis records the worker consumes and deliberately prevents stale evidence from becoming a current failure vector. Reporter-visible stale evidence remains available; only current blocker ranking is corrected.

## Next
Use the live PR Quality result to confirm stale security alerts remain non-blocking while current runtime evidence remains primary. Then extend the replayable benchmark harness with security freshness misuse scenarios before considering any remediation authority.
