### PR TITLE
Replay security freshness evidence in benchmark harness

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -709,6 +709,15 @@ jobs:
             --format json \
             > build/pr-quality/runtime-guard-benchmark/runtime-guard-benchmark-cli.json
 
+          mkdir -p build/pr-quality/security-freshness-benchmark
+          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
+            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_stale_runtime_oracle.json \
+            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_current_primary_oracle.json \
+            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_authority_unsafe.json \
+            --out-dir build/pr-quality/security-freshness-benchmark \
+            --format json \
+            > build/pr-quality/security-freshness-benchmark/security-freshness-benchmark-cli.json
+
           if [ -s build/pr-quality/diagnostic-job/diagnostic-job.md ]; then
             printf '\n' >> build/pr-quality/pr-comment-body.md
             cat build/pr-quality/diagnostic-job/diagnostic-job.md >> build/pr-quality/pr-comment-body.md
@@ -729,6 +738,9 @@ jobs:
 
           printf '\n' >> build/pr-quality/pr-comment-body.md
           cat build/pr-quality/runtime-guard-benchmark/benchmark-report.md >> build/pr-quality/pr-comment-body.md
+
+          printf '\n' >> build/pr-quality/pr-comment-body.md
+          cat build/pr-quality/security-freshness-benchmark/benchmark-report.md >> build/pr-quality/pr-comment-body.md
 
       - name: Build verified operator evidence loop
         if: always()
@@ -794,6 +806,7 @@ jobs:
             build/pr-quality/candidate-visibility/
             build/pr-quality/candidate-validation/
             build/pr-quality/runtime-guard-benchmark/
+            build/pr-quality/security-freshness-benchmark/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
             build/sdetkit/operator-loop/

--- a/src/sdetkit/replayable_benchmark_harness.py
+++ b/src/sdetkit/replayable_benchmark_harness.py
@@ -49,6 +49,29 @@ DIAGNOSTIC_WORKER_REQUIRED_SCENARIO_TYPES = (
     RUNTIME_GUARD_WORKER_NOP_PASS,
     RUNTIME_GUARD_WORKER_AUTHORITY_FAIL,
 )
+SECURITY_FRESHNESS_REPORT_SCHEMA_VERSION = (
+    "sdetkit.replayable_benchmark_harness.security_freshness.v1"
+)
+SECURITY_FRESHNESS_REPORT_MODE = "_".join(
+    ("diagnostic", "worker", "security", "freshness", "fixture")
+)
+SECURITY_FRESHNESS_STALE_RUNTIME_PASS = "_".join(
+    ("security", "freshness", "stale", "runtime", "pass")
+)
+SECURITY_FRESHNESS_CURRENT_PRIMARY_PASS = "_".join(
+    ("security", "freshness", "current", "primary", "pass")
+)
+SECURITY_FRESHNESS_AUTHORITY_FAIL = "_".join(("security", "freshness", "authority", "fail"))
+SECURITY_FRESHNESS_SCENARIO_TYPES = {
+    SECURITY_FRESHNESS_STALE_RUNTIME_PASS,
+    SECURITY_FRESHNESS_CURRENT_PRIMARY_PASS,
+    SECURITY_FRESHNESS_AUTHORITY_FAIL,
+}
+SECURITY_FRESHNESS_REQUIRED_SCENARIO_TYPES = (
+    SECURITY_FRESHNESS_STALE_RUNTIME_PASS,
+    SECURITY_FRESHNESS_CURRENT_PRIMARY_PASS,
+    SECURITY_FRESHNESS_AUTHORITY_FAIL,
+)
 
 SCENARIO_TYPES = {
     "nop_fail",
@@ -155,6 +178,32 @@ def load_diagnostic_worker_scenarios(paths: list[Path]) -> list[JsonObject]:
             raise ValueError(
                 f"unsupported diagnostic worker scenario_type for {scenario_id}: {scenario_type}"
             )
+        if not _as_dict(scenario.get("runtime_proof_artifacts")):
+            raise ValueError(f"runtime_proof_artifacts is required in {path}")
+        identifiers.add(scenario_id)
+        scenarios.append(scenario)
+
+    return scenarios
+
+
+def load_security_freshness_scenarios(paths: list[Path]) -> list[JsonObject]:
+    scenarios: list[JsonObject] = []
+    identifiers: set[str] = set()
+
+    for path in paths:
+        scenario = _read_json_object(path)
+        scenario_id = _string(scenario.get("scenario_id"))
+        scenario_type = _string(scenario.get("scenario_type"))
+        if not scenario_id:
+            raise ValueError(f"scenario_id is required in {path}")
+        if scenario_id in identifiers:
+            raise ValueError(f"duplicate scenario_id: {scenario_id}")
+        if scenario_type not in SECURITY_FRESHNESS_SCENARIO_TYPES:
+            raise ValueError(
+                f"unsupported security freshness scenario_type for {scenario_id}: {scenario_type}"
+            )
+        if not _as_dict(scenario.get("security_review")):
+            raise ValueError(f"security_review is required in {path}")
         if not _as_dict(scenario.get("runtime_proof_artifacts")):
             raise ValueError(f"runtime_proof_artifacts is required in {path}")
         identifiers.add(scenario_id)
@@ -970,6 +1019,296 @@ def build_diagnostic_worker_benchmark_report(scenarios: list[Mapping[str, Any]])
     }
 
 
