### PR TITLE
fix: prefer active python for first proof

### DIFF
--- a/scripts/first_proof.py
+++ b/scripts/first_proof.py
@@ -103,11 +103,12 @@ def _resolve_python(explicit: str | None) -> str:
     if explicit:
         return explicit
 
+    active_version = _python_version_tuple(sys.executable)
+    if active_version is not None and active_version >= (3, 10):
+        return sys.executable
+
     candidates: list[str] = []
-    for raw in [sys.executable, "python3.13", "python3.12", "python3.11", "python3"]:
-        if raw == sys.executable:
-            candidates.append(raw)
-            continue
+    for raw in ["python3.13", "python3.12", "python3.11", "python3.10", "python3"]:
         resolved = which(raw)
         if resolved:
             candidates.append(resolved)
@@ -120,7 +121,7 @@ def _resolve_python(explicit: str | None) -> str:
         version = _python_version_tuple(candidate)
         if version is None:
             continue
-        if version >= (3, 11):
+        if version >= (3, 10):
             return candidate
 
     return sys.executable

--- a/tests/test_first_proof_script.py
+++ b/tests/test_first_proof_script.py
@@ -76,3 +76,40 @@ def test_first_proof_release_dry_run_flag_is_forwarded(monkeypatch, tmp_path: Pa
     assert rc == 0
     gate_release_cmd = captured_commands[1]
     assert "--dry-run" in gate_release_cmd
+
+
+def test_resolve_python_prefers_active_supported_interpreter(monkeypatch: object) -> None:
+    import scripts.first_proof as first_proof
+
+    monkeypatch.setattr(first_proof.sys, "executable", "/venv/bin/python")
+    monkeypatch.setattr(
+        first_proof,
+        "_python_version_tuple",
+        lambda candidate: (3, 10) if candidate == "/venv/bin/python" else (3, 12),
+    )
+    monkeypatch.setattr(first_proof, "which", lambda raw: f"/usr/bin/{raw}")
+
+    assert first_proof._resolve_python(None) == "/venv/bin/python"
+
+
+def test_resolve_python_falls_back_to_supported_python_when_active_is_too_old(
+    monkeypatch: object,
+) -> None:
+    import scripts.first_proof as first_proof
+
+    versions = {
+        "/old/bin/python": (3, 9),
+        "/usr/bin/python3.10": (3, 10),
+    }
+
+    monkeypatch.setattr(first_proof.sys, "executable", "/old/bin/python")
+    monkeypatch.setattr(
+        first_proof, "_python_version_tuple", lambda candidate: versions.get(candidate)
+    )
+    monkeypatch.setattr(
+        first_proof,
+        "which",
+        lambda raw: "/usr/bin/python3.10" if raw == "python3.10" else None,
+    )
+
+    assert first_proof._resolve_python(None) == "/usr/bin/python3.10"


### PR DESCRIPTION
Fixes first-proof interpreter selection so onboarding uses the active supported Python interpreter instead of silently switching to another global Python.

## Summary
- prefer the active interpreter when it satisfies the documented Python 3.10+ runtime
- keep explicit --python override behavior
- fall back to supported python binaries only when the active interpreter is too old
- add resolver guardrail tests

## Proof
- python -m pytest -q tests/test_first_proof_script.py -o addopts=
- python -m pre_commit run -a
- make first-proof-local
- selected_python matched sys.executable