### PR TITLE
fix: add filelock security floor

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,3 +13,4 @@ mutmut==3.5.0
 
 # Security scanner transitive dependency floors
 idna==3.17
+filelock==3.29.0


### PR DESCRIPTION
Fixes open OSV alerts for vulnerable transitive filelock 3.19.1.

## Summary
- add an explicit filelock test dependency floor at 3.29.0
- keep the change in the existing security scanner transitive dependency section

## Proof
- python -m pip install -r requirements-test.txt
- python -m pip check
- python -m pre_commit run -a
- python -m pytest -q -o addopts=