### PR TITLE
Report read-only diagnostic signal snapshot

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -693,6 +693,44 @@ jobs:
             } > build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md
           fi
 
+          mkdir -p build/pr-quality/diagnostic-signal-snapshot
+          diagnostic_signal_snapshot_rc=2
+          if [ "$diagnostic_job_rc" -eq 0 ] \
+            && [ -s build/pr-quality/diagnostic-job/diagnostic-worker-result.json ]; then
+            diagnostic_signal_snapshot_rc=0
+            PYTHONPATH=src python -m sdetkit.diagnostic_signal_snapshot \
+              --evidence-narrative build/pr-quality/pr-evidence-narrative.json \
+              --evidence-graph build/sdetkit/evidence-graph/evidence-graph.json \
+              --diagnostic-worker-result build/pr-quality/diagnostic-job/diagnostic-worker-result.json \
+              --runtime-proof-artifacts build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json \
+              --security-finding-diagnosis build/pr-quality/security-diagnosis/security-finding-diagnosis.json \
+              --out-dir build/pr-quality/diagnostic-signal-snapshot \
+              --format json \
+              > build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot-cli.json \
+              || diagnostic_signal_snapshot_rc=$?
+          fi
+          printf '%s\n' "$diagnostic_signal_snapshot_rc" \
+            > build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot-exit-code.txt
+
+          if [ "$diagnostic_signal_snapshot_rc" -ne 0 ] \
+            && [ ! -s build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md ]; then
+            {
+              printf '%s\n' \
+                '## Diagnostic signal KPI snapshot' \
+                '' \
+                '- Evidence type: `current_pr_reporting_only_snapshot`' \
+                '- Status: `collection_failed`' \
+                '- Current PR decision input: `false`' \
+                '- Feeds RepoMemory: `false`' \
+                '- Patch application allowed: `false`' \
+                '- Automation allowed: `false`' \
+                '- Merge authorized: `false`' \
+                '- Semantic equivalence proven: `false`' \
+                '' \
+                '- Interpretation: signal snapshot collection failed; the existing PR decision, diagnostic worker evidence, and RepoMemory inputs remain unchanged.'
+            } > build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md
+          fi
+
           mkdir -p build/pr-quality/candidate-validation
           PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
             --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
@@ -727,6 +765,11 @@ jobs:
           if [ -s build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md ]; then
             printf '\n' >> build/pr-quality/pr-comment-body.md
             cat build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md >> build/pr-quality/pr-comment-body.md
