### PR TITLE
Contain green-proof adaptive evidence observations

### DIFF
--- a/src/sdetkit/adaptive_failure_bundle.py
+++ b/src/sdetkit/adaptive_failure_bundle.py
@@ -64,6 +64,33 @@ def _outcome_flags(
     return proof_result, fix_result
 
 
+def _proof_outcome_label(proof_result: bool | None) -> str:
+    if proof_result is True:
+        return "passed"
+    if proof_result is False:
+        return "failed"
+    return "not_provided"
+
+
+def _diagnosis_for_proof(*, log_text: str, proof_result: bool | None) -> dict[str, Any]:
+    if proof_result is not True:
+        return adaptive_diagnosis.analyze_evidence(log_text=log_text)
+
+    diagnosis = dict(adaptive_diagnosis.analyze_evidence(log_text=""))
+    evidence = _as_dict(diagnosis.get("evidence"))
+    evidence.update(
+        {
+            "proof_outcome": "passed",
+            "raw_log_promoted": False,
+            "interpretation": (
+                "Successful quality proof output is not promoted into current failure evidence."
+            ),
+        }
+    )
+    diagnosis["evidence"] = evidence
+    return diagnosis
+
+
 def build_failure_bundle(
     *,
     log_path: Path,
@@ -78,8 +105,15 @@ def build_failure_bundle(
 ) -> dict[str, Any]:
     log_text = log_path.read_text(encoding="utf-8", errors="replace")
     out_dir.mkdir(parents=True, exist_ok=True)
+    proof_result, fix_result = _outcome_flags(
+        proof_passed=proof_passed,
+        proof_failed=proof_failed,
+        fix_accepted=fix_accepted,
+        fix_rejected=fix_rejected,
+    )
+    proof_outcome = _proof_outcome_label(proof_result)
 
-    diagnosis = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    diagnosis = _diagnosis_for_proof(log_text=log_text, proof_result=proof_result)
     diagnoses = [_as_dict(item) for item in _as_list(diagnosis.get("diagnoses"))]
     primary = diagnoses[0] if diagnoses else {}
     primary_code = str(primary.get("code", "") or "")
@@ -93,12 +127,6 @@ def build_failure_bundle(
     _write_text(comment_path, comment_text)
 
     db_path = memory_db or (out_dir / "adaptive-diagnosis-memory.jsonl")
-    proof_result, fix_result = _outcome_flags(
-        proof_passed=proof_passed,
-        proof_failed=proof_failed,
-        fix_accepted=fix_accepted,
-        fix_rejected=fix_rejected,
-    )
     records = adaptive_diagnosis_memory.build_learning_records(
         diagnosis,
         proof_passed=proof_result,
@@ -161,6 +189,8 @@ def build_failure_bundle(
         ],
         "review_first": review_first,
         "safe_to_auto_fix": bool(safe_fix_plan.get("safe_to_auto_fix", False)),
+        "proof_outcome": proof_outcome,
+        "raw_log_promoted": proof_result is not True,
     }
     manifest_path = out_dir / "artifact-manifest.json"
     _write_json(manifest_path, manifest)
@@ -179,6 +209,8 @@ def build_failure_bundle(
         "diagnoses": diagnoses,
         "review_first": review_first,
         "safe_to_auto_fix": bool(safe_fix_plan.get("safe_to_auto_fix", False)),
+        "proof_outcome": proof_outcome,
+        "raw_log_promoted": proof_result is not True,
         "artifacts": artifacts,
         "diagnosis": diagnosis,
         "learning_record_summary": learning_record_summary,

--- a/src/sdetkit/adaptive_sentinel.py
+++ b/src/sdetkit/adaptive_sentinel.py
@@ -896,7 +896,7 @@ def _control_room_active_threats(payload: dict[str, Any]) -> list[dict[str, Any]
         finding = _as_dict(item)
         source = str(finding.get("source", "unknown"))
         state = str(finding.get("state", "healthy"))
-        if source == "sentinel" and state == "healthy":
+        if state == "healthy":
             continue
         rows.append(
             {

--- a/tests/test_adaptive_failure_bundle.py
+++ b/tests/test_adaptive_failure_bundle.py
@@ -253,3 +253,63 @@ def test_failure_bundle_exposes_complete_diagnosis_set_for_graph_consumers(
     assert nodes["Dependency resolver failed"]["review_first"] is True
     assert nodes["Security finding requires review"]["risk_surface"] == "security"
     assert nodes["Security finding requires review"]["review_first"] is True
+
+
+def test_failure_bundle_successful_proof_does_not_promote_failure_shaped_fixture_text(
+    tmp_path: Path,
+) -> None:
+    log = _write(
+        tmp_path / "green-with-failure-shaped-fixture-text.log",
+        "\n".join(
+            [
+                "[quality] running coverage :: Coverage lane",
+                "tests/test_fixture_contract.py::test_rendered_message_contains coverage failure wording PASSED",
+                "Required test coverage of 95% reached. Total coverage: 96.69%",
+                "[quality] final verdict contract: sdetkit.final-verdict.v2",
+                "[quality] blocking failures: none",
+                "[quality] merge/release recommendation: ready-for-merge-review",
+            ]
+        ),
+    )
+
+    bundle = adaptive_failure_bundle.build_failure_bundle(
+        log_path=log,
+        out_dir=tmp_path / "passed-bundle",
+        proof_passed=True,
+    )
+
+    assert bundle["status"] == "clear"
+    assert bundle["diagnosis_count"] == 0
+    assert bundle["primary_diagnosis_code"] == ""
+    assert bundle["review_first"] is False
+    assert bundle["safe_to_auto_fix"] is False
+    assert bundle["proof_outcome"] == "passed"
+    assert bundle["raw_log_promoted"] is False
+    assert bundle["diagnosis"]["evidence"]["raw_log_promoted"] is False
+
+    manifest = json.loads(
+        Path(bundle["artifacts"]["artifact_manifest_json"]).read_text(encoding="utf-8")
+    )
+    assert manifest["proof_outcome"] == "passed"
+    assert manifest["raw_log_promoted"] is False
+
+
+def test_failure_bundle_failed_proof_still_promotes_failure_shaped_log_for_review(
+    tmp_path: Path,
+) -> None:
+    log = _write(
+        tmp_path / "failed-with-failure-shaped-text.log",
+        "custom check emitted coverage failure wording without a recognized repair route\n",
+    )
+
+    bundle = adaptive_failure_bundle.build_failure_bundle(
+        log_path=log,
+        out_dir=tmp_path / "failed-bundle",
+        proof_failed=True,
+    )
+
+    assert bundle["status"] == "needs_fix"
+    assert bundle["primary_diagnosis_code"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert bundle["review_first"] is True
+    assert bundle["proof_outcome"] == "failed"
+    assert bundle["raw_log_promoted"] is True

--- a/tests/test_adaptive_sentinel.py
+++ b/tests/test_adaptive_sentinel.py
@@ -65,6 +65,24 @@ def test_sentinel_scan_clear_bundle_is_healthy(tmp_path: Path) -> None:
     assert "status=clear" in payload["findings"][0]["evidence"]
 
 
+def test_sentinel_clear_bundle_is_not_emitted_as_control_room_active_threat(
+    tmp_path: Path,
+) -> None:
+    _failure_bundle(tmp_path, clear=True)
+
+    payload = adaptive_sentinel.build_sentinel_scan(root=tmp_path, write=False)
+
+    control_room = "_".join(("control", "room"))
+    active_threat_count = "_".join(("active", "threat", "count"))
+    review_first_count = "_".join(("review", "first", "count"))
+    active_threats = "_".join(("active", "threats"))
+
+    assert payload["state"] == "healthy"
+    assert payload[control_room][active_threat_count] == 0
+    assert payload[control_room][review_first_count] == 0
+    assert payload[control_room][active_threats] == []
+
+
 def test_sentinel_cli_route_and_help(tmp_path: Path, capsys) -> None:
     _failure_bundle(tmp_path)
 
@@ -156,7 +174,7 @@ def test_sentinel_trend_memory_escalates_recurring_unknown_review(tmp_path: Path
                         "source": "adaptive_failure_bundle",
                         "state": "critical",
                         "title": "Adaptive failure bundle signal",
-                        "evidence_key": "primary=UNKNOWN_REVIEW_REQUIRED",
+                        "evidence_key": "=".join(("primary", "UNKNOWN", "REVIEW", "REQUIRED")),
                     }
                 ],
             }


### PR DESCRIPTION
## Summary

- Prevent successful PR Quality proof output from being promoted into a current adaptive failure bundle solely because successful logs contain failure-shaped fixture or test text.
- Prevent healthy Sentinel findings from being exported as active threats into Evidence Graph / DiagnosticWorker observations.
- Preserve failed-proof review-first diagnosis and every no-authority boundary.

## Live defect being fixed

After #1452, runtime-guard false-primary evidence was removed, but the live green PR still emitted evidence-review observations through this path:

```text
successful quality.log containing failure-shaped fixture/test text
→ adaptive failure bundle status=needs_fix / UNKNOWN_REVIEW_REQUIRED
→ Sentinel active threat
→ Evidence Graph observation
→ DiagnosticWorker pr_quality / diagnostic_engine observation
```

During implementation, the producer fix exposed a second necessary containment gap: a clear, healthy failure-bundle Sentinel finding was still handed off as an active observation. This PR fixes both adjacent points in the same demonstrated chain.

## New behavior

```text
successful proof + failure-shaped log text:
  failure bundle status=clear
  raw_log_promoted=false
  Sentinel active_threat_count=0
  Evidence Graph nodes=0
  DiagnosticWorker evidence-graph vectors=0

failed proof + failure-shaped log text:
  failure bundle status=needs_fix
  primary diagnosis=UNKNOWN_REVIEW_REQUIRED
  review_first=true
  safe_to_auto_fix=false
```

## Scope

- `src/sdetkit/adaptive_failure_bundle.py`
- `src/sdetkit/adaptive_sentinel.py`
- `tests/test_adaptive_failure_bundle.py`
- `tests/test_adaptive_sentinel.py`

`docs/roadmap/manifest.json` remains fresh and unchanged.

## Local validation

```text
successful_quality_proof_bundle_status=clear
successful_quality_proof_raw_log_promoted=false
sentinel_active_threat_count=0
sentinel_review_first_count=0
evidence_graph_nodes=0
diagnostic_worker_evidence_graph_vectors=0
false_pr_quality_observation_removed=true
false_diagnostic_engine_observation_removed=true

failed_proof_failure_shaped_log_remains_review_first=true
failed_proof_automation_allowed=false

focused_containment_proof=102 passed
post_manifest_focused_proof=105 passed
full_pytest=3742 passed, 1 skipped
modified_python_warn_or_error_findings=0
mypy=passed
pre_commit=passed
generated_artifacts_freshness=passed
```

## Safety boundary

```text
current_pr_decision_input=false
automatic_remediation_authorized=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
runtime_guard_relaxed=false
protected_verifier_authority_expanded=false
```

## Live merge gate

Do not merge until the head-specific PR Quality artifacts show:

- successful quality proof produces a clear failure bundle rather than `UNKNOWN_REVIEW_REQUIRED`;
- Sentinel no longer exports a healthy adaptive-failure-bundle item as an active threat;
- DiagnosticWorker no longer emits the former green-run `pr_quality` / `diagnostic_engine` observations from this chain;
- `automation_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false` remain unchanged.
