### PR TITLE
fix: report unavailable secret scanning status

### DIFF
--- a/.github/workflows/secret-protection-review-bot.yml
+++ b/.github/workflows/secret-protection-review-bot.yml
@@ -63,16 +63,17 @@ jobs:
 
             async function fetchSecretAlerts() {
               try {
-                return await github.paginate('GET /repos/{owner}/{repo}/secret-scanning/alerts', {
+                const alerts = await github.paginate('GET /repos/{owner}/{repo}/secret-scanning/alerts', {
                   owner,
                   repo,
                   state: 'open',
                   per_page: 100,
                   headers,
                 });
+                return { available: true, alerts };
               } catch (error) {
                 notes.push(`Secret scanning alerts unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`);
-                return [];
+                return { available: false, alerts: [] };
               }
             }
 
@@ -107,9 +108,17 @@ jobs:
             }
 
             const configuration = await fetchConfiguration();
-            const secretAlerts = await fetchSecretAlerts();
-            const bypassedAlerts = secretAlerts.filter((alert) => alert.push_protection_bypassed === true);
-            const topTypes = topSecretTypes(secretAlerts);
+            const secretAlertsResult = await fetchSecretAlerts();
+            const secretAlerts = secretAlertsResult.alerts;
+            const secretAlertsAvailable = secretAlertsResult.available === true;
+            const bypassedAlerts = secretAlertsAvailable
+              ? secretAlerts.filter((alert) => alert.push_protection_bypassed === true)
+              : [];
+            const topTypes = secretAlertsAvailable ? topSecretTypes(secretAlerts) : [];
+            const secretCount = (count) => secretAlertsAvailable ? String(count) : 'unavailable';
+            const secretAgeBuckets = secretAlertsAvailable
+              ? JSON.stringify(ageBuckets(secretAlerts))
+              : 'unavailable';
             const configRows = [
               ['secret_scanning', 'Secret scanning'],
               ['secret_scanning_push_protection', 'Push protection'],
@@ -143,14 +152,16 @@ jobs:
               'This issue is auto-generated to keep newer GitHub secret protection controls visible, owned, and tied to the open secret-scanning queue.',
               '',
               '## Open secret alert review',
-              `- Open secret scanning alerts: **${secretAlerts.length}**`,
-              `- Push-protection bypass follow-up alerts: **${bypassedAlerts.length}**`,
-              `- Alert age buckets: \`${JSON.stringify(ageBuckets(secretAlerts))}\``,
+              `- Open secret scanning alerts: **${secretCount(secretAlerts.length)}**`,
+              `- Push-protection bypass follow-up alerts: **${secretCount(bypassedAlerts.length)}**`,
+              `- Alert age buckets: \`${secretAgeBuckets}\``,
               '',
               '## Most common open secret types',
-              ...(topTypes.length
-                ? topTypes.map(([name, count]) => `- **${name}**: ${count}`)
-                : ['- No open secret alerts were returned for this repository.']),
+              ...(secretAlertsAvailable
+                ? (topTypes.length
+                  ? topTypes.map(([name, count]) => `- **${name}**: ${count}`)
+                  : ['- No open secret alerts were returned for this repository.'])
+                : ['- Secret scanning alerts were unavailable for this run.']),
               '',
               '## Repository secret protection configuration',
               ...configSection,

--- a/tests/test_secret_protection_review_workflow.py
+++ b/tests/test_secret_protection_review_workflow.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/secret-protection-review-bot.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_secret_protection_review_preserves_secret_alert_availability_status() -> None:
+    text = _workflow_text()
+
+    assert "return { available: true, alerts };" in text
+    assert "return { available: false, alerts: [] };" in text
+    assert "const secretAlertsResult = await fetchSecretAlerts();" in text
+    assert "const secretAlertsAvailable = secretAlertsResult.available === true;" in text
+    assert "const secretCount = (count) => secretAlertsAvailable ? String(count) : 'unavailable';" in text
+    assert "const secretAgeBuckets = secretAlertsAvailable" in text
+
+
+def test_secret_protection_review_does_not_render_unavailable_secret_alerts_as_zero() -> None:
+    text = _workflow_text()
+
+    assert "`- Open secret scanning alerts: **${secretCount(secretAlerts.length)}**`" in text
+    assert "`- Push-protection bypass follow-up alerts: **${secretCount(bypassedAlerts.length)}**`" in text
+    assert "`- Alert age buckets: \\`${secretAgeBuckets}\\``" in text
+    assert "- Secret scanning alerts were unavailable for this run." in text

--- a/tests/test_secret_protection_review_workflow.py
+++ b/tests/test_secret_protection_review_workflow.py
@@ -16,7 +16,10 @@ def test_secret_protection_review_preserves_secret_alert_availability_status() -
     assert "return { available: false, alerts: [] };" in text
     assert "const secretAlertsResult = await fetchSecretAlerts();" in text
     assert "const secretAlertsAvailable = secretAlertsResult.available === true;" in text
-    assert "const secretCount = (count) => secretAlertsAvailable ? String(count) : 'unavailable';" in text
+    assert (
+        "const secretCount = (count) => secretAlertsAvailable ? String(count) : 'unavailable';"
+        in text
+    )
     assert "const secretAgeBuckets = secretAlertsAvailable" in text
 
 
@@ -24,6 +27,9 @@ def test_secret_protection_review_does_not_render_unavailable_secret_alerts_as_z
     text = _workflow_text()
 
     assert "`- Open secret scanning alerts: **${secretCount(secretAlerts.length)}**`" in text
-    assert "`- Push-protection bypass follow-up alerts: **${secretCount(bypassedAlerts.length)}**`" in text
+    assert (
+        "`- Push-protection bypass follow-up alerts: **${secretCount(bypassedAlerts.length)}**`"
+        in text
+    )
     assert "`- Alert age buckets: \\`${secretAgeBuckets}\\``" in text
     assert "- Secret scanning alerts were unavailable for this run." in text


### PR DESCRIPTION
Fixes #1465.

## Summary
- preserve whether secret-scanning API collection succeeded
- render unavailable secret-scanning metrics as unavailable instead of 0
- avoid saying no secret alerts were returned when the API was inaccessible
- add workflow guardrail tests

## Proof
- python -m pytest -q tests/test_secret_protection_review_workflow.py -o addopts=
- python -m pre_commit run -a