### PR TITLE
feat: preserve safe remediation no-automation boundary

### DIFF
--- a/src/sdetkit/safe_remediation_eligibility.py
+++ b/src/sdetkit/safe_remediation_eligibility.py
@@ -29,6 +29,38 @@ FILE_PATH_RE = re.compile(
 )
 
 
+def _decision_boundary() -> JsonObject:
+    return {
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "requires_human_review": True,
+    }
+
+
+def _result(
+    *,
+    safe_to_auto_fix: bool,
+    strategy: str,
+    category: str,
+    reason: str,
+    affected_files: list[str] | None = None,
+    proof_commands: list[str] | None = None,
+) -> JsonObject:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "safe_to_auto_fix": safe_to_auto_fix,
+        "strategy": strategy,
+        "category": category,
+        "affected_files": list(affected_files or []),
+        "reason": reason,
+        "proof_commands": list(proof_commands or []),
+        **_decision_boundary(),
+    }
+
+
 def _extract_affected_files(text: str) -> list[str]:
     values: list[str] = []
     seen: set[str] = set()
@@ -143,73 +175,61 @@ def classify_check_failure(
     )
 
     if kind == "check_run_annotation":
-        return {
-            "schema_version": SCHEMA_VERSION,
-            "safe_to_auto_fix": False,
-            "strategy": REVIEW_FIRST_STRATEGY,
-            "category": "review_first",
-            "affected_files": affected_files,
-            "reason": "Sanitized Check Run annotation evidence is review-first and cannot authorize mutation.",
-            "proof_commands": [],
-        }
+        return _result(
+            safe_to_auto_fix=False,
+            strategy=REVIEW_FIRST_STRATEGY,
+            category="review_first",
+            affected_files=affected_files,
+            reason="Sanitized Check Run annotation evidence is review-first and cannot authorize mutation.",
+        )
 
     unsafe_signal = _contains_any(combined, UNSAFE_REVIEW_MARKERS)
     formatting_signal = kind == "format_drift" or _contains_any(combined, SAFE_FORMAT_MARKERS)
 
     if unsafe_signal:
-        return {
-            "schema_version": SCHEMA_VERSION,
-            "safe_to_auto_fix": False,
-            "strategy": REVIEW_FIRST_STRATEGY,
-            "category": "review_first",
-            "affected_files": affected_files,
-            "reason": "Review-first evidence dominates any formatting-only signal.",
-            "proof_commands": [],
-        }
+        return _result(
+            safe_to_auto_fix=False,
+            strategy=REVIEW_FIRST_STRATEGY,
+            category="review_first",
+            affected_files=affected_files,
+            reason="Review-first evidence dominates any formatting-only signal.",
+        )
 
     if formatting_signal:
         if not affected_files:
-            return {
-                "schema_version": SCHEMA_VERSION,
-                "safe_to_auto_fix": False,
-                "strategy": REVIEW_FIRST_STRATEGY,
-                "category": "review_first",
-                "affected_files": [],
-                "reason": "Formatting evidence has no identified affected files.",
-                "proof_commands": [],
-            }
+            return _result(
+                safe_to_auto_fix=False,
+                strategy=REVIEW_FIRST_STRATEGY,
+                category="review_first",
+                reason="Formatting evidence has no identified affected files.",
+            )
 
         unsafe_files = [value for value in affected_files if not _is_safe_repo_owned_path(value)]
         if unsafe_files:
-            return {
-                "schema_version": SCHEMA_VERSION,
-                "safe_to_auto_fix": False,
-                "strategy": REVIEW_FIRST_STRATEGY,
-                "category": "review_first",
-                "affected_files": affected_files,
-                "reason": "Formatting evidence includes files outside approved safe-fix paths.",
-                "proof_commands": [],
-            }
+            return _result(
+                safe_to_auto_fix=False,
+                strategy=REVIEW_FIRST_STRATEGY,
+                category="review_first",
+                affected_files=affected_files,
+                reason="Formatting evidence includes files outside approved safe-fix paths.",
+            )
 
