### PR TITLE
fix: surface runtime watchlist routing output

### DIFF
--- a/.github/workflows/runtime-watchlist-bot.yml
+++ b/.github/workflows/runtime-watchlist-bot.yml
@@ -47,6 +47,35 @@ jobs:
               except ValueError:
                   return raw
 
+          def markdown_excerpt(path: Path, *, max_lines: int = 36, max_chars: int = 4000) -> list[str]:
+              if not path.exists():
+                  return ["- Output not found in worker artifact directory."]
+              text = path.read_text(encoding="utf-8", errors="replace").strip()
+              if not text:
+                  return ["- Output was empty."]
+              lines = text.splitlines()
+              selected: list[str] = []
+              used = 0
+              for line in lines:
+                  if len(selected) >= max_lines:
+                      break
+                  next_used = used + len(line) + 1
+                  if next_used > max_chars:
+                      break
+                  selected.append(line)
+                  used = next_used
+              if len(selected) < len(lines):
+                  selected.append("...")
+              return selected
+
+          worker_dir = Path(".sdetkit/agent/template-runs/runtime-watchlist-worker")
+          runtime_watchlist_excerpt = markdown_excerpt(worker_dir / "runtime-watchlist.md")
+          runtime_route_map_excerpt = markdown_excerpt(
+              worker_dir / "route-map.json",
+              max_lines=60,
+              max_chars=6000,
+          )
+
           lines = [
               "# Runtime fast-follow watchlist",
               "",
@@ -66,6 +95,14 @@ jobs:
           ]
           lines.extend([f"- `{display_path(path)}`" for path in artifacts[:3]] or ["- None"])
           lines.extend([
+              "",
+              "## Runtime watchlist output",
+              *runtime_watchlist_excerpt,
+              "",
+              "## Runtime route-map output",
+              "```json",
+              *runtime_route_map_excerpt,
+              "```",
               "",
               "## Artifacts",
               "- `build/runtime-watchlist-worker-run.json`",

--- a/tests/test_runtime_watchlist_workflow.py
+++ b/tests/test_runtime_watchlist_workflow.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/runtime-watchlist-bot.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_runtime_watchlist_issue_embeds_worker_outputs() -> None:
+    text = _workflow_text()
+
+    assert 'worker_dir = Path(".sdetkit/agent/template-runs/runtime-watchlist-worker")' in text
+    assert 'runtime_watchlist_excerpt = markdown_excerpt(worker_dir / "runtime-watchlist.md")' in text
+    assert 'worker_dir / "route-map.json",' in text
+    assert '"## Runtime watchlist output",' in text
+    assert "*runtime_watchlist_excerpt," in text
+    assert '"## Runtime route-map output",' in text
+    assert "*runtime_route_map_excerpt," in text
+
+
+def test_runtime_watchlist_issue_limits_embedded_output_size() -> None:
+    text = _workflow_text()
+
+    assert "def markdown_excerpt(path: Path, *, max_lines: int = 36, max_chars: int = 4000)" in text
+    assert "if len(selected) >= max_lines:" in text
+    assert "if next_used > max_chars:" in text
+    assert 'selected.append("...")' in text

--- a/tests/test_runtime_watchlist_workflow.py
+++ b/tests/test_runtime_watchlist_workflow.py
@@ -13,7 +13,9 @@ def test_runtime_watchlist_issue_embeds_worker_outputs() -> None:
     text = _workflow_text()
 
     assert 'worker_dir = Path(".sdetkit/agent/template-runs/runtime-watchlist-worker")' in text
-    assert 'runtime_watchlist_excerpt = markdown_excerpt(worker_dir / "runtime-watchlist.md")' in text
+    assert (
+        'runtime_watchlist_excerpt = markdown_excerpt(worker_dir / "runtime-watchlist.md")' in text
+    )
     assert 'worker_dir / "route-map.json",' in text
     assert '"## Runtime watchlist output",' in text
     assert "*runtime_watchlist_excerpt," in text


### PR DESCRIPTION
Fixes #1464.

## Summary
- embed the generated runtime watchlist excerpt in the issue body
- embed the generated runtime route-map excerpt in the issue body
- cap embedded output so the issue stays readable
- add workflow guardrail tests

## Proof
- python -m pytest -q tests/test_runtime_watchlist_workflow.py tests/test_agent_templates_engine.py -o addopts=
- python -m sdetkit agent templates run runtime-watchlist-worker --output-dir build/runtime-watchlist-worker-proof > build/runtime-watchlist-worker-run.json
- test -s build/runtime-watchlist-worker-proof/runtime-watchlist.md
- test -s build/runtime-watchlist-worker-proof/route-map.json
- python -m pre_commit run -a