### PR TITLE
feat: add proof command purpose to adoption surface

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -87,6 +87,24 @@ def _add_named(items: list[dict[str, Any]], name: str, **fields: Any) -> None:
     items.append({"name": name, **fields})
 
 
+def _add_proof_command(
+    items: list[dict[str, Any]],
+    *,
+    surface: str,
+    command: str,
+    confidence: str,
+    purpose: str,
+) -> None:
+    items.append(
+        {
+            "surface": surface,
+            "command": command,
+            "confidence": confidence,
+            "purpose": purpose,
+        }
+    )
+
+
 def _workflow_files(root: Path) -> list[str]:
     return _glob_files(root, ".github/workflows/*.yml") + _glob_files(
         root, ".github/workflows/*.yaml"
@@ -170,32 +188,32 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             confidence="high",
             commands=["python -m pytest -q -o addopts="],
         )
-        recommended_proof_commands.append(
-            {
-                "surface": "python",
-                "command": "python -m pytest -q -o addopts=",
-                "confidence": "high",
-            }
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="python",
+            command="python -m pytest -q -o addopts=",
+            confidence="high",
+            purpose="test",
         )
     elif python_evidence:
         review_first_unknowns.append("Python project detected but test command is not proven")
 
     if _file(root, ".pre-commit-config.yaml"):
-        recommended_proof_commands.append(
-            {
-                "surface": "quality",
-                "command": _quality_proof_command(root),
-                "confidence": "high",
-            }
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="quality",
+            command=_quality_proof_command(root),
+            confidence="high",
+            purpose="quality",
         )
 
     if _file(root, "mkdocs.yml"):
-        recommended_proof_commands.append(
-            {
-                "surface": "docs",
-                "command": "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict",
-                "confidence": "high",
-            }
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="docs",
+            command="NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict",
+            confidence="high",
+            purpose="docs",
         )
 
     js_evidence = [
@@ -229,8 +247,12 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             confidence="medium",
             commands=["npm test"],
         )
