### PR TITLE
fix: install package before repo optimization bot run

### DIFF
--- a/.github/workflows/repo-optimization-bot.yml
+++ b/.github/workflows/repo-optimization-bot.yml
@@ -13,6 +13,17 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install SDETKit
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt -e .
+
       - name: Run optimize lane snapshot
         run: |
           set -euo pipefail

--- a/tests/test_repo_optimization_bot_workflow.py
+++ b/tests/test_repo_optimization_bot_workflow.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW = Path(".github/workflows/repo-optimization-bot.yml")
+
+
+def _steps() -> list[dict[str, object]]:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return payload["jobs"]["optimize"]["steps"]
+
+
+def test_repo_optimization_bot_installs_sdetkit_before_module_execution() -> None:
+    steps = _steps()
+    names = [str(step.get("name", "")) for step in steps]
+
+    assert "Set up Python" in names
+    assert "Install SDETKit" in names
+    assert "Run optimize lane snapshot" in names
+    assert names.index("Install SDETKit") < names.index("Run optimize lane snapshot")
+
+    install_step = next(step for step in steps if step.get("name") == "Install SDETKit")
+    run = str(install_step.get("run", ""))
+
+    assert "python -m pip install --upgrade pip" in run
+    assert "python -m pip install -c constraints-ci.txt -e ." in run
+
+
+def test_repo_optimization_bot_keeps_manual_recovery_trigger() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    triggers = payload[True]
+
+    assert "workflow_dispatch" in triggers
+    assert "schedule" in triggers

--- a/tests/test_repo_optimization_bot_workflow.py
+++ b/tests/test_repo_optimization_bot_workflow.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import yaml
 
-
 WORKFLOW = Path(".github/workflows/repo-optimization-bot.yml")
 
 


### PR DESCRIPTION
Fixes the recurring Repo Optimization Bot scheduled failure by installing SDETKit through the repo constraints before invoking python -m sdetkit on a fresh GitHub runner.

## Summary
- add pinned setup-python to repo-optimization-bot
- install SDETKit with constraints-ci.txt before running the optimize lane snapshot
- add workflow contract coverage for install ordering and manual recovery trigger

## Issue
- addresses #1488

## Proof
- python -m pytest -q tests/test_repo_optimization_bot_workflow.py tests/test_workflow_dependency_install_contract.py tests/test_workflow_external_tool_pin_contract.py tests/test_workflow_contract.py tests/test_optimization.py tests/test_optimization_foundation.py -o addopts=
- python -m pre_commit run -a