### PR TITLE
docs: prefer proof-after-format developer workflow

### DIFF
--- a/docs/ci-contract.md
+++ b/docs/ci-contract.md
@@ -18,6 +18,6 @@
 - Network tests must opt in with `@pytest.mark.network`.
 
 ## Local parity commands
-- `python -m pre_commit run -a`
+- `make proof-after-format`
 - `pytest -q`
 - `bash quality.sh cov`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ Use this page as a concise handoff, then follow the detailed path in [`CONTRIBUT
 ## Baseline contributor validation commands
 
 ```bash
-python -m pre_commit run -a
+make proof-after-format
 bash quality.sh cov
 NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
 ```

--- a/docs/first-contribution-quickstart.md
+++ b/docs/first-contribution-quickstart.md
@@ -52,14 +52,14 @@ Purpose in order:
 Run minimum checks:
 
 ```bash
-python -m pre_commit run -a
+make proof-after-format
 bash quality.sh cov
 ```
 
 For docs-only changes:
 
 ```bash
-python -m pre_commit run -a
+make proof-after-format
 NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
 ```
 

--- a/docs/premium-quality-gate.md
+++ b/docs/premium-quality-gate.md
@@ -17,7 +17,7 @@ Run these from repo root:
 
 ```bash
 python -m ruff format --check .
-python -m pre_commit run -a
+make proof-after-format
 bash quality.sh cov
 python -m build
 python -m twine check dist/*


### PR DESCRIPTION
## Summary
- Update local operator proof guidance to prefer `make proof-after-format`.
- Keep CI/sample/historical roadmap examples unchanged.
- Align contributor and quality-gate docs with the new formatter-before-proof workflow.

## Why
- `make proof-after-format` now applies mechanical formatting first, then runs pre-commit.
- This avoids the repeated formatter-modified-files loop in local proof.
- The guidance remains explicit and non-authorizing.

## Verification
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_mkdocs_exclude_docs_scope.py tests/test_docs_qa.py::test_repository_front_doors_are_polished_and_consistent -o addopts=`
- `make proof-after-format`

## Risk
- Low.
- Docs-only.
- No CI weakening.
- No generated sample rewrite.
- No automation or merge authority added.
- Rollback: revert the four docs edits.
