### PR TITLE
Retain diagnostic signal snapshots as advisory history

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -731,6 +731,131 @@ jobs:
             } > build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md
           fi
 
+          mkdir -p build/pr-quality/trusted-diagnostic-signal-snapshot-history
+          trusted_diagnostic_signal_snapshot_history_rc=2
+          trusted_snapshot_history_summary=""
+          trusted_snapshot_history_jsonl=""
+          trusted_snapshot_history_run_id=""
+          trusted_snapshot_history_head_sha=""
+          trusted_snapshot_history_file_count=0
+          trusted_snapshot_download_root="${RUNNER_TEMP}/sdetkit-trusted-diagnostic-snapshot-history"
+          rm -rf "$trusted_snapshot_download_root"
+          mkdir -p "$trusted_snapshot_download_root"
+
+          while IFS=$'\t' read -r candidate_run_id candidate_head_sha; do
+            if [ -z "$candidate_run_id" ] || [ -z "$candidate_head_sha" ]; then
+              continue
+            fi
+            if ! git merge-base --is-ancestor "$candidate_head_sha" "$PR_BASE_SHA"; then
+              continue
+            fi
+
+            candidate_dir="$trusted_snapshot_download_root/$candidate_run_id"
+            mkdir -p "$candidate_dir"
+            candidate_download_rc=0
+            gh run download "$candidate_run_id" \
+              --repo "$REPOSITORY" \
+              --name repo-memory-profile-history \
+              --dir "$candidate_dir" >/dev/null 2>&1 \
+              || candidate_download_rc=$?
+            if [ "$candidate_download_rc" -ne 0 ]; then
+              continue
+            fi
+
+            candidate_summary="$(
+              find "$candidate_dir" \
+                -name diagnostic-signal-snapshot-history-summary.json \
+                -print \
+                -quit
+            )"
+            candidate_jsonl="$(
+              find "$candidate_dir" \
+                -name diagnostic-signal-snapshot-history.jsonl \
+                -print \
+                -quit
+            )"
+            candidate_file_count=0
+            if [ -n "$candidate_summary" ] && [ -f "$candidate_summary" ]; then
+              candidate_file_count=$((candidate_file_count + 1))
+            fi
+            if [ -n "$candidate_jsonl" ] && [ -f "$candidate_jsonl" ]; then
+              candidate_file_count=$((candidate_file_count + 1))
+            fi
+            if [ "$candidate_file_count" -eq 0 ]; then
+              continue
+            fi
+
+            trusted_snapshot_history_summary="$candidate_summary"
+            trusted_snapshot_history_jsonl="$candidate_jsonl"
+            trusted_snapshot_history_run_id="$candidate_run_id"
+            trusted_snapshot_history_head_sha="$candidate_head_sha"
+            trusted_snapshot_history_file_count="$candidate_file_count"
+            break
+          done < build/pr-quality/trusted-history/successful-main-runs.tsv
+
+          if [ "$trusted_snapshot_history_file_count" -eq 0 ]; then
+            trusted_diagnostic_signal_snapshot_history_rc=2
+          elif [ "$trusted_snapshot_history_file_count" -ne 2 ]; then
+            trusted_diagnostic_signal_snapshot_history_rc=3
+          else
+            trusted_diagnostic_signal_snapshot_history_rc=0
+            PYTHONPATH=src python -m sdetkit.trusted_diagnostic_signal_snapshot_history \
+              --history-summary "$trusted_snapshot_history_summary" \
+              --history-jsonl "$trusted_snapshot_history_jsonl" \
+              --repo-root . \
+              --selected-retention-run-id "$trusted_snapshot_history_run_id" \
+              --selected-head-sha "$trusted_snapshot_history_head_sha" \
+              --base-sha "$PR_BASE_SHA" \
+              --out-dir build/pr-quality/trusted-diagnostic-signal-snapshot-history \
+              --format json \
+              > build/pr-quality/trusted-diagnostic-signal-snapshot-history/evidence-cli.json \
+              || trusted_diagnostic_signal_snapshot_history_rc=3
+          fi
+          printf '%s\n' "$trusted_diagnostic_signal_snapshot_history_rc" \
+            > build/pr-quality/trusted-diagnostic-signal-snapshot-history/exit-code.txt
+
+          if [ "$trusted_diagnostic_signal_snapshot_history_rc" -eq 2 ] \
+            && [ ! -s build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md ]; then
+            {
+              printf '%s\n' \
+                '## Trusted diagnostic signal snapshot history' \
+                '' \
+                '- Evidence type: `accepted_main_reporting_only_snapshot_history`' \
+                '- Collection status: `not_collected`' \
+                '- Status: `not_collected`' \
+                '- Advisor false-positive rate status: `requires_reviewed_history`' \
+                '- Current PR decision input: `false`' \
+                '- Feeds RepoMemory: `false`' \
+                '- Patch application allowed: `false`' \
+                '- Automation allowed: `false`' \
+                '- Merge authorized: `false`' \
+                '- Semantic equivalence proven: `false`' \
+                '- Historical snapshot authorizes current action: `false`' \
+                '' \
+                '- Interpretation: accepted-main DiagnosticSignalSnapshot history is not yet available from a verified ancestor artifact; no authority is granted.'
+            } > build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md
+          elif [ "$trusted_diagnostic_signal_snapshot_history_rc" -ne 0 ] \
+            && [ ! -s build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md ]; then
+            {
+              printf '%s\n' \
+                '## Trusted diagnostic signal snapshot history' \
+                '' \
+                '- Evidence type: `accepted_main_reporting_only_snapshot_history`' \
+                '- Collection status: `collection_failed`' \
+                '- Status: `collection_failed`' \
+                '- Advisor false-positive rate status: `requires_reviewed_history`' \
+                '- Current PR decision input: `false`' \
+                '- Feeds RepoMemory: `false`' \
+                '- Patch application allowed: `false`' \
+                '- Automation allowed: `false`' \
+                '- Merge authorized: `false`' \
+                '- Semantic equivalence proven: `false`' \
+                '- Historical snapshot authorizes current action: `false`' \
+                '' \
+                '- Interpretation: present accepted-main DiagnosticSignalSnapshot history failed validation or is incomplete; no authority is granted and this run must fail after comment publication.'
+            } > build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md
+          fi
+
           mkdir -p build/pr-quality/candidate-validation
           PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
             --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
@@ -770,6 +895,11 @@ jobs:
           if [ -s build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md ]; then
             printf '\n' >> build/pr-quality/pr-comment-body.md
             cat build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md >> build/pr-quality/pr-comment-body.md
+          fi
+
+          if [ -s build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md >> build/pr-quality/pr-comment-body.md
           fi
 
           if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then
@@ -848,6 +978,7 @@ jobs:
             build/pr-quality/runtime-proof/
             build/pr-quality/diagnostic-job/
             build/pr-quality/diagnostic-signal-snapshot/
+            build/pr-quality/trusted-diagnostic-signal-snapshot-history/
             build/pr-quality/candidate-visibility/
             build/pr-quality/candidate-validation/
             build/pr-quality/runtime-guard-benchmark/
@@ -1233,5 +1364,24 @@ jobs:
           if trusted_history_semantic_equivalence_proven:
               raise SystemExit(
                   "PR Quality trusted history attempted to claim semantic equivalence"
+              )
+
+          trusted_snapshot_history_exit_path = Path(
+              "build/pr-quality/trusted-diagnostic-signal-snapshot-history/exit-code.txt"
+          )
+          trusted_snapshot_history_exit_code = (
+              trusted_snapshot_history_exit_path.read_text(encoding="utf-8").strip()
+              if trusted_snapshot_history_exit_path.exists()
+              else "missing"
+          )
+          print(
+              "trusted_diagnostic_signal_snapshot_history_exit_code="
+              f"{trusted_snapshot_history_exit_code}"
+          )
+          if trusted_snapshot_history_exit_code not in {"0", "2"}:
+              raise SystemExit(
+                  "PR Quality trusted diagnostic snapshot history validation failed after "
+                  "diagnostic comment publication: "
+                  f"exit_code={trusted_snapshot_history_exit_code}"
               )
           PY

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -731,6 +731,67 @@ jobs:
             } > build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md
           fi
 
