### PR TITLE
feat: summarize real check evidence quality

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -1136,6 +1136,64 @@ def _record_identities(record: JsonObject, *, index: int) -> set[str]:
     return {item for item in identities if item}
 
 
+def _real_evidence_quality_summary(
+    *,
+    checks_seen: int,
+    failed_checks: list[JsonObject],
+    queued_checks: list[JsonObject],
+    cancelled_checks: list[JsonObject],
+    startup_failures: list[JsonObject],
+    missing_required_contexts: list[str],
+) -> JsonObject:
+    failed_count = len(failed_checks)
+    failed_with_logs = sum(1 for check in failed_checks if bool(check.get("log_collected")))
+    failed_with_first_failure = sum(
+        1
+        for check in failed_checks
+        if bool(_string(check.get("first_failure_line")) or _as_dict(check.get("first_failure")))
+    )
+    stale_evidence_count = sum(1 for check in failed_checks if bool(check.get("stale_evidence")))
+    unknown_diagnosis_count = sum(
+        1 for check in failed_checks if _is_unknown_diagnosis(_as_dict(check.get("diagnosis")))
+    )
+    actionable_diagnosis_count = failed_count - unknown_diagnosis_count
+
+    evidence_gaps: list[str] = []
+    if failed_count and failed_with_logs < failed_count:
+        evidence_gaps.append("failed_check_logs_missing")
+    if failed_count and failed_with_first_failure < failed_count:
+        evidence_gaps.append("first_failure_not_extracted")
+    if stale_evidence_count:
+        evidence_gaps.append("stale_failed_check_evidence")
+    if missing_required_contexts:
+        evidence_gaps.append("required_contexts_missing")
+
+    return {
+        "schema_version": "sdetkit.real_check_evidence_quality.v1",
+        "checks_seen": checks_seen,
+        "failed_checks": failed_count,
+        "failed_with_logs": failed_with_logs,
+        "failed_without_logs": failed_count - failed_with_logs,
+        "failed_with_first_failure": failed_with_first_failure,
+        "failed_without_first_failure": failed_count - failed_with_first_failure,
+        "queued_checks": len(queued_checks),
+        "cancelled_checks": len(cancelled_checks),
+        "startup_failures": len(startup_failures),
+        "missing_required_contexts": len(missing_required_contexts),
+        "stale_failed_check_evidence": stale_evidence_count,
+        "current_failed_check_evidence": failed_count - stale_evidence_count,
+        "unknown_diagnosis_count": unknown_diagnosis_count,
+        "actionable_diagnosis_count": actionable_diagnosis_count,
+        "evidence_gaps": evidence_gaps,
+        "evidence_complete_for_failed_checks": not evidence_gaps,
+        "reporting_only": True,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
 def build_check_intelligence(
     *,
     checks_json: Path,
@@ -1190,15 +1248,26 @@ def build_check_intelligence(
             }
         )
 
+    checks_seen = len(records) + len(missing_required_contexts)
+    real_evidence_quality = _real_evidence_quality_summary(
+        checks_seen=checks_seen,
+        failed_checks=failed_checks,
+        queued_checks=queued_checks,
+        cancelled_checks=cancelled_checks,
+        startup_failures=startup_failures,
+        missing_required_contexts=missing_required_contexts,
+    )
+
     return {
         "schema_version": CHECK_INTELLIGENCE_SCHEMA_VERSION,
-        "checks_seen": len(records) + len(missing_required_contexts),
+        "checks_seen": checks_seen,
         "required_contexts": sorted(required_contexts),
         "missing_required_contexts": missing_required_contexts,
         "failed_checks": failed_checks,
         "queued_checks": queued_checks,
         "cancelled_checks": cancelled_checks,
         "startup_failures": startup_failures,
+        "real_evidence_quality": real_evidence_quality,
         "security_review": _security_review_summary(review_threads_json),
         "code_scanning_review": _code_scanning_review_summary(
             code_scanning_alerts_json,
@@ -1372,6 +1441,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 ),
                 "security_review": security_review,
                 "code_scanning_review": intelligence.get("code_scanning_review", {}),
+                "real_evidence_quality": intelligence.get("real_evidence_quality", {}),
             },
         }
 
