### PR TITLE
feat: validate adoption surface artifact contract

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -26,6 +26,27 @@
       "stability": "public"
     },
     {
+      "id": "adoption-surface-json",
+      "path": "build/sdetkit/adoption-surface.json",
+      "produced_by": "python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text",
+      "schema_version": "sdetkit.adoption_surface.v1",
+      "required_fields": [
+        "schema_version",
+        "detected_languages",
+        "package_managers",
+        "test_runners",
+        "ci_systems",
+        "security_tools",
+        "artifact_surfaces",
+        "recommended_proof_commands",
+        "review_first_unknowns",
+        "automation_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "doctor-json",
       "path": "build/doctor.json",
       "produced_by": "python -m sdetkit doctor --format json --out build/doctor.json",

--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -9,6 +9,23 @@ from typing import Any
 
 SCHEMA_VERSION = "sdetkit.adoption_surface.v1"
 
+REQUIRED_LIST_FIELDS = (
+    "detected_languages",
+    "package_managers",
+    "test_runners",
+    "ci_systems",
+    "security_tools",
+    "artifact_surfaces",
+    "recommended_proof_commands",
+    "review_first_unknowns",
+)
+
+REQUIRED_FALSE_FIELDS = (
+    "automation_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
 IGNORED_PARTS = {
     ".git",
     ".mypy_cache",
@@ -306,6 +323,36 @@ def write_adoption_surface_artifact(
         "merge_authorized": payload["merge_authorized"],
         "semantic_equivalence_proven": payload["semantic_equivalence_proven"],
     }
+
+
+def validate_adoption_surface_payload(payload: object) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["payload must be a JSON object"]
+
+    errors: list[str] = []
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+
+    for field in REQUIRED_LIST_FIELDS:
+        if not isinstance(payload.get(field), list):
+            errors.append(f"{field} must be a list")
+
+    for field in REQUIRED_FALSE_FIELDS:
+        if payload.get(field) is not False:
+            errors.append(f"{field} must be false")
+
+    return errors
+
+
+def validate_adoption_surface_artifact(path: str | Path) -> list[str]:
+    artifact = Path(path)
+    try:
+        payload = json.loads(artifact.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return [f"artifact could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [f"artifact is not valid JSON: {exc}"]
+    return validate_adoption_surface_payload(payload)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from . import doctor, review
+from . import adoption_surface, doctor, review
 from .checks import artifacts as check_artifacts
 
 INDEX_SCHEMA_VERSION = "sdetkit.artifact-contract-index.v1"
@@ -28,6 +28,27 @@ def build_index() -> dict[str, Any]:
                 "schema_version": None,
                 "required_fields": ["ok", "failed_steps", "profile"],
                 "stability": "public",
+            },
+            {
+                "id": "adoption-surface-json",
+                "path": "build/sdetkit/adoption-surface.json",
+                "produced_by": "python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text",
+                "schema_version": adoption_surface.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "detected_languages",
+                    "package_managers",
+                    "test_runners",
+                    "ci_systems",
+                    "security_tools",
+                    "artifact_surfaces",
+                    "recommended_proof_commands",
+                    "review_first_unknowns",
+                    "automation_allowed",
+                    "merge_authorized",
+                    "semantic_equivalence_proven",
+                ],
+                "stability": "advanced",
             },
             {
                 "id": "doctor-json",

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -134,3 +134,42 @@ def test_adoption_surface_cli_dispatch_writes_artifact(tmp_path: Path) -> None:
     assert payload["automation_allowed"] is False
     assert payload["merge_authorized"] is False
     assert payload["semantic_equivalence_proven"] is False
+
+
+def test_adoption_surface_payload_validator_accepts_generated_payload(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
+
+    from sdetkit.adoption_surface import (
+        validate_adoption_surface_artifact,
+        validate_adoption_surface_payload,
+        write_adoption_surface_artifact,
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    assert validate_adoption_surface_payload(payload) == []
+
+    out = tmp_path / "build" / "sdetkit" / "adoption-surface.json"
+    write_adoption_surface_artifact(repo_root=tmp_path, out=out)
+    assert validate_adoption_surface_artifact(out) == []
+
+
+def test_adoption_surface_payload_validator_rejects_authority_escalation() -> None:
+    from sdetkit.adoption_surface import validate_adoption_surface_payload
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "detected_languages": [],
+        "package_managers": [],
+        "test_runners": [],
+        "ci_systems": [],
+        "security_tools": [],
+        "artifact_surfaces": [],
+        "recommended_proof_commands": [],
+        "review_first_unknowns": [],
+        "automation_allowed": True,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    assert validate_adoption_surface_payload(payload) == ["automation_allowed must be false"]

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit import doctor, review
+from sdetkit import adoption_surface, doctor, review
 from sdetkit.artifact_contract_index import INDEX_SCHEMA_VERSION, build_index, write_index
 from sdetkit.checks import artifacts as check_artifacts
 
@@ -13,6 +13,13 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
     assert payload["schema_version"] == INDEX_SCHEMA_VERSION
 
     entries = {item["id"]: item for item in payload["artifacts"]}
+    assert entries["adoption-surface-json"]["schema_version"] == adoption_surface.SCHEMA_VERSION
+    assert {
+        "schema_version",
+        "automation_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+    }.issubset(set(entries["adoption-surface-json"]["required_fields"]))
     assert entries["doctor-json"]["schema_version"] == doctor.SCHEMA_VERSION
     assert entries["doctor-evidence-json"]["schema_version"] == doctor.EVIDENCE_SCHEMA_VERSION
     assert (


### PR DESCRIPTION
## Summary
- Add validation helpers for the adoption-surface JSON artifact contract.
- Reject authority escalation fields such as `automation_allowed=true`.
- Register `build/sdetkit/adoption-surface.json` in the artifact contract index and regenerate `docs/artifact-contract-index.json`.

## Why
- PR #1496 added adoption-surface discovery.
- PR #1498 added the CLI artifact renderer.
- PR #1499 and #1501 documented the workflow and artifact map.
- This PR makes the generated artifact contract explicit and testable.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `python -m pytest -q tests/test_artifact_contract_index.py -o addopts=`
- `python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text`
- `python - <<'PY'
from sdetkit.adoption_surface import validate_adoption_surface_artifact

errors = validate_adoption_surface_artifact("build/sdetkit/adoption-surface.json")
if errors:
    raise SystemExit(errors)
print("adoption surface artifact contract ok")
PY`
- `python -m pre_commit run -a`

## Risk
- Low.
- Contract validation only.
- No proof execution is performed by the validator.
- No automation or merge authority is added.

## Notes
- `automation_allowed` must remain `false`.
- `merge_authorized` must remain `false`.
- `semantic_equivalence_proven` must remain `false`.
