### PR TITLE
feat: prefer repo-native proof target in adoption surface

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -105,6 +105,23 @@ def _package_json_has_test(root: Path) -> bool:
     return bool(str(scripts.get("test", "")).strip())
 
 
+def _make_target_exists(root: Path, target: str) -> bool:
+    makefile = root / "Makefile"
+    if not makefile.is_file():
+        return False
+    prefix = f"{target}:"
+    for line in makefile.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if line.startswith(prefix):
+            return True
+    return False
+
+
+def _quality_proof_command(root: Path) -> str:
+    if _make_target_exists(root, "proof-after-format"):
+        return "make proof-after-format"
+    return "python -m pre_commit run -a"
+
+
 def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root)
     requirements = _glob_files(root, "requirements*.txt")
@@ -167,7 +184,7 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
         recommended_proof_commands.append(
             {
                 "surface": "quality",
-                "command": "python -m pre_commit run -a",
+                "command": _quality_proof_command(root),
                 "confidence": "high",
             }
         )

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -25,6 +25,10 @@ def test_adoption_surface_detects_python_github_security_and_proof_commands(
     _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
     _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
     _write(tmp_path / ".pre-commit-config.yaml", "repos: []\n")
+    _write(
+        tmp_path / "Makefile",
+        ".PHONY: proof-after-format\nproof-after-format:\n\tpython -m pre_commit run -a\n",
+    )
     _write(tmp_path / "mkdocs.yml", "site_name: Example\n")
     _write(tmp_path / "src" / "sdetkit" / "__init__.py")
     _write(
@@ -44,7 +48,7 @@ def test_adoption_surface_detects_python_github_security_and_proof_commands(
     assert "github_actions" in _names(payload["ci_systems"])
     assert {"codeql", "dependency_review"} <= _names(payload["security_tools"])
     assert "python -m pytest -q -o addopts=" in _commands(payload)
-    assert "python -m pre_commit run -a" in _commands(payload)
+    assert "make proof-after-format" in _commands(payload)
     assert "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict" in _commands(payload)
 
 
@@ -152,6 +156,17 @@ def test_adoption_surface_payload_validator_accepts_generated_payload(tmp_path: 
     out = tmp_path / "build" / "sdetkit" / "adoption-surface.json"
     write_adoption_surface_artifact(repo_root=tmp_path, out=out)
     assert validate_adoption_surface_artifact(out) == []
+
+
+def test_adoption_surface_falls_back_to_pre_commit_when_make_target_is_absent(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "pyproject.toml", "[project]\ndependencies = []\n")
+    _write(tmp_path / ".pre-commit-config.yaml", "repos: []\n")
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "python -m pre_commit run -a" in _commands(payload)
 
 
 def test_adoption_surface_payload_validator_rejects_authority_escalation() -> None:


### PR DESCRIPTION
## Summary
- Prefer repo-native `make proof-after-format` in adoption-surface recommended proof commands when the Make target exists.
- Preserve fallback to `python -m pre_commit run -a` when the repo does not expose the target.
- Add tests for both repo-native target selection and fallback behavior.

## Why
- SDETKit should read the repo it is installed into and recommend the best local proof path.
- This repo now has an explicit formatter-before-proof workflow, so adoption discovery should surface that safer operator command.
- The change improves adoption-surface discovery without adding automation authority.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text`
- Inline artifact assertion that `make proof-after-format` is recommended and authority fields stay false.
- `make proof-after-format`

## Risk
- Low.
- Adoption-surface recommendation logic and tests only.
- Fallback remains compatible for repos without `proof-after-format`.
- No CI behavior change.
- No automation, merge authority, or semantic-equivalence claim added.
- Rollback: revert the two changed files.
