### PR TITLE
feat: surface failed step evidence in reports

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -1693,6 +1693,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 "url": check.get("url", ""),
                 "first_failure": check.get("first_failure", {}),
                 "first_failure_line": check.get("first_failure_line", ""),
+                FAILED_STEP_EVIDENCE_KEY: check.get(FAILED_STEP_EVIDENCE_KEY, {}),
                 "head_sha": check.get("head_sha", ""),
                 "current_pr_head_sha": check.get("current_pr_head_sha", ""),
                 "stale_evidence": check.get("stale_evidence", False),

--- a/src/sdetkit/current_head_failure_bundle.py
+++ b/src/sdetkit/current_head_failure_bundle.py
@@ -8,6 +8,7 @@ JsonObject = dict[str, Any]
 
 
 SCHEMA_VERSION = "sdetkit.current_head_failure_bundle.v1"
+FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -80,6 +81,7 @@ def build_current_head_failure_bundle(
                     "line_number": _int(first_failure.get("line_number")),
                     "tool": _string(first_failure.get("tool") or "unknown"),
                     "kind": _string(first_failure.get("kind") or "unknown"),
+                    FAILED_STEP_EVIDENCE_KEY: _as_dict(item.get(FAILED_STEP_EVIDENCE_KEY)),
                 }
             )
 
@@ -162,6 +164,16 @@ def render_current_head_failure_bundle_markdown(bundle: JsonObject) -> str:
                 f"`{_string(item.get('line'))}` ({location}, "
                 f"{_string(item.get('tool') or 'unknown')}/{_string(item.get('kind') or 'unknown')})"
             )
+            step = _as_dict(item.get(FAILED_STEP_EVIDENCE_KEY))
+            if step:
+                lines.append(
+                    f"  - Failed step evidence: `{_string(step.get('status') or 'unknown')}`"
+                )
+                command = _string(step.get("command"))
+                if command:
+                    lines.append(f"  - Failed command: `{command}`")
+                lines.append("- Reporting only: `true`")
+                lines.append("- Automation allowed: `false`")
     else:
         lines.append("- none")
 

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -47,6 +47,9 @@ HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
     ("historical", "disposition", "authorizes", "current", "action")
 )
 
+
+FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
+
 BANNED_EDUCATIONAL_PHRASES = (
     "Quality is green, so the review focus is not coverage.",
     "The comment must guide maintainers toward the changed risk surface.",
@@ -398,6 +401,29 @@ def _security_finding_diagnosis_lines(security_finding_diagnosis: JsonObject | N
     return lines
 
 
+def _failed_step_evidence_lines(payload: JsonObject, *, prefix: str = "  - ") -> list[str]:
+    step = _as_dict(payload.get(FAILED_STEP_EVIDENCE_KEY))
+    if not step:
+        return []
+
+    status = _string(step.get("status") or "unknown")
+    command = _string(step.get("command"))
+    source = _string(step.get("source") or "unknown")
+    line_number = _int(step.get("line_number"))
+    failure_line_number = _int(step.get("failure_line_number"))
+
+    lines = [f"{prefix}Failed step evidence: `{status}`"]
+    if command:
+        lines.append(f"{prefix}Failed command: `{command}`")
+    if line_number or failure_line_number:
+        location = f"command line {line_number or 'unknown'}, failure line {failure_line_number or 'unknown'}"
+        lines.append(f"{prefix}Failed step location: `{location}`")
+    lines.append(f"{prefix}Failed step source: `{source}`")
+    lines.append(f"{prefix}Failed step reporting only: `true`")
+    lines.append(f"{prefix}Failed step automation allowed: `false`")
+    return lines
+
+
 def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
     failed = [_as_dict(item) for item in _as_list(check_intelligence.get("failed_checks"))]
     if not failed:
@@ -421,6 +447,7 @@ def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
             lines.append(f"  - First failure: `{first_line}`")
             lines.append(f"  - Failure location: `{location}`")
             lines.append(f"  - Failure tool/kind: `{tool}` / `{kind}`")
+        lines.extend(_failed_step_evidence_lines(item))
         safe_remediation = _as_dict(item.get("safe_remediation"))
         if bool(safe_remediation.get("safe_to_auto_fix", False)):
             strategy = _string(safe_remediation.get("strategy") or "unknown")
@@ -482,6 +509,7 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
         lines.append(f"- First failure: `{first_line}`")
         lines.append(f"- Failure location: `{location}`")
         lines.append(f"- Failure tool/kind: `{tool}` / `{kind}`")
+    lines.extend(_failed_step_evidence_lines(primary, prefix="- "))
     safe_remediation = _as_dict(primary.get("safe_remediation"))
     if bool(safe_remediation.get("safe_to_auto_fix", False)):
         strategy = _string(safe_remediation.get("strategy") or "unknown")

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -825,6 +825,16 @@ def test_action_report_comment_renders_failed_check_first_failure() -> None:
                 "kind": "type_contract",
             },
             "first_failure_line": "src/sdetkit/example.py:10: error: Incompatible return value type",
+            check_intelligence.FAILED_STEP_EVIDENCE_KEY: {
+                "status": "found",
+                "command": "python -m mypy src",
+                "source": "github_actions_group",
+                "line_number": 4,
+                "failure_line_number": 12,
+                "reporting_only": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+            },
         },
         "automation": {"attempted": False, "allowed": False, "reason": "review-first"},
         "recommended_actions": ["Fix the first reported contract violation."],
