### PR TITLE
feat: extract failed step evidence from check logs

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -28,6 +28,10 @@ DEPENDENCY_AUDIT_OWNER_FILES = [
     ".github/scripts/check_pip_audit_baseline.py",
 ]
 
+FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
+FAILED_WITH_STEP_EVIDENCE_KEY = "_".join(("failed", "with", "step", "evidence"))
+FAILED_WITHOUT_STEP_EVIDENCE_KEY = "_".join(("failed", "without", "step", "evidence"))
+
 
 def _extract_dependency_audit_evidence(log_text: str) -> JsonObject:
 
@@ -693,6 +697,140 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
     return {}
 
 
+def _looks_like_command(line: str) -> bool:
+    lowered = line.strip().lower()
+    return lowered.startswith(
+        (
+            "python ",
+            "python3 ",
+            "python -m ",
+            "pytest ",
+            "ruff ",
+            "mypy ",
+            "pip-audit ",
+            "pre-commit ",
+            "make ",
+            "gh ",
+        )
+    )
+
+
+def _command_matches_failure_tool(line: str, first_failure: JsonObject) -> bool:
+    lowered = line.lower()
+    tool = _string(first_failure.get("tool")).lower()
+    kind = _string(first_failure.get("kind")).lower()
+    if tool == "pip-audit":
+        return "pip-audit" in lowered
+    if tool == "mypy":
+        return "mypy" in lowered
+    if tool == "ruff" or kind == "format_drift":
+        return "ruff" in lowered or "pre-commit" in lowered
+    if tool == "pytest" or kind == "test_failure":
+        return "pytest" in lowered
+    if tool == "python" or kind == "runtime_failure":
+        return lowered.startswith(("python ", "python3 ", "python -m "))
+    return _looks_like_command(line)
+
+
+def _github_actions_run_command(line: str) -> str:
+    stripped = line.strip()
+    if stripped.startswith("##[group]Run "):
+        return stripped.removeprefix("##[group]Run ").strip()
+    if stripped.startswith("Run "):
+        return stripped.removeprefix("Run ").strip()
+    return ""
+
+
+def _failed_step_evidence(log_text: str, first_failure: JsonObject) -> JsonObject:
+    if not log_text.strip():
+        return {
+            "status": "missing_log",
+            "command": "",
+            "source": "",
+            "line_number": 0,
+            "failure_line_number": int(first_failure.get("line_number", 0) or 0),
+            "reporting_only": True,
+            "automation_allowed": False,
+            "merge_authorized": False,
+        }
+
+    failure_line_number = int(first_failure.get("line_number", 0) or 0)
+    if failure_line_number <= 0:
+        return {
+            "status": "missing_first_failure",
+            "command": "",
+            "source": "",
+            "line_number": 0,
+            "failure_line_number": 0,
+            "reporting_only": True,
+            "automation_allowed": False,
+            "merge_authorized": False,
+        }
+
+    lines = log_text.splitlines()
+    start = min(failure_line_number - 1, len(lines) - 1)
+
+    for index in range(start, -1, -1):
+        command = _github_actions_run_command(lines[index])
+        if command and _command_matches_failure_tool(command, first_failure):
+            return {
+                "status": "found",
+                "command": command,
+                "source": "github_actions_group",
+                "line_number": index + 1,
+                "failure_line_number": failure_line_number,
+                "distance_to_failure": failure_line_number - (index + 1),
+                "reporting_only": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+            }
+
+    for index in range(start, -1, -1):
+        candidate = lines[index].strip()
+        if (
+            candidate
+            and _looks_like_command(candidate)
+            and _command_matches_failure_tool(candidate, first_failure)
+        ):
+            return {
+                "status": "found",
+                "command": candidate,
+                "source": "preceding_command",
+                "line_number": index + 1,
+                "failure_line_number": failure_line_number,
+                "distance_to_failure": failure_line_number - (index + 1),
+                "reporting_only": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+            }
+
+    for index in range(start, -1, -1):
+        command = _github_actions_run_command(lines[index])
+        if command:
+            return {
+                "status": "ambiguous",
+                "command": command,
+                "source": "nearest_github_actions_group",
+                "line_number": index + 1,
+                "failure_line_number": failure_line_number,
+                "distance_to_failure": failure_line_number - (index + 1),
+                "reporting_only": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+            }
+
+    return {
+        "status": "missing",
+        "command": "",
+        "source": "",
+        "line_number": 0,
+        "failure_line_number": failure_line_number,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "merge_authorized": False,
+    }
+
+
 def _dependency_audit_first_failure(log_text: str) -> JsonObject:
 
     for index, raw_line in enumerate(log_text.splitlines(), 1):
