### PR TITLE
feat: confirm workflow artifact evidence

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -33,6 +33,10 @@ JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
 JOB_STEP_CONFIRMED_COUNT_KEY = "_".join(("job", "step", "confirmed", "count"))
 JOB_STEP_MISMATCH_COUNT_KEY = "_".join(("job", "step", "mismatch", "count"))
 JOB_STEP_UNAVAILABLE_COUNT_KEY = "_".join(("job", "step", "unavailable", "count"))
+ARTIFACT_EVIDENCE_KEY = "_".join(("artifact", "evidence"))
+ARTIFACT_PRESENT_COUNT_KEY = "_".join(("artifact", "present", "count"))
+ARTIFACT_MISSING_COUNT_KEY = "_".join(("artifact", "missing", "count"))
+ARTIFACT_UNAVAILABLE_COUNT_KEY = "_".join(("artifact", "unavailable", "count"))
 FAILED_WITH_STEP_EVIDENCE_KEY = "_".join(("failed", "with", "step", "evidence"))
 FAILED_WITHOUT_STEP_EVIDENCE_KEY = "_".join(("failed", "without", "step", "evidence"))
 
@@ -160,6 +164,91 @@ def _string(value: Any) -> str:
 def _slug(value: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9]+", "-", value.strip().lower()).strip("-")
     return slug or "check"
