### PR TITLE
feat: evaluate formatting candidate family without writes

### DIFF
--- a/src/sdetkit/pr_quality_candidate_validation.py
+++ b/src/sdetkit/pr_quality_candidate_validation.py
@@ -86,6 +86,37 @@ def evaluate_scenario(payload: Mapping[str, Any], *, source_path: Path) -> JsonO
     }
 
 
+def build_family_evaluation(scenarios: Sequence[Mapping[str, Any]]) -> JsonObject:
+    structurally_verified = sum(
+        1
+        for scenario in scenarios
+        if _string(scenario.get("observed_status")) == "candidate_structurally_verified"
+        and _string(scenario.get("observed_verifier_status")) == "structurally_verified_candidate"
+        and scenario.get("passed") is True
+    )
+    review_first_blocked = sum(
+        1
+        for scenario in scenarios
+        if _string(scenario.get("observed_status")) == "candidate_review_first_after_verification"
+        and _string(scenario.get("observed_verifier_status")) == "blocked_review_first"
+        and scenario.get("passed") is True
+    )
+    return {
+        "schema_version": "sdetkit.formatting_candidate_family_evaluation.v1",
+        "family": "formatting_only",
+        "evaluation_mode": "read_only_without_writes",
+        "scenario_count": len(scenarios),
+        "passed_count": sum(1 for scenario in scenarios if scenario.get("passed") is True),
+        "structurally_verified_count": structurally_verified,
+        "review_first_blocked_count": review_first_blocked,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "current_pr_decision_input": False,
+    }
+
+
 def build_validation_report(scenario_paths: Sequence[Path]) -> JsonObject:
     scenarios = [
         evaluate_scenario(_read_scenario(path), source_path=path) for path in scenario_paths
@@ -97,6 +128,7 @@ def build_validation_report(scenario_paths: Sequence[Path]) -> JsonObject:
         "scenario_count": len(scenarios),
         "passed_count": passed_count,
         "scenarios": scenarios,
+        "family_evaluation": build_family_evaluation(scenarios),
         "boundary": {
             "controlled_fixture_inputs_only": True,
             "contributes_to_current_pr_decision": False,
@@ -109,6 +141,7 @@ def build_validation_report(scenario_paths: Sequence[Path]) -> JsonObject:
 
 def render_markdown(report: Mapping[str, Any]) -> str:
     boundary = _as_dict(report.get("boundary"))
+    family = _as_dict(report.get("family_evaluation"))
     lines = [
         "## Controlled read-only candidate evidence validation",
         "",
@@ -123,6 +156,19 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             f"`{str(bool(boundary.get('semantic_equivalence_proven', False))).lower()}`"
         ),
         "- Interpretation: this section validates the read-only evidence renderer; it does not identify a remediation candidate in the current PR.",
+        "",
+        "### Formatting-only family evaluation",
+        "",
+        f"- Family: `{_string(family.get('family') or 'unknown')}`",
+        f"- Evaluation mode: `{_string(family.get('evaluation_mode') or 'unknown')}`",
+        f"- Structurally verified candidates: `{int(family.get('structurally_verified_count', 0) or 0)}`",
+        f"- Review-first blocked candidates: `{int(family.get('review_first_blocked_count', 0) or 0)}`",
+        (
+            "- Patch application allowed: "
+            f"`{str(bool(family.get('patch_application_allowed', False))).lower()}`"
+        ),
+        f"- Automation allowed: `{str(bool(family.get('automation_allowed', False))).lower()}`",
+        f"- Merge authorized: `{str(bool(family.get('merge_authorized', False))).lower()}`",
         "",
         "### Controlled scenario outcomes",
         "",
@@ -177,6 +223,7 @@ def main(argv: list[str] | None = None) -> int:
                     "status": report["status"],
                     "scenario_count": report["scenario_count"],
                     "passed_count": report["passed_count"],
+                    "family_evaluation": report["family_evaluation"],
                     "boundary": report["boundary"],
                     "artifacts": artifacts,
                 },

--- a/tests/test_pr_quality_candidate_validation.py
+++ b/tests/test_pr_quality_candidate_validation.py
@@ -44,6 +44,18 @@ def test_controlled_validation_exercises_verified_and_review_first_states_withou
     assert all(row["automation_allowed"] is False for row in rows.values())
     assert all(row["merge_authorized"] is False for row in rows.values())
 
+    family = report["family_evaluation"]
+    assert family["schema_version"] == "sdetkit.formatting_candidate_family_evaluation.v1"
+    assert family["family"] == "formatting_only"
+    assert family["evaluation_mode"] == "read_only_without_writes"
+    assert family["structurally_verified_count"] == 1
+    assert family["review_first_blocked_count"] == 1
+    assert family["patch_application_allowed"] is False
+    assert family["automation_allowed"] is False
+    assert family["merge_authorized"] is False
+    assert family["semantic_equivalence_proven"] is False
+    assert family["current_pr_decision_input"] is False
+
     boundary = report["boundary"]
     assert boundary["controlled_fixture_inputs_only"] is True
     assert boundary["contributes_to_current_pr_decision"] is False
@@ -61,6 +73,12 @@ def test_controlled_validation_markdown_marks_evidence_as_non_decision_input() -
     assert "Scenarios passed: `2/2`" in markdown
     assert "Automation allowed: `false`" in markdown
     assert "Merge authorized: `false`" in markdown
+    assert "Formatting-only family evaluation" in markdown
+    assert "Family: `formatting_only`" in markdown
+    assert "Evaluation mode: `read_only_without_writes`" in markdown
+    assert "Structurally verified candidates: `1`" in markdown
+    assert "Review-first blocked candidates: `1`" in markdown
+    assert "Patch application allowed: `false`" in markdown
     assert "does not identify a remediation candidate in the current PR" in markdown
 
 
@@ -87,6 +105,9 @@ def test_controlled_validation_cli_writes_report_artifacts(tmp_path: Path, capsy
     assert printed["status"] == "passed"
     assert printed["scenario_count"] == 2
     assert printed["passed_count"] == 2
+    assert printed["family_evaluation"]["family"] == "formatting_only"
+    assert printed["family_evaluation"]["patch_application_allowed"] is False
     assert printed["boundary"]["contributes_to_current_pr_decision"] is False
+    assert report["family_evaluation"]["evaluation_mode"] == "read_only_without_writes"
     assert report["status"] == "passed"
     assert "Current PR decision input: `false`" in markdown


### PR DESCRIPTION
Implements the PR B roadmap slice by making the controlled candidate validation report explicitly evaluate the formatting-only remediation family end to end without applying patches or granting authority.

## Summary
- add a formatting-only family evaluation summary to candidate validation
- record structurally verified and review-first blocked formatter scenarios
- preserve patch_application_allowed=false, automation_allowed=false, merge_authorized=false, and semantic_equivalence_proven=false
- expose the family evaluation in JSON, markdown, and CLI output

## Proof
- python -m pytest -q tests/test_pr_quality_candidate_validation.py tests/test_pr_quality_candidate_visibility.py tests/test_patch_scorer.py tests/test_protected_verifier.py tests/test_diagnostic_vector_engine.py -o addopts=
- python -m pre_commit run -a
- python -m sdetkit.pr_quality_candidate_validation --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json --scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json --out-dir build/pr-quality/candidate-validation --format json
- family_evaluation reported formatting_only/read_only_without_writes with no authority expansion