### PR TITLE
feat: render adoption surface artifact

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import argparse
 import json
+import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -285,3 +288,49 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
         "merge_authorized": False,
         "semantic_equivalence_proven": False,
     }
+
+
+def write_adoption_surface_artifact(
+    *,
+    repo_root: str | Path = ".",
+    out: str | Path = "build/sdetkit/adoption-surface.json",
+) -> dict[str, Any]:
+    payload = discover_adoption_surface(repo_root)
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {
+        "schema_version": payload["schema_version"],
+        "adoption_surface_json": out_path.as_posix(),
+        "automation_allowed": payload["automation_allowed"],
+        "merge_authorized": payload["merge_authorized"],
+        "semantic_equivalence_proven": payload["semantic_equivalence_proven"],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit adoption-surface",
+        description="Write a read-only adoption surface discovery artifact.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--out", default="build/sdetkit/adoption-surface.json")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    summary = write_adoption_surface_artifact(repo_root=ns.root, out=ns.out)
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(f"adoption_surface_json={summary['adoption_surface_json']}\n")
+        sys.stdout.write(f"automation_allowed={str(summary['automation_allowed']).lower()}\n")
+        sys.stdout.write(f"merge_authorized={str(summary['merge_authorized']).lower()}\n")
+        sys.stdout.write(
+            f"semantic_equivalence_proven={str(summary['semantic_equivalence_proven']).lower()}\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -675,6 +675,14 @@ Then use stability-aware command discovery:
     adp.add_argument("--escalation-min-runs", type=int, default=None)
     adp.add_argument("--escalation-min-p0-rate", type=float, default=None)
 
+    adoption_surface = sub.add_parser(
+        "adoption-surface",
+        help="[Advanced but supported] Write read-only adoption surface discovery artifact",
+    )
+    adoption_surface.add_argument("--root", default=".")
+    adoption_surface.add_argument("--out", default="build/sdetkit/adoption-surface.json")
+    adoption_surface.add_argument("--format", choices=["json", "text"], default="json")
+
     fit = sub.add_parser("fit", help="Risk-based fit recommendation planner")
     fit.add_argument("--repo-size", choices=["small", "medium", "large"], default="small")
     fit.add_argument("--team-size", choices=["small", "medium", "large"], default="small")
@@ -1231,6 +1239,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         if ns.escalation_min_p0_rate is not None:
             forwarded.extend(["--escalation-min-p0-rate", str(ns.escalation_min_p0_rate)])
         return _run_module_main("sdetkit.adoption", forwarded)
+
+    if ns.cmd == "adoption-surface":
+        forwarded = [
+            "--root",
+            str(ns.root),
+            "--out",
+            str(ns.out),
+            "--format",
+            str(ns.format),
+        ]
+        return _run_module_main("sdetkit.adoption_surface", forwarded)
 
     if ns.cmd == "boost":
         if getattr(ns, "boost_cmd", None) == "scan":

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -85,3 +85,52 @@ def test_adoption_surface_detects_multi_language_evidence_without_running_comman
     assert "mvn test" in _commands(payload)
     assert "dotnet test" in _commands(payload)
     assert payload["artifact_surfaces"] == [{"name": "coverage", "paths": ["coverage.xml"]}]
+
+
+def test_adoption_surface_module_writes_deterministic_artifact(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
+    out = tmp_path / "build" / "sdetkit" / "adoption-surface.json"
+
+    from sdetkit.adoption_surface import main
+
+    rc = main(["--root", str(tmp_path), "--out", str(out), "--format", "json"])
+
+    assert rc == 0
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert stdout["adoption_surface_json"] == out.as_posix()
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["automation_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_adoption_surface_cli_dispatch_writes_artifact(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
+    out = tmp_path / "adoption-surface.json"
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-surface",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["automation_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False


### PR DESCRIPTION
## Summary
- Add `sdetkit adoption-surface` as a read-only CLI artifact renderer.
- Write deterministic adoption-surface evidence to `build/sdetkit/adoption-surface.json`.
- Preserve non-authorizing boundaries: no proof execution, no patch application, no automation authority, no merge authority.

## Why
- PR #1496 added the adoption surface discovery engine.
- This PR makes that capability operator-usable through a stable artifact path and CLI smoke path.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `python -m pytest -q tests/test_diagnostic_vector_engine.py -o addopts=`
- `python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text`
- `test -s build/sdetkit/adoption-surface.json`
- `python -m pre_commit run -a`

## Risk
- Low.
- CLI/artifact rendering only.
- Rollback: revert changes to `src/sdetkit/adoption_surface.py`, `src/sdetkit/cli.py`, and `tests/test_adoption_surface.py`.

## Notes
- `automation_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`
