### PR TITLE
feat: report patch scorer dimensions in candidate validation

### DIFF
--- a/src/sdetkit/pr_quality_candidate_validation.py
+++ b/src/sdetkit/pr_quality_candidate_validation.py
@@ -33,6 +33,36 @@ def _string(value: Any) -> str:
     return str(value or "").strip()
 
 
+DIMENSION_NAMES = (
+    "diagnostic_precision",
+    "patch_scope_safety",
+    "proof_strength",
+    "reviewability",
+    "anti_cheat_integrity",
+    "regression_risk",
+)
+
+
+def _dimension_status_counts(scenarios: Sequence[Mapping[str, Any]]) -> JsonObject:
+    summary: JsonObject = {}
+    for name in DIMENSION_NAMES:
+        counts: JsonObject = {}
+        for scenario in scenarios:
+            dimensions = _as_dict(scenario.get("patch_score_dimensions"))
+            status = _string(_as_dict(dimensions.get(name)).get("status") or "unknown")
+            counts[status] = int(counts.get(status, 0) or 0) + 1
+        summary[name] = counts
+    return summary
+
+
+def _primary_categories(scenarios: Sequence[Mapping[str, Any]]) -> list[str]:
+    categories = {
+        _string(_as_dict(scenario.get("step_error_taxonomy")).get("primary_category") or "none")
+        for scenario in scenarios
+    }
+    return sorted(category for category in categories if category)
+
+
 def _read_scenario(path: Path) -> JsonObject:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -56,6 +86,9 @@ def evaluate_scenario(payload: Mapping[str, Any], *, source_path: Path) -> JsonO
         verification_evidence=_as_dict(payload.get("verification_evidence")),
     )
     decision = _as_dict(visibility.get("decision_boundary"))
+    score = _as_dict(visibility.get("patch_score"))
+    dimensions = _as_dict(score.get("dimensions"))
+    taxonomy = _as_dict(score.get("step_error_taxonomy"))
     verifier = _as_dict(_as_dict(visibility.get("protected_verifier")).get("decision"))
     rendered = render_candidate_markdown(visibility)
     expected_status = _string(payload.get("expected_status"))
@@ -79,6 +112,9 @@ def evaluate_scenario(payload: Mapping[str, Any], *, source_path: Path) -> JsonO
         "observed_verifier_status": _string(verifier.get("status")),
         "candidate_renderer_exercised": bool(rendered),
         "candidate_markdown": rendered,
+        "patch_score_dimensions": dimensions,
+        "step_error_taxonomy": taxonomy,
+        "step_error_primary_category": _string(taxonomy.get("primary_category") or "none"),
         "automation_allowed": bool(decision.get("automation_allowed", False)),
         "merge_authorized": bool(decision.get("merge_authorized", False)),
         "semantic_equivalence_proven": bool(decision.get("semantic_equivalence_proven", False)),
@@ -114,6 +150,8 @@ def build_family_evaluation(scenarios: Sequence[Mapping[str, Any]]) -> JsonObjec
         "merge_authorized": False,
         "semantic_equivalence_proven": False,
         "current_pr_decision_input": False,
+        "patch_score_dimension_statuses": _dimension_status_counts(scenarios),
+        "step_error_primary_categories": _primary_categories(scenarios),
     }
 
 
@@ -170,9 +208,28 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         f"- Automation allowed: `{str(bool(family.get('automation_allowed', False))).lower()}`",
         f"- Merge authorized: `{str(bool(family.get('merge_authorized', False))).lower()}`",
         "",
-        "### Controlled scenario outcomes",
+        "### PatchScorer dimension reporting",
         "",
     ]
