### PR TITLE
fix: honor monthly GHAS workflow freshness cadence

### DIFF
--- a/.github/workflows/ghas-metrics-export-bot.yml
+++ b/.github/workflows/ghas-metrics-export-bot.yml
@@ -51,7 +51,11 @@ jobs:
             };
             const notes = [];
             const dayMs = 24 * 60 * 60 * 1000;
-            const staleWorkflowDays = 14;
+            const defaultStaleWorkflowDays = 14;
+            const workflowFreshnessThresholdDays = {
+              'security-configuration-audit-bot.yml': 45,
+              'workflow-governance-bot.yml': 45,
+            };
 
             function ageInDays(isoAt) {
               const at = new Date(isoAt || '').getTime();
@@ -132,12 +136,14 @@ jobs:
                 });
                 const latest = runs.data.workflow_runs?.[0];
                 const updatedAgeDays = ageInDays(latest?.updated_at);
+                const staleThresholdDays = workflowFreshnessThresholdDays[workflowFile] || defaultStaleWorkflowDays;
                 workflowFreshness.push({
                   workflow: workflowFile,
                   latest_result: latest ? (latest.conclusion || latest.status || 'unknown') : 'no-runs',
                   updated_at: latest?.updated_at || null,
                   updated_age_days: updatedAgeDays,
-                  stale_14d: updatedAgeDays !== null ? updatedAgeDays >= staleWorkflowDays : null,
+                  stale_threshold_days: staleThresholdDays,
+                  stale: updatedAgeDays !== null ? updatedAgeDays >= staleThresholdDays : null,
                   url: latest?.html_url || `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               } catch (error) {
@@ -147,7 +153,8 @@ jobs:
                   latest_result: 'inspection-failed',
                   updated_at: null,
                   updated_age_days: null,
-                  stale_14d: null,
+                  stale_threshold_days: null,
+                  stale: null,
                   url: `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               }
@@ -207,9 +214,9 @@ jobs:
               `- Secret scanning: \`${JSON.stringify(snapshot.alerts.secret_scanning.age_buckets)}\``,
               '',
               '## Workflow freshness',
-              '| Workflow | Latest result | Updated at | Age (days) | 14d stale | Link |',
-              '| --- | --- | --- | --- | --- | --- |',
-              ...workflowFreshness.map((row) => `| ${row.workflow} | ${row.latest_result} | ${row.updated_at || 'n/a'} | ${row.updated_age_days ?? 'n/a'} | ${row.stale_14d === null ? 'n/a' : (row.stale_14d ? 'yes' : 'no')} | [open](${row.url}) |`),
+              '| Workflow | Latest result | Updated at | Age (days) | Stale threshold (days) | Stale | Link |',
+              '| --- | --- | --- | --- | ---: | --- | --- |',
+              ...workflowFreshness.map((row) => `| ${row.workflow} | ${row.latest_result} | ${row.updated_at || 'n/a'} | ${row.updated_age_days ?? 'n/a'} | ${row.stale_threshold_days ?? 'n/a'} | ${row.stale === null ? 'n/a' : (row.stale ? 'yes' : 'no')} | [open](${row.url}) |`),
               '',
               '## Artifact',
               '- Action artifact: `ghas-metrics-snapshot` (`build/ghas-metrics.json`)',

--- a/tests/test_ghas_metrics_export_workflow.py
+++ b/tests/test_ghas_metrics_export_workflow.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/ghas-metrics-export-bot.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_ghas_metrics_monthly_governance_workflows_use_monthly_stale_threshold() -> None:
+    text = _workflow_text()
+
+    assert "const defaultStaleWorkflowDays = 14;" in text
+    assert "const workflowFreshnessThresholdDays = {" in text
+    assert "'security-configuration-audit-bot.yml': 45," in text
+    assert "'workflow-governance-bot.yml': 45," in text
+    assert (
+        "const staleThresholdDays = "
+        "workflowFreshnessThresholdDays[workflowFile] || defaultStaleWorkflowDays;"
+    ) in text
+    assert "stale_threshold_days: staleThresholdDays," in text
+    assert "stale: updatedAgeDays !== null ? updatedAgeDays >= staleThresholdDays : null," in text
+
+
+def test_ghas_metrics_workflow_freshness_table_reports_generic_stale_threshold() -> None:
+    text = _workflow_text()
+
+    assert "| Stale threshold (days) | Stale |" in text
+    assert "14d stale" not in text
+    assert "stale_14d" not in text


### PR DESCRIPTION
Fixes #1462.

## Summary
- use a monthly-safe freshness threshold for monthly GHAS governance/audit workflows
- replace the hard-coded 14d stale table label with an explicit threshold column
- add workflow guardrail tests for the GHAS metrics exporter

## Proof
- python -m pytest -q tests/test_ghas_metrics_export_workflow.py -o addopts=
- python -m pre_commit run -a