### PR TITLE
feat: register runtime proof artifact contract

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -26,6 +26,23 @@
       "stability": "public"
     },
     {
+      "id": "pr-quality-runtime-proof-artifacts-json",
+      "path": "build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json",
+      "produced_by": "python -m sdetkit.pr_quality_runtime_proof_artifacts --isolated-proof <isolated-proof.json> --live-benchmark-report <benchmark-report.json> --repo-memory-profile <repo-memory-profile.json> --trusted-history-evidence <trusted-history.json> --out-dir build/pr-quality/runtime-proof/summary --format json",
+      "schema_version": "sdetkit.pr_quality_runtime_proof_artifacts.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "collected_components",
+        "isolated_proof",
+        "live_benchmark",
+        "repo_memory",
+        "trusted_history",
+        "decision_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "protected-verifier-result-json",
       "path": "build/protected-verifier/protected-verifier-result.json",
       "produced_by": "python -m sdetkit.protected_verifier --patch-score <patch-score.json> --verification-evidence <verification-evidence.json> --out-dir build/protected-verifier --format json",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -7,6 +7,7 @@ from . import (
     adoption_surface,
     check_intelligence,
     doctor,
+    pr_quality_runtime_proof_artifacts,
     protected_verifier,
     replayable_benchmark_harness,
     repo_memory,
@@ -38,6 +39,26 @@ def build_index() -> dict[str, Any]:
                 "schema_version": None,
                 "required_fields": ["ok", "failed_steps", "profile"],
                 "stability": "public",
+            },
+            {
+                "id": "pr-quality-runtime-proof-artifacts-json",
+                "path": (
+                    pr_quality_runtime_proof_artifacts.DEFAULT_OUT_DIR
+                    / pr_quality_runtime_proof_artifacts.SUMMARY_JSON
+                ).as_posix(),
+                "produced_by": "python -m sdetkit.pr_quality_runtime_proof_artifacts --isolated-proof <isolated-proof.json> --live-benchmark-report <benchmark-report.json> --repo-memory-profile <repo-memory-profile.json> --trusted-history-evidence <trusted-history.json> --out-dir build/pr-quality/runtime-proof/summary --format json",
+                "schema_version": pr_quality_runtime_proof_artifacts.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "collected_components",
+                    "isolated_proof",
+                    "live_benchmark",
+                    "repo_memory",
+                    "trusted_history",
+                    "decision_boundary",
+                ],
+                "stability": "advanced",
             },
             {
                 "id": "protected-verifier-result-json",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -7,6 +7,7 @@ from sdetkit import (
     adoption_surface,
     check_intelligence,
     doctor,
+    pr_quality_runtime_proof_artifacts,
     protected_verifier,
     replayable_benchmark_harness,
     repo_memory,
@@ -23,6 +24,15 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
     assert payload["schema_version"] == INDEX_SCHEMA_VERSION
 
     entries = {item["id"]: item for item in payload["artifacts"]}
+    assert (
+        entries["pr-quality-runtime-proof-artifacts-json"]["schema_version"]
+        == pr_quality_runtime_proof_artifacts.SCHEMA_VERSION
+    )
+    assert {
+        "schema_version",
+        "collected_components",
+        "decision_boundary",
+    }.issubset(set(entries["pr-quality-runtime-proof-artifacts-json"]["required_fields"]))
     assert (
         entries["protected-verifier-result-json"]["schema_version"]
         == protected_verifier.SCHEMA_VERSION


### PR DESCRIPTION
## Summary
- Register `build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json` in the artifact contract index.
- Regenerate `docs/artifact-contract-index.json`.
- Add tests that pin the runtime-proof artifact schema version and required contract fields.

## Why
- `pr_quality_runtime_proof_artifacts.py` already emits a stable runtime-proof summary artifact.
- This PR documents/contracts that existing artifact path without changing behavior.
- The artifact preserves the read-only/non-authorizing boundary:
  - `reporting_only=true`
  - `proof_commands_executed_by_renderer=false`
  - `automation_allowed=false`
  - `merge_authorized=false`
  - `semantic_equivalence_proven=false`

## Verification
- `python -m pytest -q tests/test_artifact_contract_index.py -o addopts=`
- `python -m pytest -q tests/test_pr_quality_runtime_proof_artifacts.py -o addopts=`
- `python -m pytest -q tests/test_pr_quality_action_report.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Artifact contract index and tests only.
- No behavior change to runtime proof collection.
- No automation or merge authority added.