+def _run_security_freshness_worker_fixture(
+    scenario: Mapping[str, Any],
+) -> tuple[JsonObject, JsonObject, JsonObject]:
+    scenario_id = _string(scenario.get("scenario_id"))
+    job = build_diagnostic_job(
+        repo="controlled-fixture/replayable-benchmark",
+        base_sha="fixture-base",
+        head_sha=f"fixture-head-{scenario_id}",
+        event_name="replayable_benchmark",
+        pr_number=0,
+        input_artifacts={
+            "security_review": f"fixture:{scenario_id}",
+            "runtime_proof_artifacts": f"fixture:{scenario_id}",
+        },
+    )
+    with tempfile.TemporaryDirectory(prefix="sdetkit-security-freshness-benchmark-") as temp_dir:
+        worker_dir = Path(temp_dir) / "worker"
+        result = run_diagnostic_worker(
+            job,
+            security_review=_as_dict(scenario.get("security_review")),
+            runtime_proof_artifacts=_as_dict(scenario.get("runtime_proof_artifacts")),
+            out_dir=worker_dir,
+        )
+        vector = _read_json_object(worker_dir / "vector" / "diagnostic-vector.json")
+    return job, result, vector
+
+
+def evaluate_security_freshness_scenario(scenario: Mapping[str, Any]) -> JsonObject:
+    scenario_id = _string(scenario.get("scenario_id"))
+    scenario_type = _string(scenario.get("scenario_type"))
+    if scenario_type not in SECURITY_FRESHNESS_SCENARIO_TYPES:
+        raise ValueError(f"unsupported security freshness scenario_type: {scenario_type}")
+
+    job, worker_result, diagnostic_vector = _run_security_freshness_worker_fixture(scenario)
+    result_summary = _as_dict(worker_result.get("summary"))
+    primary = _as_dict(worker_result.get("primary_diagnosis"))
+    boundary = _as_dict(worker_result.get("decision_boundary"))
+    expected = _as_dict(scenario.get("expected"))
+    diagnoses = [_as_dict(item) for item in _as_list(diagnostic_vector.get("diagnoses"))]
+    primary_vector = _as_dict(diagnoses[0].get("failure_vector")) if diagnoses else {}
+    checks: list[JsonObject] = [
+        _check(
+            name="worker_automation_boundary",
+            passed=not _bool(boundary.get("automation_allowed")),
+            expected=False,
+            actual=_bool(boundary.get("automation_allowed")),
+        ),
+        _check(
+            name="worker_merge_boundary",
+            passed=not _bool(boundary.get("merge_authorized")),
+            expected=False,
+            actual=_bool(boundary.get("merge_authorized")),
+        ),
+        _check(
+            name="worker_semantic_boundary",
+            passed=not _bool(boundary.get("semantic_equivalence_proven")),
+            expected=False,
+            actual=_bool(boundary.get("semantic_equivalence_proven")),
+        ),
+    ]
+    trajectory_records: list[JsonObject] = []
+    observed_error = ""
+
+    if scenario_type == SECURITY_FRESHNESS_STALE_RUNTIME_PASS:
+        trajectory_records = build_worker_trajectory_records(
+            job=job,
+            worker_result=worker_result,
+            diagnostic_vector=diagnostic_vector,
+            repo="controlled-fixture/replayable-benchmark",
+            branch="fixture",
+            commit_sha="fixture-security-freshness-stale-runtime",
+        )
+        checks.extend(
+            [
+                _check(
+                    name="stale_security_is_not_worker_vector",
+                    passed=all(
+                        _string(row.get("failure_surface")) != "security" for row in diagnoses
+                    ),
+                    expected=True,
+                    actual=all(
+                        _string(row.get("failure_surface")) != "security" for row in diagnoses
+                    ),
+                ),
+                _check(
+                    name="runtime_remains_primary_when_security_is_stale",
+                    passed=_string(primary.get("failure_surface"))
+                    == _string(expected.get("primary_surface"))
+                    and _string(result_summary.get("primary_action"))
+                    == _string(expected.get("primary_action"))
+                    and _int(result_summary.get("diagnosis_count"))
+                    == _int(expected.get("diagnosis_count")),
+                    expected=True,
+                    actual=_string(primary.get("failure_surface"))
+                    == _string(expected.get("primary_surface"))
+                    and _string(result_summary.get("primary_action"))
+                    == _string(expected.get("primary_action"))
+                    and _int(result_summary.get("diagnosis_count"))
+                    == _int(expected.get("diagnosis_count")),
+                ),
+                _check(
+                    name="stale_security_runtime_trajectory_is_advisory",
+                    passed=len(trajectory_records) == 1
+                    and all(
+                        not _bool(_as_dict(row.get("decision")).get("auto_fix_allowed"))
+                        for row in trajectory_records
+                    ),
+                    expected=True,
+                    actual=len(trajectory_records) == 1
+                    and all(
+                        not _bool(_as_dict(row.get("decision")).get("auto_fix_allowed"))
+                        for row in trajectory_records
+                    ),
+                ),
+            ]
+        )
+    elif scenario_type == SECURITY_FRESHNESS_CURRENT_PRIMARY_PASS:
+        trajectory_records = build_worker_trajectory_records(
+            job=job,
+            worker_result=worker_result,
+            diagnostic_vector=diagnostic_vector,
+            repo="controlled-fixture/replayable-benchmark",
+            branch="fixture",
+            commit_sha="fixture-security-freshness-current-primary",
+        )
+        checks.extend(
+            [
+                _check(
+                    name="current_security_is_primary",
+                    passed=_string(primary.get("failure_surface"))
+                    == _string(expected.get("primary_surface"))
+                    and _string(result_summary.get("primary_action"))
+                    == _string(expected.get("primary_action"))
+                    and _int(result_summary.get("diagnosis_count"))
+                    == _int(expected.get("diagnosis_count")),
+                    expected=True,
+                    actual=_string(primary.get("failure_surface"))
+                    == _string(expected.get("primary_surface"))
+                    and _string(result_summary.get("primary_action"))
+                    == _string(expected.get("primary_action"))
+                    and _int(result_summary.get("diagnosis_count"))
+                    == _int(expected.get("diagnosis_count")),
+                ),
+                _check(
+                    name="current_security_vector_is_review_first",
+                    passed=_string(primary_vector.get("source")) == "security_review"
+                    and _string(primary_vector.get("failure_class")) == "security"
+                    and _string(diagnoses[0].get("stale_or_current_signal")) == "current"
+                    and _bool(diagnoses[0].get("review_first"))
+                    and not _bool(diagnoses[0].get("safe_fix_candidate")),
+                    expected=True,
+                    actual=_string(primary_vector.get("source")) == "security_review"
+                    and _string(primary_vector.get("failure_class")) == "security"
+                    and _string(diagnoses[0].get("stale_or_current_signal")) == "current"
+                    and _bool(diagnoses[0].get("review_first"))
+                    and not _bool(diagnoses[0].get("safe_fix_candidate")),
+                ),
+                _check(
+                    name="current_security_trajectory_has_no_fix_authority",
+                    passed=len(trajectory_records) == 2
+                    and all(
+                        not _bool(_as_dict(row.get("decision")).get("auto_fix_allowed"))
+                        for row in trajectory_records
+                    ),
+                    expected=True,
+                    actual=len(trajectory_records) == 2
+                    and all(
+                        not _bool(_as_dict(row.get("decision")).get("auto_fix_allowed"))
+                        for row in trajectory_records
+                    ),
+                ),
+            ]
+        )
+    else:
+        forged = json.loads(json.dumps(worker_result))
+        _as_dict(forged.get("decision_boundary")).update(
+            _as_dict(scenario.get("forged_worker_boundary"))
+        )
+        expected_error = _string(scenario.get("expected_error"))
+        rejected = False
+        try:
+            build_worker_trajectory_records(
+                job=job,
+                worker_result=forged,
+                diagnostic_vector=diagnostic_vector,
+                repo="controlled-fixture/replayable-benchmark",
+                branch="fixture",
+                commit_sha="fixture-security-freshness-authority-unsafe",
+            )
+        except ValueError as exc:
+            observed_error = str(exc)
+            rejected = expected_error in observed_error
+        checks.extend(
+            [
+                _check(
+                    name="current_security_before_forgery_is_review_first",
+                    passed=_string(primary.get("failure_surface")) == "security"
+                    and not _bool(primary.get("safe_fix_candidate")),
+                    expected=True,
+                    actual=_string(primary.get("failure_surface")) == "security"
+                    and not _bool(primary.get("safe_fix_candidate")),
+                ),
+                _check(
+                    name="forged_security_worker_authority_rejected",
+                    passed=rejected,
+                    expected=expected_error,
+                    actual=observed_error,
+                ),
+                _check(
+                    name="forged_security_worker_emits_no_trajectory",
+                    passed=trajectory_records == [],
+                    expected=[],
+                    actual=trajectory_records,
+                ),
+            ]
+        )
+
+    passed = all(_bool(item.get("passed")) for item in checks)
+    return {
+        "scenario_id": scenario_id,
+        "scenario_type": scenario_type,
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "attempt_scored": False,
+        "attempt_score": 0,
+        "checks": checks,
+        "diagnosis_count": _int(result_summary.get("diagnosis_count")),
+        "trajectory_record_count": len(trajectory_records),
+        "observed_error": observed_error,
+    }
+
+
+def build_security_freshness_benchmark_report(scenarios: list[Mapping[str, Any]]) -> JsonObject:
+    results = [evaluate_security_freshness_scenario(scenario) for scenario in scenarios]
+    type_counts = Counter(_string(item.get("scenario_type")) for item in results)
+    required_present = all(
+        type_counts.get(item, 0) >= 1 for item in SECURITY_FRESHNESS_REQUIRED_SCENARIO_TYPES
+    )
+    required_passed = all(
+        any(
+            result.get("scenario_type") == scenario_type and result.get("passed") is True
+            for result in results
+        )
+        for scenario_type in SECURITY_FRESHNESS_REQUIRED_SCENARIO_TYPES
+    )
+    passed_count = sum(1 for item in results if item.get("passed") is True)
+    boundary = {
+        "execution_model": "_".join(
+            ("read", "only", "security", "freshness", "fixture", "evaluation")
+        ),
+        "automation_allowed_count": 0,
+        "merge_authorized_count": 0,
+        "semantic_equivalence_claimed_count": 0,
+        "preserved": True,
+        "contributes_to_current_pr_decision": False,
+        "feeds_repo_memory": False,
+        "executes_patch": False,
+        "protected_verifier_semantics_expanded": False,
+    }
+    passed = bool(results) and passed_count == len(results) and required_present and required_passed
+    return {
+        "schema_version": SECURITY_FRESHNESS_REPORT_SCHEMA_VERSION,
+        "report_mode": SECURITY_FRESHNESS_REPORT_MODE,
+        "status": "passed" if passed else "failed",
+        "scenario_count": len(results),
+        "passed_count": passed_count,
+        "failed_count": len(results) - passed_count,
+        "scenario_type_counts": dict(sorted(type_counts.items())),
+        "required_contract": {
+            "required_scenario_types": list(SECURITY_FRESHNESS_REQUIRED_SCENARIO_TYPES),
+            "all_required_present": required_present,
+            "all_required_passed": required_passed,
+            "stale_exclusion_pass_rate": _type_rate(results, SECURITY_FRESHNESS_STALE_RUNTIME_PASS),
+            "current_primary_pass_rate": _type_rate(
+                results, SECURITY_FRESHNESS_CURRENT_PRIMARY_PASS
+            ),
+            "unsafe_authority_rejection_rate": _type_rate(
+                results, SECURITY_FRESHNESS_AUTHORITY_FAIL
+            ),
+        },
+        "safety_boundary": boundary,
+        "attempt_scored_count": 0,
+        "scenarios": results,
+        "next_boundary": (
+            "Keep security-freshness worker evidence review-first and non-authorizing; "
+            "do not add security dismissal or remediation authority."
+        ),
+    }
+
+
 def render_markdown(report: Mapping[str, Any]) -> str:
     required = _as_dict(report.get("required_contract"))
     boundary = _as_dict(report.get("safety_boundary"))