@@ -1448,6 +1518,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 ),
                 "security_review": security_review,
                 "code_scanning_review": code_scanning_review,
+                "real_evidence_quality": intelligence.get("real_evidence_quality", {}),
             },
         }
 
@@ -1518,6 +1589,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 ),
                 "security_review": intelligence.get("security_review", {}),
                 "code_scanning_review": intelligence.get("code_scanning_review", {}),
+                "real_evidence_quality": intelligence.get("real_evidence_quality", {}),
             },
         }
 
@@ -1559,6 +1631,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 "required_startup_failure_count": len(required_startup),
                 "security_review": intelligence.get("security_review", {}),
                 "code_scanning_review": intelligence.get("code_scanning_review", {}),
+                "real_evidence_quality": intelligence.get("real_evidence_quality", {}),
             },
         }
 
@@ -1581,6 +1654,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
             "required_startup_failure_count": 0,
             "security_review": intelligence.get("security_review", {}),
             "code_scanning_review": intelligence.get("code_scanning_review", {}),
+            "real_evidence_quality": intelligence.get("real_evidence_quality", {}),
         },
     }
 
@@ -1629,6 +1703,43 @@ def render_action_report(report: JsonObject) -> str:
     lines.extend(["", "## Proof commands", ""])
     commands = [str(item) for item in _as_list(report.get("proof_commands"))]
     lines.extend([f"- `{item}`" for item in commands] or ["- none"])
+
+    evidence = _as_dict(report.get("evidence"))
+    quality = _as_dict(evidence.get("real_evidence_quality"))
+    if quality:
+        gaps = [str(item) for item in _as_list(quality.get("evidence_gaps"))]
+        lines.extend(
+            [
+                "",
+                "## Real check evidence quality",
+                "",
+                f"- Checks seen: `{int(quality.get('checks_seen', 0) or 0)}`",
+                f"- Failed checks: `{int(quality.get('failed_checks', 0) or 0)}`",
+                f"- Failed checks with logs: `{int(quality.get('failed_with_logs', 0) or 0)}`",
+                (
+                    "- Failed checks with first failure: "
+                    f"`{int(quality.get('failed_with_first_failure', 0) or 0)}`"
+                ),
+                f"- Queued checks: `{int(quality.get('queued_checks', 0) or 0)}`",
+                f"- Startup failures: `{int(quality.get('startup_failures', 0) or 0)}`",
+                (
+                    "- Missing required contexts: "
+                    f"`{int(quality.get('missing_required_contexts', 0) or 0)}`"
+                ),
+                (
+                    "- Stale failed-check evidence: "
+                    f"`{int(quality.get('stale_failed_check_evidence', 0) or 0)}`"
+                ),
+                (
+                    "- Evidence complete for failed checks: "
+                    f"`{str(bool(quality.get('evidence_complete_for_failed_checks', False))).lower()}`"
+                ),
+                "- Evidence gaps: " + (", ".join(f"`{gap}`" for gap in gaps) or "`none`"),
+                "- Reporting only: `true`",
+                "- Automation allowed: `false`",
+            ]
+        )
+
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -44,6 +44,8 @@ def test_check_intelligence_reports_green_when_all_checks_pass(tmp_path: Path) -
     assert intelligence["checks_seen"] == 2
     assert intelligence["failed_checks"] == []
     assert intelligence["queued_checks"] == []
+    assert intelligence["real_evidence_quality"]["evidence_complete_for_failed_checks"] is True
+    assert intelligence["real_evidence_quality"]["evidence_gaps"] == []
     assert report["schema_version"] == check_intelligence.ACTION_REPORT_SCHEMA_VERSION
     assert report["status"] == "green"
     assert report["primary_blocker"] == {}