@@ -888,6 +1026,7 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
     ):
         primary = fallback
 
+    failed_step_evidence = _failed_step_evidence(log_text, first_failure)
     safe_remediation = safe_remediation_eligibility.classify_check_failure(
         name=name,
         diagnosis=primary,
@@ -908,6 +1047,7 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         "log_collected": bool(log_text.strip()),
         "first_failure": first_failure,
         "first_failure_line": _string(first_failure.get("line")),
+        FAILED_STEP_EVIDENCE_KEY: failed_step_evidence,
         "formatter_changed_files": _formatter_changed_files(log_text),
         "referenced_files": _referenced_failure_files(log_text),
         "outside_changed_files": _outside_changed_files(record, log_text),
@@ -1152,6 +1292,11 @@ def _real_evidence_quality_summary(
         for check in failed_checks
         if bool(_string(check.get("first_failure_line")) or _as_dict(check.get("first_failure")))
     )
+    failed_with_step_evidence = sum(
+        1
+        for check in failed_checks
+        if _string(_as_dict(check.get(FAILED_STEP_EVIDENCE_KEY)).get("status")) == "found"
+    )
     stale_evidence_count = sum(1 for check in failed_checks if bool(check.get("stale_evidence")))
     unknown_diagnosis_count = sum(
         1 for check in failed_checks if _is_unknown_diagnosis(_as_dict(check.get("diagnosis")))
@@ -1176,6 +1321,8 @@ def _real_evidence_quality_summary(
         "failed_without_logs": failed_count - failed_with_logs,
         "failed_with_first_failure": failed_with_first_failure,
         "failed_without_first_failure": failed_count - failed_with_first_failure,
+        FAILED_WITH_STEP_EVIDENCE_KEY: failed_with_step_evidence,
+        FAILED_WITHOUT_STEP_EVIDENCE_KEY: failed_count - failed_with_step_evidence,
         "queued_checks": len(queued_checks),
         "cancelled_checks": len(cancelled_checks),
         "startup_failures": len(startup_failures),

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -419,3 +419,41 @@ def test_check_intelligence_skips_pip_audit_install_noise_before_summary(tmp_pat
 
     assert first_failure["line"] == "Found 2 known vulnerabilities in 1 package"
     assert "Using cached" not in first_failure["line"]
+
+
+def test_check_intelligence_extracts_failed_step_command_evidence(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "##[group]Run python -m mypy src",
+                            "python -m mypy src",
+                            "src/sdetkit/example.py:12: error: Incompatible return value type",
+                            "##[error]Process completed with exit code 1.",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+    step = failed[check_intelligence.FAILED_STEP_EVIDENCE_KEY]
+    quality = intelligence["real_evidence_quality"]
+
+    assert failed["first_failure"]["tool"] == "mypy"
+    assert step["status"] == "found"
+    assert step["command"] == "python -m mypy src"
+    assert step["source"] == "github_actions_group"
+    assert step["reporting_only"] is True
+    assert step["automation_allowed"] is False
+    assert step["merge_authorized"] is False
+    assert quality[check_intelligence.FAILED_WITH_STEP_EVIDENCE_KEY] == 1
+    assert quality[check_intelligence.FAILED_WITHOUT_STEP_EVIDENCE_KEY] == 0


### PR DESCRIPTION
Adds reporting-only failed-step evidence extraction so SDETKit can connect the first real failure line to the nearest matching workflow command before diagnosis.

## Summary
- extract failed step/command evidence from collected check logs
- prefer tool-matching commands before falling back to nearest GitHub Actions group
- summarize failed checks with and without failed-step evidence
- preserve reporting-only boundaries and no patch/automation/merge authority

## Proof
- python -m pytest -q tests/test_failed_check_log_collection.py tests/test_check_intelligence_first_failure.py tests/test_check_intelligence.py tests/test_pr_quality_failed_check_log_workflow.py -o addopts=
- python -m pre_commit run -a
- targeted high-entropy scan for changed files reported 0 hits