@@ -847,6 +857,16 @@ def test_action_report_comment_renders_failed_check_first_failure() -> None:
                     "tool": "mypy",
                     "kind": "type_contract",
                 },
+                check_intelligence.FAILED_STEP_EVIDENCE_KEY: {
+                    "status": "found",
+                    "command": "python -m mypy src",
+                    "source": "github_actions_group",
+                    "line_number": 4,
+                    "failure_line_number": 12,
+                    "reporting_only": True,
+                    "automation_allowed": False,
+                    "merge_authorized": False,
+                },
             }
         ],
         "queued_checks": [],
@@ -862,6 +882,10 @@ def test_action_report_comment_renders_failed_check_first_failure() -> None:
     )
     assert "Failure location: `line 12`" in body
     assert "Failure tool/kind: `mypy` / `type_contract`" in body
+    assert "Failed step evidence: `found`" in body
+    assert "Failed command: `python -m mypy src`" in body
+    assert "Failed step reporting only: `true`" in body
+    assert "Failed step automation allowed: `false`" in body
 
 
 def test_action_report_comment_renders_safe_remediation_eligibility() -> None:

--- a/tests/test_pr_quality_current_head_failure_bundle.py
+++ b/tests/test_pr_quality_current_head_failure_bundle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from sdetkit import check_intelligence
 from sdetkit.pr_quality_action_report import main, write_comment_body
 
 
@@ -49,6 +50,16 @@ def test_pr_quality_action_report_writes_optional_current_head_failure_bundle(tm
                         "line_number": 17,
                         "tool": "pytest",
                         "kind": "test_failure",
+                    },
+                    check_intelligence.FAILED_STEP_EVIDENCE_KEY: {
+                        "status": "found",
+                        "command": "python -m pytest -q tests/test_contract.py -o addopts=",
+                        "source": "github_actions_group",
+                        "line_number": 9,
+                        "failure_line_number": 17,
+                        "reporting_only": True,
+                        "automation_allowed": False,
+                        "merge_authorized": False,
                     },
                     "diagnosis": {
                         "code": "TEST_FAILURE",
@@ -105,6 +116,13 @@ def test_pr_quality_action_report_writes_optional_current_head_failure_bundle(tm
     assert manifest["review_first"] is True
     assert manifest["safe_fix_allowed"] is False
     assert bundle["first_failures"][0]["line"] == "FAILED tests/test_contract.py::test_contract"
+    step = bundle["first_failures"][0][check_intelligence.FAILED_STEP_EVIDENCE_KEY]
+    assert step["status"] == "found"
+    assert step["command"] == "python -m pytest -q tests/test_contract.py -o addopts="
+    assert step["reporting_only"] is True
+    assert step["automation_allowed"] is False
+    assert "Failed step evidence: `found`" in markdown
+    assert "Failed command: `python -m pytest -q tests/test_contract.py -o addopts=`" in markdown
     assert "src/sdetkit/check_intelligence.py" in bundle["owner_files"]
     assert "# Current-head failure evidence bundle" in markdown
     assert "Full CI lane" in markdown


### PR DESCRIPTION
Surfaces reporting-only failed-step evidence in PR Quality comments and current-head failure bundles so operators can connect the first failure line to the failed workflow command.

## Summary
- render failed-step evidence and failed command in failed-check diagnoses
- render failed-step evidence on the primary blocker
- carry failed-step evidence into current-head failure bundles
- preserve reporting-only boundaries and no patch/automation/merge authority

## Proof
- python -m pytest -q tests/test_check_intelligence_first_failure.py tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_pr_quality_current_head_failure_bundle.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=
- python -m pre_commit run -a
- targeted high-entropy scan for changed files reported 0 hits