-        return {
-            "schema_version": SCHEMA_VERSION,
-            "safe_to_auto_fix": True,
-            "strategy": FORMAT_SAFE_STRATEGY,
-            "category": "formatting_only",
-            "affected_files": affected_files,
-            "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
-            "proof_commands": [
+        return _result(
+            safe_to_auto_fix=True,
+            strategy=FORMAT_SAFE_STRATEGY,
+            category="formatting_only",
+            affected_files=affected_files,
+            reason="Failure is limited to deterministic formatting or whitespace hooks.",
+            proof_commands=[
                 "python -m pre_commit run -a",
                 "python -m ruff check src tests",
                 "python -m mypy src",
             ],
-        }
+        )
 
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "safe_to_auto_fix": False,
-        "strategy": REVIEW_FIRST_STRATEGY,
-        "category": "unknown",
-        "reason": "Failure is not in the approved safe-remediation allowlist.",
-        "proof_commands": [],
-    }
+    return _result(
+        safe_to_auto_fix=False,
+        strategy=REVIEW_FIRST_STRATEGY,
+        category="unknown",
+        reason="Failure is not in the approved safe-remediation allowlist.",
+    )

--- a/tests/test_safe_remediation_eligibility.py
+++ b/tests/test_safe_remediation_eligibility.py
@@ -154,3 +154,44 @@ def test_safe_remediation_blocks_formatting_with_unapproved_path_evidence() -> N
     assert result["safe_to_auto_fix"] is False
     assert result["strategy"] == "review_first"
     assert "outside approved safe-fix paths" in result["reason"]
+
+
+def _assert_no_automation_boundary(result: dict) -> None:
+    assert result["automation_allowed"] is False
+    assert result["auto_fix_allowed_now"] is False
+    assert result["patch_application_allowed"] is False
+    assert result["merge_authorized"] is False
+    assert result["semantic_equivalence_proven"] is False
+    assert result["requires_human_review"] is True
+
+
+def test_safe_remediation_candidate_preserves_no_automation_boundary() -> None:
+    result = eligibility.classify_check_failure(
+        name="autopilot",
+        diagnosis={"code": "PRE_COMMIT_FORMAT_DRIFT"},
+        first_failure={
+            "line": "- files were modified by this hook",
+            "tool": "pre_commit",
+            "kind": "format_drift",
+            "context": [{"text": "Fixing tests/test_example.py"}],
+        },
+    )
+
+    assert result["safe_to_auto_fix"] is True
+    _assert_no_automation_boundary(result)
+
+
+def test_safe_remediation_review_first_preserves_no_automation_boundary() -> None:
+    result = eligibility.classify_check_failure(
+        name="Full CI lane",
+        diagnosis={"code": "PYTEST_ASSERTION_FAILURE"},
+        first_failure={
+            "line": "FAILED tests/test_behavior.py::test_contract - AssertionError",
+            "tool": "pytest",
+            "kind": "test_failure",
+        },
+    )
+
+    assert result["safe_to_auto_fix"] is False
+    assert result["strategy"] == "review_first"
+    _assert_no_automation_boundary(result)


### PR DESCRIPTION
## Summary
- Preserve explicit no-automation boundary fields on every safe-remediation eligibility result.
- Keep safe formatting remediation as a candidate signal only, not permission to mutate.
- Add tests for both candidate and review-first decisions.

## Why
- The existing `safe_remediation_eligibility` surface already classifies formatting-only failures and blocks unsafe/review-first signals.
- This PR makes the safety boundary explicit in every eligibility payload:
  - `automation_allowed=false`
  - `auto_fix_allowed_now=false`
  - `patch_application_allowed=false`
  - `merge_authorized=false`
  - `semantic_equivalence_proven=false`
  - `requires_human_review=true`

## Verification
- `python -m pytest -q tests/test_safe_remediation_eligibility.py -o addopts=`
- `python -m pytest -q tests/test_check_intelligence_safe_remediation.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Existing module and tests only.
- No patch application is added.
- No automation or merge authority is added.

## Notes
- `safe_to_auto_fix=true` remains a candidate classification only.
- `auto_fix_allowed_now=false` remains explicit.