-        recommended_proof_commands.append(
-            {"surface": "javascript_typescript", "command": "npm test", "confidence": "medium"}
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="javascript_typescript",
+            command="npm test",
+            confidence="medium",
+            purpose="test",
         )
     elif _file(root, "package.json"):
         review_first_unknowns.append(
@@ -240,16 +262,24 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     if _file(root, "go.mod"):
         _add_named(detected_languages, "go", confidence="high", evidence=["go.mod"])
         _add_named(package_managers, "go_modules", files=["go.mod"])
-        recommended_proof_commands.append(
-            {"surface": "go", "command": "go test ./...", "confidence": "high"}
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="go",
+            command="go test ./...",
+            confidence="high",
+            purpose="test",
         )
 
     if _file(root, "Cargo.toml"):
         rust_files = [path for path in ["Cargo.toml", "Cargo.lock"] if _file(root, path)]
         _add_named(detected_languages, "rust", confidence="high", evidence=rust_files)
         _add_named(package_managers, "cargo", files=rust_files)
-        recommended_proof_commands.append(
-            {"surface": "rust", "command": "cargo test", "confidence": "high"}
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="rust",
+            command="cargo test",
+            confidence="high",
+            purpose="test",
         )
 
     java_files = [
@@ -261,21 +291,33 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
         _add_named(detected_languages, "java", confidence="high", evidence=java_files)
         if _file(root, "pom.xml"):
             _add_named(package_managers, "maven", files=["pom.xml"])
-            recommended_proof_commands.append(
-                {"surface": "java", "command": "mvn test", "confidence": "high"}
+            _add_proof_command(
+                recommended_proof_commands,
+                surface="java",
+                command="mvn test",
+                confidence="high",
+                purpose="test",
             )
         if _file(root, "build.gradle") or _file(root, "build.gradle.kts"):
             _add_named(package_managers, "gradle", files=java_files)
-            recommended_proof_commands.append(
-                {"surface": "java", "command": "./gradlew test", "confidence": "medium"}
+            _add_proof_command(
+                recommended_proof_commands,
+                surface="java",
+                command="./gradlew test",
+                confidence="medium",
+                purpose="test",
             )
 
     dotnet_files = _recursive_files(root, "*.sln") + _recursive_files(root, "*.csproj")
     if dotnet_files:
         _add_named(detected_languages, "dotnet", confidence="high", evidence=dotnet_files)
         _add_named(package_managers, "nuget", files=dotnet_files)
-        recommended_proof_commands.append(
-            {"surface": "dotnet", "command": "dotnet test", "confidence": "high"}
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="dotnet",
+            command="dotnet test",
+            confidence="high",
+            purpose="test",
         )
 
     if workflows:

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -19,6 +19,11 @@ def _commands(payload: dict) -> set[str]:
     return {str(item["command"]) for item in payload["recommended_proof_commands"]}
 
 
+def _proof_command(payload: dict, command: str) -> dict:
+    commands = {str(item["command"]): item for item in payload["recommended_proof_commands"]}
+    return commands[command]
+
+
 def test_adoption_surface_detects_python_github_security_and_proof_commands(
     tmp_path: Path,
 ) -> None:
@@ -50,6 +55,12 @@ def test_adoption_surface_detects_python_github_security_and_proof_commands(
     assert "python -m pytest -q -o addopts=" in _commands(payload)
     assert "make proof-after-format" in _commands(payload)
     assert "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict" in _commands(payload)
+    assert _proof_command(payload, "python -m pytest -q -o addopts=")["purpose"] == "test"
+    assert _proof_command(payload, "make proof-after-format")["purpose"] == "quality"
+    assert (
+        _proof_command(payload, "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict")["purpose"]
+        == "docs"
+    )
 
 
 def test_adoption_surface_marks_unknown_javascript_test_command_review_first(
@@ -69,6 +80,47 @@ def test_adoption_surface_marks_unknown_javascript_test_command_review_first(
     assert payload["review_first_unknowns"] == [
         "JavaScript/TypeScript package manifest detected but test command is not proven"
     ]
+
+
+def test_adoption_surface_recommended_proof_commands_include_operator_purpose(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
+    _write(tmp_path / ".pre-commit-config.yaml", "repos: []\n")
+    _write(
+        tmp_path / "Makefile",
+        ".PHONY: proof-after-format\nproof-after-format:\n\tpython -m pre_commit run -a\n",
+    )
+    _write(tmp_path / "mkdocs.yml", "site_name: Example\n")
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "demo", "scripts": {"test": "vitest"}}),
+    )
+    _write(tmp_path / "package-lock.json", "{}\n")
+    _write(tmp_path / "go.mod", "module example\n")
+    _write(tmp_path / "Cargo.toml", "[package]\nname = 'example'\n")
+    _write(tmp_path / "pom.xml", "<project />\n")
+    _write(tmp_path / "service" / "App.csproj", "<Project />\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = payload["recommended_proof_commands"]
+
+    assert commands
+    assert all(
+        {"surface", "command", "confidence", "purpose"} <= set(command) for command in commands
+    )
+    assert _proof_command(payload, "python -m pytest -q -o addopts=")["purpose"] == "test"
+    assert _proof_command(payload, "make proof-after-format")["purpose"] == "quality"
+    assert (
+        _proof_command(payload, "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict")["purpose"]
+        == "docs"
+    )
+    assert _proof_command(payload, "npm test")["purpose"] == "test"
+    assert _proof_command(payload, "go test ./...")["purpose"] == "test"
+    assert _proof_command(payload, "cargo test")["purpose"] == "test"
+    assert _proof_command(payload, "mvn test")["purpose"] == "test"
+    assert _proof_command(payload, "dotnet test")["purpose"] == "test"
 
 
 def test_adoption_surface_detects_multi_language_evidence_without_running_commands(


### PR DESCRIPTION
## Summary
- Add `purpose` to each adoption-surface recommended proof command.
- Classify proof commands by operator intent, including `test`, `quality`, and `docs`.
- Add tests that require proof-command entries to expose `surface`, `command`, `confidence`, and `purpose`.

## Why
- SDETKit should make adoption-surface recommendations easier for operators and future PR comments to consume.
- A raw command list is useful, but purpose labels make the artifact more readable and actionable.
- This improves adoption discovery without adding automation authority.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text`
- Inline artifact assertion that every recommended proof command includes `surface`, `command`, `confidence`, and `purpose`.
- `make proof-after-format`

## Risk
- Low.
- Adoption-surface artifact enrichment and tests only.
- No CI behavior change.
- No proof execution behavior change.
- No automation, merge authority, or semantic-equivalence claim added.
- Rollback: revert the two changed files.
