### PR TITLE
feat: confirm failed steps against job metadata

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -29,6 +29,10 @@ DEPENDENCY_AUDIT_OWNER_FILES = [
 ]
 
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
+JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
+JOB_STEP_CONFIRMED_COUNT_KEY = "_".join(("job", "step", "confirmed", "count"))
+JOB_STEP_MISMATCH_COUNT_KEY = "_".join(("job", "step", "mismatch", "count"))
+JOB_STEP_UNAVAILABLE_COUNT_KEY = "_".join(("job", "step", "unavailable", "count"))
 FAILED_WITH_STEP_EVIDENCE_KEY = "_".join(("failed", "with", "step", "evidence"))
 FAILED_WITHOUT_STEP_EVIDENCE_KEY = "_".join(("failed", "without", "step", "evidence"))
 
@@ -831,6 +835,105 @@ def _failed_step_evidence(log_text: str, first_failure: JsonObject) -> JsonObjec
     }
 
 
+def _job_steps_from_record(record: JsonObject) -> list[JsonObject]:
+    for value in (
+        record.get("steps"),
+        record.get("job_steps"),
+        _as_dict(record.get("workflow_job")).get("steps"),
+        _as_dict(record.get("job")).get("steps"),
+    ):
+        steps = [_as_dict(item) for item in _as_list(value)]
+        if steps:
+            return steps
+    return []
+
+
+def _normal_step_text(value: str) -> str:
+    text = " ".join(value.strip().lower().split())
+    if text.startswith("run "):
+        text = text.removeprefix("run ").strip()
+    return text
+
+
+def _step_name(step: JsonObject) -> str:
+    return _string(step.get("name") or step.get("title") or step.get("command"))
+
+
+def _step_conclusion(step: JsonObject) -> str:
+    return _string(step.get("conclusion") or step.get("status")).lower()
+
+
+def _is_failed_job_step(step: JsonObject) -> bool:
+    return _step_conclusion(step) in {
+        "failure",
+        "failed",
+        "timed_out",
+        "cancelled",
+        "action_required",
+    }
+
+
+def _step_matches_log_command(step: JsonObject, command: str) -> bool:
+    needle = _normal_step_text(command)
+    haystack = _normal_step_text(_step_name(step))
+    return bool(needle and haystack and (needle == haystack or needle in haystack))
+
+
+def _job_step_confirmation(record: JsonObject, failed_step: JsonObject) -> JsonObject:
+    command = _string(failed_step.get("command"))
+    steps = _job_steps_from_record(record)
+    base = {
+        "log_command": command,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    if not command:
+        return {
+            **base,
+            "status": "missing",
+            "source": "absent",
+            "job_step_name": "",
+            "job_step_conclusion": "",
+            "job_step_count": len(steps),
+            "failed_job_step_count": len([step for step in steps if _is_failed_job_step(step)]),
+        }
+
+    if not steps:
+        return {
+            **base,
+            "status": "unavailable",
+            "source": "absent",
+            "job_step_name": "",
+            "job_step_conclusion": "",
+            "job_step_count": 0,
+            "failed_job_step_count": 0,
+        }
+
+    matched = next((step for step in steps if _step_matches_log_command(step, command)), {})
+    failed_steps = [step for step in steps if _is_failed_job_step(step)]
+    chosen = matched or (failed_steps[0] if failed_steps else {})
+
+    if matched:
+        status = "confirmed" if _is_failed_job_step(matched) else "mismatch"
+    elif failed_steps:
+        status = "mismatch"
+    else:
+        status = "missing"
+
+    return {
+        **base,
+        "status": status,
+        "source": "github_job_steps",
+        "job_step_name": _step_name(chosen),
+        "job_step_conclusion": _step_conclusion(chosen),
+        "job_step_count": len(steps),
+        "failed_job_step_count": len(failed_steps),
+    }
+
+
 def _dependency_audit_first_failure(log_text: str) -> JsonObject:
 
     for index, raw_line in enumerate(log_text.splitlines(), 1):
@@ -1027,6 +1130,7 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         primary = fallback
 
     failed_step_evidence = _failed_step_evidence(log_text, first_failure)
+    job_step_confirmation = _job_step_confirmation(record, failed_step_evidence)
     safe_remediation = safe_remediation_eligibility.classify_check_failure(
         name=name,
         diagnosis=primary,
@@ -1048,6 +1152,7 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         "first_failure": first_failure,
         "first_failure_line": _string(first_failure.get("line")),
         FAILED_STEP_EVIDENCE_KEY: failed_step_evidence,
+        JOB_STEP_CONFIRMATION_KEY: job_step_confirmation,
         "formatter_changed_files": _formatter_changed_files(log_text),
         "referenced_files": _referenced_failure_files(log_text),
         "outside_changed_files": _outside_changed_files(record, log_text),
@@ -1297,6 +1402,22 @@ def _real_evidence_quality_summary(
         for check in failed_checks
         if _string(_as_dict(check.get(FAILED_STEP_EVIDENCE_KEY)).get("status")) == "found"
     )
+    job_step_confirmed_count = sum(
+        1
+        for check in failed_checks
+        if _string(_as_dict(check.get(JOB_STEP_CONFIRMATION_KEY)).get("status")) == "confirmed"
+    )
+    job_step_mismatch_count = sum(
+        1
+        for check in failed_checks
+        if _string(_as_dict(check.get(JOB_STEP_CONFIRMATION_KEY)).get("status")) == "mismatch"
+    )
+    job_step_unavailable_count = sum(
+        1
+        for check in failed_checks
+        if _string(_as_dict(check.get(JOB_STEP_CONFIRMATION_KEY)).get("status"))
+        in {"unavailable", "missing"}
+    )
     stale_evidence_count = sum(1 for check in failed_checks if bool(check.get("stale_evidence")))
     unknown_diagnosis_count = sum(
         1 for check in failed_checks if _is_unknown_diagnosis(_as_dict(check.get("diagnosis")))
@@ -1323,6 +1444,9 @@ def _real_evidence_quality_summary(
         "failed_without_first_failure": failed_count - failed_with_first_failure,
         FAILED_WITH_STEP_EVIDENCE_KEY: failed_with_step_evidence,
         FAILED_WITHOUT_STEP_EVIDENCE_KEY: failed_count - failed_with_step_evidence,
+        JOB_STEP_CONFIRMED_COUNT_KEY: job_step_confirmed_count,
+        JOB_STEP_MISMATCH_COUNT_KEY: job_step_mismatch_count,
+        JOB_STEP_UNAVAILABLE_COUNT_KEY: job_step_unavailable_count,
         "queued_checks": len(queued_checks),
         "cancelled_checks": len(cancelled_checks),
         "startup_failures": len(startup_failures),
@@ -1694,6 +1818,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 "first_failure": check.get("first_failure", {}),
                 "first_failure_line": check.get("first_failure_line", ""),
                 FAILED_STEP_EVIDENCE_KEY: check.get(FAILED_STEP_EVIDENCE_KEY, {}),
+                JOB_STEP_CONFIRMATION_KEY: check.get(JOB_STEP_CONFIRMATION_KEY, {}),
                 "head_sha": check.get("head_sha", ""),
                 "current_pr_head_sha": check.get("current_pr_head_sha", ""),
                 "stale_evidence": check.get("stale_evidence", False),

--- a/src/sdetkit/current_head_failure_bundle.py
+++ b/src/sdetkit/current_head_failure_bundle.py
@@ -9,6 +9,7 @@ JsonObject = dict[str, Any]
 
 SCHEMA_VERSION = "sdetkit.current_head_failure_bundle.v1"
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
+JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -82,6 +83,7 @@ def build_current_head_failure_bundle(
                     "tool": _string(first_failure.get("tool") or "unknown"),
                     "kind": _string(first_failure.get("kind") or "unknown"),
                     FAILED_STEP_EVIDENCE_KEY: _as_dict(item.get(FAILED_STEP_EVIDENCE_KEY)),
+                    JOB_STEP_CONFIRMATION_KEY: _as_dict(item.get(JOB_STEP_CONFIRMATION_KEY)),
                 }
             )
 
@@ -174,6 +176,15 @@ def render_current_head_failure_bundle_markdown(bundle: JsonObject) -> str:
                     lines.append(f"  - Failed command: `{command}`")
                 lines.append("- Reporting only: `true`")
                 lines.append("- Automation allowed: `false`")
+            confirmation = _as_dict(item.get(JOB_STEP_CONFIRMATION_KEY))
+            if confirmation:
+                lines.append(
+                    f"  - Job step confirmation: `{_string(confirmation.get('status') or 'unknown')}`"
+                )
+                step_name = _string(confirmation.get("job_step_name"))
+                if step_name:
+                    lines.append(f"  - GitHub job step: `{step_name}`")
+                lines.append("- Job step automation allowed: `false`")
     else:
         lines.append("- none")
 

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -49,6 +49,7 @@ HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
 
 
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
+JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
 
 BANNED_EDUCATIONAL_PHRASES = (
     "Quality is green, so the review focus is not coverage.",
@@ -401,6 +402,25 @@ def _security_finding_diagnosis_lines(security_finding_diagnosis: JsonObject | N
     return lines
 
 
+def _job_step_confirmation_lines(payload: JsonObject, *, prefix: str = "  - ") -> list[str]:
+    confirmation = _as_dict(payload.get(JOB_STEP_CONFIRMATION_KEY))
+    if not confirmation:
+        return []
+
+    status = _string(confirmation.get("status") or "unknown")
+    source = _string(confirmation.get("source") or "unknown")
+    name = _string(confirmation.get("job_step_name"))
+    conclusion = _string(confirmation.get("job_step_conclusion") or "unknown")
+    lines = [f"{prefix}Job step confirmation: `{status}`"]
+    if name:
+        lines.append(f"{prefix}GitHub job step: `{name}`")
+    lines.append(f"{prefix}GitHub job step conclusion: `{conclusion}`")
+    lines.append(f"{prefix}Job step source: `{source}`")
+    lines.append(f"{prefix}Job step reporting only: `true`")
+    lines.append(f"{prefix}Job step automation allowed: `false`")
+    return lines
+
+
 def _failed_step_evidence_lines(payload: JsonObject, *, prefix: str = "  - ") -> list[str]:
     step = _as_dict(payload.get(FAILED_STEP_EVIDENCE_KEY))
     if not step:
@@ -421,6 +441,7 @@ def _failed_step_evidence_lines(payload: JsonObject, *, prefix: str = "  - ") ->
     lines.append(f"{prefix}Failed step source: `{source}`")
     lines.append(f"{prefix}Failed step reporting only: `true`")
     lines.append(f"{prefix}Failed step automation allowed: `false`")
+    lines.extend(_job_step_confirmation_lines(payload, prefix=prefix))
     return lines
 
 

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -457,3 +457,84 @@ def test_check_intelligence_extracts_failed_step_command_evidence(tmp_path: Path
     assert step["merge_authorized"] is False
     assert quality[check_intelligence.FAILED_WITH_STEP_EVIDENCE_KEY] == 1
     assert quality[check_intelligence.FAILED_WITHOUT_STEP_EVIDENCE_KEY] == 0
+
+
+def test_check_intelligence_confirms_failed_step_with_job_step_metadata(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "##[group]Run python -m mypy src",
+                            "python -m mypy src",
+                            "src/sdetkit/example.py:12: error: Incompatible return value type",
+                        ]
+                    ),
+                    "steps": [
+                        {"name": "Set up Python", "conclusion": "success"},
+                        {"name": "Run python -m mypy src", "conclusion": "failure"},
+                    ],
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+    confirmation = failed[check_intelligence.JOB_STEP_CONFIRMATION_KEY]
+    quality = intelligence["real_evidence_quality"]
+
+    assert confirmation["status"] == "confirmed"
+    assert confirmation["source"] == "github_job_steps"
+    assert confirmation["job_step_name"] == "Run python -m mypy src"
+    assert confirmation["job_step_conclusion"] == "failure"
+    assert confirmation["log_command"] == "python -m mypy src"
+    assert confirmation["reporting_only"] is True
+    assert confirmation["automation_allowed"] is False
+    assert confirmation["merge_authorized"] is False
+    assert confirmation["semantic_equivalence_proven"] is False
+    assert quality[check_intelligence.JOB_STEP_CONFIRMED_COUNT_KEY] == 1
+    assert quality[check_intelligence.JOB_STEP_MISMATCH_COUNT_KEY] == 0
+    assert quality[check_intelligence.JOB_STEP_UNAVAILABLE_COUNT_KEY] == 0
+
+
+def test_check_intelligence_reports_job_step_mismatch(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "##[group]Run python -m mypy src",
+                            "python -m mypy src",
+                            "src/sdetkit/example.py:12: error: Incompatible return value type",
+                        ]
+                    ),
+                    "steps": [
+                        {"name": "Run python -m pytest -q", "conclusion": "failure"},
+                    ],
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    confirmation = intelligence["failed_checks"][0][check_intelligence.JOB_STEP_CONFIRMATION_KEY]
+
+    assert confirmation["status"] == "mismatch"
+    assert confirmation["job_step_name"] == "Run python -m pytest -q"
+    assert confirmation["job_step_conclusion"] == "failure"
+    assert confirmation["log_command"] == "python -m mypy src"

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2144,3 +2144,46 @@ def test_action_report_runtime_lines_render_controlled_history_as_advisory_only(
     assert "Automation allowed by trusted history: `false`" in body
     assert "Merge authorized by trusted history: `false`" in body
     assert "Semantic equivalence proven by trusted history: `false`" in body
+
+
+def test_action_report_comment_renders_job_step_confirmation() -> None:
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "Fast CI lane",
+            "title": "Type contract drift detected",
+            "surface": "quality",
+            "code": "MYPY_TYPE_CONTRACT_DRIFT",
+            check_intelligence.FAILED_STEP_EVIDENCE_KEY: {
+                "status": "found",
+                "command": "python -m mypy src",
+                "source": "github_actions_group",
+                "line_number": 1,
+                "failure_line_number": 3,
+                "reporting_only": True,
+                "automation_allowed": False,
+            },
+            check_intelligence.JOB_STEP_CONFIRMATION_KEY: {
+                "status": "confirmed",
+                "source": "github_job_steps",
+                "job_step_name": "Run python -m mypy src",
+                "job_step_conclusion": "failure",
+                "log_command": "python -m mypy src",
+                "reporting_only": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+            },
+        },
+        "automation": {"attempted": False, "allowed": False, "reason": "review-first"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    body = report.render_comment_body(action_report=action, check_intelligence={})
+
+    assert "Failed step evidence: `found`" in body
+    assert "Failed command: `python -m mypy src`" in body
+    assert "Job step confirmation: `confirmed`" in body
+    assert "GitHub job step: `Run python -m mypy src`" in body
+    assert "GitHub job step conclusion: `failure`" in body
+    assert "Job step automation allowed: `false`" in body

--- a/tests/test_pr_quality_current_head_failure_bundle.py
+++ b/tests/test_pr_quality_current_head_failure_bundle.py
@@ -170,3 +170,51 @@ def test_pr_quality_action_report_cli_keeps_bundle_writing_optional(tmp_path):
 
     assert out.exists()
     assert not (tmp_path / "failure-bundle").exists()
+
+
+def test_current_head_failure_bundle_carries_job_step_confirmation() -> None:
+    from sdetkit import check_intelligence, current_head_failure_bundle
+
+    bundle = current_head_failure_bundle.build_current_head_failure_bundle(
+        pr_number=1484,
+        head_sha="head",
+        base_sha="base",
+        check_intelligence={
+            "checks_seen": 1,
+            "failed_checks": [
+                {
+                    "name": "Fast CI lane",
+                    "first_failure": {
+                        "line": "src/sdetkit/example.py:12: error: Incompatible return value type",
+                        "line_number": 3,
+                        "tool": "mypy",
+                        "kind": "type_contract",
+                    },
+                    check_intelligence.FAILED_STEP_EVIDENCE_KEY: {
+                        "status": "found",
+                        "command": "python -m mypy src",
+                        "reporting_only": True,
+                        "automation_allowed": False,
+                    },
+                    check_intelligence.JOB_STEP_CONFIRMATION_KEY: {
+                        "status": "confirmed",
+                        "source": "github_job_steps",
+                        "job_step_name": "Run python -m mypy src",
+                        "job_step_conclusion": "failure",
+                        "log_command": "python -m mypy src",
+                        "reporting_only": True,
+                        "automation_allowed": False,
+                        "merge_authorized": False,
+                    },
+                }
+            ],
+        },
+    )
+    markdown = current_head_failure_bundle.render_current_head_failure_bundle_markdown(bundle)
+    confirmation = bundle["first_failures"][0][check_intelligence.JOB_STEP_CONFIRMATION_KEY]
+
+    assert confirmation["status"] == "confirmed"
+    assert confirmation["job_step_name"] == "Run python -m mypy src"
+    assert "Job step confirmation: `confirmed`" in markdown
+    assert "GitHub job step: `Run python -m mypy src`" in markdown
+    assert "Job step automation allowed: `false`" in markdown


### PR DESCRIPTION
Adds reporting-only GitHub job-step confirmation for failed command evidence so operators can see whether log-derived failed commands match job step metadata.

## Summary
- compare log-derived failed command evidence with job step metadata when available
- report confirmed, mismatch, missing, and unavailable job-step confirmation states
- summarize confirmation counts in real evidence quality
- render job-step confirmation in PR Quality comments and current-head failure bundles
- preserve reporting-only boundaries and no patch/automation/merge authority

## Proof
- python -m pytest -q tests/test_failed_check_log_collection.py tests/test_check_intelligence_first_failure.py tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_pr_quality_current_head_failure_bundle.py -o addopts=
- python -m pre_commit run -a
- targeted high-entropy scan for changed files reported 0 hits