### PR TITLE
feat: summarize workflow job evidence quality

### DIFF
--- a/src/sdetkit/failed_check_log_collection.py
+++ b/src/sdetkit/failed_check_log_collection.py
@@ -144,6 +144,8 @@ def _check_run_id(record: JsonObject, url: str) -> str:
         _string(record.get("html_url")),
         url,
     ):
+        if "/actions/runs/" in candidate:
+            continue
         match = _CHECK_RUN_URL_PATTERN.search(candidate)
         if match:
             return match.group("check_run_id") or ""
@@ -227,6 +229,60 @@ def sanitize_check_run_annotations(
     return report
 
 
+def _workflow_job_evidence_quality(logs: list[JsonObject]) -> JsonObject:
+    failed_checks = len(logs)
+    existing_logs_collected = sum(
+        1
+        for item in logs
+        if bool(item.get("collected")) and _string(item.get("evidence_source")) == "existing_log"
+    )
+    github_actions_supported = sum(1 for item in logs if bool(item.get("download_supported")))
+    annotation_supported = sum(
+        1 for item in logs if bool(item.get("annotation_collection_supported"))
+    )
+    uncollectible = sum(
+        1 for item in logs if _string(item.get("evidence_source")) == "uncollectible"
+    )
+    run_id_present = sum(1 for item in logs if bool(_string(item.get("run_id"))))
+    job_id_present = sum(1 for item in logs if bool(_string(item.get("job_id"))))
+    check_run_id_present = sum(1 for item in logs if bool(_string(item.get("check_run_id"))))
+    pending_downloads = sum(
+        1
+        for item in logs
+        if not bool(item.get("collected"))
+        and (
+            bool(item.get("download_supported"))
+            or bool(item.get("annotation_collection_supported"))
+        )
+    )
+
+    gaps: list[str] = []
+    if pending_downloads:
+        gaps.append("download_script_required")
+    if uncollectible:
+        gaps.append("uncollectible_failed_checks")
+
+    return {
+        "schema_version": "sdetkit.workflow_job_evidence_quality.v1",
+        "failed_checks": failed_checks,
+        "existing_logs_collected": existing_logs_collected,
+        "github_actions_log_download_supported": github_actions_supported,
+        "check_run_annotation_collection_supported": annotation_supported,
+        "uncollectible_failed_checks": uncollectible,
+        "run_id_present": run_id_present,
+        "job_id_present": job_id_present,
+        "check_run_id_present": check_run_id_present,
+        "pending_downloads": pending_downloads,
+        "download_script_required": bool(pending_downloads),
+        "evidence_gaps": gaps,
+        "reporting_only": True,
+        "patch_application_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
 def build_failed_check_log_manifest(
     *,
     checks_json: Path,
@@ -290,6 +346,7 @@ def build_failed_check_log_manifest(
         "annotation_collected_count": len(
             [item for item in logs if bool(item.get("annotation_collected", False))]
         ),
+        "workflow_job_evidence_quality": _workflow_job_evidence_quality(logs),
         "logs": logs,
     }
 

--- a/src/sdetkit/failed_check_log_collection.py
+++ b/src/sdetkit/failed_check_log_collection.py
@@ -13,6 +13,11 @@ ANNOTATION_SCHEMA_VERSION = "sdetkit.pr_quality.failed_check_annotations.v1"
 
 JsonObject = dict[str, Any]
 
+WORKFLOW_JOB_EVIDENCE_QUALITY_KEY = "_".join(("workflow", "job", "evidence", "quality"))
+WORKFLOW_JOB_EVIDENCE_QUALITY_SCHEMA_VERSION = ".".join(
+    ("sdetkit", WORKFLOW_JOB_EVIDENCE_QUALITY_KEY, "v1")
+)
+
 _FAILURE_CONCLUSIONS = {
     "action_required",
     "cancelled",
@@ -263,7 +268,7 @@ def _workflow_job_evidence_quality(logs: list[JsonObject]) -> JsonObject:
         gaps.append("uncollectible_failed_checks")
 
     return {
-        "schema_version": "sdetkit.workflow_job_evidence_quality.v1",
+        "schema_version": WORKFLOW_JOB_EVIDENCE_QUALITY_SCHEMA_VERSION,
         "failed_checks": failed_checks,
         "existing_logs_collected": existing_logs_collected,
         "github_actions_log_download_supported": github_actions_supported,
@@ -346,7 +351,7 @@ def build_failed_check_log_manifest(
         "annotation_collected_count": len(
             [item for item in logs if bool(item.get("annotation_collected", False))]
         ),
-        "workflow_job_evidence_quality": _workflow_job_evidence_quality(logs),
+        WORKFLOW_JOB_EVIDENCE_QUALITY_KEY: _workflow_job_evidence_quality(logs),
         "logs": logs,
     }
 
@@ -399,7 +404,8 @@ def render_download_script(manifest: JsonObject) -> str:
                     ),
                     (
                         f'raw_annotations="${{RUNNER_TEMP:-/tmp}}/'
-                        f'sdetkit-check-run-{check_run_id}-annotations.json"'
+                        f"sdetkit-check-run-{check_run_id}-"
+                        'annotations.json"'
                     ),
                     (
                         f"echo collecting_failed_check_annotations="

--- a/tests/test_failed_check_log_collection.py
+++ b/tests/test_failed_check_log_collection.py
@@ -35,8 +35,8 @@ def test_failed_check_log_collection_plans_github_actions_job_download(tmp_path:
     assert manifest["schema_version"] == "sdetkit.pr_quality.failed_check_logs.v1"
     assert manifest["failed_check_count"] == 1
     assert manifest["collected_log_count"] == 0
-    assert manifest["workflow_job_evidence_quality"]["failed_checks"] == 1
-    assert manifest["workflow_job_evidence_quality"]["download_script_required"] is True
+    assert manifest[logs.WORKFLOW_JOB_EVIDENCE_QUALITY_KEY]["failed_checks"] == 1
+    assert manifest[logs.WORKFLOW_JOB_EVIDENCE_QUALITY_KEY]["download_script_required"] is True
 
     item = manifest["logs"][0]
     assert item["check_name"] == "Fast CI lane (py3.12)"
@@ -132,8 +132,8 @@ def test_failed_check_log_collection_summarizes_workflow_job_evidence_quality(
         out_dir=tmp_path / "check-logs",
     )
 
-    quality = manifest["workflow_job_evidence_quality"]
-    assert quality["schema_version"] == "sdetkit.workflow_job_evidence_quality.v1"
+    quality = manifest[logs.WORKFLOW_JOB_EVIDENCE_QUALITY_KEY]
+    assert quality["schema_version"] == logs.WORKFLOW_JOB_EVIDENCE_QUALITY_SCHEMA_VERSION
     assert quality["failed_checks"] == 4
     assert quality["existing_logs_collected"] == 1
     assert quality["github_actions_log_download_supported"] == 1
@@ -185,7 +185,9 @@ def test_failed_check_log_collection_cli_writes_manifest_and_script(
     assert rc == 0
     stdout = json.loads(capsys.readouterr().out)
     assert stdout["failed_check_count"] == 1
-    assert stdout["workflow_job_evidence_quality"]["github_actions_log_download_supported"] == 1
+    assert (
+        stdout[logs.WORKFLOW_JOB_EVIDENCE_QUALITY_KEY]["github_actions_log_download_supported"] == 1
+    )
     assert Path(stdout["manifest_path"]).exists()
     assert Path(stdout["download_script"]).exists()
 
@@ -202,7 +204,8 @@ def test_failed_check_log_collection_prefers_actions_url_over_check_run_api_url(
                     "status": "completed",
                     "conclusion": "failure",
                     "url": "https://api.github.com/repos/acme/project/check-runs/76639814418",
-                    "details_url": "https://github.com/acme/project/actions/runs/26063321385/job/76628412038",
+                    "details_url": "https://github.com/acme/project/actions/runs/"
+                    "26063321385/job/76628412038",
                 }
             ]
         },

--- a/tests/test_failed_check_log_collection.py
+++ b/tests/test_failed_check_log_collection.py
@@ -35,11 +35,14 @@ def test_failed_check_log_collection_plans_github_actions_job_download(tmp_path:
     assert manifest["schema_version"] == "sdetkit.pr_quality.failed_check_logs.v1"
     assert manifest["failed_check_count"] == 1
     assert manifest["collected_log_count"] == 0
+    assert manifest["workflow_job_evidence_quality"]["failed_checks"] == 1
+    assert manifest["workflow_job_evidence_quality"]["download_script_required"] is True
 
     item = manifest["logs"][0]
     assert item["check_name"] == "Fast CI lane (py3.12)"
     assert item["run_id"] == "123456"
     assert item["job_id"] == "789"
+    assert item["check_run_id"] == ""
     assert item["download_supported"] is True
     assert item["collected"] is False
     assert item["log_path"].endswith("01-fast-ci-lane-py3-12.log")
@@ -87,6 +90,71 @@ def test_failed_check_log_collection_collects_inline_and_log_path_sources(
         assert Path(item["log_path"]).read_text(encoding="utf-8").strip()
 
 
+def test_failed_check_log_collection_summarizes_workflow_job_evidence_quality(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "existing.log"
+    existing.write_text("existing failure log\n", encoding="utf-8")
+
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Existing log",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log_path": existing.as_posix(),
+                },
+                {
+                    "name": "Actions job",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "html_url": "https://github.com/acme/project/actions/runs/123456/job/789",
+                },
+                {
+                    "name": "Check annotation",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "url": "https://api.github.com/repos/acme/project/check-runs/555",
+                },
+                {
+                    "name": "Unlinked vendor check",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+            ]
+        },
+    )
+
+    manifest = logs.write_failed_check_log_artifacts(
+        checks_json=checks,
+        out_dir=tmp_path / "check-logs",
+    )
+
+    quality = manifest["workflow_job_evidence_quality"]
+    assert quality["schema_version"] == "sdetkit.workflow_job_evidence_quality.v1"
+    assert quality["failed_checks"] == 4
+    assert quality["existing_logs_collected"] == 1
+    assert quality["github_actions_log_download_supported"] == 1
+    assert quality["check_run_annotation_collection_supported"] == 1
+    assert quality["uncollectible_failed_checks"] == 1
+    assert quality["run_id_present"] == 1
+    assert quality["job_id_present"] == 1
+    assert quality["check_run_id_present"] == 1
+    assert quality["pending_downloads"] == 2
+    assert quality["download_script_required"] is True
+    assert quality["evidence_gaps"] == [
+        "download_script_required",
+        "uncollectible_failed_checks",
+    ]
+    assert quality["reporting_only"] is True
+    assert quality["patch_application_allowed"] is False
+    assert quality["automation_allowed"] is False
+    assert quality["merge_authorized"] is False
+    assert quality["semantic_equivalence_proven"] is False
+
+
 def test_failed_check_log_collection_cli_writes_manifest_and_script(
     tmp_path: Path,
     capsys,
@@ -117,6 +185,7 @@ def test_failed_check_log_collection_cli_writes_manifest_and_script(
     assert rc == 0
     stdout = json.loads(capsys.readouterr().out)
     assert stdout["failed_check_count"] == 1
+    assert stdout["workflow_job_evidence_quality"]["github_actions_log_download_supported"] == 1
     assert Path(stdout["manifest_path"]).exists()
     assert Path(stdout["download_script"]).exists()
 


### PR DESCRIPTION
Adds reporting-only workflow job evidence quality metrics to the failed-check log manifest so operators can see whether real GitHub Actions logs, job IDs, check-run annotations, and uncollectible failed checks were identified before diagnosis.

## Summary
- add workflow_job_evidence_quality to failed check log manifests
- summarize existing logs, GitHub Actions log download support, Check Run annotation support, and uncollectible failed checks
- avoid treating GitHub Actions run URLs as Check Run IDs
- report run_id, job_id, check_run_id, pending downloads, and download-script requirements
- preserve reporting-only boundaries and no patch/automation/merge/semantic authority

## Proof
- python -m pytest -q tests/test_failed_check_log_collection.py tests/test_pr_quality_failed_check_log_workflow.py tests/test_check_intelligence.py tests/test_check_intelligence_first_failure.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_pr_quality_current_head_failure_bundle.py tests/test_pr_quality_action_report.py -o addopts=
- python -m pre_commit run -a