@@ -978,6 +1317,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     report_mode = _string(report.get("report_mode") or "fixture_declared")
     is_live = report_mode == LIVE_EVIDENCE_SOURCE
     is_diagnostic_worker = report_mode == DIAGNOSTIC_WORKER_REPORT_MODE
+    is_security_freshness = report_mode == SECURITY_FRESHNESS_REPORT_MODE
 
     lines = [
         "# Replayable Benchmark Harness report",
@@ -991,7 +1331,44 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         "",
     ]
 
-    if is_diagnostic_worker:
+    if is_security_freshness:
+        lines.extend(
+            [
+                "## Required security-freshness worker replay contract",
+                "",
+                (
+                    "- All required scenarios present: "
+                    f"`{str(_bool(required.get('all_required_present'))).lower()}`"
+                ),
+                (
+                    "- All required scenarios passed: "
+                    f"`{str(_bool(required.get('all_required_passed'))).lower()}`"
+                ),
+                (
+                    "- Stale exclusion pass rate: "
+                    f"`{float(required.get('stale_exclusion_pass_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (
+                    "- Current security primary pass rate: "
+                    f"`{float(required.get('current_primary_pass_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (
+                    "- Unsafe authority rejection rate: "
+                    f"`{float(required.get('unsafe_authority_rejection_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (
+                    "- Current PR decision input: "
+                    f"`{str(_bool(boundary.get('contributes_to_current_pr_decision'))).lower()}`"
+                ),
+                f"- Feeds RepoMemory: `{str(_bool(boundary.get('feeds_repo_memory'))).lower()}`",
+                (
+                    "- ProtectedVerifier semantics expanded: "
+                    f"`{str(_bool(boundary.get('protected_verifier_semantics_expanded'))).lower()}`"
+                ),
+                "",
+            ]
+        )
+    elif is_diagnostic_worker:
         lines.extend(
             [
                 "## Required runtime-guard worker replay contract",
@@ -1145,7 +1522,17 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         )
 
     lines.extend(["", "## Boundary", ""])
-    if is_diagnostic_worker:
+    if is_security_freshness:
+        lines.extend(
+            [
+                "- This harness replays security-freshness DiagnosticWorker behavior through controlled fixture inputs.",
+                "- It proves stale security does not displace current runtime diagnosis.",
+                "- It proves current security remains review-first and rejects forged worker authority.",
+                "- It does not feed current PR decisions or RepoMemory.",
+                "- It does not authorize security dismissal, remediation, or merge.",
+            ]
+        )
+    elif is_diagnostic_worker:
         lines.extend(
             [
                 "- This harness replays runtime-guard DiagnosticWorker behavior through controlled fixture inputs.",
@@ -1198,6 +1585,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fixture-backed benchmark scenario JSON. May be supplied more than once.",
     )
     parser.add_argument(
+        "--security-freshness-scenario",
+        type=Path,
+        action="append",
+        default=[],
+        help="Controlled DiagnosticWorker security-freshness scenario JSON.",
+    )
+    parser.add_argument(
         "--diagnostic-worker-scenario",
         type=Path,
         action="append",
@@ -1227,7 +1621,20 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        if args.diagnostic_worker_scenario:
+        if args.security_freshness_scenario:
+            if (
+                args.diagnostic_worker_scenario
+                or args.scenario
+                or args.isolated_scenario
+                or args.isolated_repo_root
+            ):
+                raise ValueError(
+                    "security-freshness scenarios cannot be combined with other benchmark modes"
+                )
+            report = build_security_freshness_benchmark_report(
+                load_security_freshness_scenarios(args.security_freshness_scenario)
+            )
+        elif args.diagnostic_worker_scenario:
             if args.scenario or args.isolated_scenario or args.isolated_repo_root:
                 raise ValueError(
                     "diagnostic-worker scenarios cannot be combined with other benchmark modes"

--- a/tests/fixtures/remediation_benchmark/security_freshness_authority_unsafe.json
+++ b/tests/fixtures/remediation_benchmark/security_freshness_authority_unsafe.json
@@ -1,0 +1,32 @@
+{
+  "scenario_id": "current_security_cannot_expand_worker_authority",
+  "scenario_type": "security_freshness_authority_fail",
+  "security_review": {
+    "schema_version": "sdetkit.security-finding-diagnosis.v1",
+    "diagnoses": [
+      {
+        "tool": "CodeQL",
+        "rule_id": "py/credential-exposure",
+        "path": "src/sdetkit/current_security.py",
+        "line": 7,
+        "freshness": "current",
+        "classification": "codeql_security_review_required",
+        "diagnosis": "A current CodeQL finding requires rule-specific human security review.",
+        "recommended_action": "review_codeql_finding",
+        "safe_to_auto_fix": false,
+        "automation_allowed": false
+      }
+    ]
+  },
+  "runtime_proof_artifacts": {
+    "isolated_proof": {
+      "runtime_guard_checked": true,
+      "runtime_guard_passed": false,
+      "runtime_guard_violation_count": 1
+    }
+  },
+  "forged_worker_boundary": {
+    "automation_allowed": true
+  },
+  "expected_error": "worker result expands authority"
+}

--- a/tests/fixtures/remediation_benchmark/security_freshness_current_primary_oracle.json
+++ b/tests/fixtures/remediation_benchmark/security_freshness_current_primary_oracle.json
@@ -1,0 +1,38 @@
+{
+  "scenario_id": "current_security_remains_review_first_primary",
+  "scenario_type": "security_freshness_current_primary_pass",
+  "security_review": {
+    "schema_version": "sdetkit.security-finding-diagnosis.v1",
+    "summary": {
+      "open_findings": 1,
+      "current_findings": 1,
+      "stale_findings": 0
+    },
+    "diagnoses": [
+      {
+        "tool": "CodeQL",
+        "rule_id": "py/credential-exposure",
+        "path": "src/sdetkit/current_security.py",
+        "line": 7,
+        "freshness": "current",
+        "classification": "codeql_security_review_required",
+        "diagnosis": "A current CodeQL finding requires rule-specific human security review.",
+        "recommended_action": "review_codeql_finding",
+        "safe_to_auto_fix": false,
+        "automation_allowed": false
+      }
+    ]
+  },
+  "runtime_proof_artifacts": {
+    "isolated_proof": {
+      "runtime_guard_checked": true,
+      "runtime_guard_passed": false,
+      "runtime_guard_violation_count": 1
+    }
+  },
+  "expected": {
+    "primary_surface": "security",
+    "primary_action": "review_first_security_review",
+    "diagnosis_count": 2
+  }
+}

--- a/tests/fixtures/remediation_benchmark/security_freshness_stale_runtime_oracle.json
+++ b/tests/fixtures/remediation_benchmark/security_freshness_stale_runtime_oracle.json
@@ -1,0 +1,50 @@
+{
+  "scenario_id": "stale_security_does_not_displace_current_runtime",
+  "scenario_type": "security_freshness_stale_runtime_pass",
+  "security_review": {
+    "schema_version": "sdetkit.security-finding-diagnosis.v1",
+    "summary": {
+      "open_findings": 3,
+      "current_findings": 0,
+      "stale_findings": 3
+    },
+    "diagnoses": [
+      {
+        "tool": "osv-scanner",
+        "rule_id": "CVE-2025-68146",
+        "path": "requirements-test.txt",
+        "line": 1,
+        "freshness": "stale",
+        "classification": "stale_or_outdated_alert",
+        "diagnosis": "The alert does not point at the current PR head.",
+        "recommended_action": "wait_for_code_scanning_refresh",
+        "safe_to_auto_fix": false,
+        "automation_allowed": false
+      },
+      {
+        "tool": "sdetkit-security-gate",
+        "rule_id": "SEC_HIGH_ENTROPY_STRING",
+        "path": "src/sdetkit/flaky_test_registry_evidence.py",
+        "line": 218,
+        "freshness": "stale",
+        "classification": "stale_or_outdated_alert",
+        "diagnosis": "The alert does not point at the current PR head.",
+        "recommended_action": "wait_for_code_scanning_refresh",
+        "safe_to_auto_fix": false,
+        "automation_allowed": false
+      }
+    ]
+  },
+  "runtime_proof_artifacts": {
+    "isolated_proof": {
+      "runtime_guard_checked": true,
+      "runtime_guard_passed": false,
+      "runtime_guard_violation_count": 1
+    }
+  },
+  "expected": {
+    "primary_surface": "runtime",
+    "primary_action": "review_first_runtime_debug",
+    "diagnosis_count": 1
+  }
+}

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -798,3 +798,63 @@ def test_pr_quality_workflow_runs_runtime_guard_worker_benchmark_as_non_decision
     assert "build/pr-quality/runtime-guard-benchmark/" in build_comment
     assert "--commit-safe-fixes" not in text
     assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_runs_security_freshness_benchmark_as_non_decision_evidence() -> None:
+    text = _workflow_text()
+    marker = (
+        "--security-freshness-scenario tests/fixtures/remediation_benchmark/"
+        "security_freshness_stale_runtime_oracle.json"
+    )
+    marker_location = text.index(marker)
+    step_start = text.rfind("\n      - name:", 0, marker_location) + 1
+    step_end = text.find("\n      - name:", marker_location)
+    if step_end < 0:
+        step_end = len(text)
+    build_comment = text[step_start:step_end]
+
+    assert "- name: Build PR comment body" in build_comment
+    security_command = build_comment.rfind(
+        "python -m sdetkit.replayable_benchmark_harness",
+        0,
+        build_comment.index(marker),
+    )
+    runtime_command = build_comment.rfind(
+        "python -m sdetkit.replayable_benchmark_harness",
+        0,
+        security_command,
+    )
+    assert runtime_command >= 0
+    runtime_append = build_comment.index(
+        "cat build/pr-quality/runtime-guard-benchmark/benchmark-report.md"
+    )
+    security_append = build_comment.index(
+        "cat build/pr-quality/security-freshness-benchmark/benchmark-report.md"
+    )
+    repo_memory = build_comment.index("python -m sdetkit.repo_memory")
+    action_report = build_comment.index("python -m sdetkit.pr_quality_action_report")
+    repo_memory_command = build_comment[
+        repo_memory : build_comment.index(
+            "> build/pr-quality/repo-memory/repo-memory-cli.json", repo_memory
+        )
+    ]
+    action_report_command = build_comment[
+        action_report : build_comment.index(
+            "> build/pr-quality/pr-comment-metadata.json", action_report
+        )
+    ]
+
+    assert runtime_command < security_command < runtime_append < security_append
+    assert "security-freshness-benchmark" not in repo_memory_command
+    assert "security-freshness-benchmark" not in action_report_command
+    assert (
+        "--security-freshness-scenario tests/fixtures/remediation_benchmark/"
+        "security_freshness_current_primary_oracle.json" in build_comment
+    )
+    assert (
+        "--security-freshness-scenario tests/fixtures/remediation_benchmark/"
+        "security_freshness_authority_unsafe.json" in build_comment
+    )
+    assert "build/pr-quality/security-freshness-benchmark/" in build_comment
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text

--- a/tests/test_replayable_benchmark_harness.py
+++ b/tests/test_replayable_benchmark_harness.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from sdetkit.replayable_benchmark_harness import (
     build_benchmark_report,
     build_diagnostic_worker_benchmark_report,
+    build_security_freshness_benchmark_report,
     evaluate_scenario,
     load_diagnostic_worker_scenarios,
     load_scenarios,
+    load_security_freshness_scenarios,
     main,
     render_markdown,
 )
@@ -24,6 +26,11 @@ DIAGNOSTIC_WORKER_PATHS = [
     FIXTURES / "runtime_guard_worker_oracle.json",
     FIXTURES / "runtime_guard_worker_nop.json",
     FIXTURES / "runtime_guard_worker_unsafe.json",
+]
+SECURITY_FRESHNESS_PATHS = [
+    FIXTURES / "security_freshness_stale_runtime_oracle.json",
+    FIXTURES / "security_freshness_current_primary_oracle.json",
+    FIXTURES / "security_freshness_authority_unsafe.json",
 ]
 
 
@@ -196,5 +203,64 @@ def test_replayable_benchmark_runtime_guard_worker_cli_writes_report(
     assert printed["status"] == "passed"
     assert printed["scenario_count"] == 3
     assert saved["report_mode"] == "diagnostic_worker_runtime_guard_fixture"
+    assert saved["safety_boundary"]["feeds_repo_memory"] is False
+    assert "Current PR decision input: `false`" in markdown
+
+
+def test_replayable_benchmark_security_freshness_worker_mode_proves_stale_current_and_unsafe() -> (
+    None
+):
+    report = build_security_freshness_benchmark_report(
+        load_security_freshness_scenarios(SECURITY_FRESHNESS_PATHS)
+    )
+
+    assert report["status"] == "passed"
+    assert report["report_mode"] == "diagnostic_worker_security_freshness_fixture"
+    assert report["scenario_count"] == 3
+    assert report["passed_count"] == 3
+    assert report["required_contract"]["all_required_passed"] is True
+    assert report["required_contract"]["stale_exclusion_pass_rate"] == 1.0
+    assert report["required_contract"]["current_primary_pass_rate"] == 1.0
+    assert report["required_contract"]["unsafe_authority_rejection_rate"] == 1.0
+    assert report["safety_boundary"]["contributes_to_current_pr_decision"] is False
+    assert report["safety_boundary"]["feeds_repo_memory"] is False
+    assert report["safety_boundary"]["executes_patch"] is False
+    assert report["safety_boundary"]["automation_allowed_count"] == 0
+    assert report["safety_boundary"]["merge_authorized_count"] == 0
+    assert report["safety_boundary"]["protected_verifier_semantics_expanded"] is False
+
+
+def test_replayable_benchmark_security_freshness_markdown_is_non_authorizing() -> None:
+    report = build_security_freshness_benchmark_report(
+        load_security_freshness_scenarios(SECURITY_FRESHNESS_PATHS)
+    )
+    markdown = render_markdown(report)
+
+    assert "Required security-freshness worker replay contract" in markdown
+    assert "Stale exclusion pass rate: `1.0000`" in markdown
+    assert "Current security primary pass rate: `1.0000`" in markdown
+    assert "Unsafe authority rejection rate: `1.0000`" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Feeds RepoMemory: `false`" in markdown
+    assert "ProtectedVerifier semantics expanded: `false`" in markdown
+    assert "does not authorize security dismissal, remediation, or merge" in markdown
+
+
+def test_replayable_benchmark_security_freshness_cli_writes_report(tmp_path: Path, capsys) -> None:
+    out_dir = tmp_path / "security-freshness-benchmark-report"
+    argv: list[str] = []
+    for path in SECURITY_FRESHNESS_PATHS:
+        argv.extend(["--security-freshness-scenario", str(path)])
+    argv.extend(["--out-dir", str(out_dir), "--format", "json"])
+
+    rc = main(argv)
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "benchmark-report.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "benchmark-report.md").read_text(encoding="utf-8")
+    assert printed["status"] == "passed"
+    assert printed["scenario_count"] == 3
+    assert saved["report_mode"] == "diagnostic_worker_security_freshness_fixture"
     assert saved["safety_boundary"]["feeds_repo_memory"] is False
     assert "Current PR decision input: `false`" in markdown


### PR DESCRIPTION
## Summary
- Extends the existing `ReplayableBenchmarkHarness` with a separate controlled security-freshness DiagnosticWorker fixture mode.
- Adds stale-security/current-runtime, current-security-primary, and authority-expansion rejection scenarios.
- Renders the new deterministic benchmark report in PR Quality after existing decision/report inputs are constructed.
- Preserves the existing isolated-proof and runtime-guard benchmark modes.

## Why
PR #1450 fixed the live producer/consumer mismatch and proved that stale security alerts are not emitted as current worker vectors. The next roadmap step is to make that real security-freshness behavior replayable and deterministic before any remediation authority can be considered.

The live PR #1450 vector artifact proved its three diagnoses were runtime and evidence-graph surfaces, with no stale security vector.

## New benchmark contract
```text
stale security + current runtime:
  stale security is excluded from current worker vectors
  runtime remains primary
  advisory trajectory only

current security + current runtime:
  security becomes review-first primary
  safe_fix_candidate=false
  no authority granted

current security + forged automation authority:
  authority-expanding worker result is rejected
  no authorized trajectory or remediation path is created
```

## Safety boundary
```text
existing_isolated_proof_harness_preserved=true
existing_runtime_guard_benchmark_preserved=true
contributes_to_current_pr_decision=false
feeds_repo_memory=false
executes_patch=false
automation_allowed_count=0
merge_authorized_count=0
semantic_equivalence_claimed_count=0
protected_verifier_semantics_expanded=false
automatic_security_fix_added=false
automatic_remediation_added=false
```

## Scope
- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/replayable_benchmark_harness.py`
- `tests/fixtures/remediation_benchmark/security_freshness_authority_unsafe.json`
- `tests/fixtures/remediation_benchmark/security_freshness_current_primary_oracle.json`
- `tests/fixtures/remediation_benchmark/security_freshness_stale_runtime_oracle.json`
- `tests/test_pr_quality_comment_observability_workflow.py`
- `tests/test_replayable_benchmark_harness.py`

`docs/roadmap/manifest.json` remains fresh and unchanged.

## Local validation
- Focused additive security-freshness benchmark suite: `97 passed`.
- Post-manifest focused suite: `100 passed`.
- Full pytest suite: `3738 passed, 1 skipped`.
- Modified Python file security finding check: `0` warn/error findings.
- `python -m mypy src`: passed.
- `python -m pre_commit run -a`: passed.
- `python scripts/check_generated_artifacts_freshness.py`: passed.
- `python -m sdetkit.roadmap_manifest check`: passed.
- Controlled security-freshness benchmark artifact proof: passed.

## Risk
Medium. This adds a new fixture mode and PR Quality report section to an established harness. It does not replace prior benchmark behavior, feed decisions or RepoMemory, execute patches, expand ProtectedVerifier semantic claims, or authorize security remediation/dismissal.

## Next
Use the live PR Quality output to confirm the security-freshness replay contract appears in CI as non-authorizing evidence. Do not add automated remediation, security dismissal, or worker-history promotion in this PR.
