### PR TITLE
feat: make optimizer quality boost actionable

### DIFF
--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -155,7 +155,22 @@ def optimize_payload(
         },
         "missing_domains": [],
         "operating_sequence": [{"stage": "doctor-first"}, {"stage": "intelligent-autofix"}],
-        "next_boosts": [{"id": "quality-boost"}],
+        "next_boosts": [
+            {
+                "id": "quality-boost",
+                "title": "Strengthen first-proof quality evidence",
+                "summary": (
+                    "Refresh the first-proof health, dashboard, and readiness threshold "
+                    "artifacts so the optimization loop points operators to concrete "
+                    "quality evidence rather than a bare boost identifier."
+                ),
+                "commands": [
+                    "make first-proof-health-score",
+                    "make first-proof-dashboard",
+                    "make first-proof-readiness-threshold",
+                ],
+            }
+        ],
         "alignment_score": {"score": 95, "status": "maximized"},
         "search_queries": [{"topic": "doctor-upgrade-lane"}],
         "blueprint": blueprint_payload(goal, selected_kits, limit),

--- a/tests/test_optimizer_quality_boost_payload.py
+++ b/tests/test_optimizer_quality_boost_payload.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_optimizer_quality_boost_is_operator_actionable() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "kits",
+            "optimize",
+            "repo optimization control loop",
+            "--format",
+            "json",
+            "--limit",
+            "10",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    boost = next(
+        item for item in payload["next_boosts"] if item["id"] == "quality-boost"
+    )
+
+    assert boost["title"] == "Strengthen first-proof quality evidence"
+    assert "first-proof health" in boost["summary"]
+    assert boost["commands"] == [
+        "make first-proof-health-score",
+        "make first-proof-dashboard",
+        "make first-proof-readiness-threshold",
+    ]

--- a/tests/test_optimizer_quality_boost_payload.py
+++ b/tests/test_optimizer_quality_boost_payload.py
@@ -25,9 +25,7 @@ def test_optimizer_quality_boost_is_operator_actionable() -> None:
     )
     payload = json.loads(result.stdout)
 
-    boost = next(
-        item for item in payload["next_boosts"] if item["id"] == "quality-boost"
-    )
+    boost = next(item for item in payload["next_boosts"] if item["id"] == "quality-boost")
 
     assert boost["title"] == "Strengthen first-proof quality evidence"
     assert "first-proof health" in boost["summary"]


### PR DESCRIPTION
Makes the repo optimization control-loop quality boost actionable by adding operator-facing title, summary, and proof commands instead of returning only a bare boost id.

## Summary
- enrich quality-boost with title, summary, and concrete first-proof commands
- preserve existing optimization score and boost id contract
- add focused coverage for operator-actionable optimize payload

## Issue
- addresses #1492

## Proof
- python -m pytest -q tests/test_optimizer_quality_boost_payload.py tests/test_optimization.py tests/test_optimization_foundation.py tests/test_onboarding_optimization.py tests/test_cli_productized_workflow_aliases.py tests/test_render_first_proof_dashboard.py tests/test_kits_umbrella_cli.py tests/test_kits_blueprint.py -o addopts=
- python -m pre_commit run -a
- python -m sdetkit kits optimize "repo optimization control loop" --format json --limit 10