### PR TITLE
feat: register check intelligence artifact contracts

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -26,6 +26,39 @@
       "stability": "public"
     },
     {
+      "id": "check-intelligence-json",
+      "path": "build/pr-quality/check-intelligence.json",
+      "produced_by": "python -m sdetkit.check_intelligence --checks-json <checks.json> --out-dir build/pr-quality",
+      "schema_version": "sdetkit.pr_quality.check_intelligence.v1",
+      "required_fields": [
+        "schema_version",
+        "checks_seen",
+        "failed_checks",
+        "queued_checks",
+        "startup_failures",
+        "real_evidence_quality",
+        "security_review",
+        "code_scanning_review"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "check-intelligence-action-report-json",
+      "path": "build/pr-quality/action-report.json",
+      "produced_by": "python -m sdetkit.check_intelligence --checks-json <checks.json> --out-dir build/pr-quality",
+      "schema_version": "sdetkit.pr_quality.action_report.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "primary_blocker",
+        "automation",
+        "recommended_actions",
+        "proof_commands",
+        "evidence"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "adoption-surface-json",
       "path": "build/sdetkit/adoption-surface.json",
       "produced_by": "python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from . import adoption_surface, doctor, review
+from . import adoption_surface, check_intelligence, doctor, review
 from .checks import artifacts as check_artifacts
 
 INDEX_SCHEMA_VERSION = "sdetkit.artifact-contract-index.v1"
@@ -28,6 +28,39 @@ def build_index() -> dict[str, Any]:
                 "schema_version": None,
                 "required_fields": ["ok", "failed_steps", "profile"],
                 "stability": "public",
+            },
+            {
+                "id": "check-intelligence-json",
+                "path": "build/pr-quality/check-intelligence.json",
+                "produced_by": "python -m sdetkit.check_intelligence --checks-json <checks.json> --out-dir build/pr-quality",
+                "schema_version": check_intelligence.CHECK_INTELLIGENCE_SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "checks_seen",
+                    "failed_checks",
+                    "queued_checks",
+                    "startup_failures",
+                    "real_evidence_quality",
+                    "security_review",
+                    "code_scanning_review",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "check-intelligence-action-report-json",
+                "path": "build/pr-quality/action-report.json",
+                "produced_by": "python -m sdetkit.check_intelligence --checks-json <checks.json> --out-dir build/pr-quality",
+                "schema_version": check_intelligence.ACTION_REPORT_SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "primary_blocker",
+                    "automation",
+                    "recommended_actions",
+                    "proof_commands",
+                    "evidence",
+                ],
+                "stability": "advanced",
             },
             {
                 "id": "adoption-surface-json",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit import adoption_surface, doctor, review
+from sdetkit import adoption_surface, check_intelligence, doctor, review
 from sdetkit.artifact_contract_index import INDEX_SCHEMA_VERSION, build_index, write_index
 from sdetkit.checks import artifacts as check_artifacts
 
@@ -13,6 +13,24 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
     assert payload["schema_version"] == INDEX_SCHEMA_VERSION
 
     entries = {item["id"]: item for item in payload["artifacts"]}
+    assert (
+        entries["check-intelligence-json"]["schema_version"]
+        == check_intelligence.CHECK_INTELLIGENCE_SCHEMA_VERSION
+    )
+    assert (
+        entries["check-intelligence-action-report-json"]["schema_version"]
+        == check_intelligence.ACTION_REPORT_SCHEMA_VERSION
+    )
+    assert {
+        "schema_version",
+        "failed_checks",
+        "real_evidence_quality",
+    }.issubset(set(entries["check-intelligence-json"]["required_fields"]))
+    assert {
+        "schema_version",
+        "automation",
+        "evidence",
+    }.issubset(set(entries["check-intelligence-action-report-json"]["required_fields"]))
     assert entries["adoption-surface-json"]["schema_version"] == adoption_surface.SCHEMA_VERSION
     assert {
         "schema_version",


### PR DESCRIPTION
## Summary
- Register `build/pr-quality/check-intelligence.json` in the artifact contract index.
- Register `build/pr-quality/action-report.json` in the artifact contract index.
- Regenerate `docs/artifact-contract-index.json`.
- Add tests that pin the check-intelligence and action-report schema versions/required fields.

## Why
- `check_intelligence.py` already writes these artifacts.
- Safe-remediation eligibility is embedded in `check-intelligence.json`, so this PR documents/contracts the existing artifact path instead of adding a duplicate renderer.

## Verification
- `python -m pytest -q tests/test_artifact_contract_index.py -o addopts=`
- `python -m pytest -q tests/test_check_intelligence_safe_remediation.py -o addopts=`
- `python -m pytest -q tests/test_safe_remediation_eligibility.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Artifact contract index and tests only.
- No behavior change to check-intelligence generation.
- No automation or merge authority added.
