### PR TITLE
feat: register diagnostic signal artifact contracts

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -26,6 +26,45 @@
       "stability": "public"
     },
     {
+      "id": "diagnostic-signal-snapshot-json",
+      "path": "build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.json",
+      "produced_by": "python -m sdetkit.diagnostic_signal_snapshot --evidence-narrative <evidence-narrative.json> --evidence-graph <evidence-graph.json> --diagnostic-worker-result <diagnostic-worker-result.json> --runtime-proof-artifacts <runtime-proof-artifacts.json> --security-finding-diagnosis <security-finding-diagnosis.json> --out-dir build/pr-quality/diagnostic-signal-snapshot --format json",
+      "schema_version": "sdetkit.diagnostic.signal.snapshot.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "snapshot_type",
+        "quiet_green_advisory_baseline",
+        "measurements",
+        "kpi_readiness",
+        "decision_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "diagnostic-signal-snapshot-history-summary-json",
+      "path": "build/repo-memory-history/diagnostic-signal-snapshots/diagnostic-signal-snapshot-history-summary.json",
+      "produced_by": "python -m sdetkit.diagnostic_signal_snapshot_history --diagnostic-signal-snapshot <diagnostic-signal-snapshot.json> --associated-pr-json <associated-pr.json> --source-run-id <run-id> --source-run-conclusion success --source-head-sha <head-sha> --retention-run-id <retention-run-id> --accepted-main-sha <main-sha> --out-dir build/repo-memory-history/diagnostic-signal-snapshots --format json",
+      "schema_version": "sdetkit.diagnostic.signal.snapshot.history.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "history_path",
+        "prior_history_collected",
+        "prior_record_count",
+        "appended",
+        "record_count",
+        "quiet_green_advisory_baseline_record_count",
+        "review_signal_record_count",
+        "integration_proof_signal_record_count",
+        "snapshot_status_counts",
+        "advisor_false_positive_rate_status",
+        "latest_record",
+        "decision_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "pr-quality-runtime-proof-artifacts-json",
       "path": "build/pr-quality/runtime-proof/summary/runtime-proof-artifacts.json",
       "produced_by": "python -m sdetkit.pr_quality_runtime_proof_artifacts --isolated-proof <isolated-proof.json> --live-benchmark-report <benchmark-report.json> --repo-memory-profile <repo-memory-profile.json> --trusted-history-evidence <trusted-history.json> --out-dir build/pr-quality/runtime-proof/summary --format json",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -6,6 +6,8 @@ from typing import Any
 from . import (
     adoption_surface,
     check_intelligence,
+    diagnostic_signal_snapshot,
+    diagnostic_signal_snapshot_history,
     doctor,
     pr_quality_runtime_proof_artifacts,
     protected_verifier,
@@ -39,6 +41,51 @@ def build_index() -> dict[str, Any]:
                 "schema_version": None,
                 "required_fields": ["ok", "failed_steps", "profile"],
                 "stability": "public",
+            },
+            {
+                "id": "diagnostic-signal-snapshot-json",
+                "path": (
+                    diagnostic_signal_snapshot.DEFAULT_OUT_DIR
+                    / diagnostic_signal_snapshot.SNAPSHOT_JSON
+                ).as_posix(),
+                "produced_by": "python -m sdetkit.diagnostic_signal_snapshot --evidence-narrative <evidence-narrative.json> --evidence-graph <evidence-graph.json> --diagnostic-worker-result <diagnostic-worker-result.json> --runtime-proof-artifacts <runtime-proof-artifacts.json> --security-finding-diagnosis <security-finding-diagnosis.json> --out-dir build/pr-quality/diagnostic-signal-snapshot --format json",
+                "schema_version": diagnostic_signal_snapshot.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "snapshot_type",
+                    "quiet_green_advisory_baseline",
+                    "measurements",
+                    "kpi_readiness",
+                    "decision_boundary",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "diagnostic-signal-snapshot-history-summary-json",
+                "path": (
+                    diagnostic_signal_snapshot_history.DEFAULT_OUT_DIR
+                    / diagnostic_signal_snapshot_history.SUMMARY_JSON
+                ).as_posix(),
+                "produced_by": "python -m sdetkit.diagnostic_signal_snapshot_history --diagnostic-signal-snapshot <diagnostic-signal-snapshot.json> --associated-pr-json <associated-pr.json> --source-run-id <run-id> --source-run-conclusion success --source-head-sha <head-sha> --retention-run-id <retention-run-id> --accepted-main-sha <main-sha> --out-dir build/repo-memory-history/diagnostic-signal-snapshots --format json",
+                "schema_version": diagnostic_signal_snapshot_history.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "history_path",
+                    "prior_history_collected",
+                    "prior_record_count",
+                    "appended",
+                    "record_count",
+                    "quiet_green_advisory_baseline_record_count",
+                    "review_signal_record_count",
+                    "integration_proof_signal_record_count",
+                    "snapshot_status_counts",
+                    "advisor_false_positive_rate_status",
+                    "latest_record",
+                    "decision_boundary",
+                ],
+                "stability": "advanced",
             },
             {
                 "id": "pr-quality-runtime-proof-artifacts-json",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from sdetkit import (
     adoption_surface,
     check_intelligence,
+    diagnostic_signal_snapshot,
+    diagnostic_signal_snapshot_history,
     doctor,
     pr_quality_runtime_proof_artifacts,
     protected_verifier,
@@ -24,6 +26,24 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
     assert payload["schema_version"] == INDEX_SCHEMA_VERSION
 
     entries = {item["id"]: item for item in payload["artifacts"]}
+    assert (
+        entries["diagnostic-signal-snapshot-json"]["schema_version"]
+        == diagnostic_signal_snapshot.SCHEMA_VERSION
+    )
+    assert (
+        entries["diagnostic-signal-snapshot-history-summary-json"]["schema_version"]
+        == diagnostic_signal_snapshot_history.SCHEMA_VERSION
+    )
+    assert {
+        "schema_version",
+        "measurements",
+        "decision_boundary",
+    }.issubset(set(entries["diagnostic-signal-snapshot-json"]["required_fields"]))
+    assert {
+        "schema_version",
+        "latest_record",
+        "decision_boundary",
+    }.issubset(set(entries["diagnostic-signal-snapshot-history-summary-json"]["required_fields"]))
     assert (
         entries["pr-quality-runtime-proof-artifacts-json"]["schema_version"]
         == pr_quality_runtime_proof_artifacts.SCHEMA_VERSION


### PR DESCRIPTION
## Summary
- Register `build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.json` in the artifact contract index.
- Register `build/repo-memory-history/diagnostic-signal-snapshots/diagnostic-signal-snapshot-history-summary.json` in the artifact contract index.
- Regenerate `docs/artifact-contract-index.json`.
- Add tests that pin diagnostic-signal snapshot/history schema versions and required contract fields.

## Why
- DiagnosticSignalSnapshot and DiagnosticSignalSnapshotHistory already emit read-only diagnostic/KPI artifacts.
- This PR documents/contracts those existing artifact paths without changing behavior.
- The registered artifacts preserve the reporting-only/no-authority boundary:
  - no current PR decision input
  - no RepoMemory feed from current PR snapshots
  - no proof execution
  - no patch application
  - no automation
  - no merge authorization
  - no semantic-equivalence claim

## Verification
- `python -m pytest -q tests/test_artifact_contract_index.py -o addopts=`
- `python -m pytest -q tests/test_diagnostic_signal_snapshot.py -o addopts=`
- `python -m pytest -q tests/test_diagnostic_signal_snapshot_history.py -o addopts=`
- `python -m pytest -q tests/test_pr_quality_action_report.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Artifact contract index and tests only.
- No behavior change to diagnostic signal snapshot generation/history retention.
- No automation or merge authority added.
