### PR TITLE
feat: make dependency radar opportunity actionable

### DIFF
--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -132,7 +132,25 @@ def optimize_payload(
             "focus": ["runtime", "integration"],
         },
         "innovation_opportunities": [
-            {"id": "dependency-radar"},
+            {
+                "id": "dependency-radar",
+                "title": "Review validation-linked dependency upgrade candidates",
+                "summary": (
+                    "Run the dependency radar dashboard and upgrade audit so operators "
+                    "can pick one dependency candidate with validation evidence instead "
+                    "of seeing only a bare innovation opportunity identifier."
+                ),
+                "commands": [
+                    "python -m sdetkit kits radar --repo-usage-tier hot-path --format json",
+                    "python -m sdetkit intelligence upgrade-audit --format json --used-in-repo-only --top 10",
+                    "python -m sdetkit agent templates run dependency-radar-worker",
+                ],
+                "acceptance_criteria": [
+                    "dependency radar payload is generated",
+                    "upgrade audit lists validation-linked candidates or confirms none are actionable",
+                    "selected upgrade candidate links back to the monthly enhancement intake",
+                ],
+            },
             {"id": "runtime-core-fast-follow"},
             {"id": "integration-topology-radar"},
         ],

--- a/tests/test_optimizer_dependency_radar_opportunity_payload.py
+++ b/tests/test_optimizer_dependency_radar_opportunity_payload.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_optimizer_dependency_radar_opportunity_is_operator_actionable() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "kits",
+            "optimize",
+            "repo optimization control loop",
+            "--format",
+            "json",
+            "--limit",
+            "10",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    opportunity = next(
+        item for item in payload["innovation_opportunities"] if item["id"] == "dependency-radar"
+    )
+
+    assert opportunity["title"] == "Review validation-linked dependency upgrade candidates"
+    assert "validation evidence" in opportunity["summary"]
+    assert opportunity["commands"] == [
+        "python -m sdetkit kits radar --repo-usage-tier hot-path --format json",
+        "python -m sdetkit intelligence upgrade-audit --format json --used-in-repo-only --top 10",
+        "python -m sdetkit agent templates run dependency-radar-worker",
+    ]
+    assert opportunity["acceptance_criteria"] == [
+        "dependency radar payload is generated",
+        "upgrade audit lists validation-linked candidates or confirms none are actionable",
+        "selected upgrade candidate links back to the monthly enhancement intake",
+    ]


### PR DESCRIPTION
Makes the dependency-radar innovation opportunity actionable by adding operator-facing title, summary, commands, and acceptance criteria instead of returning only a bare opportunity id.

## User pain point
The optimizer exposed dependency-radar as an innovation opportunity, but did not tell an operator what to run or what proof to collect.

## Acceptance criteria
- dependency-radar keeps its stable id
- dependency-radar includes title, summary, commands, and acceptance criteria
- optimize output points operators to radar, upgrade-audit, and dependency-radar-worker evidence

## Issue
- addresses #1487

## Proof
- python -m pytest -q tests/test_optimizer_dependency_radar_opportunity_payload.py tests/test_optimization.py tests/test_optimization_foundation.py tests/test_kits_umbrella_cli.py tests/test_kits_blueprint.py tests/test_agent_actions_extra.py -o addopts=
- python -m pre_commit run -a
- python -m sdetkit kits optimize "repo optimization control loop" --format json --limit 10