### PR TITLE
fix: declare repo optimization bot permissions at top level

### DIFF
--- a/.github/workflows/repo-optimization-bot.yml
+++ b/.github/workflows/repo-optimization-bot.yml
@@ -5,12 +5,13 @@ on:
     - cron: '0 8 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   optimize:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python

--- a/tests/test_repo_optimization_bot_workflow.py
+++ b/tests/test_repo_optimization_bot_workflow.py
@@ -34,3 +34,13 @@ def test_repo_optimization_bot_keeps_manual_recovery_trigger() -> None:
 
     assert "workflow_dispatch" in triggers
     assert "schedule" in triggers
+
+
+def test_repo_optimization_bot_declares_top_level_permissions() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert payload["permissions"] == {
+        "contents": "read",
+        "issues": "write",
+    }
+    assert "permissions" not in payload["jobs"]["optimize"]


### PR DESCRIPTION
Fixes the workflow governance audit finding by moving Repo Optimization Bot permissions to a top-level least-privilege block.

## Summary
- add top-level contents:read and issues:write permissions
- remove redundant job-level permissions
- add workflow contract coverage for the governance finding

## Issue
- addresses #1491

## Proof
- python -m pytest -q tests/test_repo_optimization_bot_workflow.py tests/test_workflow_contract.py tests/test_workflow_template_hygiene.py tests/test_workflow_external_tool_pin_contract.py -o addopts=
- python -m pre_commit run -a