### PR TITLE
docs: document adoption surface artifact workflow

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -32,6 +32,19 @@ For maintainers validating the external-install contract itself (from this repos
 python -m pytest -q tests/test_external_first_run_contract.py
 ```
 
+
+## Optional preflight — capture the adoption surface
+
+Before choosing rollout depth, capture a read-only repository surface artifact:
+
+```bash
+python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text
+```
+
+Use the generated `build/sdetkit/adoption-surface.json` to review detected languages, package managers, CI systems, security tooling, artifact surfaces, and recommended proof commands.
+
+This is an evidence-only handoff. It does not run proof commands, install dependencies, mutate the repository, authorize automation, or authorize merge.
+
 ## Stage 1 — local proof in the team repo
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,6 +89,27 @@ Available utility lanes include:
 
 `triage-ci` reads a saved failed CI job log and emits an advisory report in text, JSON, or Markdown. Use it before patching when the final process-exit line is only wrapper noise.
 
+## Adoption surface artifact
+
+Use `adoption-surface` when an operator needs a read-only map of the repository before choosing proof commands or rollout depth.
+
+```bash
+python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text
+```
+
+The command writes a deterministic JSON artifact at `build/sdetkit/adoption-surface.json` by default. It detects repository evidence such as languages, package managers, CI systems, security tools, artifact surfaces, and recommended proof commands.
+
+Safety boundary:
+
+- it does not run the recommended proof commands
+- it does not install dependencies
+- it does not apply patches
+- it does not authorize automation or merge
+- the emitted payload keeps `automation_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false`
+
+Use this artifact as an operator handoff before expanding into CI rollout, investigation, or portfolio automation.
+
+
 - `triage-ci`, `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `ops`, `notify`, `agent`
 
 ## Transition-era and legacy-oriented material


### PR DESCRIPTION
## Summary
- Document the `sdetkit adoption-surface` CLI artifact workflow.
- Add the command to the CLI reference as a read-only operator handoff.
- Add an optional adoption preflight step for capturing `build/sdetkit/adoption-surface.json`.

## Why
- PR #1496 added adoption-surface discovery.
- PR #1498 added the CLI artifact renderer.
- This docs-only PR makes the workflow discoverable for operators without changing behavior.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `python -m pytest -q tests/test_docs_qa.py::test_repository_front_doors_are_polished_and_consistent -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`

## Risk
- Low.
- Docs-only.
- Rollback: revert changes to `docs/cli.md` and `docs/adoption.md`.

## Notes
- No implementation changes.
- No automation authority added.
- No merge authority added.