+          mkdir -p build/pr-quality/candidate-validation
+          PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
+            --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
+            --scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json \
+            --out-dir build/pr-quality/candidate-validation \
+            --format json \
+            > build/pr-quality/candidate-validation/candidate-validation-cli.json
+
+          mkdir -p build/pr-quality/runtime-guard-benchmark
+          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
+            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_oracle.json \
+            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_nop.json \
+            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_unsafe.json \
+            --out-dir build/pr-quality/runtime-guard-benchmark \
+            --format json \
+            > build/pr-quality/runtime-guard-benchmark/runtime-guard-benchmark-cli.json
+
+          mkdir -p build/pr-quality/security-freshness-benchmark
+          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
+            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_stale_runtime_oracle.json \
+            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_current_primary_oracle.json \
+            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_authority_unsafe.json \
+            --out-dir build/pr-quality/security-freshness-benchmark \
+            --format json \
+            > build/pr-quality/security-freshness-benchmark/security-freshness-benchmark-cli.json
+
+          if [ -s build/pr-quality/diagnostic-job/diagnostic-job.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/diagnostic-job/diagnostic-job.md >> build/pr-quality/pr-comment-body.md
+          fi
+
+          if [ -s build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md >> build/pr-quality/pr-comment-body.md
+          fi
+
+          if [ -s build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md >> build/pr-quality/pr-comment-body.md
+          fi
+
+          if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then
+            printf '\n' >> build/pr-quality/pr-comment-body.md
+            cat build/pr-quality/candidate-visibility/candidate-visibility.md >> build/pr-quality/pr-comment-body.md
+          fi
+
+          printf '\n' >> build/pr-quality/pr-comment-body.md
+          cat build/pr-quality/candidate-validation/candidate-validation.md >> build/pr-quality/pr-comment-body.md
+
+          printf '\n' >> build/pr-quality/pr-comment-body.md
+          cat build/pr-quality/runtime-guard-benchmark/benchmark-report.md >> build/pr-quality/pr-comment-body.md
+
+          printf '\n' >> build/pr-quality/pr-comment-body.md
+          cat build/pr-quality/security-freshness-benchmark/benchmark-report.md >> build/pr-quality/pr-comment-body.md
+
+      - name: Build trusted diagnostic signal snapshot history visibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
           mkdir -p build/pr-quality/trusted-diagnostic-signal-snapshot-history
           trusted_diagnostic_signal_snapshot_history_rc=2
           trusted_snapshot_history_summary=""
@@ -856,65 +917,28 @@ jobs:
             } > build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md
           fi
 
-          mkdir -p build/pr-quality/candidate-validation
-          PYTHONPATH=src python -m sdetkit.pr_quality_candidate_validation \
-            --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json \
-            --scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json \
-            --out-dir build/pr-quality/candidate-validation \
-            --format json \
-            > build/pr-quality/candidate-validation/candidate-validation-cli.json
+          python - <<'PY'
+          from pathlib import Path
 
-          mkdir -p build/pr-quality/runtime-guard-benchmark
-          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
-            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_oracle.json \
-            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_nop.json \
-            --diagnostic-worker-scenario tests/fixtures/remediation_benchmark/runtime_guard_worker_unsafe.json \
-            --out-dir build/pr-quality/runtime-guard-benchmark \
-            --format json \
-            > build/pr-quality/runtime-guard-benchmark/runtime-guard-benchmark-cli.json
+          body_path = Path("build/pr-quality/pr-comment-body.md")
+          snapshot_path = Path(
+              "build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md"
+          )
+          history_path = Path(
+              "build/pr-quality/trusted-diagnostic-signal-snapshot-history/"
+              "trusted-diagnostic-signal-snapshot-history.md"
+          )
 
-          mkdir -p build/pr-quality/security-freshness-benchmark
-          PYTHONPATH=src python -m sdetkit.replayable_benchmark_harness \
-            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_stale_runtime_oracle.json \
-            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_current_primary_oracle.json \
-            --security-freshness-scenario tests/fixtures/remediation_benchmark/security_freshness_authority_unsafe.json \
-            --out-dir build/pr-quality/security-freshness-benchmark \
-            --format json \
-            > build/pr-quality/security-freshness-benchmark/security-freshness-benchmark-cli.json
-
-          if [ -s build/pr-quality/diagnostic-job/diagnostic-job.md ]; then
-            printf '\n' >> build/pr-quality/pr-comment-body.md
-            cat build/pr-quality/diagnostic-job/diagnostic-job.md >> build/pr-quality/pr-comment-body.md
-          fi
-
-          if [ -s build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md ]; then
-            printf '\n' >> build/pr-quality/pr-comment-body.md
-            cat build/pr-quality/diagnostic-job/trajectory/diagnostic-worker-trajectory.md >> build/pr-quality/pr-comment-body.md
-          fi
-
-          if [ -s build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md ]; then
-            printf '\n' >> build/pr-quality/pr-comment-body.md
-            cat build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.md >> build/pr-quality/pr-comment-body.md
-          fi
-
-          if [ -s build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md ]; then
-            printf '\n' >> build/pr-quality/pr-comment-body.md
-            cat build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.md >> build/pr-quality/pr-comment-body.md
-          fi
-
-          if [ -s build/pr-quality/candidate-visibility/candidate-visibility.md ]; then
-            printf '\n' >> build/pr-quality/pr-comment-body.md
-            cat build/pr-quality/candidate-visibility/candidate-visibility.md >> build/pr-quality/pr-comment-body.md
-          fi
-
-          printf '\n' >> build/pr-quality/pr-comment-body.md
-          cat build/pr-quality/candidate-validation/candidate-validation.md >> build/pr-quality/pr-comment-body.md
-
-          printf '\n' >> build/pr-quality/pr-comment-body.md
-          cat build/pr-quality/runtime-guard-benchmark/benchmark-report.md >> build/pr-quality/pr-comment-body.md
-
-          printf '\n' >> build/pr-quality/pr-comment-body.md
-          cat build/pr-quality/security-freshness-benchmark/benchmark-report.md >> build/pr-quality/pr-comment-body.md
+          body = body_path.read_text(encoding="utf-8")
+          snapshot = snapshot_path.read_text(encoding="utf-8").rstrip("\n")
+          history = history_path.read_text(encoding="utf-8").rstrip("\n")
+          if not snapshot or not history:
+              raise SystemExit("diagnostic visibility markdown is missing")
+          if body.count(snapshot) != 1:
+              raise SystemExit("current diagnostic snapshot insertion anchor is ambiguous")
+          body = body.replace(snapshot, f"{snapshot}\n\n{history}", 1)
+          body_path.write_text(body.rstrip("\n") + "\n", encoding="utf-8")
+          PY
 
       - name: Build verified operator evidence loop
         if: always()

--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -209,6 +209,7 @@ jobs:
 
           if [ -z "$prior_run_id" ]; then
             echo "prior_history_jsonl=" >> "$GITHUB_OUTPUT"
+            echo "prior_diagnostic_signal_snapshot_jsonl=" >> "$GITHUB_OUTPUT"
             echo "prior_run_id=" >> "$GITHUB_OUTPUT"
             echo "prior_head_sha=" >> "$GITHUB_OUTPUT"
             echo "No prior successful trusted-main history artifact found; starting initial history chain."
@@ -236,8 +237,57 @@ jobs:
             find build/repo-memory-history/prior-download               -name security-reviewed-disposition-history.jsonl               -print               -quit
           )"
 
+          prior_diagnostic_signal_snapshot_jsonl="$(
+            find build/repo-memory-history/prior-download \
+              -name diagnostic-signal-snapshot-history.jsonl \
+              -print \
+              -quit
+          )"
+
+          if [ -z "$prior_diagnostic_signal_snapshot_jsonl" ]; then
+            diagnostic_prior_root="${RUNNER_TEMP}/sdetkit-prior-diagnostic-snapshot-history"
+            rm -rf "$diagnostic_prior_root"
+            mkdir -p "$diagnostic_prior_root"
+
+            while IFS=$'\t' read -r candidate_run_id candidate_head_sha; do
+              if [ -z "$candidate_run_id" ] \
+                || [ "$candidate_run_id" = "${GITHUB_RUN_ID}" ] \
+                || [ "$candidate_run_id" = "$prior_run_id" ]; then
+                continue
+              fi
+              if ! git merge-base --is-ancestor "$candidate_head_sha" "$GITHUB_SHA"; then
+                continue
+              fi
+
+              candidate_dir="$diagnostic_prior_root/$candidate_run_id"
+              mkdir -p "$candidate_dir"
+              if ! gh run download "$candidate_run_id" \
+                --repo "$GITHUB_REPOSITORY" \
+                --name repo-memory-profile-history \
+                --dir "$candidate_dir" >/dev/null 2>&1; then
+                continue
+              fi
+
+              candidate_jsonl="$(
+                find "$candidate_dir" \
+                  -name diagnostic-signal-snapshot-history.jsonl \
+                  -print \
+                  -quit
+              )"
+              if [ -n "$candidate_jsonl" ] && [ -f "$candidate_jsonl" ]; then
+                prior_diagnostic_signal_snapshot_jsonl="$candidate_jsonl"
+                break
+              fi
+            done < <(
+              gh api --paginate \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/repo-memory-history.yml/runs?branch=main&event=push&status=completed&per_page=100" \
+                --jq '.workflow_runs[] | select(.conclusion == "success") | [.id, .head_sha] | @tsv'
+            )
+          fi
+
           echo "prior_history_jsonl=$prior_history_jsonl" >> "$GITHUB_OUTPUT"
           echo "prior_security_disposition_jsonl=$prior_security_disposition_jsonl" >> "$GITHUB_OUTPUT"
+          echo "prior_diagnostic_signal_snapshot_jsonl=$prior_diagnostic_signal_snapshot_jsonl" >> "$GITHUB_OUTPUT"
           echo "prior_run_id=$prior_run_id" >> "$GITHUB_OUTPUT"
           echo "prior_head_sha=$prior_head_sha" >> "$GITHUB_OUTPUT"
 
@@ -384,6 +434,148 @@ jobs:
           ).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
           PY
 
