### PR TITLE
feat: register protected verifier artifact contracts

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -26,6 +26,44 @@
       "stability": "public"
     },
     {
+      "id": "protected-verifier-result-json",
+      "path": "build/protected-verifier/protected-verifier-result.json",
+      "produced_by": "python -m sdetkit.protected_verifier --patch-score <patch-score.json> --verification-evidence <verification-evidence.json> --out-dir build/protected-verifier --format json",
+      "schema_version": "sdetkit.protected_verifier.v1",
+      "required_fields": [
+        "schema_version",
+        "patch_id",
+        "diagnosis_id",
+        "patch_score",
+        "scored_files",
+        "observed_changed_files",
+        "allowed_files",
+        "proof_requirements",
+        "findings",
+        "decision"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "replayable-benchmark-report-json",
+      "path": "build/replayable-benchmark-harness/benchmark-report.json",
+      "produced_by": "python -m sdetkit.replayable_benchmark_harness --scenario <scenario.json> --out-dir build/replayable-benchmark-harness --format json",
+      "schema_version": "sdetkit.replayable_benchmark_harness.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "scenario_count",
+        "passed_count",
+        "failed_count",
+        "required_contract",
+        "safety_boundary",
+        "attempt_scored_count",
+        "scenarios",
+        "next_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "trajectory-jsonl",
       "path": "build/sdetkit/trajectory.jsonl",
       "produced_by": "python -m sdetkit.trajectory_store --diagnostic-vector <diagnostic-vector.json> --remediation-plan <remediation-plan.json> --out build/sdetkit/trajectory.jsonl --format json",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -7,6 +7,8 @@ from . import (
     adoption_surface,
     check_intelligence,
     doctor,
+    protected_verifier,
+    replayable_benchmark_harness,
     repo_memory,
     review,
     safe_fix_history_memory,
@@ -36,6 +38,49 @@ def build_index() -> dict[str, Any]:
                 "schema_version": None,
                 "required_fields": ["ok", "failed_steps", "profile"],
                 "stability": "public",
+            },
+            {
+                "id": "protected-verifier-result-json",
+                "path": (
+                    protected_verifier.DEFAULT_OUT_DIR / protected_verifier.RESULT_JSON
+                ).as_posix(),
+                "produced_by": "python -m sdetkit.protected_verifier --patch-score <patch-score.json> --verification-evidence <verification-evidence.json> --out-dir build/protected-verifier --format json",
+                "schema_version": protected_verifier.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "patch_id",
+                    "diagnosis_id",
+                    "patch_score",
+                    "scored_files",
+                    "observed_changed_files",
+                    "allowed_files",
+                    "proof_requirements",
+                    "findings",
+                    "decision",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "replayable-benchmark-report-json",
+                "path": (
+                    replayable_benchmark_harness.DEFAULT_OUT_DIR
+                    / replayable_benchmark_harness.REPORT_JSON
+                ).as_posix(),
+                "produced_by": "python -m sdetkit.replayable_benchmark_harness --scenario <scenario.json> --out-dir build/replayable-benchmark-harness --format json",
+                "schema_version": replayable_benchmark_harness.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "scenario_count",
+                    "passed_count",
+                    "failed_count",
+                    "required_contract",
+                    "safety_boundary",
+                    "attempt_scored_count",
+                    "scenarios",
+                    "next_boundary",
+                ],
+                "stability": "advanced",
             },
             {
                 "id": "trajectory-jsonl",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -7,6 +7,8 @@ from sdetkit import (
     adoption_surface,
     check_intelligence,
     doctor,
+    protected_verifier,
+    replayable_benchmark_harness,
     repo_memory,
     review,
     safe_fix_history_memory,
@@ -21,6 +23,24 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
     assert payload["schema_version"] == INDEX_SCHEMA_VERSION
 
     entries = {item["id"]: item for item in payload["artifacts"]}
+    assert (
+        entries["protected-verifier-result-json"]["schema_version"]
+        == protected_verifier.SCHEMA_VERSION
+    )
+    assert (
+        entries["replayable-benchmark-report-json"]["schema_version"]
+        == replayable_benchmark_harness.SCHEMA_VERSION
+    )
+    assert {
+        "schema_version",
+        "decision",
+        "findings",
+    }.issubset(set(entries["protected-verifier-result-json"]["required_fields"]))
+    assert {
+        "schema_version",
+        "required_contract",
+        "safety_boundary",
+    }.issubset(set(entries["replayable-benchmark-report-json"]["required_fields"]))
     assert entries["trajectory-jsonl"]["schema_version"] == trajectory_store.SCHEMA_VERSION
     assert entries["repo-memory-profile-json"]["schema_version"] == repo_memory.SCHEMA_VERSION
     assert (


### PR DESCRIPTION
## Summary
- Register `build/protected-verifier/protected-verifier-result.json` in the artifact contract index.
- Register `build/replayable-benchmark-harness/benchmark-report.json` in the artifact contract index.
- Regenerate `docs/artifact-contract-index.json`.
- Add tests that pin schema versions and required contract fields.

## Why
- ProtectedVerifier and Replayable Benchmark Harness already emit read-only verification/benchmark artifacts.
- This PR documents/contracts those existing artifact paths without changing behavior or adding authority.
- The registered artifacts keep automation, merge, and semantic-equivalence boundaries explicit.

## Verification
- `python -m pytest -q tests/test_artifact_contract_index.py -o addopts=`
- `python -m pytest -q tests/test_protected_verifier.py -o addopts=`
- `python -m pytest -q tests/test_replayable_benchmark_harness.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Artifact contract index and tests only.
- No behavior change to ProtectedVerifier or Replayable Benchmark Harness.
- No automation or merge authority added.