+          fi
+
+          if [ -s build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md >> build/pr-quality/pr-comment-body.md
           fi
 
           if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then
@@ -804,6 +847,7 @@ jobs:
             build/pr-quality/trusted-history/
             build/pr-quality/runtime-proof/
             build/pr-quality/diagnostic-job/
+            build/pr-quality/diagnostic-signal-snapshot/
             build/pr-quality/candidate-visibility/
             build/pr-quality/candidate-validation/
             build/pr-quality/runtime-guard-benchmark/

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -360,7 +360,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.evidence_narrative",
         "module_path": "src/sdetkit/evidence_narrative.py",
-        "tests_referencing_module": 13
+        "tests_referencing_module": 14
       },
       {
         "contract_script_paths": [
@@ -396,7 +396,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.expansion",
         "module_path": "src/sdetkit/expansion.py",
-        "tests_referencing_module": 27
+        "tests_referencing_module": 28
       },
       {
         "contract_script_paths": [
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 120
+        "tests_referencing_module": 121
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/diagnostic_signal_snapshot.py
+++ b/src/sdetkit/diagnostic_signal_snapshot.py
@@ -1,0 +1,302 @@
+# Render a read-only diagnostic-signal baseline snapshot for PR Quality.
+#
+# This artifact measures observed signal counts for later reviewed KPI
+# aggregation. It does not infer a historical false-positive rate, change a
+# PR decision, execute proof commands, apply patches, or authorize remediation.
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = ".".join(("sdetkit", "diagnostic", "signal", "snapshot", "v1"))
+DEFAULT_OUT_DIR = Path("build") / "pr-quality" / "diagnostic-signal-snapshot"
+SNAPSHOT_JSON = "diagnostic-signal-snapshot.json"
+REPORT_MD = "diagnostic-signal-snapshot.md"
+QUIET_GREEN_STATUS = "_".join(("quiet", "green", "advisory", "baseline"))
+OBSERVED_STATUS = "_".join(("diagnostic", "signal", "observed"))
+RATE_STATUS = "_".join(("requires", "reviewed", "history"))
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _bool(value: Any) -> bool:
+    return value is True
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _read_json(path: Path) -> JsonObject:
+    if not path.exists():
+        raise ValueError(f"declared diagnostic signal snapshot input is missing: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _boundary() -> JsonObject:
+    return {
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "feeds_repo_memory": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _assert_non_authorizing(payload: Mapping[str, Any], *, source: str) -> None:
+    boundary = _as_dict(payload.get("decision_boundary"))
+    prohibited = (
+        "current_pr_decision_input",
+        "patch_application_allowed",
+        "automation_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+    )
+    expanded = [key for key in prohibited if _bool(boundary.get(key))]
+    if expanded:
+        raise ValueError(f"{source} expands authority: {', '.join(expanded)}")
+
+
+def build_snapshot(
+    *,
+    evidence_narrative: Mapping[str, Any],
+    evidence_graph: Mapping[str, Any],
+    diagnostic_worker_result: Mapping[str, Any],
+    runtime_proof_artifacts: Mapping[str, Any],
+    security_finding_diagnosis: Mapping[str, Any],
+) -> JsonObject:
+    _assert_non_authorizing(diagnostic_worker_result, source="diagnostic worker result")
+    _assert_non_authorizing(runtime_proof_artifacts, source="runtime proof artifacts")
+
+    quality = _as_dict(evidence_narrative.get("quality"))
+    narrative_graph = _as_dict(evidence_narrative.get("graph"))
+    graph_nodes = [
+        _as_dict(item) for item in _as_list(evidence_graph.get("nodes")) if _as_dict(item)
+    ]
+    declared_graph_count = _int(narrative_graph.get("node_count"))
+    if declared_graph_count != len(graph_nodes):
+        raise ValueError("evidence narrative graph count does not match Evidence Graph nodes")
+
+    worker_summary = _as_dict(diagnostic_worker_result.get("summary"))
+    isolated = _as_dict(runtime_proof_artifacts.get("isolated_proof"))
+    security_rows = [
+        _as_dict(item)
+        for item in _as_list(security_finding_diagnosis.get("diagnoses"))
+        if _as_dict(item)
+    ]
+    current_security_count = sum(
+        1 for row in security_rows if _string(row.get("freshness")).lower() == "current"
+    )
+    stale_security_count = sum(
+        1 for row in security_rows if _string(row.get("freshness")).lower() == "stale"
+    )
+    primary_signal = _as_dict(evidence_narrative.get("primary_signal"))
+    primary_kind = _string(primary_signal.get("kind") or "unknown")
+    primary_surface = _string(primary_signal.get("surface") or "unknown")
+
+    measurements = {
+        "quality_gate_passed": _bool(quality.get("ok")),
+        "primary_signal_kind": primary_kind,
+        "primary_signal_surface": primary_surface,
+        "review_signal_present": primary_kind == "review_signal",
+        "integration_proof_signal_present": primary_kind == "integration_proof",
+        "evidence_graph_node_count": len(graph_nodes),
+        "evidence_graph_review_first_count": _int(narrative_graph.get("review_first_count")),
+        "diagnostic_worker_diagnosis_count": _int(worker_summary.get("diagnosis_count")),
+        "diagnostic_worker_review_first_count": _int(worker_summary.get("review_first_count")),
+        "diagnostic_worker_safe_fix_candidate_count": _int(
+            worker_summary.get("safe_fix_candidate_count")
+        ),
+        "runtime_guard_violation_count": _int(isolated.get("runtime_guard_violation_count")),
+        "runtime_guard_passed": _bool(isolated.get("runtime_guard_passed")),
+        "current_security_finding_count": current_security_count,
+        "stale_security_finding_count": stale_security_count,
+    }
+    quiet_green = (
+        measurements["quality_gate_passed"]
+        and measurements["evidence_graph_node_count"] == 0
+        and measurements["evidence_graph_review_first_count"] == 0
+        and measurements["diagnostic_worker_diagnosis_count"] == 0
+        and measurements["diagnostic_worker_review_first_count"] == 0
+        and measurements["diagnostic_worker_safe_fix_candidate_count"] == 0
+        and measurements["runtime_guard_passed"]
+        and measurements["runtime_guard_violation_count"] == 0
+        and measurements["current_security_finding_count"] == 0
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": QUIET_GREEN_STATUS if quiet_green else OBSERVED_STATUS,
+        "snapshot_type": "current_pr_reporting_only",
+        "quiet_green_advisory_baseline": quiet_green,
+        "measurements": measurements,
+        "kpi_readiness": {
+            "advisor_false_positive_rate_status": RATE_STATUS,
+            "reason": (
+                "This current-PR snapshot records signal counts only; a false-positive "
+                "rate requires reviewed labels aggregated through trusted history."
+            ),
+            "reviewed_false_positive_count": None,
+            "reviewed_observation_count": None,
+        },
+        "decision_boundary": _boundary(),
+    }
+
+
+def render_markdown(snapshot: Mapping[str, Any]) -> str:
+    measurements = _as_dict(snapshot.get("measurements"))
+    readiness = _as_dict(snapshot.get("kpi_readiness"))
+    boundary = _as_dict(snapshot.get("decision_boundary"))
+    return "\n".join(
+        [
+            "## Diagnostic signal KPI snapshot",
+            "",
+            "- Evidence type: `current_pr_reporting_only_snapshot`",
+            f"- Status: `{_string(snapshot.get('status'))}`",
+            (
+                "- Quiet green advisory baseline: "
+                f"`{str(_bool(snapshot.get('quiet_green_advisory_baseline'))).lower()}`"
+            ),
+            f"- Quality gate passed: `{str(_bool(measurements.get('quality_gate_passed'))).lower()}`",
+            f"- Primary narrative signal kind: `{_string(measurements.get('primary_signal_kind'))}`",
+            (
+                "- Review signal present: "
+                f"`{str(_bool(measurements.get('review_signal_present'))).lower()}`"
+            ),
+            (
+                "- Integration proof signal present: "
+                f"`{str(_bool(measurements.get('integration_proof_signal_present'))).lower()}`"
+            ),
+            f"- Evidence Graph nodes: `{_int(measurements.get('evidence_graph_node_count'))}`",
+            (
+                "- Evidence Graph review-first nodes: "
+                f"`{_int(measurements.get('evidence_graph_review_first_count'))}`"
+            ),
+            (
+                "- DiagnosticWorker diagnoses: "
+                f"`{_int(measurements.get('diagnostic_worker_diagnosis_count'))}`"
+            ),
+            (
+                "- DiagnosticWorker review-first diagnoses: "
+                f"`{_int(measurements.get('diagnostic_worker_review_first_count'))}`"
+            ),
+            (
+                "- DiagnosticWorker safe-fix candidates: "
+                f"`{_int(measurements.get('diagnostic_worker_safe_fix_candidate_count'))}`"
+            ),
+            (
+                "- Runtime guard violations: "
+                f"`{_int(measurements.get('runtime_guard_violation_count'))}`"
+            ),
+            (
+                "- Current security findings: "
+                f"`{_int(measurements.get('current_security_finding_count'))}`"
+            ),
+            (
+                "- Stale security findings retained as context: "
+                f"`{_int(measurements.get('stale_security_finding_count'))}`"
+            ),
+            (
+                "- Advisor false-positive rate status: "
+                f"`{_string(readiness.get('advisor_false_positive_rate_status'))}`"
+            ),
+            "- Interpretation: this snapshot records live diagnostic-signal counts for later reviewed KPI aggregation; it does not label observations as false positives by itself.",
+            "",
+            "### Boundary",
+            "",
+            f"- Reporting only: `{str(_bool(boundary.get('reporting_only'))).lower()}`",
+            (
+                "- Current PR decision input: "
+                f"`{str(_bool(boundary.get('current_pr_decision_input'))).lower()}`"
+            ),
+            f"- Feeds RepoMemory: `{str(_bool(boundary.get('feeds_repo_memory'))).lower()}`",
+            (
+                "- Proof commands executed: "
+                f"`{str(_bool(boundary.get('proof_commands_executed'))).lower()}`"
+            ),
+            (
+                "- Patch application allowed: "
+                f"`{str(_bool(boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`",
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            "",
+        ]
+    )
+
+
+def write_snapshot(snapshot: Mapping[str, Any], *, out_dir: Path) -> JsonObject:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / SNAPSHOT_JSON
+    markdown_path = out_dir / REPORT_MD
+    json_path.write_text(
+        json.dumps(dict(snapshot), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    markdown_path.write_text(render_markdown(snapshot), encoding="utf-8")
+    return {
+        "diagnostic_signal_snapshot_json": json_path.as_posix(),
+        "diagnostic_signal_snapshot_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.diagnostic_signal_snapshot")
+    parser.add_argument("--evidence-narrative", type=Path, required=True)
+    parser.add_argument("--evidence-graph", type=Path, required=True)
+    parser.add_argument("--diagnostic-worker-result", type=Path, required=True)
+    parser.add_argument("--runtime-proof-artifacts", type=Path, required=True)
+    parser.add_argument("--security-finding-diagnosis", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    snapshot = build_snapshot(
+        evidence_narrative=_read_json(args.evidence_narrative),
+        evidence_graph=_read_json(args.evidence_graph),
+        diagnostic_worker_result=_read_json(args.diagnostic_worker_result),
+        runtime_proof_artifacts=_read_json(args.runtime_proof_artifacts),
+        security_finding_diagnosis=_read_json(args.security_finding_diagnosis),
+    )
+    artifacts = write_snapshot(snapshot, out_dir=args.out_dir)
+    output = {"snapshot": snapshot, "artifacts": artifacts}
+    if args.format == "json":
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(snapshot), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_diagnostic_signal_snapshot.py
+++ b/tests/test_diagnostic_signal_snapshot.py
@@ -1,0 +1,181 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.diagnostic_signal_snapshot import (
+    QUIET_GREEN_STATUS,
+    RATE_STATUS,
+    build_snapshot,
+    main,
+    render_markdown,
+)
+
+
+def _narrative(*, nodes: int = 0, review_first: int = 0) -> dict[str, object]:
+    return {
+        "quality": {"ok": True},
+        "graph": {"node_count": nodes, "review_first_count": review_first},
+        "primary_signal": {"kind": "review_signal", "surface": "workflow"},
+    }
+
+
+def _worker(*, diagnoses: int = 0, review_first: int = 0) -> dict[str, object]:
+    return {
+        "summary": {
+            "diagnosis_count": diagnoses,
+            "review_first_count": review_first,
+            "safe_fix_candidate_count": 0,
+        },
+        "decision_boundary": {
+            "current_pr_decision_input": False,
+            "patch_application_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _runtime(*, violations: int = 0) -> dict[str, object]:
+    return {
+        "isolated_proof": {
+            "runtime_guard_passed": violations == 0,
+            "runtime_guard_violation_count": violations,
+        },
+        "decision_boundary": {
+            "current_pr_decision_input": False,
+            "patch_application_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def test_snapshot_records_quiet_green_baseline_without_claiming_false_positive_rate() -> None:
+    snapshot = build_snapshot(
+        evidence_narrative=_narrative(),
+        evidence_graph={"nodes": []},
+        diagnostic_worker_result=_worker(),
+        runtime_proof_artifacts=_runtime(),
+        security_finding_diagnosis={"diagnoses": [{"freshness": "stale"}]},
+    )
+
+    assert snapshot["status"] == QUIET_GREEN_STATUS
+    assert snapshot["quiet_green_advisory_baseline"] is True
+    measurements = snapshot["measurements"]
+    assert measurements["primary_signal_kind"] == "review_signal"
+    assert measurements["review_signal_present"] is True
+    assert measurements["integration_proof_signal_present"] is False
+    assert measurements["evidence_graph_node_count"] == 0
+    assert measurements["diagnostic_worker_diagnosis_count"] == 0
+    assert measurements["stale_security_finding_count"] == 1
+    assert snapshot["kpi_readiness"]["advisor_false_positive_rate_status"] == RATE_STATUS
+    assert snapshot["decision_boundary"]["automation_allowed"] is False
+
+
+def test_snapshot_distinguishes_integration_proof_from_review_signal() -> None:
+    narrative = _narrative()
+    narrative["primary_signal"] = {"kind": "integration_proof", "surface": "tests"}
+    snapshot = build_snapshot(
+        evidence_narrative=narrative,
+        evidence_graph={"nodes": []},
+        diagnostic_worker_result=_worker(),
+        runtime_proof_artifacts=_runtime(),
+        security_finding_diagnosis={"diagnoses": []},
+    )
+
+    measurements = snapshot["measurements"]
+    assert measurements["primary_signal_kind"] == "integration_proof"
+    assert measurements["review_signal_present"] is False
+    assert measurements["integration_proof_signal_present"] is True
+
+
+def test_snapshot_records_observed_signal_without_granting_authority() -> None:
+    snapshot = build_snapshot(
+        evidence_narrative=_narrative(nodes=1, review_first=1),
+        evidence_graph={"nodes": [{"review_first": True}]},
+        diagnostic_worker_result=_worker(diagnoses=1, review_first=1),
+        runtime_proof_artifacts=_runtime(),
+        security_finding_diagnosis={"diagnoses": []},
+    )
+
+    assert snapshot["quiet_green_advisory_baseline"] is False
+    assert snapshot["measurements"]["diagnostic_worker_review_first_count"] == 1
+    assert snapshot["decision_boundary"]["current_pr_decision_input"] is False
+    assert snapshot["decision_boundary"]["feeds_repo_memory"] is False
+
+
+def test_snapshot_rejects_worker_authority_expansion() -> None:
+    worker = _worker()
+    worker["decision_boundary"]["automation_allowed"] = True
+
+    with pytest.raises(ValueError, match="expands authority"):
+        build_snapshot(
+            evidence_narrative=_narrative(),
+            evidence_graph={"nodes": []},
+            diagnostic_worker_result=worker,
+            runtime_proof_artifacts=_runtime(),
+            security_finding_diagnosis={"diagnoses": []},
+        )
+
+
+def test_snapshot_markdown_keeps_baseline_and_boundary_explicit() -> None:
+    snapshot = build_snapshot(
+        evidence_narrative=_narrative(),
+        evidence_graph={"nodes": []},
+        diagnostic_worker_result=_worker(),
+        runtime_proof_artifacts=_runtime(),
+        security_finding_diagnosis={"diagnoses": []},
+    )
+
+    markdown = render_markdown(snapshot)
+    assert "Diagnostic signal KPI snapshot" in markdown
+    assert "Quiet green advisory baseline: `true`" in markdown
+    assert "Primary narrative signal kind: `review_signal`" in markdown
+    assert "Review signal present: `true`" in markdown
+    assert "Integration proof signal present: `false`" in markdown
+    assert "Advisor false-positive rate status: `requires_reviewed_history`" in markdown
+    assert "Feeds RepoMemory: `false`" in markdown
+    assert "Automation allowed: `false`" in markdown
+
+
+def test_snapshot_cli_writes_json_and_markdown_artifacts(tmp_path: Path) -> None:
+    paths: dict[str, Path] = {}
+    payloads = {
+        "evidence_narrative": _narrative(),
+        "evidence_graph": {"nodes": []},
+        "diagnostic_worker_result": _worker(),
+        "runtime_proof_artifacts": _runtime(),
+        "security_finding_diagnosis": {"diagnoses": []},
+    }
+    for name, payload in payloads.items():
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        paths[name] = path
+
+    out_dir = tmp_path / "out"
+    assert (
+        main(
+            [
+                "--evidence-narrative",
+                str(paths["evidence_narrative"]),
+                "--evidence-graph",
+                str(paths["evidence_graph"]),
+                "--diagnostic-worker-result",
+                str(paths["diagnostic_worker_result"]),
+                "--runtime-proof-artifacts",
+                str(paths["runtime_proof_artifacts"]),
+                "--security-finding-diagnosis",
+                str(paths["security_finding_diagnosis"]),
+                "--out-dir",
+                str(out_dir),
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    assert (out_dir / "diagnostic-signal-snapshot.json").is_file()
+    assert (out_dir / "diagnostic-signal-snapshot.md").is_file()

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -861,3 +861,53 @@ def test_pr_quality_workflow_runs_security_freshness_benchmark_as_non_decision_e
     assert "build/pr-quality/security-freshness-benchmark/" in build_comment
     assert "--commit-safe-fixes" not in text
     assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_renders_diagnostic_signal_snapshot_after_worker_as_reporting_only() -> (
+    None
+):
+    text = _workflow_text()
+    build_comment = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build verified operator evidence loop"
+        )
+    ]
+
+    repo_memory = build_comment.index("python -m sdetkit.repo_memory")
+    action_report = build_comment.index("python -m sdetkit.pr_quality_action_report")
+    diagnostic_job = build_comment.index("python -m sdetkit.diagnostic_job")
+    trajectory = build_comment.index("python -m sdetkit.diagnostic_worker_trajectory")
+    snapshot = build_comment.index("python -m sdetkit.diagnostic_signal_snapshot")
+    candidate_validation = build_comment.index("python -m sdetkit.pr_quality_candidate_validation")
+    snapshot_append = build_comment.index(
+        "cat build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md"
+    )
+    repo_memory_command = build_comment[
+        repo_memory : build_comment.index(
+            "> build/pr-quality/repo-memory/repo-memory-cli.json", repo_memory
+        )
+    ]
+    action_report_command = build_comment[
+        action_report : build_comment.index(
+            "> build/pr-quality/pr-comment-metadata.json", action_report
+        )
+    ]
+
+    assert (
+        repo_memory < action_report < diagnostic_job < trajectory < snapshot < candidate_validation
+    )
+    assert snapshot < snapshot_append
+    assert "diagnostic-signal-snapshot" not in repo_memory_command
+    assert "diagnostic-signal-snapshot" not in action_report_command
+    assert (
+        "--diagnostic-worker-result build/pr-quality/diagnostic-job/diagnostic-worker-result.json"
+        in build_comment
+    )
+    assert "Diagnostic signal KPI snapshot" in build_comment
+    assert "current_pr_reporting_only_snapshot" in build_comment
+    assert "Current PR decision input: `false`" in build_comment
+    assert "Feeds RepoMemory: `false`" in build_comment
+    assert "Automation allowed: `false`" in build_comment
+    assert "Merge authorized: `false`" in build_comment
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text


### PR DESCRIPTION
## Summary

- Add a read-only `DiagnosticSignalSnapshot` artifact to report the current PR's diagnostic signal baseline.
- Render that snapshot in PR Quality only after existing decision-producing and worker-reporting inputs.
- Distinguish `review_signal` from `integration_proof` rather than collapsing both into a misleading proof metric.
- Preserve all no-authority boundaries and do not feed RepoMemory.

## Why this is the next roadmap step

After the green-signal containment sequence, accepted `main` has a quiet advisory baseline:

```text
quality_gate_passed=true
evidence_graph_node_count=0
diagnostic_worker_diagnosis_count=0
runtime_guard_violation_count=0
current_security_finding_count=0
```

The roadmap calls for advisor false-positive measurement, but a single PR artifact cannot truthfully claim a rate. This PR therefore records a current-PR snapshot only and states:

```text
advisor_false_positive_rate_status=requires_reviewed_history
```

A later trusted-history change can aggregate reviewed labels into a rate.

## Corrected signal semantics

The snapshot records distinct signal types:

```text
primary_signal_kind=review_signal
review_signal_present=true
integration_proof_signal_present=false
```

A normal review signal is not misreported as an integration-proof event.

## Reporting-only boundary

```text
current_pr_decision_input=false
feeds_repo_memory=false
proof_commands_executed=false
patch_application_allowed=false
automation_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
```

## Scope

- `.github/workflows/pr-quality-comment.yml`
- `docs/roadmap/manifest.json`
- `src/sdetkit/diagnostic_signal_snapshot.py`
- `tests/test_diagnostic_signal_snapshot.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

## Local proof

```text
diagnostic_signal_snapshot_status=quiet_green_advisory_baseline
quiet_green_advisory_baseline=true
primary_signal_kind=review_signal
review_signal_present=true
integration_proof_signal_present=false
advisor_false_positive_rate_status=requires_reviewed_history
snapshot_contributes_to_current_pr_decision=false
snapshot_feeds_repo_memory=false
automatic_remediation_authorized=false

focused_corrected_snapshot_proof=89 passed
post_manifest_focused_proof=92 passed
full_pytest=3750 passed, 1 skipped
modified_python_warn_or_error_findings=0
mypy=passed
pre_commit=passed
generated_artifacts_freshness=passed
```

## Live merge gate

Do not merge until the head-specific PR Quality output proves:

- the `Diagnostic signal KPI snapshot` section renders successfully;
- `status=quiet_green_advisory_baseline`;
- `primary_signal_kind=review_signal`, `review_signal_present=true`, and `integration_proof_signal_present=false` for this workflow-changing PR;
- graph nodes and DiagnosticWorker diagnoses remain zero;
- `advisor_false_positive_rate_status=requires_reviewed_history`;
- `current_pr_decision_input=false`, `feeds_repo_memory=false`, `automation_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false`.