@@ -165,6 +167,73 @@ def test_check_intelligence_treats_queued_checks_as_incomplete_not_green(
     assert "queued" in report["primary_blocker"]["impact"]
 
 
+def test_check_intelligence_summarizes_real_evidence_quality(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "required_contexts": ["required-ci"],
+            "check_runs": [
+                {
+                    "name": "Runtime lane",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "headSha": "old-head",
+                    "currentHeadSha": "new-head",
+                    "log": "\n".join(
+                        [
+                            "Traceback (most recent call last):",
+                            '  File "/home/runner/work/repo/src/sdetkit/runtime.py", line 7, in main',
+                            "RuntimeError: boom",
+                        ]
+                    ),
+                },
+                {
+                    "name": "Mystery vendor check",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+                {
+                    "name": "Optional slow lane",
+                    "status": "queued",
+                    "conclusion": "",
+                    "required": False,
+                },
+            ],
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+    markdown = check_intelligence.render_action_report(report)
+
+    quality = intelligence["real_evidence_quality"]
+    assert quality["schema_version"] == "sdetkit.real_check_evidence_quality.v1"
+    assert quality["checks_seen"] == 4
+    assert quality["failed_checks"] == 2
+    assert quality["failed_with_logs"] == 1
+    assert quality["failed_without_logs"] == 1
+    assert quality["failed_with_first_failure"] == 1
+    assert quality["failed_without_first_failure"] == 1
+    assert quality["queued_checks"] == 2
+    assert quality["missing_required_contexts"] == 1
+    assert quality["stale_failed_check_evidence"] == 1
+    assert quality["current_failed_check_evidence"] == 1
+    assert quality["evidence_complete_for_failed_checks"] is False
+    assert "failed_check_logs_missing" in quality["evidence_gaps"]
+    assert "first_failure_not_extracted" in quality["evidence_gaps"]
+    assert "stale_failed_check_evidence" in quality["evidence_gaps"]
+    assert "required_contexts_missing" in quality["evidence_gaps"]
+    assert quality["reporting_only"] is True
+    assert quality["automation_allowed"] is False
+    assert quality["merge_authorized"] is False
+
+    assert report["evidence"]["real_evidence_quality"] == quality
+    assert "Real check evidence quality" in markdown
+    assert "Failed checks with logs: `1`" in markdown
+    assert "Evidence gaps:" in markdown
+    assert "Automation allowed: `false`" in markdown
+
+
 def test_check_intelligence_cli_writes_json_and_markdown_artifacts(tmp_path: Path, capsys) -> None:
     checks = _write_json(
         tmp_path / "checks.json",
@@ -193,7 +262,9 @@ def test_check_intelligence_cli_writes_json_and_markdown_artifacts(tmp_path: Pat
 
     assert intelligence["checks_seen"] == 1
     assert report["status"] == "green"
+    assert "real_evidence_quality" in report["evidence"]
     assert "SDETKit Check Intelligence Action Report" in markdown
+    assert "Real check evidence quality" in markdown
 
 
 def test_check_intelligence_prioritizes_actionable_ruff_failure_over_ci_noise(


### PR DESCRIPTION
Adds reporting-only real check evidence quality metrics so operators can see whether failed checks had logs, first-failure extraction, current/stale evidence, queued checks, startup failures, and missing required contexts.

## Summary
- add real_evidence_quality to check intelligence output
- summarize failed checks with/without logs and first-failure extraction
- report queued, startup, missing required context, stale/current failed-check evidence counts
- render evidence-quality metrics in the action report markdown
- preserve reporting-only boundaries and no automation/merge/semantic authority

## Proof
- python -m pytest -q tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_diagnostic_vector_engine.py tests/test_evidence_graph.py -o addopts=
- python -m pre_commit run -a