+      - name: Collect accepted-main diagnostic signal snapshot source
+        id: diagnostic-snapshot-source
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          out_dir="build/repo-memory-history/diagnostic-signal-snapshots/source"
+          associated_pr="build/repo-memory-history/security-reviewed-dispositions/associated-merged-pr.json"
+          mkdir -p "$out_dir/download"
+
+          source_match_count="$(
+            jq -er --arg sha "${GITHUB_SHA}" \
+              '[.[] | select(.merged_at and .merge_commit_sha == $sha)] | length' \
+              "$associated_pr"
+          )"
+          if [ "$source_match_count" -gt 1 ]; then
+            echo "Accepted-main commit maps to multiple merged PRs; refusing ambiguous snapshot provenance."
+            exit 1
+          fi
+          if [ "$source_match_count" -eq 0 ]; then
+            echo "source_available=false" >> "$GITHUB_OUTPUT"
+            echo "No merged PR maps to accepted-main head; no diagnostic snapshot observation will be appended."
+            exit 0
+          fi
+
+          source_pr_number="$(
+            jq -er --arg sha "${GITHUB_SHA}" \
+              '[.[] | select(.merged_at and .merge_commit_sha == $sha)][0].number' \
+              "$associated_pr"
+          )"
+          source_head_sha="$(
+            jq -er --arg sha "${GITHUB_SHA}" \
+              '[.[] | select(.merged_at and .merge_commit_sha == $sha)][0].head.sha' \
+              "$associated_pr"
+          )"
+
+          gh api --paginate \
+            "repos/${REPOSITORY}/actions/workflows/pr-quality-comment.yml/runs?event=pull_request&status=completed&per_page=100" \
+            --jq '.workflow_runs[] | select(.conclusion == "success") | [.id, .head_sha, (.pull_requests | map(.number | tostring) | join(","))] | @tsv' \
+            > "$out_dir/successful-pr-quality-runs.tsv"
+
+          source_run_id=""
+          while IFS=$'\t' read -r candidate_run_id candidate_head_sha candidate_pr_numbers; do
+            if [ "$candidate_head_sha" != "$source_head_sha" ]; then
+              continue
+            fi
+            case ",${candidate_pr_numbers}," in
+              *,"${source_pr_number}",*)
+                source_run_id="$candidate_run_id"
+                break
+                ;;
+            esac
+          done < "$out_dir/successful-pr-quality-runs.tsv"
+
+          if [ -z "$source_run_id" ]; then
+            echo "No successful PR Quality run was found for merged PR #$source_pr_number at $source_head_sha."
+            exit 1
+          fi
+
+          gh run download "$source_run_id" \
+            --repo "$REPOSITORY" \
+            --name pr-quality-comment \
+            --dir "$out_dir/download"
+
+          source_snapshot="$(
+            find "$out_dir/download" \
+              -name diagnostic-signal-snapshot.json \
+              -print \
+              -quit
+          )"
+          if [ -z "$source_snapshot" ] || [ ! -f "$source_snapshot" ]; then
+            echo "Successful PR Quality run supplied no DiagnosticSignalSnapshot artifact."
+            exit 1
+          fi
+
+          cp "$source_snapshot" "$out_dir/diagnostic-signal-snapshot.json"
+          echo "source_available=true" >> "$GITHUB_OUTPUT"
+          echo "source_run_id=$source_run_id" >> "$GITHUB_OUTPUT"
+          echo "source_head_sha=$source_head_sha" >> "$GITHUB_OUTPUT"
+          echo "source_pr_number=$source_pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Record trusted accepted-main diagnostic signal snapshot history
+        if: steps.diagnostic-snapshot-source.outputs.source_available == 'true'
+        shell: bash
+        env:
+          PRIOR_DIAGNOSTIC_SIGNAL_SNAPSHOT_JSONL: ${{ steps.prior.outputs.prior_diagnostic_signal_snapshot_jsonl }}
+          SOURCE_RUN_ID: ${{ steps.diagnostic-snapshot-source.outputs.source_run_id }}
+          SOURCE_HEAD_SHA: ${{ steps.diagnostic-snapshot-source.outputs.source_head_sha }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p build/repo-memory-history/diagnostic-signal-snapshots/output
+          args=(
+            --diagnostic-signal-snapshot build/repo-memory-history/diagnostic-signal-snapshots/source/diagnostic-signal-snapshot.json
+            --associated-pr-json build/repo-memory-history/security-reviewed-dispositions/associated-merged-pr.json
+            --source-run-id "$SOURCE_RUN_ID"
+            --source-run-conclusion success
+            --source-head-sha "$SOURCE_HEAD_SHA"
+            --retention-run-id "${GITHUB_RUN_ID}"
+            --accepted-main-sha "${GITHUB_SHA}"
+            --out-dir build/repo-memory-history/diagnostic-signal-snapshots/output
+            --format json
+          )
+          if [ -n "$PRIOR_DIAGNOSTIC_SIGNAL_SNAPSHOT_JSONL" ]; then
+            args+=(--prior-history-jsonl "$PRIOR_DIAGNOSTIC_SIGNAL_SNAPSHOT_JSONL")
+          fi
+
+          PYTHONPATH=src python -m sdetkit.diagnostic_signal_snapshot_history \
+            "${args[@]}" \
+            > build/repo-memory-history/diagnostic-signal-snapshots/history-cli.json
+
+          python - <<'PYCODE'
+          import json
+          import os
+          from pathlib import Path
+
+          summary = json.loads(
+              Path(
+                  "build/repo-memory-history/diagnostic-signal-snapshots/output/"
+                  "diagnostic-signal-snapshot-history-summary.json"
+              ).read_text(encoding="utf-8")
+          )
+          assert summary["status"] == "diagnostic_signal_snapshot_history_recorded"
+          assert summary["record_count"] >= 1
+          assert summary["advisor_false_positive_rate_status"] == "requires_reviewed_history"
+          assert summary["reviewed_false_positive_count"] is None
+          assert summary["reviewed_observation_count"] is None
+          assert summary["latest_record"]["accepted_main_sha"] == os.environ["GITHUB_SHA"]
+          boundary = summary["decision_boundary"]
+          assert boundary["current_pr_decision_input"] is False
+          assert boundary["feeds_repo_memory"] is False
+          assert boundary["patch_application_allowed"] is False
+          assert boundary["automation_allowed"] is False
+          assert boundary["merge_authorized"] is False
+          assert boundary["semantic_equivalence_proven"] is False
+          assert boundary["historical_snapshot_authorizes_current_action"] is False
+          print("Trusted accepted-main diagnostic signal snapshot history passed.")
+          PYCODE
+
       - name: Record trusted accepted-main reviewed security disposition history
         shell: bash
         env:
@@ -445,6 +637,7 @@ jobs:
             build/repo-memory-history/pattern-insights/
             build/repo-memory-history/flaky-test-registry/
             build/repo-memory-history/candidate-validation/
+            build/repo-memory-history/diagnostic-signal-snapshots/
             build/repo-memory-history/security-reviewed-dispositions/
           if-no-files-found: error
           retention-days: 90

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 121
+        "tests_referencing_module": 123
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/diagnostic_signal_snapshot_history.py
+++ b/src/sdetkit/diagnostic_signal_snapshot_history.py
@@ -1,0 +1,588 @@
+"""Retain provenance-checked read-only DiagnosticSignalSnapshot observations."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = ".".join(("sdetkit", "diagnostic", "signal", "snapshot", "history", "v1"))
+RECORD_SCHEMA_VERSION = ".".join(
+    ("sdetkit", "diagnostic", "signal", "snapshot", "history", "record", "v1")
+)
+SNAPSHOT_SCHEMA_VERSION = ".".join(("sdetkit", "diagnostic", "signal", "snapshot", "v1"))
+DEFAULT_OUT_DIR = Path("build") / "repo-memory-history" / "diagnostic-signal-snapshots"
+SUMMARY_JSON = "diagnostic-signal-snapshot-history-summary.json"
+SUMMARY_MD = "diagnostic-signal-snapshot-history-summary.md"
+HISTORY_JSONL = "diagnostic-signal-snapshot-history.jsonl"
+
+HISTORY_RECORDED = "_".join(("diagnostic", "signal", "snapshot", "history", "recorded"))
+QUIET_GREEN_STATUS = "_".join(("quiet", "green", "advisory", "baseline"))
+OBSERVED_STATUS = "_".join(("diagnostic", "signal", "observed"))
+RATE_STATUS = "_".join(("requires", "reviewed", "history"))
+SOURCE_WORKFLOW = "PR Quality Comment"
+RETENTION_WORKFLOW = "RepoMemory Profile History"
+CURRENT_SNAPSHOT_TYPE = "_".join(("current", "pr", "reporting", "only"))
+HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION = "_".join(
+    ("historical", "snapshot", "authorizes", "current", "action")
+)
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _required_bool(value: Any, *, key: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _required_count(value: Any, *, key: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{key} must be a non-negative integer")
+    return value
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_jsonl(path: Path | None) -> list[JsonObject]:
+    if path is None or not path.exists():
+        return []
+
+    records: list[JsonObject] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object on line {line_number} in {path}")
+        records.append(payload)
+    return records
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _history_boundary() -> JsonObject:
+    return {
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "feeds_repo_memory": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION: False,
+        "prior_history_is_read_only_input": True,
+    }
+
+
+def _assert_no_authority(boundary: Mapping[str, Any], *, source: str) -> None:
+    expected = {
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "feeds_repo_memory": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    for key, expected_value in expected.items():
+        if boundary.get(key) is not expected_value:
+            raise ValueError(f"{source} does not preserve no-authority boundary: {key}")
+
+
+def _snapshot_observation(snapshot: Mapping[str, Any]) -> JsonObject:
+    if _text(snapshot.get("schema_version")) != SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError("diagnostic signal snapshot schema is not supported")
+    if _text(snapshot.get("snapshot_type")) != CURRENT_SNAPSHOT_TYPE:
+        raise ValueError("only current_pr_reporting_only snapshots may enter history")
+
+    status = _text(snapshot.get("status"))
+    if status not in {QUIET_GREEN_STATUS, OBSERVED_STATUS}:
+        raise ValueError("diagnostic signal snapshot status is not supported")
+
+    quiet_green = _required_bool(
+        snapshot.get("quiet_green_advisory_baseline"),
+        key="quiet_green_advisory_baseline",
+    )
+    if quiet_green != (status == QUIET_GREEN_STATUS):
+        raise ValueError("diagnostic signal snapshot status and quiet-green flag disagree")
+
+    measurements = _as_dict(snapshot.get("measurements"))
+    primary_signal_kind = _text(measurements.get("primary_signal_kind"))
+    review_signal_present = _required_bool(
+        measurements.get("review_signal_present"),
+        key="review_signal_present",
+    )
+    integration_proof_signal_present = _required_bool(
+        measurements.get("integration_proof_signal_present"),
+        key="integration_proof_signal_present",
+    )
+    if review_signal_present != (primary_signal_kind == "review_signal"):
+        raise ValueError("review signal presence does not match primary signal kind")
+    if integration_proof_signal_present != (primary_signal_kind == "integration_proof"):
+        raise ValueError("integration proof signal presence does not match primary signal kind")
+
+    readiness = _as_dict(snapshot.get("kpi_readiness"))
+    if _text(readiness.get("advisor_false_positive_rate_status")) != RATE_STATUS:
+        raise ValueError(
+            "snapshot cannot claim an advisor false-positive rate without reviewed history"
+        )
+    if readiness.get("reviewed_false_positive_count") is not None:
+        raise ValueError(
+            "snapshot cannot retain reviewed false-positive counts without reviewed history"
+        )
+    if readiness.get("reviewed_observation_count") is not None:
+        raise ValueError(
+            "snapshot cannot retain reviewed observation counts without reviewed history"
+        )
+
+    _assert_no_authority(
+        _as_dict(snapshot.get("decision_boundary")),
+        source="diagnostic signal snapshot",
+    )
+
+    return {
+        "status": status,
+        "quiet_green_advisory_baseline": quiet_green,
+        "primary_signal_kind": primary_signal_kind,
+        "review_signal_present": review_signal_present,
+        "integration_proof_signal_present": integration_proof_signal_present,
+        "evidence_graph_node_count": _required_count(
+            measurements.get("evidence_graph_node_count"),
+            key="evidence_graph_node_count",
+        ),
+        "diagnostic_worker_diagnosis_count": _required_count(
+            measurements.get("diagnostic_worker_diagnosis_count"),
+            key="diagnostic_worker_diagnosis_count",
+        ),
+        "runtime_guard_violation_count": _required_count(
+            measurements.get("runtime_guard_violation_count"),
+            key="runtime_guard_violation_count",
+        ),
+        "current_security_finding_count": _required_count(
+            measurements.get("current_security_finding_count"),
+            key="current_security_finding_count",
+        ),
+        "advisor_false_positive_rate_status": RATE_STATUS,
+        "reviewed_false_positive_count": None,
+        "reviewed_observation_count": None,
+    }
+
+
+def _select_merged_pr(payload: Any, *, accepted_main_sha: str, source_head_sha: str) -> JsonObject:
+    candidates = payload if isinstance(payload, list) else [payload]
+    matches = [
+        _as_dict(item)
+        for item in candidates
+        if isinstance(item, dict)
+        and _text(_as_dict(item).get("merged_at"))
+        and _text(_as_dict(item).get("merge_commit_sha")) == accepted_main_sha
+    ]
+    if len(matches) != 1:
+        raise ValueError("accepted-main SHA must map to exactly one merged pull request")
+
+    merged_pr = matches[0]
+    head = _as_dict(merged_pr.get("head"))
+    if _text(head.get("sha")) != source_head_sha:
+        raise ValueError("diagnostic snapshot source head does not match merged pull request head")
+    if (
+        not isinstance(merged_pr.get("number"), int)
+        or isinstance(merged_pr.get("number"), bool)
+        or int(merged_pr["number"]) < 1
+    ):
+        raise ValueError("merged pull request number is required")
+    return merged_pr
+
+
+def validate_record(record: Mapping[str, Any]) -> None:
+    if _text(record.get("schema_version")) != RECORD_SCHEMA_VERSION:
+        raise ValueError("diagnostic signal snapshot history record schema is not supported")
+    source = _as_dict(record.get("source"))
+    if _text(source.get("workflow")) != SOURCE_WORKFLOW:
+        raise ValueError("snapshot history source workflow is not supported")
+    if _text(source.get("retention_workflow")) != RETENTION_WORKFLOW:
+        raise ValueError("snapshot history retention workflow is not supported")
+    if _text(source.get("source_run_conclusion")) != "success":
+        raise ValueError("only successful PR Quality snapshot runs may enter history")
+    for key in ("source_run_id", "source_head_sha", "retention_run_id", "accepted_main_sha"):
+        if not _text(source.get(key)):
+            raise ValueError(f"snapshot history source is missing {key}")
+    if (
+        not isinstance(source.get("merged_pr_number"), int)
+        or isinstance(source.get("merged_pr_number"), bool)
+        or int(source["merged_pr_number"]) < 1
+    ):
+        raise ValueError("snapshot history record lacks merged PR number provenance")
+    if source.get("merged_pr_verified") is not True:
+        raise ValueError("snapshot history record lacks merged PR provenance")
+    boundary = _as_dict(record.get("decision_boundary"))
+    _assert_no_authority(
+        boundary,
+        source="diagnostic signal snapshot history record",
+    )
+    if boundary.get(HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION) is not False:
+        raise ValueError("historical snapshot cannot authorize a current action")
+    if boundary.get("prior_history_is_read_only_input") is not True:
+        raise ValueError("historical snapshot does not preserve read-only prior-history input")
+    observation = _as_dict(record.get("snapshot"))
+    status = _text(observation.get("status"))
+    if status not in {QUIET_GREEN_STATUS, OBSERVED_STATUS}:
+        raise ValueError("historical snapshot status is not supported")
+    quiet_green = _required_bool(
+        observation.get("quiet_green_advisory_baseline"),
+        key="quiet_green_advisory_baseline",
+    )
+    if quiet_green != (status == QUIET_GREEN_STATUS):
+        raise ValueError("historical snapshot status and quiet-green flag disagree")
+    primary_signal_kind = _text(observation.get("primary_signal_kind"))
+    review_signal_present = _required_bool(
+        observation.get("review_signal_present"),
+        key="review_signal_present",
+    )
+    integration_proof_signal_present = _required_bool(
+        observation.get("integration_proof_signal_present"),
+        key="integration_proof_signal_present",
+    )
+    if review_signal_present != (primary_signal_kind == "review_signal"):
+        raise ValueError("historical review signal presence does not match primary signal kind")
+    if integration_proof_signal_present != (primary_signal_kind == "integration_proof"):
+        raise ValueError(
+            "historical integration proof signal presence does not match primary signal kind"
+        )
+    if _text(observation.get("advisor_false_positive_rate_status")) != RATE_STATUS:
+        raise ValueError("historical snapshot cannot claim an advisor false-positive rate")
+    if observation.get("reviewed_false_positive_count") is not None:
+        raise ValueError("historical snapshot cannot contain reviewed false-positive counts")
+    if observation.get("reviewed_observation_count") is not None:
+        raise ValueError("historical snapshot cannot contain reviewed observation counts")
+    for key in (
+        "evidence_graph_node_count",
+        "diagnostic_worker_diagnosis_count",
+        "runtime_guard_violation_count",
+        "current_security_finding_count",
+    ):
+        _required_count(observation.get(key), key=key)
+
+    observation_identity = {
+        "source": {key: value for key, value in source.items() if key != "retention_run_id"},
+        "snapshot": observation,
+        "decision_boundary": boundary,
+    }
+    if _text(record.get("record_id")) != _stable_hash(observation_identity):
+        raise ValueError(
+            "diagnostic snapshot history record id does not match retained observation"
+        )
+
+
+def build_history_record(
+    snapshot: Mapping[str, Any],
+    *,
+    associated_pr_payload: Any,
+    source_run_id: str,
+    source_run_conclusion: str,
+    source_head_sha: str,
+    retention_run_id: str,
+    accepted_main_sha: str,
+    recorded_at_utc: str | None = None,
+) -> JsonObject:
+    source_run = _text(source_run_id)
+    source_head = _text(source_head_sha)
+    retention_run = _text(retention_run_id)
+    accepted_main = _text(accepted_main_sha)
+    if not source_run or not source_head or not retention_run or not accepted_main:
+        raise ValueError("snapshot history provenance fields are required")
+    if _text(source_run_conclusion) != "success":
+        raise ValueError("only successful PR Quality snapshot runs may enter history")
+
+    merged_pr = _select_merged_pr(
+        associated_pr_payload,
+        accepted_main_sha=accepted_main,
+        source_head_sha=source_head,
+    )
+    observation = _snapshot_observation(snapshot)
+    source = {
+        "workflow": SOURCE_WORKFLOW,
+        "source_run_id": source_run,
+        "source_run_conclusion": "success",
+        "source_head_sha": source_head,
+        "retention_workflow": RETENTION_WORKFLOW,
+        "retention_run_id": retention_run,
+        "accepted_main_sha": accepted_main,
+        "merged_pr_number": int(merged_pr["number"]),
+        "merged_pr_verified": True,
+    }
+    stable = {
+        "source": source,
+        "snapshot": observation,
+        "decision_boundary": _history_boundary(),
+    }
+    observation_identity = {
+        "source": {key: value for key, value in source.items() if key != "retention_run_id"},
+        "snapshot": observation,
+        "decision_boundary": _history_boundary(),
+    }
+    record = {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "record_id": _stable_hash(observation_identity),
+        "recorded_at_utc": recorded_at_utc or _utc_now(),
+        **stable,
+    }
+    validate_record(record)
+    return record
+
+
+def merge_history_records(
+    prior_records: list[Mapping[str, Any]],
+    record: Mapping[str, Any],
+) -> tuple[list[JsonObject], bool]:
+    validate_record(record)
+    records = [dict(item) for item in prior_records]
+    for existing in records:
+        validate_record(existing)
+    record_id = _text(record.get("record_id"))
+    matching_indexes = [
+        index for index, item in enumerate(records) if _text(item.get("record_id")) == record_id
+    ]
+    if len(matching_indexes) > 1:
+        raise ValueError("diagnostic snapshot history contains duplicate observation identities")
+    appended = not matching_indexes
+    if appended:
+        records.append(dict(record))
+    else:
+        # A retention workflow rerun republishes the same observation without
+        # increasing advisory counts; refresh only its retention provenance so
+        # readers can bind the downloaded artifact to the successful run.
+        records[matching_indexes[0]] = dict(record)
+    return records, appended
+
+
+def write_history_jsonl(records: list[Mapping[str, Any]], *, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    history_path = out_dir / HISTORY_JSONL
+    history_path.write_text(
+        "".join(json.dumps(dict(item), sort_keys=True) + "\n" for item in records),
+        encoding="utf-8",
+    )
+    return history_path
+
+
+def build_history_summary(
+    records: list[Mapping[str, Any]],
+    *,
+    appended: bool,
+    history_path: Path,
+    prior_history_collected: bool,
+    prior_record_count: int,
+) -> JsonObject:
+    for record in records:
+        validate_record(record)
+    latest = _as_dict(records[-1]) if records else {}
+    latest_source = _as_dict(latest.get("source"))
+    latest_snapshot = _as_dict(latest.get("snapshot"))
+    statuses = Counter(_text(_as_dict(item.get("snapshot")).get("status")) for item in records)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": HISTORY_RECORDED,
+        "history_path": history_path.as_posix(),
+        "prior_history_collected": prior_history_collected,
+        "prior_record_count": prior_record_count,
+        "appended": appended,
+        "record_count": len(records),
+        "quiet_green_advisory_baseline_record_count": sum(
+            1
+            for item in records
+            if _as_dict(item.get("snapshot")).get("quiet_green_advisory_baseline") is True
+        ),
+        "review_signal_record_count": sum(
+            1
+            for item in records
+            if _as_dict(item.get("snapshot")).get("review_signal_present") is True
+        ),
+        "integration_proof_signal_record_count": sum(
+            1
+            for item in records
+            if _as_dict(item.get("snapshot")).get("integration_proof_signal_present") is True
+        ),
+        "snapshot_status_counts": dict(sorted(statuses.items())),
+        "advisor_false_positive_rate_status": RATE_STATUS,
+        "reviewed_false_positive_count": None,
+        "reviewed_observation_count": None,
+        "latest_record": {
+            "record_id": _text(latest.get("record_id")),
+            "source_run_id": _text(latest_source.get("source_run_id")),
+            "source_head_sha": _text(latest_source.get("source_head_sha")),
+            "retention_run_id": _text(latest_source.get("retention_run_id")),
+            "accepted_main_sha": _text(latest_source.get("accepted_main_sha")),
+            "merged_pr_number": int(latest_source.get("merged_pr_number") or 0),
+            "status": _text(latest_snapshot.get("status")),
+            "primary_signal_kind": _text(latest_snapshot.get("primary_signal_kind")),
+        },
+        "decision_boundary": _history_boundary(),
+    }
+
+
+def render_markdown(summary: Mapping[str, Any]) -> str:
+    latest = _as_dict(summary.get("latest_record"))
+    boundary = _as_dict(summary.get("decision_boundary"))
+    return "\n".join(
+        [
+            "# Diagnostic signal snapshot advisory history",
+            "",
+            f"- Status: `{_text(summary.get('status'))}`",
+            f"- Prior history collected: `{str(summary.get('prior_history_collected') is True).lower()}`",
+            f"- Records: `{int(summary.get('record_count') or 0)}`",
+            (
+                "- Quiet-green advisory baseline records: "
+                f"`{int(summary.get('quiet_green_advisory_baseline_record_count') or 0)}`"
+            ),
+            f"- Review-signal records: `{int(summary.get('review_signal_record_count') or 0)}`",
+            (
+                "- Integration-proof-signal records: "
+                f"`{int(summary.get('integration_proof_signal_record_count') or 0)}`"
+            ),
+            (
+                "- Advisor false-positive rate status: "
+                f"`{_text(summary.get('advisor_false_positive_rate_status'))}`"
+            ),
+            "",
+            "## Latest retained snapshot",
+            "",
+            f"- Accepted main sha: `{_text(latest.get('accepted_main_sha'))}`",
+            f"- Merged PR number: `{int(latest.get('merged_pr_number') or 0)}`",
+            f"- Status: `{_text(latest.get('status'))}`",
+            f"- Primary signal kind: `{_text(latest.get('primary_signal_kind'))}`",
+            "",
+            "## Boundary",
+            "",
+            f"- Reporting only: `{str(boundary.get('reporting_only') is True).lower()}`",
+            (
+                "- Current PR decision input: "
+                f"`{str(boundary.get('current_pr_decision_input') is True).lower()}`"
+            ),
+            f"- Feeds RepoMemory: `{str(boundary.get('feeds_repo_memory') is True).lower()}`",
+            f"- Automation allowed: `{str(boundary.get('automation_allowed') is True).lower()}`",
+            f"- Merge authorized: `{str(boundary.get('merge_authorized') is True).lower()}`",
+            (
+                "- Historical snapshot authorizes current action: "
+                f"`{str(boundary.get(HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION) is True).lower()}`"
+            ),
+            "",
+        ]
+    )
+
+
+def write_summary(summary: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / SUMMARY_JSON
+    markdown_path = out_dir / SUMMARY_MD
+    json_path.write_text(
+        json.dumps(dict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    markdown_path.write_text(render_markdown(summary), encoding="utf-8")
+    return {
+        "history_summary_json": json_path.as_posix(),
+        "history_summary_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.diagnostic_signal_snapshot_history")
+    parser.add_argument("--diagnostic-signal-snapshot", type=Path, required=True)
+    parser.add_argument("--associated-pr-json", type=Path, required=True)
+    parser.add_argument("--prior-history-jsonl", type=Path)
+    parser.add_argument("--source-run-id", required=True)
+    parser.add_argument("--source-run-conclusion", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--retention-run-id", required=True)
+    parser.add_argument("--accepted-main-sha", required=True)
+    parser.add_argument("--recorded-at-utc")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        snapshot_payload = _read_json(args.diagnostic_signal_snapshot)
+        associated_pr_payload = _read_json(args.associated_pr_json)
+        if not isinstance(snapshot_payload, dict):
+            raise ValueError("diagnostic signal snapshot must be a JSON object")
+        if args.prior_history_jsonl is not None and not args.prior_history_jsonl.exists():
+            raise ValueError(f"prior history input does not exist: {args.prior_history_jsonl}")
+        record = build_history_record(
+            snapshot_payload,
+            associated_pr_payload=associated_pr_payload,
+            source_run_id=args.source_run_id,
+            source_run_conclusion=args.source_run_conclusion,
+            source_head_sha=args.source_head_sha,
+            retention_run_id=args.retention_run_id,
+            accepted_main_sha=args.accepted_main_sha,
+            recorded_at_utc=args.recorded_at_utc,
+        )
+        prior_records = _read_jsonl(args.prior_history_jsonl)
+        records, appended = merge_history_records(prior_records, record)
+        history_path = write_history_jsonl(records, out_dir=args.out_dir)
+        summary = build_history_summary(
+            records,
+            appended=appended,
+            history_path=history_path,
+            prior_history_collected=args.prior_history_jsonl is not None,
+            prior_record_count=len(prior_records),
+        )
+        artifacts = write_summary(summary, out_dir=args.out_dir)
+        artifacts["history_jsonl"] = history_path.as_posix()
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": summary["status"],
+                    "record_count": summary["record_count"],
+                    "appended": summary["appended"],
+                    "artifacts": artifacts,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/trusted_diagnostic_signal_snapshot_history.py
+++ b/src/sdetkit/trusted_diagnostic_signal_snapshot_history.py
@@ -341,22 +341,6 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error={exc}", file=sys.stderr)
         return 2
 
-    if args.format == "json":
-        print(
-            json.dumps(
-                {
-                    "artifacts_written": True,
-                    "collection_status": COLLECTED,
-                    "status": TRUSTED_HISTORY_VERIFIED,
-                },
-                indent=2,
-                sort_keys=True,
-            )
-        )
-    else:
-        print(f"status={TRUSTED_HISTORY_VERIFIED}")
-        print(f"collection_status={COLLECTED}")
-        print("artifacts_written=true")
     return 0
 
 

--- a/src/sdetkit/trusted_diagnostic_signal_snapshot_history.py
+++ b/src/sdetkit/trusted_diagnostic_signal_snapshot_history.py
@@ -336,15 +336,27 @@ def main(argv: list[str] | None = None) -> int:
             base_sha=args.base_sha,
             base_ancestry_verified=True,
         )
-        artifacts = write_evidence(evidence, out_dir=args.out_dir)
+        write_evidence(evidence, out_dir=args.out_dir)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"error={exc}", file=sys.stderr)
         return 2
 
     if args.format == "json":
-        print(json.dumps({"evidence": evidence, "artifacts": artifacts}, indent=2, sort_keys=True))
+        print(
+            json.dumps(
+                {
+                    "artifacts_written": True,
+                    "collection_status": COLLECTED,
+                    "status": TRUSTED_HISTORY_VERIFIED,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
     else:
-        print(render_markdown(evidence), end="")
+        print(f"status={TRUSTED_HISTORY_VERIFIED}")
+        print(f"collection_status={COLLECTED}")
+        print("artifacts_written=true")
     return 0
 
 

--- a/src/sdetkit/trusted_diagnostic_signal_snapshot_history.py
+++ b/src/sdetkit/trusted_diagnostic_signal_snapshot_history.py
@@ -1,0 +1,352 @@
+"""Read accepted-main DiagnosticSignalSnapshot history without granting authority."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.diagnostic_signal_snapshot_history import (
+    HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION,
+    HISTORY_RECORDED,
+    RATE_STATUS,
+    RETENTION_WORKFLOW,
+    validate_record,
+)
+
+SCHEMA_VERSION = ".".join(
+    ("sdetkit", "trusted", "diagnostic", "signal", "snapshot", "history", "v1")
+)
+DEFAULT_OUT_DIR = Path("build") / "pr-quality" / "trusted-diagnostic-signal-snapshot-history"
+EVIDENCE_JSON = "trusted-diagnostic-signal-snapshot-history.json"
+EVIDENCE_MD = "trusted-diagnostic-signal-snapshot-history.md"
+COLLECTED = "collected"
+TRUSTED_HISTORY_VERIFIED = "_".join(
+    ("trusted", "diagnostic", "signal", "snapshot", "history", "verified")
+)
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool(value: Any) -> bool:
+    return value is True
+
+
+def _read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _read_jsonl(path: Path) -> list[JsonObject]:
+    records: list[JsonObject] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object on line {line_number} in {path}")
+        records.append(payload)
+    return records
+
+
+def _assert_no_authority(boundary: Mapping[str, Any], *, source: str) -> None:
+    expected = {
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "feeds_repo_memory": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION: False,
+        "prior_history_is_read_only_input": True,
+    }
+    for key, expected_value in expected.items():
+        if boundary.get(key) is not expected_value:
+            raise ValueError(f"{source} does not preserve no-authority boundary: {key}")
+
+
+def verify_base_ancestry(
+    *,
+    repo_root: Path,
+    selected_head_sha: str,
+    base_sha: str,
+) -> None:
+    selected = _text(selected_head_sha)
+    base = _text(base_sha)
+    if not selected:
+        raise ValueError("selected_head_sha is required")
+    if not base:
+        raise ValueError("base_sha is required")
+
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", selected, base],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 1:
+        raise ValueError(
+            "selected diagnostic snapshot history head is not an ancestor of the PR base"
+        )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or "git ancestry verification failed"
+        raise ValueError(detail)
+
+
+def build_trusted_snapshot_history_evidence(
+    *,
+    summary: Mapping[str, Any],
+    records: list[Mapping[str, Any]],
+    selected_retention_run_id: str,
+    selected_head_sha: str,
+    base_sha: str,
+    base_ancestry_verified: bool,
+) -> JsonObject:
+    if not base_ancestry_verified:
+        raise ValueError("diagnostic snapshot history base ancestry was not verified")
+    if not records:
+        raise ValueError("diagnostic snapshot history contains no records")
+    for record in records:
+        validate_record(record)
+
+    if _text(summary.get("status")) != HISTORY_RECORDED:
+        raise ValueError("diagnostic snapshot history summary status is not supported")
+    if _int(summary.get("record_count")) != len(records):
+        raise ValueError("diagnostic snapshot history summary count does not match JSONL records")
+    if _text(summary.get("advisor_false_positive_rate_status")) != RATE_STATUS:
+        raise ValueError("diagnostic snapshot history cannot claim an advisor false-positive rate")
+    if summary.get("reviewed_false_positive_count") is not None:
+        raise ValueError("diagnostic snapshot history cannot carry reviewed false-positive counts")
+    if summary.get("reviewed_observation_count") is not None:
+        raise ValueError("diagnostic snapshot history cannot carry reviewed observation counts")
+    _assert_no_authority(
+        _as_dict(summary.get("decision_boundary")),
+        source="diagnostic snapshot history summary",
+    )
+
+    expected_quiet = sum(
+        1
+        for record in records
+        if _as_dict(record.get("snapshot")).get("quiet_green_advisory_baseline") is True
+    )
+    expected_review = sum(
+        1
+        for record in records
+        if _as_dict(record.get("snapshot")).get("review_signal_present") is True
+    )
+    expected_integration = sum(
+        1
+        for record in records
+        if _as_dict(record.get("snapshot")).get("integration_proof_signal_present") is True
+    )
+    expected_counts = {
+        "quiet_green_advisory_baseline_record_count": expected_quiet,
+        "review_signal_record_count": expected_review,
+        "integration_proof_signal_record_count": expected_integration,
+    }
+    for key, expected in expected_counts.items():
+        if _int(summary.get(key)) != expected:
+            raise ValueError("diagnostic snapshot history signal totals do not match records")
+
+    selected_run = _text(selected_retention_run_id)
+    selected_head = _text(selected_head_sha)
+    latest = _as_dict(records[-1])
+    latest_source = _as_dict(latest.get("source"))
+    summary_latest = _as_dict(summary.get("latest_record"))
+    if _text(latest_source.get("retention_run_id")) != selected_run:
+        raise ValueError("selected retention run does not match latest JSONL record")
+    if _text(latest_source.get("accepted_main_sha")) != selected_head:
+        raise ValueError("selected accepted-main head does not match latest JSONL record")
+    if _text(summary_latest.get("retention_run_id")) != selected_run:
+        raise ValueError("selected retention run does not match latest summary record")
+    if _text(summary_latest.get("accepted_main_sha")) != selected_head:
+        raise ValueError("selected accepted-main head does not match latest summary record")
+
+    latest_snapshot = _as_dict(latest.get("snapshot"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "collection_status": COLLECTED,
+        "status": TRUSTED_HISTORY_VERIFIED,
+        "source": {
+            "workflow": RETENTION_WORKFLOW,
+            "run_id": selected_run,
+            "head_sha": selected_head,
+            "base_sha": _text(base_sha),
+            "base_ancestry_verified": True,
+        },
+        "history": {
+            "record_count": len(records),
+            **expected_counts,
+            "latest_snapshot_status": _text(latest_snapshot.get("status")),
+            "latest_primary_signal_kind": _text(latest_snapshot.get("primary_signal_kind")),
+            "advisor_false_positive_rate_status": RATE_STATUS,
+            "reviewed_false_positive_count": None,
+            "reviewed_observation_count": None,
+            "prior_history_is_read_only_input": True,
+        },
+        "decision_boundary": {
+            "reporting_only": True,
+            "current_pr_decision_input": False,
+            "feeds_repo_memory": False,
+            "proof_commands_executed": False,
+            "patch_application_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION: False,
+            "prior_history_is_read_only_input": True,
+        },
+    }
+
+
+def render_markdown(evidence: Mapping[str, Any]) -> str:
+    source = _as_dict(evidence.get("source"))
+    history = _as_dict(evidence.get("history"))
+    boundary = _as_dict(evidence.get("decision_boundary"))
+    return "\n".join(
+        [
+            "## Trusted diagnostic signal snapshot history",
+            "",
+            "- Evidence type: `accepted_main_reporting_only_snapshot_history`",
+            f"- Collection status: `{_text(evidence.get('collection_status'))}`",
+            f"- Status: `{_text(evidence.get('status'))}`",
+            f"- Source workflow: `{_text(source.get('workflow'))}`",
+            f"- Latest accepted main head: `{_text(source.get('head_sha'))}`",
+            f"- Base ancestry verified: `{str(_bool(source.get('base_ancestry_verified'))).lower()}`",
+            f"- Records: `{_int(history.get('record_count'))}`",
+            (
+                "- Quiet-green advisory baseline records: "
+                f"`{_int(history.get('quiet_green_advisory_baseline_record_count'))}`"
+            ),
+            f"- Review-signal records: `{_int(history.get('review_signal_record_count'))}`",
+            (
+                "- Integration-proof-signal records: "
+                f"`{_int(history.get('integration_proof_signal_record_count'))}`"
+            ),
+            (
+                "- Latest retained snapshot status: "
+                f"`{_text(history.get('latest_snapshot_status'))}`"
+            ),
+            (
+                "- Advisor false-positive rate status: "
+                f"`{_text(history.get('advisor_false_positive_rate_status'))}`"
+            ),
+            "- Interpretation: accepted-main snapshot history shows advisory signal availability only; reviewed false-positive labels and a valid denominator are not present.",
+            "",
+            "### Boundary",
+            "",
+            f"- Reporting only: `{str(_bool(boundary.get('reporting_only'))).lower()}`",
+            (
+                "- Current PR decision input: "
+                f"`{str(_bool(boundary.get('current_pr_decision_input'))).lower()}`"
+            ),
+            f"- Feeds RepoMemory: `{str(_bool(boundary.get('feeds_repo_memory'))).lower()}`",
+            (
+                "- Prior history is read-only input: "
+                f"`{str(_bool(boundary.get('prior_history_is_read_only_input'))).lower()}`"
+            ),
+            (
+                "- Proof commands executed: "
+                f"`{str(_bool(boundary.get('proof_commands_executed'))).lower()}`"
+            ),
+            (
+                "- Patch application allowed: "
+                f"`{str(_bool(boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`",
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            (
+                "- Historical snapshot authorizes current action: "
+                f"`{str(_bool(boundary.get(HISTORICAL_SNAPSHOT_AUTHORIZES_CURRENT_ACTION))).lower()}`"
+            ),
+            "",
+        ]
+    )
+
+
+def write_evidence(evidence: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / EVIDENCE_JSON
+    markdown_path = out_dir / EVIDENCE_MD
+    json_path.write_text(
+        json.dumps(dict(evidence), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    markdown_path.write_text(render_markdown(evidence), encoding="utf-8")
+    return {
+        "trusted_diagnostic_signal_snapshot_history_json": json_path.as_posix(),
+        "trusted_diagnostic_signal_snapshot_history_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.trusted_diagnostic_signal_snapshot_history"
+    )
+    parser.add_argument("--history-summary", type=Path, required=True)
+    parser.add_argument("--history-jsonl", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--selected-retention-run-id", required=True)
+    parser.add_argument("--selected-head-sha", required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        verify_base_ancestry(
+            repo_root=args.repo_root,
+            selected_head_sha=args.selected_head_sha,
+            base_sha=args.base_sha,
+        )
+        evidence = build_trusted_snapshot_history_evidence(
+            summary=_read_json(args.history_summary),
+            records=_read_jsonl(args.history_jsonl),
+            selected_retention_run_id=args.selected_retention_run_id,
+            selected_head_sha=args.selected_head_sha,
+            base_sha=args.base_sha,
+            base_ancestry_verified=True,
+        )
+        artifacts = write_evidence(evidence, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps({"evidence": evidence, "artifacts": artifacts}, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(evidence), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_diagnostic_signal_snapshot_history.py
+++ b/tests/test_diagnostic_signal_snapshot_history.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.diagnostic_signal_snapshot_history import (
+    HISTORY_JSONL,
+    HISTORY_RECORDED,
+    RATE_STATUS,
+    build_history_record,
+    build_history_summary,
+    main,
+    merge_history_records,
+    render_markdown,
+    write_history_jsonl,
+)
+
+
+def _snapshot() -> dict:
+    return {
+        "schema_version": "sdetkit.diagnostic.signal.snapshot.v1",
+        "status": "quiet_green_advisory_baseline",
+        "snapshot_type": "current_pr_reporting_only",
+        "quiet_green_advisory_baseline": True,
+        "measurements": {
+            "primary_signal_kind": "review_signal",
+            "review_signal_present": True,
+            "integration_proof_signal_present": False,
+            "evidence_graph_node_count": 0,
+            "diagnostic_worker_diagnosis_count": 0,
+            "runtime_guard_violation_count": 0,
+            "current_security_finding_count": 0,
+        },
+        "kpi_readiness": {
+            "advisor_false_positive_rate_status": RATE_STATUS,
+            "reviewed_false_positive_count": None,
+            "reviewed_observation_count": None,
+        },
+        "decision_boundary": {
+            "reporting_only": True,
+            "current_pr_decision_input": False,
+            "feeds_repo_memory": False,
+            "proof_commands_executed": False,
+            "patch_application_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _associated_pr(*, merge_sha: str = "merge123", head_sha: str = "head123") -> list[dict]:
+    return [
+        {
+            "number": 1456,
+            "merged_at": "2026-05-28T09:33:53Z",
+            "merge_commit_sha": merge_sha,
+            "head": {"sha": head_sha},
+        }
+    ]
+
+
+def _record(run_id: str = "quality-run-1", retention_run_id: str = "history-run-1") -> dict:
+    return build_history_record(
+        _snapshot(),
+        associated_pr_payload=_associated_pr(),
+        source_run_id=run_id,
+        source_run_conclusion="success",
+        source_head_sha="head123",
+        retention_run_id=retention_run_id,
+        accepted_main_sha="merge123",
+        recorded_at_utc="2026-05-28T10:00:00Z",
+    )
+
+
+def test_history_record_retains_snapshot_observation_without_authority_or_rate() -> None:
+    record = _record()
+    snapshot = record["snapshot"]
+    boundary = record["decision_boundary"]
+
+    assert snapshot["status"] == "quiet_green_advisory_baseline"
+    assert snapshot["primary_signal_kind"] == "review_signal"
+    assert snapshot["review_signal_present"] is True
+    assert snapshot["integration_proof_signal_present"] is False
+    assert snapshot["advisor_false_positive_rate_status"] == RATE_STATUS
+    assert snapshot["reviewed_observation_count"] is None
+    assert boundary["current_pr_decision_input"] is False
+    assert boundary["feeds_repo_memory"] is False
+    assert boundary["automation_allowed"] is False
+    assert boundary["merge_authorized"] is False
+    assert boundary["historical_snapshot_authorizes_current_action"] is False
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["current_pr_decision_input", "feeds_repo_memory", "automation_allowed", "merge_authorized"],
+)
+def test_history_rejects_snapshot_that_expands_authority(key: str) -> None:
+    snapshot = _snapshot()
+    snapshot["decision_boundary"][key] = True
+
+    with pytest.raises(ValueError, match="no-authority boundary"):
+        build_history_record(
+            snapshot,
+            associated_pr_payload=_associated_pr(),
+            source_run_id="quality-run-1",
+            source_run_conclusion="success",
+            source_head_sha="head123",
+            retention_run_id="history-run-1",
+            accepted_main_sha="merge123",
+        )
+
+
+def test_history_rejects_snapshot_that_claims_false_positive_rate() -> None:
+    snapshot = _snapshot()
+    snapshot["kpi_readiness"]["advisor_false_positive_rate_status"] = "measured"
+
+    with pytest.raises(ValueError, match="without reviewed history"):
+        build_history_record(
+            snapshot,
+            associated_pr_payload=_associated_pr(),
+            source_run_id="quality-run-1",
+            source_run_conclusion="success",
+            source_head_sha="head123",
+            retention_run_id="history-run-1",
+            accepted_main_sha="merge123",
+        )
+
+
+def test_history_rejects_mismatched_accepted_main_provenance() -> None:
+    with pytest.raises(ValueError, match="exactly one merged pull request"):
+        build_history_record(
+            _snapshot(),
+            associated_pr_payload=_associated_pr(merge_sha="other-merge"),
+            source_run_id="quality-run-1",
+            source_run_conclusion="success",
+            source_head_sha="head123",
+            retention_run_id="history-run-1",
+            accepted_main_sha="merge123",
+        )
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "message"),
+    [
+        ("status", "unsupported", "status is not supported"),
+        (
+            "quiet_green_advisory_baseline",
+            False,
+            "status and quiet-green flag disagree",
+        ),
+        (
+            "review_signal_present",
+            False,
+            "review signal presence does not match primary signal kind",
+        ),
+    ],
+)
+def test_history_rejects_inconsistent_imported_snapshot_observation(
+    key: str, value: object, message: str
+) -> None:
+    prior = _record()
+    prior["snapshot"][key] = value
+
+    with pytest.raises(ValueError, match=message):
+        merge_history_records(
+            [prior],
+            _record(run_id="quality-run-2", retention_run_id="history-run-2"),
+        )
+
+
+def test_history_summary_counts_signals_without_rate(tmp_path: Path) -> None:
+    second_snapshot = _snapshot()
+    second_snapshot["status"] = "diagnostic_signal_observed"
+    second_snapshot["quiet_green_advisory_baseline"] = False
+    second_snapshot["measurements"]["primary_signal_kind"] = "integration_proof"
+    second_snapshot["measurements"]["review_signal_present"] = False
+    second_snapshot["measurements"]["integration_proof_signal_present"] = True
+    second = build_history_record(
+        second_snapshot,
+        associated_pr_payload=_associated_pr(merge_sha="merge456", head_sha="head456"),
+        source_run_id="quality-run-2",
+        source_run_conclusion="success",
+        source_head_sha="head456",
+        retention_run_id="history-run-2",
+        accepted_main_sha="merge456",
+        recorded_at_utc="2026-05-29T10:00:00Z",
+    )
+    records, appended = merge_history_records([_record()], second)
+    history_path = write_history_jsonl(records, out_dir=tmp_path)
+    summary = build_history_summary(
+        records,
+        appended=appended,
+        history_path=history_path,
+        prior_history_collected=True,
+        prior_record_count=1,
+    )
+
+    assert summary["status"] == HISTORY_RECORDED
+    assert summary["record_count"] == 2
+    assert summary["quiet_green_advisory_baseline_record_count"] == 1
+    assert summary["review_signal_record_count"] == 1
+    assert summary["integration_proof_signal_record_count"] == 1
+    assert summary["advisor_false_positive_rate_status"] == RATE_STATUS
+    assert summary["reviewed_false_positive_count"] is None
+
+    markdown = render_markdown(summary)
+    assert "Advisor false-positive rate status: `requires_reviewed_history`" in markdown
+    assert "Feeds RepoMemory: `false`" in markdown
+
+
+def test_history_cli_deduplicates_source_snapshot_across_retention_reruns_without_mutating_prior_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    snapshot_path = tmp_path / "snapshot.json"
+    pr_path = tmp_path / "associated-pr.json"
+    snapshot_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+    pr_path.write_text(json.dumps(_associated_pr()), encoding="utf-8")
+
+    first_out = tmp_path / "first"
+    first_rc = main(
+        [
+            "--diagnostic-signal-snapshot",
+            str(snapshot_path),
+            "--associated-pr-json",
+            str(pr_path),
+            "--source-run-id",
+            "quality-run-1",
+            "--source-run-conclusion",
+            "success",
+            "--source-head-sha",
+            "head123",
+            "--retention-run-id",
+            "history-run-1",
+            "--accepted-main-sha",
+            "merge123",
+            "--recorded-at-utc",
+            "2026-05-28T10:00:00Z",
+            "--out-dir",
+            str(first_out),
+            "--format",
+            "json",
+        ]
+    )
+    assert first_rc == 0
+    capsys.readouterr()
+
+    prior_path = first_out / HISTORY_JSONL
+    prior_before = prior_path.read_text(encoding="utf-8")
+    second_out = tmp_path / "second"
+    second_rc = main(
+        [
+            "--diagnostic-signal-snapshot",
+            str(snapshot_path),
+            "--associated-pr-json",
+            str(pr_path),
+            "--prior-history-jsonl",
+            str(prior_path),
+            "--source-run-id",
+            "quality-run-1",
+            "--source-run-conclusion",
+            "success",
+            "--source-head-sha",
+            "head123",
+            "--retention-run-id",
+            "history-run-rerun",
+            "--accepted-main-sha",
+            "merge123",
+            "--recorded-at-utc",
+            "2026-05-28T10:00:00Z",
+            "--out-dir",
+            str(second_out),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert second_rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["record_count"] == 1
+    assert printed["appended"] is False
+    assert prior_path.read_text(encoding="utf-8") == prior_before
+
+
+def test_history_dedup_refreshes_latest_retention_provenance_without_increasing_counts() -> None:
+    first = _record(retention_run_id="history-run-1")
+    rerun = _record(retention_run_id="history-run-rerun")
+
+    records, appended = merge_history_records([first], rerun)
+
+    assert appended is False
+    assert len(records) == 1
+    assert records[0]["record_id"] == first["record_id"]
+    assert records[0]["source"]["retention_run_id"] == "history-run-rerun"
+
+
+def test_history_rejects_imported_record_with_forged_identity() -> None:
+    record = _record()
+    record["record_id"] = "forged-record-id"
+
+    with pytest.raises(ValueError, match="record id does not match retained observation"):
+        merge_history_records([record], _record(retention_run_id="history-run-2"))
+
+
+def test_history_rejects_imported_record_without_read_only_prior_history_boundary() -> None:
+    record = _record()
+    record["decision_boundary"]["prior_history_is_read_only_input"] = False
+
+    with pytest.raises(ValueError, match="does not preserve read-only prior-history input"):
+        merge_history_records([record], _record(retention_run_id="history-run-2"))
+
+
+def test_history_rejects_imported_record_without_positive_merged_pr_number() -> None:
+    record = _record()
+    record["source"]["merged_pr_number"] = 0
+
+    with pytest.raises(ValueError, match="lacks merged PR number provenance"):
+        merge_history_records([record], _record(retention_run_id="history-run-2"))

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -911,3 +911,95 @@ def test_pr_quality_workflow_renders_diagnostic_signal_snapshot_after_worker_as_
     assert "Merge authorized: `false`" in build_comment
     assert "--commit-safe-fixes" not in text
     assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_workflow_appends_trusted_diagnostic_snapshot_history_post_decision_only() -> (
+    None
+):
+    text = _workflow_text()
+    build_comment = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build verified operator evidence loop"
+        )
+    ]
+
+    repo_memory = build_comment.index("python -m sdetkit.repo_memory")
+    action_report = build_comment.index("python -m sdetkit.pr_quality_action_report")
+    current_snapshot = build_comment.index("python -m sdetkit.diagnostic_signal_snapshot")
+    trusted_snapshot_history = build_comment.index(
+        "python -m sdetkit.trusted_diagnostic_signal_snapshot_history"
+    )
+    trusted_append = build_comment.index(
+        "cat build/pr-quality/trusted-diagnostic-signal-snapshot-history/"
+        "trusted-diagnostic-signal-snapshot-history.md"
+    )
+    candidate_validation = build_comment.index("python -m sdetkit.pr_quality_candidate_validation")
+    repo_memory_command = build_comment[
+        repo_memory : build_comment.index(
+            "> build/pr-quality/repo-memory/repo-memory-cli.json", repo_memory
+        )
+    ]
+    action_report_command = build_comment[
+        action_report : build_comment.index(
+            "> build/pr-quality/pr-comment-metadata.json", action_report
+        )
+    ]
+
+    assert action_report < current_snapshot < trusted_snapshot_history < candidate_validation
+    assert trusted_snapshot_history < trusted_append
+    assert "trusted-diagnostic-signal-snapshot-history" not in repo_memory_command
+    assert "trusted-diagnostic-signal-snapshot-history" not in action_report_command
+    assert '--selected-retention-run-id "$trusted_snapshot_history_run_id"' in build_comment
+    assert '--selected-head-sha "$trusted_snapshot_history_head_sha"' in build_comment
+    assert "Advisor false-positive rate status: `requires_reviewed_history`" in build_comment
+    assert "Current PR decision input: `false`" in build_comment
+    assert "Feeds RepoMemory: `false`" in build_comment
+    assert "Historical snapshot authorizes current action: `false`" in build_comment
+
+
+def test_pr_quality_workflow_uploads_trusted_diagnostic_snapshot_history_artifact() -> None:
+    text = _workflow_text()
+
+    assert "build/pr-quality/trusted-diagnostic-signal-snapshot-history/" in text
+    assert "python -m sdetkit.trusted_diagnostic_signal_snapshot_history" in text
+    assert "--commit-safe-fixes" not in text
+    assert "--pr-quality-safe-bridge-only" not in text
+
+
+def test_pr_quality_snapshot_history_allows_bootstrap_absence_but_fails_invalid_present_history() -> (
+    None
+):
+    text = _workflow_text()
+    build_comment = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build verified operator evidence loop"
+        )
+    ]
+    verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
+
+    assert "trusted_snapshot_history_file_count=0" in build_comment
+    assert 'if [ "$trusted_snapshot_history_file_count" -eq 0 ]; then' in build_comment
+    assert 'elif [ "$trusted_snapshot_history_file_count" -ne 2 ]' in build_comment
+    assert "|| trusted_diagnostic_signal_snapshot_history_rc=3" in build_comment
+    assert "Collection status: `not_collected`" in build_comment
+    assert "Collection status: `collection_failed`" in build_comment
+    assert "failed validation or is incomplete" in build_comment
+    assert 'trusted_snapshot_history_exit_code not in {"0", "2"}' in verify_visibility
+    assert "validation failed after " in verify_visibility
+    assert "diagnostic comment publication" in verify_visibility
+
+
+def test_pr_quality_snapshot_history_falls_back_to_latest_ancestor_artifact_with_stream() -> None:
+    text = _workflow_text()
+    build_comment = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build verified operator evidence loop"
+        )
+    ]
+
+    assert "sdetkit-trusted-diagnostic-snapshot-history" in build_comment
+    assert "build/pr-quality/trusted-history/successful-main-runs.tsv" in build_comment
+    assert 'if [ "$candidate_file_count" -eq 0 ]; then' in build_comment
+    assert 'trusted_snapshot_history_run_id="$candidate_run_id"' in build_comment
+    assert '--selected-retention-run-id "$trusted_snapshot_history_run_id"' in build_comment
+    assert '--selected-head-sha "$trusted_snapshot_history_head_sha"' in build_comment

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -917,44 +917,45 @@ def test_pr_quality_workflow_appends_trusted_diagnostic_snapshot_history_post_de
     None
 ):
     text = _workflow_text()
-    build_comment = text[
+    comment_builder = text[
         text.index("- name: Build PR comment body") : text.index(
-            "- name: Build verified operator evidence loop"
+            "- name: Build trusted diagnostic signal snapshot history visibility"
         )
     ]
+    trusted_visibility = text[
+        text.index(
+            "- name: Build trusted diagnostic signal snapshot history visibility"
+        ) : text.index("- name: Build verified operator evidence loop")
+    ]
 
-    repo_memory = build_comment.index("python -m sdetkit.repo_memory")
-    action_report = build_comment.index("python -m sdetkit.pr_quality_action_report")
-    current_snapshot = build_comment.index("python -m sdetkit.diagnostic_signal_snapshot")
-    trusted_snapshot_history = build_comment.index(
-        "python -m sdetkit.trusted_diagnostic_signal_snapshot_history"
+    repo_memory = comment_builder.index("python -m sdetkit.repo_memory")
+    action_report = comment_builder.index("python -m sdetkit.pr_quality_action_report")
+    current_snapshot = comment_builder.index("python -m sdetkit.diagnostic_signal_snapshot")
+    candidate_validation = comment_builder.index(
+        "python -m sdetkit.pr_quality_candidate_validation"
     )
-    trusted_append = build_comment.index(
-        "cat build/pr-quality/trusted-diagnostic-signal-snapshot-history/"
-        "trusted-diagnostic-signal-snapshot-history.md"
-    )
-    candidate_validation = build_comment.index("python -m sdetkit.pr_quality_candidate_validation")
-    repo_memory_command = build_comment[
-        repo_memory : build_comment.index(
+    repo_memory_command = comment_builder[
+        repo_memory : comment_builder.index(
             "> build/pr-quality/repo-memory/repo-memory-cli.json", repo_memory
         )
     ]
-    action_report_command = build_comment[
-        action_report : build_comment.index(
+    action_report_command = comment_builder[
+        action_report : comment_builder.index(
             "> build/pr-quality/pr-comment-metadata.json", action_report
         )
     ]
 
-    assert action_report < current_snapshot < trusted_snapshot_history < candidate_validation
-    assert trusted_snapshot_history < trusted_append
+    assert action_report < current_snapshot < candidate_validation
+    assert "python -m sdetkit.trusted_diagnostic_signal_snapshot_history" in trusted_visibility
     assert "trusted-diagnostic-signal-snapshot-history" not in repo_memory_command
     assert "trusted-diagnostic-signal-snapshot-history" not in action_report_command
-    assert '--selected-retention-run-id "$trusted_snapshot_history_run_id"' in build_comment
-    assert '--selected-head-sha "$trusted_snapshot_history_head_sha"' in build_comment
-    assert "Advisor false-positive rate status: `requires_reviewed_history`" in build_comment
-    assert "Current PR decision input: `false`" in build_comment
-    assert "Feeds RepoMemory: `false`" in build_comment
-    assert "Historical snapshot authorizes current action: `false`" in build_comment
+    assert '--selected-retention-run-id "$trusted_snapshot_history_run_id"' in trusted_visibility
+    assert '--selected-head-sha "$trusted_snapshot_history_head_sha"' in trusted_visibility
+    assert 'body = body.replace(snapshot, f"{snapshot}\\n\\n{history}", 1)' in trusted_visibility
+    assert "Advisor false-positive rate status: `requires_reviewed_history`" in trusted_visibility
+    assert "Current PR decision input: `false`" in trusted_visibility
+    assert "Feeds RepoMemory: `false`" in trusted_visibility
+    assert "Historical snapshot authorizes current action: `false`" in trusted_visibility
 
 
 def test_pr_quality_workflow_uploads_trusted_diagnostic_snapshot_history_artifact() -> None:
@@ -970,20 +971,20 @@ def test_pr_quality_snapshot_history_allows_bootstrap_absence_but_fails_invalid_
     None
 ):
     text = _workflow_text()
-    build_comment = text[
-        text.index("- name: Build PR comment body") : text.index(
-            "- name: Build verified operator evidence loop"
-        )
+    trusted_visibility = text[
+        text.index(
+            "- name: Build trusted diagnostic signal snapshot history visibility"
+        ) : text.index("- name: Build verified operator evidence loop")
     ]
     verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
 
-    assert "trusted_snapshot_history_file_count=0" in build_comment
-    assert 'if [ "$trusted_snapshot_history_file_count" -eq 0 ]; then' in build_comment
-    assert 'elif [ "$trusted_snapshot_history_file_count" -ne 2 ]' in build_comment
-    assert "|| trusted_diagnostic_signal_snapshot_history_rc=3" in build_comment
-    assert "Collection status: `not_collected`" in build_comment
-    assert "Collection status: `collection_failed`" in build_comment
-    assert "failed validation or is incomplete" in build_comment
+    assert "trusted_snapshot_history_file_count=0" in trusted_visibility
+    assert 'if [ "$trusted_snapshot_history_file_count" -eq 0 ]; then' in trusted_visibility
+    assert 'elif [ "$trusted_snapshot_history_file_count" -ne 2 ]' in trusted_visibility
+    assert "|| trusted_diagnostic_signal_snapshot_history_rc=3" in trusted_visibility
+    assert "Collection status: `not_collected`" in trusted_visibility
+    assert "Collection status: `collection_failed`" in trusted_visibility
+    assert "failed validation or is incomplete" in trusted_visibility
     assert 'trusted_snapshot_history_exit_code not in {"0", "2"}' in verify_visibility
     assert "validation failed after " in verify_visibility
     assert "diagnostic comment publication" in verify_visibility
@@ -991,15 +992,38 @@ def test_pr_quality_snapshot_history_allows_bootstrap_absence_but_fails_invalid_
 
 def test_pr_quality_snapshot_history_falls_back_to_latest_ancestor_artifact_with_stream() -> None:
     text = _workflow_text()
-    build_comment = text[
-        text.index("- name: Build PR comment body") : text.index(
-            "- name: Build verified operator evidence loop"
-        )
+    trusted_visibility = text[
+        text.index(
+            "- name: Build trusted diagnostic signal snapshot history visibility"
+        ) : text.index("- name: Build verified operator evidence loop")
     ]
 
-    assert "sdetkit-trusted-diagnostic-snapshot-history" in build_comment
-    assert "build/pr-quality/trusted-history/successful-main-runs.tsv" in build_comment
-    assert 'if [ "$candidate_file_count" -eq 0 ]; then' in build_comment
-    assert 'trusted_snapshot_history_run_id="$candidate_run_id"' in build_comment
-    assert '--selected-retention-run-id "$trusted_snapshot_history_run_id"' in build_comment
-    assert '--selected-head-sha "$trusted_snapshot_history_head_sha"' in build_comment
+    assert "sdetkit-trusted-diagnostic-snapshot-history" in trusted_visibility
+    assert "build/pr-quality/trusted-history/successful-main-runs.tsv" in trusted_visibility
+    assert 'if [ "$candidate_file_count" -eq 0 ]; then' in trusted_visibility
+    assert 'trusted_snapshot_history_run_id="$candidate_run_id"' in trusted_visibility
+    assert '--selected-retention-run-id "$trusted_snapshot_history_run_id"' in trusted_visibility
+    assert '--selected-head-sha "$trusted_snapshot_history_head_sha"' in trusted_visibility
+
+
+def test_pr_quality_builds_trusted_snapshot_history_in_bounded_follow_on_step() -> None:
+    text = _workflow_text()
+    comment_builder = text[
+        text.index("- name: Build PR comment body") : text.index(
+            "- name: Build trusted diagnostic signal snapshot history visibility"
+        )
+    ]
+    trusted_visibility = text[
+        text.index(
+            "- name: Build trusted diagnostic signal snapshot history visibility"
+        ) : text.index("- name: Build verified operator evidence loop")
+    ]
+
+    assert "python -m sdetkit.diagnostic_signal_snapshot" in comment_builder
+    assert "python -m sdetkit.pr_quality_candidate_validation" in comment_builder
+    assert "runtime_guard_worker_oracle.json" in comment_builder
+    assert "security_freshness_stale_runtime_oracle.json" in comment_builder
+    assert "python -m sdetkit.trusted_diagnostic_signal_snapshot_history" not in comment_builder
+    assert "python -m sdetkit.trusted_diagnostic_signal_snapshot_history" in trusted_visibility
+    assert "trusted-diagnostic-signal-snapshot-history.md" in trusted_visibility
+    assert 'body = body.replace(snapshot, f"{snapshot}\\n\\n{history}", 1)' in trusted_visibility

--- a/tests/test_repo_memory_profile_history_workflow.py
+++ b/tests/test_repo_memory_profile_history_workflow.py
@@ -199,3 +199,73 @@ def test_repo_memory_history_promotes_controlled_validation_as_advisory_counts_o
     assert 'assert boundary["controlled_validation_is_advisory_only"] is True' in text
     assert "contents: write" not in text.split("jobs:", 1)[0]
     assert "git push " not in text
+
+
+def test_repo_memory_history_retains_diagnostic_snapshot_as_parallel_advisory_history() -> None:
+    text = _workflow_text()
+
+    source = text.index("Collect accepted-main diagnostic signal snapshot source")
+    producer = text.index("python -m sdetkit.diagnostic_signal_snapshot_history")
+    security_history = text.index("python -m sdetkit.security_reviewed_disposition_history")
+    repo_memory = text.index("python -m sdetkit.repo_memory")
+    repo_memory_command = text[
+        repo_memory : text.index("> build/repo-memory-history/profile-cli.json", repo_memory)
+    ]
+
+    assert source < producer < security_history
+    assert (
+        "actions/workflows/pr-quality-comment.yml/runs?event=pull_request&status=completed" in text
+    )
+    assert 'select(.conclusion == "success")' in text
+    assert "--name pr-quality-comment" in text
+    assert "diagnostic-signal-snapshot.json" in text
+    assert "--prior-history-jsonl" in text
+    assert "prior_diagnostic_signal_snapshot_jsonl" in text
+    assert (
+        'assert summary["advisor_false_positive_rate_status"] == "requires_reviewed_history"'
+        in text
+    )
+    assert 'assert boundary["current_pr_decision_input"] is False' in text
+    assert 'assert boundary["feeds_repo_memory"] is False' in text
+    assert 'assert boundary["automation_allowed"] is False' in text
+    assert 'assert boundary["merge_authorized"] is False' in text
+    assert "build/repo-memory-history/diagnostic-signal-snapshots/" in text
+    assert "diagnostic-signal-snapshot" not in repo_memory_command
+
+
+def test_repo_memory_history_snapshot_retention_remains_read_only_and_non_mutating() -> None:
+    text = _workflow_text()
+
+    assert "python -m sdetkit.diagnostic_signal_snapshot_history" in text
+    assert "--source-run-conclusion success" in text
+    assert '--retention-run-id "${GITHUB_RUN_ID}"' in text
+    assert '--accepted-main-sha "${GITHUB_SHA}"' in text
+    assert 'assert boundary["patch_application_allowed"] is False' in text
+    assert 'assert boundary["semantic_equivalence_proven"] is False' in text
+    assert 'assert boundary["historical_snapshot_authorizes_current_action"] is False' in text
+    assert "contents: write" not in text.split("jobs:", 1)[0]
+    assert "git push " not in text
+
+
+def test_repo_memory_history_binds_snapshot_source_run_to_the_merged_pr_number() -> None:
+    text = _workflow_text()
+
+    assert '(.pull_requests | map(.number | tostring) | join(","))' in text
+    assert "candidate_pr_numbers" in text
+    assert 'case ",${candidate_pr_numbers}," in' in text
+    assert '*,"${source_pr_number}",*)' in text
+
+
+def test_repo_memory_history_snapshot_retention_does_not_fail_non_pr_main_push() -> None:
+    text = _workflow_text()
+
+    assert 'source_match_count="$(' in text
+    assert 'if [ "$source_match_count" -eq 0 ]; then' in text
+    assert 'echo "source_available=false" >> "$GITHUB_OUTPUT"' in text
+    assert (
+        "No merged PR maps to accepted-main head; no diagnostic snapshot observation will be appended."
+        in text
+    )
+    assert "if: steps.diagnostic-snapshot-source.outputs.source_available == 'true'" in text
+    assert "sdetkit-prior-diagnostic-snapshot-history" in text
+    assert "-name diagnostic-signal-snapshot-history.jsonl" in text

--- a/tests/test_trusted_diagnostic_signal_snapshot_history.py
+++ b/tests/test_trusted_diagnostic_signal_snapshot_history.py
@@ -219,7 +219,6 @@ def test_trusted_history_cli_writes_reporting_only_evidence(
 
     assert rc == 0
     stdout = capsys.readouterr().out
-    printed = json.loads(stdout)
     saved = json.loads(
         (out_dir / "trusted-diagnostic-signal-snapshot-history.json").read_text(encoding="utf-8")
     )
@@ -227,14 +226,9 @@ def test_trusted_history_cli_writes_reporting_only_evidence(
         encoding="utf-8"
     )
 
-    assert printed == {
-        "artifacts_written": True,
-        "collection_status": COLLECTED,
-        "status": TRUSTED_HISTORY_VERIFIED,
-    }
-    assert "evidence" not in printed
-    assert "retention-run-1" not in stdout
-    assert accepted_head not in stdout
+    assert stdout == ""
+    assert saved["collection_status"] == COLLECTED
+    assert saved["status"] == TRUSTED_HISTORY_VERIFIED
     assert saved["decision_boundary"]["current_pr_decision_input"] is False
     assert saved["decision_boundary"]["feeds_repo_memory"] is False
     assert "Advisor false-positive rate status: `requires_reviewed_history`" in markdown

--- a/tests/test_trusted_diagnostic_signal_snapshot_history.py
+++ b/tests/test_trusted_diagnostic_signal_snapshot_history.py
@@ -218,7 +218,8 @@ def test_trusted_history_cli_writes_reporting_only_evidence(
     )
 
     assert rc == 0
-    printed = json.loads(capsys.readouterr().out)
+    stdout = capsys.readouterr().out
+    printed = json.loads(stdout)
     saved = json.loads(
         (out_dir / "trusted-diagnostic-signal-snapshot-history.json").read_text(encoding="utf-8")
     )
@@ -226,7 +227,14 @@ def test_trusted_history_cli_writes_reporting_only_evidence(
         encoding="utf-8"
     )
 
-    assert printed["evidence"]["status"] == TRUSTED_HISTORY_VERIFIED
+    assert printed == {
+        "artifacts_written": True,
+        "collection_status": COLLECTED,
+        "status": TRUSTED_HISTORY_VERIFIED,
+    }
+    assert "evidence" not in printed
+    assert "retention-run-1" not in stdout
+    assert accepted_head not in stdout
     assert saved["decision_boundary"]["current_pr_decision_input"] is False
     assert saved["decision_boundary"]["feeds_repo_memory"] is False
     assert "Advisor false-positive rate status: `requires_reviewed_history`" in markdown

--- a/tests/test_trusted_diagnostic_signal_snapshot_history.py
+++ b/tests/test_trusted_diagnostic_signal_snapshot_history.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from sdetkit.diagnostic_signal_snapshot_history import (
+    RATE_STATUS,
+    build_history_record,
+    build_history_summary,
+    merge_history_records,
+    write_history_jsonl,
+)
+from sdetkit.trusted_diagnostic_signal_snapshot_history import (
+    COLLECTED,
+    TRUSTED_HISTORY_VERIFIED,
+    build_trusted_snapshot_history_evidence,
+    main,
+    render_markdown,
+    verify_base_ancestry,
+)
+
+
+def _run(*args: str, cwd: Path) -> str:
+    completed = subprocess.run(
+        list(args),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _git_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run("git", "init", cwd=repo)
+    _run("git", "config", "user.email", "snapshot-history@example.test", cwd=repo)
+    _run("git", "config", "user.name", "Snapshot History Test", cwd=repo)
+    (repo / "state.txt").write_text("first\n", encoding="utf-8")
+    _run("git", "add", "state.txt", cwd=repo)
+    _run("git", "commit", "-m", "first", cwd=repo)
+    first = _run("git", "rev-parse", "HEAD", cwd=repo)
+    (repo / "state.txt").write_text("second\n", encoding="utf-8")
+    _run("git", "add", "state.txt", cwd=repo)
+    _run("git", "commit", "-m", "second", cwd=repo)
+    second = _run("git", "rev-parse", "HEAD", cwd=repo)
+    return repo, first, second
+
+
+def _snapshot() -> dict:
+    return {
+        "schema_version": "sdetkit.diagnostic.signal.snapshot.v1",
+        "status": "quiet_green_advisory_baseline",
+        "snapshot_type": "current_pr_reporting_only",
+        "quiet_green_advisory_baseline": True,
+        "measurements": {
+            "primary_signal_kind": "review_signal",
+            "review_signal_present": True,
+            "integration_proof_signal_present": False,
+            "evidence_graph_node_count": 0,
+            "diagnostic_worker_diagnosis_count": 0,
+            "runtime_guard_violation_count": 0,
+            "current_security_finding_count": 0,
+        },
+        "kpi_readiness": {
+            "advisor_false_positive_rate_status": RATE_STATUS,
+            "reviewed_false_positive_count": None,
+            "reviewed_observation_count": None,
+        },
+        "decision_boundary": {
+            "reporting_only": True,
+            "current_pr_decision_input": False,
+            "feeds_repo_memory": False,
+            "proof_commands_executed": False,
+            "patch_application_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _artifact(tmp_path: Path, *, accepted_head: str) -> tuple[Path, Path, dict, dict]:
+    record = build_history_record(
+        _snapshot(),
+        associated_pr_payload=[
+            {
+                "number": 1456,
+                "merged_at": "2026-05-28T09:33:53Z",
+                "merge_commit_sha": accepted_head,
+                "head": {"sha": "pr-head-1"},
+            }
+        ],
+        source_run_id="quality-run-1",
+        source_run_conclusion="success",
+        source_head_sha="pr-head-1",
+        retention_run_id="retention-run-1",
+        accepted_main_sha=accepted_head,
+        recorded_at_utc="2026-05-28T10:00:00Z",
+    )
+    history_path = write_history_jsonl([record], out_dir=tmp_path)
+    summary = build_history_summary(
+        [record],
+        appended=True,
+        history_path=history_path,
+        prior_history_collected=False,
+        prior_record_count=0,
+    )
+    summary_path = tmp_path / "diagnostic-signal-snapshot-history-summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary_path, history_path, summary, record
+
+
+def test_trusted_history_accepts_verified_ancestor_snapshot_history(tmp_path: Path) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    _summary_path, _history_path, summary, record = _artifact(
+        tmp_path / "artifact",
+        accepted_head=accepted_head,
+    )
+
+    evidence = build_trusted_snapshot_history_evidence(
+        summary=summary,
+        records=[record],
+        selected_retention_run_id="retention-run-1",
+        selected_head_sha=accepted_head,
+        base_sha=base_head,
+        base_ancestry_verified=True,
+    )
+
+    assert evidence["collection_status"] == COLLECTED
+    assert evidence["status"] == TRUSTED_HISTORY_VERIFIED
+    assert evidence["history"]["record_count"] == 1
+    assert evidence["history"]["review_signal_record_count"] == 1
+    assert evidence["history"]["advisor_false_positive_rate_status"] == RATE_STATUS
+    assert evidence["decision_boundary"]["feeds_repo_memory"] is False
+    assert evidence["decision_boundary"]["automation_allowed"] is False
+
+
+def test_trusted_history_git_verifier_rejects_nonancestor_head(tmp_path: Path) -> None:
+    repo, first, second = _git_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="not an ancestor"):
+        verify_base_ancestry(repo_root=repo, selected_head_sha=second, base_sha=first)
+
+
+def test_trusted_history_rejects_summary_totals_that_do_not_match_records(tmp_path: Path) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    _summary_path, _history_path, summary, record = _artifact(
+        tmp_path / "artifact",
+        accepted_head=accepted_head,
+    )
+    summary["review_signal_record_count"] = 99
+
+    with pytest.raises(ValueError, match="signal totals do not match records"):
+        build_trusted_snapshot_history_evidence(
+            summary=summary,
+            records=[record],
+            selected_retention_run_id="retention-run-1",
+            selected_head_sha=accepted_head,
+            base_sha=base_head,
+            base_ancestry_verified=True,
+        )
+
+
+def test_trusted_history_rejects_summary_that_expands_authority(tmp_path: Path) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    _summary_path, _history_path, summary, record = _artifact(
+        tmp_path / "artifact",
+        accepted_head=accepted_head,
+    )
+    summary["decision_boundary"]["feeds_repo_memory"] = True
+
+    with pytest.raises(ValueError, match="no-authority boundary"):
+        build_trusted_snapshot_history_evidence(
+            summary=summary,
+            records=[record],
+            selected_retention_run_id="retention-run-1",
+            selected_head_sha=accepted_head,
+            base_sha=base_head,
+            base_ancestry_verified=True,
+        )
+
+
+def test_trusted_history_cli_writes_reporting_only_evidence(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, accepted_head, base_head = _git_repo(tmp_path)
+    summary_path, history_path, _summary, _record = _artifact(
+        tmp_path / "artifact",
+        accepted_head=accepted_head,
+    )
+    out_dir = tmp_path / "out"
+
+    rc = main(
+        [
+            "--history-summary",
+            str(summary_path),
+            "--history-jsonl",
+            str(history_path),
+            "--repo-root",
+            str(repo),
+            "--selected-retention-run-id",
+            "retention-run-1",
+            "--selected-head-sha",
+            accepted_head,
+            "--base-sha",
+            base_head,
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads(
+        (out_dir / "trusted-diagnostic-signal-snapshot-history.json").read_text(encoding="utf-8")
+    )
+    markdown = (out_dir / "trusted-diagnostic-signal-snapshot-history.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert printed["evidence"]["status"] == TRUSTED_HISTORY_VERIFIED
+    assert saved["decision_boundary"]["current_pr_decision_input"] is False
+    assert saved["decision_boundary"]["feeds_repo_memory"] is False
+    assert "Advisor false-positive rate status: `requires_reviewed_history`" in markdown
+    assert "Historical snapshot authorizes current action: `false`" in markdown
+
+
+def test_trusted_history_markdown_keeps_history_advisory(tmp_path: Path) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    _summary_path, _history_path, summary, record = _artifact(
+        tmp_path / "artifact",
+        accepted_head=accepted_head,
+    )
+    evidence = build_trusted_snapshot_history_evidence(
+        summary=summary,
+        records=[record],
+        selected_retention_run_id="retention-run-1",
+        selected_head_sha=accepted_head,
+        base_sha=base_head,
+        base_ancestry_verified=True,
+    )
+
+    markdown = render_markdown(evidence)
+
+    assert (
+        "Accepted-main snapshot history shows advisory signal availability only".lower()
+        in markdown.lower()
+    )
+    assert "Current PR decision input: `false`" in markdown
+    assert "Feeds RepoMemory: `false`" in markdown
+    assert "Prior history is read-only input: `true`" in markdown
+    assert "Proof commands executed: `false`" in markdown
+    assert "Patch application allowed: `false`" in markdown
+    assert "Automation allowed: `false`" in markdown
+    assert "Merge authorized: `false`" in markdown
+    assert "Semantic equivalence proven: `false`" in markdown
+
+
+def test_trusted_history_accepts_artifact_republished_by_retention_rerun(tmp_path: Path) -> None:
+    _repo, accepted_head, base_head = _git_repo(tmp_path)
+    associated_pr = [
+        {
+            "number": 1456,
+            "merged_at": "2026-05-28T09:33:53Z",
+            "merge_commit_sha": accepted_head,
+            "head": {"sha": "pr-head-1"},
+        }
+    ]
+    first = build_history_record(
+        _snapshot(),
+        associated_pr_payload=associated_pr,
+        source_run_id="quality-run-1",
+        source_run_conclusion="success",
+        source_head_sha="pr-head-1",
+        retention_run_id="retention-run-1",
+        accepted_main_sha=accepted_head,
+    )
+    rerun = build_history_record(
+        _snapshot(),
+        associated_pr_payload=associated_pr,
+        source_run_id="quality-run-1",
+        source_run_conclusion="success",
+        source_head_sha="pr-head-1",
+        retention_run_id="retention-run-rerun",
+        accepted_main_sha=accepted_head,
+    )
+    records, appended = merge_history_records([first], rerun)
+    history_path = write_history_jsonl(records, out_dir=tmp_path / "artifact-rerun")
+    summary = build_history_summary(
+        records,
+        appended=appended,
+        history_path=history_path,
+        prior_history_collected=True,
+        prior_record_count=1,
+    )
+
+    evidence = build_trusted_snapshot_history_evidence(
+        summary=summary,
+        records=records,
+        selected_retention_run_id="retention-run-rerun",
+        selected_head_sha=accepted_head,
+        base_sha=base_head,
+        base_ancestry_verified=True,
+    )
+
+    assert appended is False
+    assert evidence["status"] == TRUSTED_HISTORY_VERIFIED
+    assert evidence["history"]["record_count"] == 1
+    assert evidence["source"]["run_id"] == "retention-run-rerun"


### PR DESCRIPTION
## Summary
- retain successful accepted-main `DiagnosticSignalSnapshot` observations as a parallel trusted advisory history stream
- render validated prior diagnostic snapshot history in PR Quality without feeding RepoMemory or current PR decisions
- preserve direct-`main` workflow continuity by appending observations only for verified merged-PR pushes and falling back to the latest ancestor artifact containing the snapshot stream

## Why
PR #1456 established a reporting-only current-PR diagnostic snapshot baseline. This PR adds provenance-checked history retention so maintainers can inspect snapshot availability and KPI readiness across accepted runs without inventing reviewed false-positive labels or granting automation authority.

## Contract
- merged-PR `main` pushes may retain one validated snapshot observation
- retention reruns deduplicate the same source observation while refreshing retention provenance
- direct/non-PR `main` pushes do not create synthetic observations and do not fail the existing history workflow
- malformed, partial, non-ancestor, or authority-expanding present history fails visibly after comment publication
- bootstrap absence remains non-authorizing and renders as `not_collected`
- historical snapshot evidence remains reporting-only

## No-authority boundary
- `advisor_false_positive_rate_status=requires_reviewed_history`
- `current_pr_decision_input=false`
- `feeds_repo_memory=false`
- `proof_commands_executed=false`
- `patch_application_allowed=false`
- `automation_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`
- `historical_snapshot_authorizes_current_action=false`

## Files
- add `src/sdetkit/diagnostic_signal_snapshot_history.py`
- add `src/sdetkit/trusted_diagnostic_signal_snapshot_history.py`
- add focused unit tests for retention, validation, reruns, and trusted rendering
- wire advisory-only retention in `.github/workflows/repo-memory-history.yml`
- wire post-decision rendering in `.github/workflows/pr-quality-comment.yml`
- update workflow contract tests and generated roadmap manifest

## Verification
- `python -m sdetkit.roadmap_manifest write` followed by stability verification
- `python -m pytest -q tests/test_diagnostic_signal_snapshot_history.py tests/test_trusted_diagnostic_signal_snapshot_history.py tests/test_diagnostic_signal_snapshot.py tests/test_trusted_history_evidence.py tests/test_repo_memory_profile_history_workflow.py tests/test_pr_quality_comment_observability_workflow.py tests/test_roadmap_manifest_tooling.py -o addopts=` — 104 passed
- `python -m pytest -q -o addopts=` — 3781 passed, 1 skipped
- `python -m mypy src` — passed across 405 source files
- `python -m pre_commit run -a` — passed
- `bash quality.sh cov` — passed, 96.69% coverage
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict` — passed
- `python -m build` — passed
- `python -m twine check dist/*` — passed
- `python -m check_wheel_contents --ignore W009 dist/*.whl` — passed
- installed-wheel smoke import for both new modules — passed

## Risk
- Medium: modifies two GitHub Actions workflows and introduces retained advisory history artifacts.
- Mitigations: strict provenance validation, exact no-authority assertions, rerun deduplication, direct-main continuity protection, ancestor fallback behavior, workflow contract tests, full repository proof.
- Rollback: revert this PR; PR #1456 current-snapshot reporting remains independently valid.