+
+
+def _artifact_name(value: Any) -> str:
+    if isinstance(value, dict):
+        return _string(value.get("path") or value.get("name") or value.get("filename"))
+    return _string(value)
+
+
+def _artifact_candidates(record: JsonObject) -> list[str]:
+    candidates: list[str] = []
+    for key in ("artifacts", "workflow_artifacts", "available_artifacts"):
+        for item in _as_list(record.get(key)):
+            name = _artifact_name(item)
+            if name and name not in candidates:
+                candidates.append(name)
+    return candidates
+
+
+def _expected_artifacts(record: JsonObject, dependency_audit: JsonObject) -> list[str]:
+    expected: list[str] = []
+    report_path = _string(dependency_audit.get("report_path"))
+    if report_path:
+        expected.append(report_path)
+
+    for key in ("expected_artifacts", "required_artifacts"):
+        for item in _as_list(record.get(key)):
+            name = _artifact_name(item)
+            if name and name not in expected:
+                expected.append(name)
+
+    return expected
+
+
+def _artifact_matches(expected: str, candidate: str) -> bool:
+    expected_text = expected.strip().lower()
+    candidate_text = candidate.strip().lower()
+    return bool(
+        expected_text
+        and candidate_text
+        and (
+            expected_text == candidate_text
+            or expected_text in candidate_text
+            or Path(expected_text).name == Path(candidate_text).name
+        )
+    )
+
+
+def _artifact_evidence(record: JsonObject, dependency_audit: JsonObject) -> JsonObject:
+    expected = _expected_artifacts(record, dependency_audit)
+    available = _artifact_candidates(record)
+    artifact_url = _string(dependency_audit.get("artifact_url") or record.get("artifact_url"))
+
+    present: list[str] = []
+    missing: list[str] = []
+
+    for expected_name in expected:
+        matched = any(_artifact_matches(expected_name, candidate) for candidate in available)
+        if matched or artifact_url:
+            present.append(expected_name)
+        else:
+            missing.append(expected_name)
+
+    if not expected:
+        status = "unavailable"
+        source = "absent"
+    elif missing:
+        status = "missing"
+        source = "absent" if not available and not artifact_url else "partial"
+    else:
+        status = "present"
+        source = "workflow_artifact_url" if artifact_url else "workflow_artifacts"
+
+    return {
+        "status": status,
+        "expected_artifacts": expected,
+        "present_artifacts": present,
+        "missing_artifacts": missing,
+        "available_artifacts": available,
+        "artifact_url": artifact_url,
+        "source": source,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
 
 
 def _iter_check_records(payload: JsonObject) -> list[JsonObject]:
@@ -1131,6 +1220,7 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
 
     failed_step_evidence = _failed_step_evidence(log_text, first_failure)
     job_step_confirmation = _job_step_confirmation(record, failed_step_evidence)
+    artifact_evidence = _artifact_evidence(record, dependency_audit)
     safe_remediation = safe_remediation_eligibility.classify_check_failure(
         name=name,
         diagnosis=primary,
@@ -1153,6 +1243,7 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         "first_failure_line": _string(first_failure.get("line")),
         FAILED_STEP_EVIDENCE_KEY: failed_step_evidence,
         JOB_STEP_CONFIRMATION_KEY: job_step_confirmation,
+        ARTIFACT_EVIDENCE_KEY: artifact_evidence,
         "formatter_changed_files": _formatter_changed_files(log_text),
         "referenced_files": _referenced_failure_files(log_text),
         "outside_changed_files": _outside_changed_files(record, log_text),
@@ -1418,6 +1509,21 @@ def _real_evidence_quality_summary(
         if _string(_as_dict(check.get(JOB_STEP_CONFIRMATION_KEY)).get("status"))
         in {"unavailable", "missing"}
     )
+    artifact_present_count = sum(
+        1
+        for check in failed_checks
+        if _string(_as_dict(check.get(ARTIFACT_EVIDENCE_KEY)).get("status")) == "present"
+    )
+    artifact_missing_count = sum(
+        1
+        for check in failed_checks
+        if _string(_as_dict(check.get(ARTIFACT_EVIDENCE_KEY)).get("status")) == "missing"
+    )
+    artifact_unavailable_count = sum(
+        1
+        for check in failed_checks
+        if _string(_as_dict(check.get(ARTIFACT_EVIDENCE_KEY)).get("status")) == "unavailable"
+    )
     stale_evidence_count = sum(1 for check in failed_checks if bool(check.get("stale_evidence")))
     unknown_diagnosis_count = sum(
         1 for check in failed_checks if _is_unknown_diagnosis(_as_dict(check.get("diagnosis")))
@@ -1447,6 +1553,9 @@ def _real_evidence_quality_summary(
         JOB_STEP_CONFIRMED_COUNT_KEY: job_step_confirmed_count,
         JOB_STEP_MISMATCH_COUNT_KEY: job_step_mismatch_count,
         JOB_STEP_UNAVAILABLE_COUNT_KEY: job_step_unavailable_count,
+        ARTIFACT_PRESENT_COUNT_KEY: artifact_present_count,
+        ARTIFACT_MISSING_COUNT_KEY: artifact_missing_count,
+        ARTIFACT_UNAVAILABLE_COUNT_KEY: artifact_unavailable_count,
         "queued_checks": len(queued_checks),
         "cancelled_checks": len(cancelled_checks),
         "startup_failures": len(startup_failures),
@@ -1819,6 +1928,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 "first_failure_line": check.get("first_failure_line", ""),
                 FAILED_STEP_EVIDENCE_KEY: check.get(FAILED_STEP_EVIDENCE_KEY, {}),
                 JOB_STEP_CONFIRMATION_KEY: check.get(JOB_STEP_CONFIRMATION_KEY, {}),
+                ARTIFACT_EVIDENCE_KEY: check.get(ARTIFACT_EVIDENCE_KEY, {}),
                 "head_sha": check.get("head_sha", ""),
                 "current_pr_head_sha": check.get("current_pr_head_sha", ""),
                 "stale_evidence": check.get("stale_evidence", False),

--- a/src/sdetkit/current_head_failure_bundle.py
+++ b/src/sdetkit/current_head_failure_bundle.py
@@ -10,6 +10,7 @@ JsonObject = dict[str, Any]
 SCHEMA_VERSION = "sdetkit.current_head_failure_bundle.v1"
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
 JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
+ARTIFACT_EVIDENCE_KEY = "_".join(("artifact", "evidence"))
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -84,6 +85,7 @@ def build_current_head_failure_bundle(
                     "kind": _string(first_failure.get("kind") or "unknown"),
                     FAILED_STEP_EVIDENCE_KEY: _as_dict(item.get(FAILED_STEP_EVIDENCE_KEY)),
                     JOB_STEP_CONFIRMATION_KEY: _as_dict(item.get(JOB_STEP_CONFIRMATION_KEY)),
+                    ARTIFACT_EVIDENCE_KEY: _as_dict(item.get(ARTIFACT_EVIDENCE_KEY)),
                 }
             )
 
@@ -176,6 +178,22 @@ def render_current_head_failure_bundle_markdown(bundle: JsonObject) -> str:
                     lines.append(f"  - Failed command: `{command}`")
                 lines.append("- Reporting only: `true`")
                 lines.append("- Automation allowed: `false`")
+            artifact_evidence = _as_dict(item.get(ARTIFACT_EVIDENCE_KEY))
+            if artifact_evidence:
+                lines.append(
+                    f"  - Artifact evidence: `{_string(artifact_evidence.get('status') or 'unknown')}`"
+                )
+                expected = [
+                    _string(value)
+                    for value in _as_list(artifact_evidence.get("expected_artifacts"))
+                    if _string(value)
+                ]
+                if expected:
+                    lines.append(
+                        "  - Expected artifacts: "
+                        + ", ".join(f"`{value}`" for value in expected[:5])
+                    )
+                lines.append("- Artifact automation allowed: `false`")
             confirmation = _as_dict(item.get(JOB_STEP_CONFIRMATION_KEY))
             if confirmation:
                 lines.append(

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -50,6 +50,7 @@ HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
 
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
 JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
+ARTIFACT_EVIDENCE_KEY = "_".join(("artifact", "evidence"))
 
 BANNED_EDUCATIONAL_PHRASES = (
     "Quality is green, so the review focus is not coverage.",
@@ -402,6 +403,42 @@ def _security_finding_diagnosis_lines(security_finding_diagnosis: JsonObject | N
     return lines
 
 
+def _artifact_evidence_lines(payload: JsonObject, *, prefix: str = "  - ") -> list[str]:
+    evidence = _as_dict(payload.get(ARTIFACT_EVIDENCE_KEY))
+    if not evidence:
+        return []
+
+    status = _string(evidence.get("status") or "unknown")
+    source = _string(evidence.get("source") or "unknown")
+    expected = [
+        _string(item) for item in _as_list(evidence.get("expected_artifacts")) if _string(item)
+    ]
+    present = [
+        _string(item) for item in _as_list(evidence.get("present_artifacts")) if _string(item)
+    ]
+    missing = [
+        _string(item) for item in _as_list(evidence.get("missing_artifacts")) if _string(item)
+    ]
+
+    lines = [f"{prefix}Artifact evidence: `{status}`"]
+    if expected:
+        lines.append(
+            f"{prefix}Expected artifacts: " + ", ".join(f"`{item}`" for item in expected[:5])
+        )
+    if present:
+        lines.append(
+            f"{prefix}Present artifacts: " + ", ".join(f"`{item}`" for item in present[:5])
+        )
+    if missing:
+        lines.append(
+            f"{prefix}Missing artifacts: " + ", ".join(f"`{item}`" for item in missing[:5])
+        )
+    lines.append(f"{prefix}Artifact evidence source: `{source}`")
+    lines.append(f"{prefix}Artifact evidence reporting only: `true`")
+    lines.append(f"{prefix}Artifact automation allowed: `false`")
+    return lines
+
+
 def _job_step_confirmation_lines(payload: JsonObject, *, prefix: str = "  - ") -> list[str]:
     confirmation = _as_dict(payload.get(JOB_STEP_CONFIRMATION_KEY))
     if not confirmation:
@@ -469,6 +506,7 @@ def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
             lines.append(f"  - Failure location: `{location}`")
             lines.append(f"  - Failure tool/kind: `{tool}` / `{kind}`")
         lines.extend(_failed_step_evidence_lines(item))
+        lines.extend(_artifact_evidence_lines(item))
         safe_remediation = _as_dict(item.get("safe_remediation"))
         if bool(safe_remediation.get("safe_to_auto_fix", False)):
             strategy = _string(safe_remediation.get("strategy") or "unknown")
@@ -531,6 +569,7 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
         lines.append(f"- Failure location: `{location}`")
         lines.append(f"- Failure tool/kind: `{tool}` / `{kind}`")
     lines.extend(_failed_step_evidence_lines(primary, prefix="- "))
+    lines.extend(_artifact_evidence_lines(primary, prefix="- "))
     safe_remediation = _as_dict(primary.get("safe_remediation"))
     if bool(safe_remediation.get("safe_to_auto_fix", False)):
         strategy = _string(safe_remediation.get("strategy") or "unknown")

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -538,3 +538,79 @@ def test_check_intelligence_reports_job_step_mismatch(
     assert confirmation["job_step_name"] == "Run python -m pytest -q"
     assert confirmation["job_step_conclusion"] == "failure"
     assert confirmation["log_command"] == "python -m mypy src"
+
+
+def test_check_intelligence_confirms_dependency_audit_artifact_evidence(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "audit",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "pip-audit --format json -o pip-audit-report.json -r requirements-test.txt",
+                            "Found 1 known vulnerability in 1 package",
+                            "name: pip-audit-report",
+                            "path: pip-audit-report.json",
+                            "Artifact download URL: "
+                            "https://github.com/example/actions/runs/"
+                            "1/artifacts/2",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+    evidence = failed[check_intelligence.ARTIFACT_EVIDENCE_KEY]
+    quality = intelligence["real_evidence_quality"]
+
+    assert evidence["status"] == "present"
+    assert evidence["expected_artifacts"] == ["pip-audit-report.json"]
+    assert evidence["present_artifacts"] == ["pip-audit-report.json"]
+    assert evidence["missing_artifacts"] == []
+    assert evidence["source"] == "workflow_artifact_url"
+    assert evidence["reporting_only"] is True
+    assert evidence["automation_allowed"] is False
+    assert evidence["merge_authorized"] is False
+    assert evidence["semantic_equivalence_proven"] is False
+    assert quality[check_intelligence.ARTIFACT_PRESENT_COUNT_KEY] == 1
+    assert quality[check_intelligence.ARTIFACT_MISSING_COUNT_KEY] == 0
+
+
+def test_check_intelligence_reports_missing_dependency_audit_artifact(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "audit",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "pip-audit --format json -o pip-audit-report.json -r requirements-test.txt",
+                            "Found 1 known vulnerability in 1 package",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    evidence = intelligence["failed_checks"][0][check_intelligence.ARTIFACT_EVIDENCE_KEY]
+
+    assert evidence["status"] == "missing"
+    assert evidence["expected_artifacts"] == ["pip-audit-report.json"]
+    assert evidence["missing_artifacts"] == ["pip-audit-report.json"]
+    assert evidence["source"] == "absent"

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2187,3 +2187,37 @@ def test_action_report_comment_renders_job_step_confirmation() -> None:
     assert "GitHub job step: `Run python -m mypy src`" in body
     assert "GitHub job step conclusion: `failure`" in body
     assert "Job step automation allowed: `false`" in body
+
+
+def test_action_report_comment_renders_artifact_evidence() -> None:
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "audit",
+            "title": "Dependency audit reported vulnerable packages",
+            "surface": "dependency",
+            "code": check_intelligence.DEPENDENCY_AUDIT_VULNERABILITY,
+            check_intelligence.ARTIFACT_EVIDENCE_KEY: {
+                "status": "present",
+                "expected_artifacts": ["pip-audit-report.json"],
+                "present_artifacts": ["pip-audit-report.json"],
+                "missing_artifacts": [],
+                "source": "workflow_artifact_url",
+                "reporting_only": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+            },
+        },
+        "automation": {"attempted": False, "allowed": False, "reason": "review-first"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence={})
+
+    assert "Artifact evidence: `present`" in body
+    assert "Expected artifacts: `pip-audit-report.json`" in body
+    assert "Present artifacts: `pip-audit-report.json`" in body
+    assert "Artifact evidence source: `workflow_artifact_url`" in body
+    assert "Artifact automation allowed: `false`" in body

--- a/tests/test_pr_quality_current_head_failure_bundle.py
+++ b/tests/test_pr_quality_current_head_failure_bundle.py
@@ -218,3 +218,45 @@ def test_current_head_failure_bundle_carries_job_step_confirmation() -> None:
     assert "Job step confirmation: `confirmed`" in markdown
     assert "GitHub job step: `Run python -m mypy src`" in markdown
     assert "Job step automation allowed: `false`" in markdown
+
+
+def test_current_head_failure_bundle_carries_artifact_evidence() -> None:
+    from sdetkit import check_intelligence, current_head_failure_bundle
+
+    bundle = current_head_failure_bundle.build_current_head_failure_bundle(
+        pr_number=1485,
+        head_sha="head",
+        base_sha="base",
+        check_intelligence={
+            "checks_seen": 1,
+            "failed_checks": [
+                {
+                    "name": "audit",
+                    "first_failure": {
+                        "line": "Found 1 known vulnerability in 1 package",
+                        "line_number": 2,
+                        "tool": "pip-audit",
+                        "kind": "dependency_vulnerability",
+                    },
+                    check_intelligence.ARTIFACT_EVIDENCE_KEY: {
+                        "status": "present",
+                        "expected_artifacts": ["pip-audit-report.json"],
+                        "present_artifacts": ["pip-audit-report.json"],
+                        "missing_artifacts": [],
+                        "source": "workflow_artifact_url",
+                        "reporting_only": True,
+                        "automation_allowed": False,
+                        "merge_authorized": False,
+                    },
+                }
+            ],
+        },
+    )
+    markdown = current_head_failure_bundle.render_current_head_failure_bundle_markdown(bundle)
+    evidence = bundle["first_failures"][0][check_intelligence.ARTIFACT_EVIDENCE_KEY]
+
+    assert evidence["status"] == "present"
+    assert evidence["expected_artifacts"] == ["pip-audit-report.json"]
+    assert "Artifact evidence: `present`" in markdown
+    assert "Expected artifacts: `pip-audit-report.json`" in markdown
+    assert "Artifact automation allowed: `false`" in markdown


### PR DESCRIPTION
Adds reporting-only artifact evidence confirmation so operators can see whether expected failure artifacts such as pip-audit reports are present, missing, or unavailable.

## Summary
- promote dependency-audit report artifact evidence into a generic artifact_evidence object
- report expected, present, and missing artifacts with source status
- summarize artifact evidence counts in real evidence quality
- render artifact evidence in PR Quality comments and current-head failure bundles
- preserve reporting-only boundaries and no patch/automation/merge authority

## Proof
- python -m pytest -q tests/test_check_intelligence_first_failure.py tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_pr_quality_current_head_failure_bundle.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_failed_check_log_collection.py -o addopts=
- python -m pre_commit run -a
- targeted high-entropy scan for changed files reported 0 hits