### PR TITLE
feat: register repo memory artifact contracts

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -26,6 +26,61 @@
       "stability": "public"
     },
     {
+      "id": "trajectory-jsonl",
+      "path": "build/sdetkit/trajectory.jsonl",
+      "produced_by": "python -m sdetkit.trajectory_store --diagnostic-vector <diagnostic-vector.json> --remediation-plan <remediation-plan.json> --out build/sdetkit/trajectory.jsonl --format json",
+      "schema_version": "sdetkit.trajectory.v1",
+      "required_fields": [
+        "schema_version",
+        "trajectory_id",
+        "environment",
+        "diagnosis",
+        "decision",
+        "response",
+        "fix",
+        "final_result"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "repo-memory-profile-json",
+      "path": "build/repo-memory/repo-memory-profile.json",
+      "produced_by": "python -m sdetkit.repo_memory --out-dir build/repo-memory --format json",
+      "schema_version": "sdetkit.repo_memory.v6",
+      "required_fields": [
+        "schema_version",
+        "profile_status",
+        "memory_mode",
+        "inputs",
+        "safe_fix_history",
+        "known_safe_candidate_count"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "safe-fix-history-json",
+      "path": "build/operator-loop/safe-fix-history/safe-fix-history.json",
+      "produced_by": "python -m sdetkit.safe_fix_history_memory --out-dir build/operator-loop/safe-fix-history",
+      "schema_version": "sdetkit.safe_fix_history_memory.v1",
+      "required_fields": [
+        "schema_version",
+        "attempts",
+        "metrics"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "safe-fix-trends-json",
+      "path": "build/operator-loop/safe-fix-history/safe-fix-trends.json",
+      "produced_by": "python -m sdetkit.safe_fix_history_memory --out-dir build/operator-loop/safe-fix-history",
+      "schema_version": "sdetkit.safe_fix_trends.v1",
+      "required_fields": [
+        "schema_version",
+        "metrics"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "check-intelligence-json",
       "path": "build/pr-quality/check-intelligence.json",
       "produced_by": "python -m sdetkit.check_intelligence --checks-json <checks.json> --out-dir build/pr-quality",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from . import adoption_surface, check_intelligence, doctor, review
+from . import (
+    adoption_surface,
+    check_intelligence,
+    doctor,
+    repo_memory,
+    review,
+    safe_fix_history_memory,
+    trajectory_store,
+)
 from .checks import artifacts as check_artifacts
 
 INDEX_SCHEMA_VERSION = "sdetkit.artifact-contract-index.v1"
@@ -28,6 +36,61 @@ def build_index() -> dict[str, Any]:
                 "schema_version": None,
                 "required_fields": ["ok", "failed_steps", "profile"],
                 "stability": "public",
+            },
+            {
+                "id": "trajectory-jsonl",
+                "path": trajectory_store.DEFAULT_OUT,
+                "produced_by": "python -m sdetkit.trajectory_store --diagnostic-vector <diagnostic-vector.json> --remediation-plan <remediation-plan.json> --out build/sdetkit/trajectory.jsonl --format json",
+                "schema_version": trajectory_store.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "trajectory_id",
+                    "environment",
+                    "diagnosis",
+                    "decision",
+                    "response",
+                    "fix",
+                    "final_result",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "repo-memory-profile-json",
+                "path": (repo_memory.DEFAULT_OUT_DIR / repo_memory.PROFILE_JSON).as_posix(),
+                "produced_by": "python -m sdetkit.repo_memory --out-dir build/repo-memory --format json",
+                "schema_version": repo_memory.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "profile_status",
+                    "memory_mode",
+                    "inputs",
+                    "safe_fix_history",
+                    "known_safe_candidate_count",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "safe-fix-history-json",
+                "path": f"{safe_fix_history_memory.DEFAULT_OUT_DIR}/{safe_fix_history_memory.HISTORY_JSON}",
+                "produced_by": "python -m sdetkit.safe_fix_history_memory --out-dir build/operator-loop/safe-fix-history",
+                "schema_version": safe_fix_history_memory.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "attempts",
+                    "metrics",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "safe-fix-trends-json",
+                "path": f"{safe_fix_history_memory.DEFAULT_OUT_DIR}/{safe_fix_history_memory.TRENDS_JSON}",
+                "produced_by": "python -m sdetkit.safe_fix_history_memory --out-dir build/operator-loop/safe-fix-history",
+                "schema_version": safe_fix_history_memory.TRENDS_SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "metrics",
+                ],
+                "stability": "advanced",
             },
             {
                 "id": "check-intelligence-json",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit import adoption_surface, check_intelligence, doctor, review
+from sdetkit import (
+    adoption_surface,
+    check_intelligence,
+    doctor,
+    repo_memory,
+    review,
+    safe_fix_history_memory,
+    trajectory_store,
+)
 from sdetkit.artifact_contract_index import INDEX_SCHEMA_VERSION, build_index, write_index
 from sdetkit.checks import artifacts as check_artifacts
 
@@ -13,6 +21,25 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
     assert payload["schema_version"] == INDEX_SCHEMA_VERSION
 
     entries = {item["id"]: item for item in payload["artifacts"]}
+    assert entries["trajectory-jsonl"]["schema_version"] == trajectory_store.SCHEMA_VERSION
+    assert entries["repo-memory-profile-json"]["schema_version"] == repo_memory.SCHEMA_VERSION
+    assert (
+        entries["safe-fix-history-json"]["schema_version"] == safe_fix_history_memory.SCHEMA_VERSION
+    )
+    assert (
+        entries["safe-fix-trends-json"]["schema_version"]
+        == safe_fix_history_memory.TRENDS_SCHEMA_VERSION
+    )
+    assert {
+        "schema_version",
+        "decision",
+        "final_result",
+    }.issubset(set(entries["trajectory-jsonl"]["required_fields"]))
+    assert {
+        "schema_version",
+        "profile_status",
+        "memory_mode",
+    }.issubset(set(entries["repo-memory-profile-json"]["required_fields"]))
     assert (
         entries["check-intelligence-json"]["schema_version"]
         == check_intelligence.CHECK_INTELLIGENCE_SCHEMA_VERSION


### PR DESCRIPTION
## Summary
- Register `build/sdetkit/trajectory.jsonl` in the artifact contract index.
- Register `build/repo-memory/repo-memory-profile.json` in the artifact contract index.
- Register safe-fix history/trends JSON artifacts in the artifact contract index.
- Regenerate `docs/artifact-contract-index.json`.
- Add tests that pin schema versions and required contract fields.

## Why
- RepoMemory, TrajectoryStore, and Safe-Fix History already emit read-only/operator memory artifacts.
- This PR documents/contracts those existing artifact paths without adding behavior or authority.
- It keeps memory surfaces discoverable and contract-checked.

## Verification
- `python -m pytest -q tests/test_artifact_contract_index.py -o addopts=`
- `python -m pytest -q tests/test_repo_memory.py -o addopts=`
- `python -m pytest -q tests/test_trajectory_store.py -o addopts=`
- `python -m pytest -q tests/test_safe_fix_history_memory.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Artifact contract index and tests only.
- No behavior change to RepoMemory, TrajectoryStore, or Safe-Fix History.
- No automation or merge authority added.