+    dimension_statuses = _as_dict(family.get("patch_score_dimension_statuses"))
+    for name in DIMENSION_NAMES:
+        counts = _as_dict(dimension_statuses.get(name))
+        if counts:
+            rendered_counts = ", ".join(
+                f"{key}={int(value or 0)}" for key, value in sorted(counts.items())
+            )
+            lines.append(f"- `{name}`: {rendered_counts}")
+
+    categories = [_string(item) for item in _as_list(family.get("step_error_primary_categories"))]
+    lines.extend(
+        [
+            "- Step error primary categories: "
+            + (", ".join(f"`{category}`" for category in categories) or "none"),
+            "",
+            "### Controlled scenario outcomes",
+            "",
+        ]
+    )
     for scenario in _as_list(report.get("scenarios")):
         row = _as_dict(scenario)
         lines.extend(

--- a/tests/test_pr_quality_candidate_validation.py
+++ b/tests/test_pr_quality_candidate_validation.py
@@ -55,6 +55,15 @@ def test_controlled_validation_exercises_verified_and_review_first_states_withou
     assert family["merge_authorized"] is False
     assert family["semantic_equivalence_proven"] is False
     assert family["current_pr_decision_input"] is False
+    assert family["step_error_primary_categories"] == ["none"]
+
+    dimensions = family["patch_score_dimension_statuses"]
+    assert dimensions["diagnostic_precision"]["supported"] == 2
+    assert dimensions["patch_scope_safety"]["contained"] == 2
+    assert dimensions["proof_strength"]["supported"] == 2
+    assert dimensions["reviewability"]["reviewable"] == 2
+    assert dimensions["anti_cheat_integrity"]["preserved"] == 2
+    assert dimensions["regression_risk"]["low"] == 2
 
     boundary = report["boundary"]
     assert boundary["controlled_fixture_inputs_only"] is True
@@ -79,6 +88,10 @@ def test_controlled_validation_markdown_marks_evidence_as_non_decision_input() -
     assert "Structurally verified candidates: `1`" in markdown
     assert "Review-first blocked candidates: `1`" in markdown
     assert "Patch application allowed: `false`" in markdown
+    assert "PatchScorer dimension reporting" in markdown
+    assert "`diagnostic_precision`: supported=2" in markdown
+    assert "`anti_cheat_integrity`: preserved=2" in markdown
+    assert "Step error primary categories: `none`" in markdown
     assert "does not identify a remediation candidate in the current PR" in markdown
 
 
@@ -107,6 +120,13 @@ def test_controlled_validation_cli_writes_report_artifacts(tmp_path: Path, capsy
     assert printed["passed_count"] == 2
     assert printed["family_evaluation"]["family"] == "formatting_only"
     assert printed["family_evaluation"]["patch_application_allowed"] is False
+    assert printed["family_evaluation"]["step_error_primary_categories"] == ["none"]
+    assert (
+        printed["family_evaluation"]["patch_score_dimension_statuses"]["proof_strength"][
+            "supported"
+        ]
+        == 2
+    )
     assert printed["boundary"]["contributes_to_current_pr_decision"] is False
     assert report["family_evaluation"]["evaluation_mode"] == "read_only_without_writes"
     assert report["status"] == "passed"


### PR DESCRIPTION
Exposes PatchScorer outcome dimensions and StepErrorTaxonomy summaries in the controlled candidate-validation report without granting patch, automation, merge, or semantic authority.

## Summary
- aggregate PatchScorer dimension statuses across controlled formatter scenarios
- expose step-error primary categories in the family evaluation report
- render dimension evidence in candidate-validation markdown
- preserve reporting-only boundaries and all authority=false fields

## Proof
- python -m pytest -q tests/test_pr_quality_candidate_validation.py tests/test_pr_quality_candidate_visibility.py tests/test_patch_scorer.py tests/test_protected_verifier.py tests/test_replayable_benchmark_harness.py tests/test_pr_quality_action_report.py -o addopts=
- python -m pre_commit run -a
- python -m sdetkit.pr_quality_candidate_validation --scenario tests/fixtures/pr_quality_candidate_visibility/formatting_candidate_verified.json --scenario tests/fixtures/pr_quality_candidate_visibility/broader_diff_review_first.json --out-dir build/pr-quality/candidate-validation --format json
- dimension report showed supported/contained/preserved formatter evidence with no authority expansion