### PR TITLE
docs: clean professional naming prose wave 2

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -1,6 +1,6 @@
 # Archive and history
 
-This section preserves **historical, transition-era, and closeout material** that is still useful for deep context.
+This section preserves **historical, transition-era, and completion report material** that is still useful for deep context.
 
 > This is not the recommended starting point for new users.
 

--- a/docs/archive/transition-era-material.md
+++ b/docs/archive/transition-era-material.md
@@ -9,7 +9,7 @@ The full name-by-name report history is preserved as top-level docs files and ex
 - Pattern: `name-*-ultra-upgrade-report.md`
 - Pattern: `name-*-big-upgrade-report.md`
 
-## Transition and closeout documents
+## Transition and completion report documents
 
 Transition-era docs are preserved as top-level docs files and grouped by naming pattern:
 
@@ -18,7 +18,7 @@ Transition-era docs are preserved as top-level docs files and grouped by naming 
 - `integrations-*-handoff-*.md`
 - `integrations-*-kickoff*.md`
 
-These files primarily document sequencing, historical rollout decisions, and closeout snapshots.
+These files primarily document sequencing, historical rollout decisions, and completion report snapshots.
 
 ## Roadmap report archive
 

--- a/docs/big-upgrade-report-42.md
+++ b/docs/big-upgrade-report-42.md
@@ -16,4 +16,4 @@ python -m sdetkit cycle42-optimization-closeout --format json --strict
 
 ## Cycle 43 handoff
 
-Cycle 42 is closed with a production-grade optimization closeout lane that converts Cycle 41 expansion evidence into Cycle 43 acceleration priorities.
+Cycle 42 is closed with a production-grade optimization completion report lane that converts Cycle 41 expansion evidence into Cycle 43 acceleration priorities.

--- a/docs/big-upgrade-report-49.md
+++ b/docs/big-upgrade-report-49.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 49 with a high-confidence weekly-review closeout lane that turns Cycle 48 objection outcomes into deterministic Cycle 50 priorities.
+Close Cycle 49 with a high-confidence weekly-review completion report lane that turns Cycle 48 objection outcomes into deterministic Cycle 50 priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 49 CLI lane: `cycle49-weekly-review-closeout`.
 - Added strict docs contract checks and delivery board lock gates.
 - Added artifact-pack emission for weekly review brief, risk register, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_weekly_review_workflow_contract.py
 
 ## Outcome
 
-Cycle 49 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 48 and deterministic handoff into Cycle 50 execution planning.
+Cycle 49 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 48 and deterministic handoff into Cycle 50 execution planning.

--- a/docs/big-upgrade-report-50.md
+++ b/docs/big-upgrade-report-50.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 50 with a high-confidence execution-prioritization closeout lane that turns Cycle 49 weekly-review outcomes into deterministic Cycle 51 release priorities.
+Close Cycle 50 with a high-confidence execution-prioritization completion report lane that turns Cycle 49 weekly-review outcomes into deterministic Cycle 51 release priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 50 CLI lane: `cycle50-execution-prioritization-closeout`.
 - Added strict docs contract checks and delivery board lock gates.
 - Added artifact-pack emission for execution brief, risk register, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_execution_prioritization_closeout_contract_50.py
 
 ## Outcome
 
-Cycle 50 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 49 and deterministic handoff into Cycle 51 release planning.
+Cycle 50 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 49 and deterministic handoff into Cycle 51 release planning.

--- a/docs/big-upgrade-report-51.md
+++ b/docs/big-upgrade-report-51.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 51 with a high-confidence case-snippet closeout lane that turns Cycle 50 execution-prioritization outcomes into deterministic Cycle 52 narrative priorities.
+Close Cycle 51 with a high-confidence case-snippet completion report lane that turns Cycle 50 execution-prioritization outcomes into deterministic Cycle 52 narrative priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 51 CLI lane: `cycle51-case-snippet-closeout`.
 - Added strict docs contract checks and delivery board lock gates for mini-case storytelling quality.
 - Added artifact-pack emission for case brief, proof map, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_case_snippet_closeout_contract_51.py
 
 ## Outcome
 
-Cycle 51 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 50 and deterministic handoff into Cycle 52 narrative execution.
+Cycle 51 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 50 and deterministic handoff into Cycle 52 narrative execution.

--- a/docs/big-upgrade-report-52.md
+++ b/docs/big-upgrade-report-52.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 52 with a high-confidence narrative closeout lane that turns Cycle 51 case-snippet outcomes into deterministic Cycle 53 expansion priorities.
+Close Cycle 52 with a high-confidence narrative completion report lane that turns Cycle 51 case-snippet outcomes into deterministic Cycle 53 expansion priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 52 CLI lane: `cycle52-narrative-closeout`.
 - Added strict docs contract checks and delivery board lock gates for narrative quality.
 - Added artifact-pack emission for narrative brief, proof map, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_narrative_closeout_contract.py
 
 ## Outcome
 
-Cycle 52 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 51 and deterministic handoff into Cycle 53 expansion execution.
+Cycle 52 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 51 and deterministic handoff into Cycle 53 expansion execution.

--- a/docs/big-upgrade-report-53.md
+++ b/docs/big-upgrade-report-53.md
@@ -9,7 +9,7 @@ Close Cycle 53 with a high-confidence docs-loop optimization lane that turns Cyc
 - Added a dedicated Cycle 53 CLI lane: `cycle53-docs-loop-closeout`.
 - Added strict docs-loop contract checks for cross-links between demos, playbooks, and CLI docs.
 - Added artifact-pack emission for docs-loop brief, cross-link map, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_docs_loop_closeout_contract.py
 
 ## Outcome
 
-Cycle 53 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 52 and deterministic handoff into Cycle 54 re-engagement execution.
+Cycle 53 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 52 and deterministic handoff into Cycle 54 re-engagement execution.

--- a/docs/big-upgrade-report-55.md
+++ b/docs/big-upgrade-report-55.md
@@ -9,7 +9,7 @@ Close Cycle 55 with a high-confidence contributor activation lane that converts 
 - Added a dedicated Cycle 55 CLI lane: `cycle55-contributor-activation-closeout`.
 - Added strict contributor-activation contract checks and discoverability checks.
 - Added artifact-pack emission for contributor brief, contributor ladder, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_contributor_activation_closeout_contract.py
 
 ## Outcome
 
-Cycle 55 is now an evidence-backed closeout lane with strict continuity to Cycle 53 and deterministic handoff into Cycle 56 prioritization.
+Cycle 55 is now an evidence-backed completion report lane with strict continuity to Cycle 53 and deterministic handoff into Cycle 56 prioritization.

--- a/docs/big-upgrade-report-56.md
+++ b/docs/big-upgrade-report-56.md
@@ -9,7 +9,7 @@ Close Cycle 56 with a high-confidence stabilization lane that converts Cycle 55 
 - Added a dedicated Cycle 56 CLI lane: `cycle56-stabilization-closeout`.
 - Added strict stabilization contract checks and discoverability checks.
 - Added artifact-pack emission for stabilization brief, risk ledger, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_stabilization_closeout_contract.py
 
 ## Outcome
 
-Cycle 56 is now an evidence-backed closeout lane with strict continuity to Cycle 55 and deterministic handoff into Cycle 57 deep audit prioritization.
+Cycle 56 is now an evidence-backed completion report lane with strict continuity to Cycle 55 and deterministic handoff into Cycle 57 deep audit prioritization.

--- a/docs/big-upgrade-report-57.md
+++ b/docs/big-upgrade-report-57.md
@@ -9,7 +9,7 @@ Close Cycle 57 with a high-confidence KPI deep-audit lane that converts Cycle 56
 - Added a dedicated Cycle 57 CLI lane: `cycle57-kpi-deep-audit-closeout`.
 - Added strict KPI deep-audit contract checks and discoverability checks.
 - Added artifact-pack emission for audit brief, risk ledger, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_kpi_deep_audit_closeout_contract.py
 
 ## Outcome
 
-Cycle 57 is now an evidence-backed closeout lane with strict continuity to Cycle 56 and deterministic handoff into Cycle 58 execution planning.
+Cycle 57 is now an evidence-backed completion report lane with strict continuity to Cycle 56 and deterministic handoff into Cycle 58 execution planning.

--- a/docs/big-upgrade-report-58.md
+++ b/docs/big-upgrade-report-58.md
@@ -23,4 +23,4 @@ python scripts/check_phase2_hardening_closeout_contract_58.py
 
 ## Closeout
 
-Cycle 58 is now an evidence-backed closeout lane with strict continuity to Cycle 57 and deterministic handoff into Cycle 59 pre-plan execution.
+Cycle 58 is now an evidence-backed completion report lane with strict continuity to Cycle 57 and deterministic handoff into Cycle 59 pre-plan execution.

--- a/docs/big-upgrade-report-59.md
+++ b/docs/big-upgrade-report-59.md
@@ -23,4 +23,4 @@ python scripts/check_phase3_preplan_closeout_contract_59.py
 
 ## Closeout
 
-Cycle 59 is now an evidence-backed closeout lane with strict continuity to Cycle 58 and deterministic handoff into Cycle 60 execution planning.
+Cycle 59 is now an evidence-backed completion report lane with strict continuity to Cycle 58 and deterministic handoff into Cycle 60 execution planning.

--- a/docs/big-upgrade-report-60.md
+++ b/docs/big-upgrade-report-60.md
@@ -23,4 +23,4 @@ python scripts/check_phase2_wrap_handoff_closeout_contract_60.py
 
 ## Closeout
 
-Cycle 60 is now an evidence-backed closeout lane with strict continuity to Cycle 59 and deterministic handoff into Cycle 61 execution planning.
+Cycle 60 is now an evidence-backed completion report lane with strict continuity to Cycle 59 and deterministic handoff into Cycle 61 execution planning.

--- a/docs/big-upgrade-report-65.md
+++ b/docs/big-upgrade-report-65.md
@@ -22,4 +22,4 @@ python scripts/check_weekly_review_workflow_contract.py
 
 ## Outcome
 
-Cycle 65 is now an evidence-backed weekly review closeout lane with strict continuity to Cycle 64 and deterministic handoff into Cycle 66 integration expansion #2.
+Cycle 65 is now an evidence-backed weekly review completion report lane with strict continuity to Cycle 64 and deterministic handoff into Cycle 66 integration expansion #2.

--- a/docs/big-upgrade-report-73.md
+++ b/docs/big-upgrade-report-73.md
@@ -23,4 +23,4 @@ python scripts/check_case_study_launch_closeout_contract.py
 
 ## Outcome
 
-Cycle 73 is now an evidence-backed case-study launch closeout lane with strict continuity to Cycle 72 and deterministic handoff into Cycle 74 distribution scaling.
+Cycle 73 is now an evidence-backed case-study launch completion report lane with strict continuity to Cycle 72 and deterministic handoff into Cycle 74 distribution scaling.

--- a/docs/big-upgrade-report-74.md
+++ b/docs/big-upgrade-report-74.md
@@ -22,4 +22,4 @@ python scripts/check_distribution_scaling_closeout_contract.py
 
 ### Outcome
 
-Cycle 74 is now an evidence-backed distribution scaling closeout lane with strict continuity to Cycle 73 and deterministic handoff into Cycle 75 trust refresh.
+Cycle 74 is now an evidence-backed distribution scaling completion report lane with strict continuity to Cycle 73 and deterministic handoff into Cycle 75 trust refresh.

--- a/docs/big-upgrade-report-75.md
+++ b/docs/big-upgrade-report-75.md
@@ -22,4 +22,4 @@ python scripts/check_trust_assets_refresh_closeout_contract.py
 
 ### Outcome
 
-Cycle 75 is now an evidence-backed trust refresh closeout lane with strict continuity to Cycle 74 and deterministic handoff into Cycle 76 contributor recognition.
+Cycle 75 is now an evidence-backed trust refresh completion report lane with strict continuity to Cycle 74 and deterministic handoff into Cycle 76 contributor recognition.

--- a/docs/big-upgrade-report-76.md
+++ b/docs/big-upgrade-report-76.md
@@ -22,4 +22,4 @@ python scripts/check_contributor_recognition_closeout_contract.py
 
 ### Outcome
 
-Cycle 76 is now an evidence-backed contributor recognition closeout lane with strict continuity to Cycle 75 and deterministic handoff into Cycle 77 scale priorities.
+Cycle 76 is now an evidence-backed contributor recognition completion report lane with strict continuity to Cycle 75 and deterministic handoff into Cycle 77 scale priorities.

--- a/docs/big-upgrade-report-77.md
+++ b/docs/big-upgrade-report-77.md
@@ -22,4 +22,4 @@ python scripts/check_community_touchpoint_closeout_contract.py
 
 ### Outcome
 
-Cycle 77 is now an evidence-backed community-touchpoint closeout lane with strict continuity to Cycle 76 and deterministic handoff into Cycle 78 ecosystem priorities.
+Cycle 77 is now an evidence-backed community-touchpoint completion report lane with strict continuity to Cycle 76 and deterministic handoff into Cycle 78 ecosystem priorities.

--- a/docs/big-upgrade-report-78.md
+++ b/docs/big-upgrade-report-78.md
@@ -22,4 +22,4 @@ python scripts/check_ecosystem_priorities_closeout_contract.py
 
 ### Outcome
 
-Cycle 78 is now an evidence-backed ecosystem-priorities closeout lane with strict continuity to Cycle 77 and deterministic handoff into Cycle 79 scale priorities.
+Cycle 78 is now an evidence-backed ecosystem-priorities completion report lane with strict continuity to Cycle 77 and deterministic handoff into Cycle 79 scale priorities.

--- a/docs/big-upgrade-report-79.md
+++ b/docs/big-upgrade-report-79.md
@@ -1,6 +1,6 @@
 # Cycle 79 big upgrade report
 
-Cycle 79 delivers a closeout-grade scale upgrade lane that promotes Cycle 78 ecosystem outcomes into enterprise onboarding execution readiness with strict contract checks, deterministic command evidence, and Cycle 80 handoff coverage.
+Cycle 79 delivers a completion report-grade scale upgrade lane that promotes Cycle 78 ecosystem outcomes into enterprise onboarding execution readiness with strict contract checks, deterministic command evidence, and Cycle 80 handoff coverage.
 
 ## What shipped
 

--- a/docs/big-upgrade-report-80.md
+++ b/docs/big-upgrade-report-80.md
@@ -5,5 +5,5 @@ Cycle 80 closes partner outreach execution by converting Cycle 79 scale signals 
 ## Delivered upgrades
 
 - Added a strict Cycle 80 partner outreach CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and test coverage for strict closeout checks.
+- Added contract validation script and test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 80 execution.

--- a/docs/big-upgrade-report-81.md
+++ b/docs/big-upgrade-report-81.md
@@ -5,5 +5,5 @@ Cycle 81 closes growth campaign execution by converting Cycle 80 partner-outreac
 ## Delivered upgrades
 
 - Added a strict Cycle 81 growth campaign CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and test coverage for strict closeout checks.
+- Added contract validation script and test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 81 execution.

--- a/docs/big-upgrade-report-82.md
+++ b/docs/big-upgrade-report-82.md
@@ -5,5 +5,5 @@ Cycle 82 closes integration feedback execution by converting Cycle 81 growth-cam
 ## Delivered upgrades
 
 - Added a strict Cycle 82 integration feedback CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and test coverage for strict closeout checks.
+- Added contract validation script and test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 82 execution.

--- a/docs/big-upgrade-report-83.md
+++ b/docs/big-upgrade-report-83.md
@@ -5,5 +5,5 @@ Cycle 83 closes trust FAQ expansion execution by converting Cycle 82 integration
 ## Delivered upgrades
 
 - Added a strict Cycle 83 trust FAQ expansion CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and dedicated test coverage for strict closeout checks.
+- Added contract validation script and dedicated test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 83 execution.

--- a/docs/big-upgrade-report-84.md
+++ b/docs/big-upgrade-report-84.md
@@ -4,7 +4,7 @@
 
 - Added `cycle84-evidence-narrative-closeout` command to score Cycle 84 readiness from Cycle 83 trust FAQ handoff artifacts.
 - Added deterministic pack emission and execution evidence generation for release-ready narrative proof.
-- Added strict contract validation script and tests that enforce Cycle 84 closeout lock quality.
+- Added strict contract validation script and tests that enforce Cycle 84 completion report lock quality.
 
 ## Command lane
 

--- a/docs/big-upgrade-report-85.md
+++ b/docs/big-upgrade-report-85.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `release-prioritization-closeout` command to score Cycle 85 readiness from Cycle 84 evidence narrative handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for release prioritization closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 85 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for release prioritization completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 85 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/big-upgrade-report-86.md
+++ b/docs/big-upgrade-report-86.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `launch-readiness-closeout` command to score Cycle 86 readiness from Cycle 85 release prioritization handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for launch readiness closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 86 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for launch readiness completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 86 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/big-upgrade-report-87.md
+++ b/docs/big-upgrade-report-87.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `governance-handoff-closeout` command to score Cycle 87 readiness from Cycle 86 launch readiness handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for governance handoff closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 87 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for governance handoff completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 87 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/big-upgrade-report-88.md
+++ b/docs/big-upgrade-report-88.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `governance-priorities-closeout` command to score Cycle 88 readiness from Cycle 87 governance handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for governance priorities closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 88 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for governance priorities completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 88 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/big-upgrade-report-89.md
+++ b/docs/big-upgrade-report-89.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `governance-scale-closeout` command to score Cycle 89 readiness from Cycle 88 governance handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for governance scale closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 89 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for governance scale completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 89 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/big-upgrade-report-90.md
+++ b/docs/big-upgrade-report-90.md
@@ -4,7 +4,7 @@
 
 - Added `cycle90-phase3-wrap-publication-closeout` command to score Cycle 90 readiness from Cycle 89 governance scale artifacts.
 - Added deterministic pack emission and execution evidence generation for phase-3 wrap and publication proof.
-- Added strict contract validation script and tests that enforce Cycle 90 closeout quality gates and next-impact roadmap handoff integrity.
+- Added strict contract validation script and tests that enforce Cycle 90 completion report quality gates and next-impact roadmap handoff integrity.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-1.md
+++ b/docs/continuous-upgrade-big-upgrade-report-1.md
@@ -4,7 +4,7 @@
 
 - Added `continuous-upgrade-closeout-1` command to score Cycle 1 readiness from Cycle 90 publication artifacts.
 - Added deterministic pack emission and execution evidence generation for continuous upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 1 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 1 completion report quality gates.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-2.md
+++ b/docs/continuous-upgrade-big-upgrade-report-2.md
@@ -4,7 +4,7 @@
 
 - Added `continuous-upgrade-closeout-2` command to score Cycle 2 readiness from Cycle 1 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-2 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 2 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 2 completion report quality gates.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-3.md
+++ b/docs/continuous-upgrade-big-upgrade-report-3.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-3` command to score cycle 3 readiness from cycle 2 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-2 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 3 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 3 completion report quality gates.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-4.md
+++ b/docs/continuous-upgrade-big-upgrade-report-4.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-4` command to score cycle 4 readiness from cycle 3 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-2 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 4 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 4 completion report quality gates.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-5.md
+++ b/docs/continuous-upgrade-big-upgrade-report-5.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-5` command to score cycle 5 readiness from cycle 4 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-5 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce cycle 5 closeout quality gates.
+- Added strict contract validation script and tests that enforce cycle 5 completion report quality gates.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-6.md
+++ b/docs/continuous-upgrade-big-upgrade-report-6.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-6` command to score cycle 6 readiness from cycle 5 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-6 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce cycle 6 closeout quality gates.
+- Added strict contract validation script and tests that enforce cycle 6 completion report quality gates.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-7.md
+++ b/docs/continuous-upgrade-big-upgrade-report-7.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-7` command to score cycle 7 readiness from cycle 6 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-7 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce cycle 7 closeout quality gates.
+- Added strict contract validation script and tests that enforce cycle 7 completion report quality gates.
 
 ## Command lane
 

--- a/docs/continuous-upgrade-big-upgrade-report-8.md
+++ b/docs/continuous-upgrade-big-upgrade-report-8.md
@@ -4,7 +4,7 @@
 
 - Added `continuous-upgrade-closeout-8` command to score Cycle 8 readiness from Cycle 7 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-8 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 8 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 8 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/big-upgrade-report-42.md
+++ b/docs/roadmap/reports/big-upgrade-report-42.md
@@ -16,4 +16,4 @@ python -m sdetkit cycle42-optimization-closeout --format json --strict
 
 ## Cycle 43 handoff
 
-Cycle 42 is closed with a production-grade optimization closeout lane that converts Cycle 41 expansion evidence into Cycle 43 acceleration priorities.
+Cycle 42 is closed with a production-grade optimization completion report lane that converts Cycle 41 expansion evidence into Cycle 43 acceleration priorities.

--- a/docs/roadmap/reports/big-upgrade-report-49.md
+++ b/docs/roadmap/reports/big-upgrade-report-49.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 49 with a high-confidence weekly-review closeout lane that turns Cycle 48 objection outcomes into deterministic Cycle 50 priorities.
+Close Cycle 49 with a high-confidence weekly-review completion report lane that turns Cycle 48 objection outcomes into deterministic Cycle 50 priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 49 CLI lane: `cycle49-weekly-review-closeout`.
 - Added strict docs contract checks and delivery board lock gates.
 - Added artifact-pack emission for weekly review brief, risk register, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_weekly_review_workflow_contract.py
 
 ## Outcome
 
-Cycle 49 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 48 and deterministic handoff into Cycle 50 execution planning.
+Cycle 49 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 48 and deterministic handoff into Cycle 50 execution planning.

--- a/docs/roadmap/reports/big-upgrade-report-50.md
+++ b/docs/roadmap/reports/big-upgrade-report-50.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 50 with a high-confidence execution-prioritization closeout lane that turns Cycle 49 weekly-review outcomes into deterministic Cycle 51 release priorities.
+Close Cycle 50 with a high-confidence execution-prioritization completion report lane that turns Cycle 49 weekly-review outcomes into deterministic Cycle 51 release priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 50 CLI lane: `cycle50-execution-prioritization-closeout`.
 - Added strict docs contract checks and delivery board lock gates.
 - Added artifact-pack emission for execution brief, risk register, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_execution_prioritization_closeout_contract_50.py
 
 ## Outcome
 
-Cycle 50 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 49 and deterministic handoff into Cycle 51 release planning.
+Cycle 50 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 49 and deterministic handoff into Cycle 51 release planning.

--- a/docs/roadmap/reports/big-upgrade-report-51.md
+++ b/docs/roadmap/reports/big-upgrade-report-51.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 51 with a high-confidence case-snippet closeout lane that turns Cycle 50 execution-prioritization outcomes into deterministic Cycle 52 narrative priorities.
+Close Cycle 51 with a high-confidence case-snippet completion report lane that turns Cycle 50 execution-prioritization outcomes into deterministic Cycle 52 narrative priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 51 CLI lane: `cycle51-case-snippet-closeout`.
 - Added strict docs contract checks and delivery board lock gates for mini-case storytelling quality.
 - Added artifact-pack emission for case brief, proof map, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_case_snippet_closeout_contract_51.py
 
 ## Outcome
 
-Cycle 51 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 50 and deterministic handoff into Cycle 52 narrative execution.
+Cycle 51 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 50 and deterministic handoff into Cycle 52 narrative execution.

--- a/docs/roadmap/reports/big-upgrade-report-52.md
+++ b/docs/roadmap/reports/big-upgrade-report-52.md
@@ -2,14 +2,14 @@
 
 ## Objective
 
-Close Cycle 52 with a high-confidence narrative closeout lane that turns Cycle 51 case-snippet outcomes into deterministic Cycle 53 expansion priorities.
+Close Cycle 52 with a high-confidence narrative completion report lane that turns Cycle 51 case-snippet outcomes into deterministic Cycle 53 expansion priorities.
 
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 52 CLI lane: `cycle52-narrative-closeout`.
 - Added strict docs contract checks and delivery board lock gates for narrative quality.
 - Added artifact-pack emission for narrative brief, proof map, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_narrative_closeout_contract.py
 
 ## Outcome
 
-Cycle 52 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 51 and deterministic handoff into Cycle 53 expansion execution.
+Cycle 52 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 51 and deterministic handoff into Cycle 53 expansion execution.

--- a/docs/roadmap/reports/big-upgrade-report-53.md
+++ b/docs/roadmap/reports/big-upgrade-report-53.md
@@ -9,7 +9,7 @@ Close Cycle 53 with a high-confidence docs-loop optimization lane that turns Cyc
 - Added a dedicated Cycle 53 CLI lane: `cycle53-docs-loop-closeout`.
 - Added strict docs-loop contract checks for cross-links between demos, playbooks, and CLI docs.
 - Added artifact-pack emission for docs-loop brief, cross-link map, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_docs_loop_closeout_contract.py
 
 ## Outcome
 
-Cycle 53 is now a fully-scored, evidence-backed closeout lane with strict continuity to Cycle 52 and deterministic handoff into Cycle 54 re-engagement execution.
+Cycle 53 is now a fully-scored, evidence-backed completion report lane with strict continuity to Cycle 52 and deterministic handoff into Cycle 54 re-engagement execution.

--- a/docs/roadmap/reports/big-upgrade-report-55.md
+++ b/docs/roadmap/reports/big-upgrade-report-55.md
@@ -9,7 +9,7 @@ Close Cycle 55 with a high-confidence contributor activation lane that converts 
 - Added a dedicated Cycle 55 CLI lane: `cycle55-contributor-activation-closeout`.
 - Added strict contributor-activation contract checks and discoverability checks.
 - Added artifact-pack emission for contributor brief, contributor ladder, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_contributor_activation_closeout_contract.py
 
 ## Outcome
 
-Cycle 55 is now an evidence-backed closeout lane with strict continuity to Cycle 53 and deterministic handoff into Cycle 56 prioritization.
+Cycle 55 is now an evidence-backed completion report lane with strict continuity to Cycle 53 and deterministic handoff into Cycle 56 prioritization.

--- a/docs/roadmap/reports/big-upgrade-report-56.md
+++ b/docs/roadmap/reports/big-upgrade-report-56.md
@@ -9,7 +9,7 @@ Close Cycle 56 with a high-confidence stabilization lane that converts Cycle 55 
 - Added a dedicated Cycle 56 CLI lane: `cycle56-stabilization-closeout`.
 - Added strict stabilization contract checks and discoverability checks.
 - Added artifact-pack emission for stabilization brief, risk ledger, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_stabilization_closeout_contract.py
 
 ## Outcome
 
-Cycle 56 is now an evidence-backed closeout lane with strict continuity to Cycle 55 and deterministic handoff into Cycle 57 deep audit prioritization.
+Cycle 56 is now an evidence-backed completion report lane with strict continuity to Cycle 55 and deterministic handoff into Cycle 57 deep audit prioritization.

--- a/docs/roadmap/reports/big-upgrade-report-57.md
+++ b/docs/roadmap/reports/big-upgrade-report-57.md
@@ -9,7 +9,7 @@ Close Cycle 57 with a high-confidence KPI deep-audit lane that converts Cycle 56
 - Added a dedicated Cycle 57 CLI lane: `cycle57-kpi-deep-audit-closeout`.
 - Added strict KPI deep-audit contract checks and discoverability checks.
 - Added artifact-pack emission for audit brief, risk ledger, KPI scorecard, and execution logs.
-- Added deterministic execution evidence capture for repeatable closeout verification.
+- Added deterministic execution evidence capture for repeatable completion report verification.
 
 ## Commands
 
@@ -22,4 +22,4 @@ python scripts/check_kpi_deep_audit_closeout_contract.py
 
 ## Outcome
 
-Cycle 57 is now an evidence-backed closeout lane with strict continuity to Cycle 56 and deterministic handoff into Cycle 58 execution planning.
+Cycle 57 is now an evidence-backed completion report lane with strict continuity to Cycle 56 and deterministic handoff into Cycle 58 execution planning.

--- a/docs/roadmap/reports/big-upgrade-report-58.md
+++ b/docs/roadmap/reports/big-upgrade-report-58.md
@@ -23,4 +23,4 @@ python scripts/check_phase2_hardening_closeout_contract_58.py
 
 ## Closeout
 
-Cycle 58 is now an evidence-backed closeout lane with strict continuity to Cycle 57 and deterministic handoff into Cycle 59 pre-plan execution.
+Cycle 58 is now an evidence-backed completion report lane with strict continuity to Cycle 57 and deterministic handoff into Cycle 59 pre-plan execution.

--- a/docs/roadmap/reports/big-upgrade-report-59.md
+++ b/docs/roadmap/reports/big-upgrade-report-59.md
@@ -23,4 +23,4 @@ python scripts/check_phase3_preplan_closeout_contract_59.py
 
 ## Closeout
 
-Cycle 59 is now an evidence-backed closeout lane with strict continuity to Cycle 58 and deterministic handoff into Cycle 60 execution planning.
+Cycle 59 is now an evidence-backed completion report lane with strict continuity to Cycle 58 and deterministic handoff into Cycle 60 execution planning.

--- a/docs/roadmap/reports/big-upgrade-report-60.md
+++ b/docs/roadmap/reports/big-upgrade-report-60.md
@@ -23,4 +23,4 @@ python scripts/check_phase2_wrap_handoff_closeout_contract_60.py
 
 ## Closeout
 
-Cycle 60 is now an evidence-backed closeout lane with strict continuity to Cycle 59 and deterministic handoff into Cycle 61 execution planning.
+Cycle 60 is now an evidence-backed completion report lane with strict continuity to Cycle 59 and deterministic handoff into Cycle 61 execution planning.

--- a/docs/roadmap/reports/big-upgrade-report-65.md
+++ b/docs/roadmap/reports/big-upgrade-report-65.md
@@ -22,4 +22,4 @@ python scripts/check_weekly_review_workflow_contract.py
 
 ## Outcome
 
-Cycle 65 is now an evidence-backed weekly review closeout lane with strict continuity to Cycle 64 and deterministic handoff into Cycle 66 integration expansion #2.
+Cycle 65 is now an evidence-backed weekly review completion report lane with strict continuity to Cycle 64 and deterministic handoff into Cycle 66 integration expansion #2.

--- a/docs/roadmap/reports/big-upgrade-report-71.md
+++ b/docs/roadmap/reports/big-upgrade-report-71.md
@@ -23,4 +23,4 @@ python scripts/check_case_study_prep3_closeout_contract.py
 
 ## Outcome
 
-Case-study prep #3 is now an evidence-backed closeout lane with strict continuity checks and a deterministic handoff into case-study prep #4.
+Case-study prep #3 is now an evidence-backed completion report lane with strict continuity checks and a deterministic handoff into case-study prep #4.

--- a/docs/roadmap/reports/big-upgrade-report-73.md
+++ b/docs/roadmap/reports/big-upgrade-report-73.md
@@ -23,4 +23,4 @@ python scripts/check_case_study_launch_closeout_contract.py
 
 ## Outcome
 
-Cycle 73 is now an evidence-backed case-study launch closeout lane with strict continuity to Cycle 72 and deterministic handoff into Cycle 74 distribution scaling.
+Cycle 73 is now an evidence-backed case-study launch completion report lane with strict continuity to Cycle 72 and deterministic handoff into Cycle 74 distribution scaling.

--- a/docs/roadmap/reports/big-upgrade-report-74.md
+++ b/docs/roadmap/reports/big-upgrade-report-74.md
@@ -22,4 +22,4 @@ python scripts/check_distribution_scaling_closeout_contract.py
 
 ### Outcome
 
-Cycle 74 is now an evidence-backed distribution scaling closeout lane with strict continuity to Cycle 73 and deterministic handoff into Cycle 75 trust refresh.
+Cycle 74 is now an evidence-backed distribution scaling completion report lane with strict continuity to Cycle 73 and deterministic handoff into Cycle 75 trust refresh.

--- a/docs/roadmap/reports/big-upgrade-report-75.md
+++ b/docs/roadmap/reports/big-upgrade-report-75.md
@@ -22,4 +22,4 @@ python scripts/check_trust_assets_refresh_closeout_contract.py
 
 ### Outcome
 
-Cycle 75 is now an evidence-backed trust refresh closeout lane with strict continuity to Cycle 74 and deterministic handoff into Cycle 76 contributor recognition.
+Cycle 75 is now an evidence-backed trust refresh completion report lane with strict continuity to Cycle 74 and deterministic handoff into Cycle 76 contributor recognition.

--- a/docs/roadmap/reports/big-upgrade-report-76.md
+++ b/docs/roadmap/reports/big-upgrade-report-76.md
@@ -22,4 +22,4 @@ python scripts/check_contributor_recognition_closeout_contract.py
 
 ### Outcome
 
-Cycle 76 is now an evidence-backed contributor recognition closeout lane with strict continuity to Cycle 75 and deterministic handoff into Cycle 77 scale priorities.
+Cycle 76 is now an evidence-backed contributor recognition completion report lane with strict continuity to Cycle 75 and deterministic handoff into Cycle 77 scale priorities.

--- a/docs/roadmap/reports/big-upgrade-report-77.md
+++ b/docs/roadmap/reports/big-upgrade-report-77.md
@@ -22,4 +22,4 @@ python scripts/check_community_touchpoint_closeout_contract.py
 
 ### Outcome
 
-Cycle 77 is now an evidence-backed community-touchpoint closeout lane with strict continuity to Cycle 76 and deterministic handoff into Cycle 78 ecosystem priorities.
+Cycle 77 is now an evidence-backed community-touchpoint completion report lane with strict continuity to Cycle 76 and deterministic handoff into Cycle 78 ecosystem priorities.

--- a/docs/roadmap/reports/big-upgrade-report-78.md
+++ b/docs/roadmap/reports/big-upgrade-report-78.md
@@ -22,4 +22,4 @@ python scripts/check_ecosystem_priorities_closeout_contract.py
 
 ### Outcome
 
-Cycle 78 is now an evidence-backed ecosystem-priorities closeout lane with strict continuity to Cycle 77 and deterministic handoff into Cycle 79 scale priorities.
+Cycle 78 is now an evidence-backed ecosystem-priorities completion report lane with strict continuity to Cycle 77 and deterministic handoff into Cycle 79 scale priorities.

--- a/docs/roadmap/reports/big-upgrade-report-79.md
+++ b/docs/roadmap/reports/big-upgrade-report-79.md
@@ -1,6 +1,6 @@
 # Cycle 79 big upgrade report
 
-Cycle 79 delivers a closeout-grade scale upgrade lane that promotes Cycle 78 ecosystem outcomes into enterprise onboarding execution readiness with strict contract checks, deterministic command evidence, and Cycle 80 handoff coverage.
+Cycle 79 delivers a completion report-grade scale upgrade lane that promotes Cycle 78 ecosystem outcomes into enterprise onboarding execution readiness with strict contract checks, deterministic command evidence, and Cycle 80 handoff coverage.
 
 ## What shipped
 

--- a/docs/roadmap/reports/big-upgrade-report-80.md
+++ b/docs/roadmap/reports/big-upgrade-report-80.md
@@ -5,5 +5,5 @@ Cycle 80 closes partner outreach execution by converting Cycle 79 scale signals 
 ## Delivered upgrades
 
 - Added a strict Cycle 80 partner outreach CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and test coverage for strict closeout checks.
+- Added contract validation script and test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 80 execution.

--- a/docs/roadmap/reports/big-upgrade-report-81.md
+++ b/docs/roadmap/reports/big-upgrade-report-81.md
@@ -5,5 +5,5 @@ Cycle 81 closes growth campaign execution by converting Cycle 80 partner-outreac
 ## Delivered upgrades
 
 - Added a strict Cycle 81 growth campaign CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and test coverage for strict closeout checks.
+- Added contract validation script and test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 81 execution.

--- a/docs/roadmap/reports/big-upgrade-report-82.md
+++ b/docs/roadmap/reports/big-upgrade-report-82.md
@@ -5,5 +5,5 @@ Cycle 82 closes integration feedback execution by converting Cycle 81 growth-cam
 ## Delivered upgrades
 
 - Added a strict Cycle 82 integration feedback CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and test coverage for strict closeout checks.
+- Added contract validation script and test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 82 execution.

--- a/docs/roadmap/reports/big-upgrade-report-83.md
+++ b/docs/roadmap/reports/big-upgrade-report-83.md
@@ -5,5 +5,5 @@ Cycle 83 closes trust FAQ expansion execution by converting Cycle 82 integration
 ## Delivered upgrades
 
 - Added a strict Cycle 83 trust FAQ expansion CLI lane with scoring, pack emission, and evidence execution hooks.
-- Added contract validation script and dedicated test coverage for strict closeout checks.
+- Added contract validation script and dedicated test coverage for strict completion report checks.
 - Added docs navigation and strategy continuity references for Cycle 83 execution.

--- a/docs/roadmap/reports/big-upgrade-report-84.md
+++ b/docs/roadmap/reports/big-upgrade-report-84.md
@@ -4,7 +4,7 @@
 
 - Added `cycle84-evidence-narrative-closeout` command to score Cycle 84 readiness from Cycle 83 trust FAQ handoff artifacts.
 - Added deterministic pack emission and execution evidence generation for release-ready narrative proof.
-- Added strict contract validation script and tests that enforce Cycle 84 closeout lock quality.
+- Added strict contract validation script and tests that enforce Cycle 84 completion report lock quality.
 
 ## Command lane
 

--- a/docs/roadmap/reports/big-upgrade-report-85.md
+++ b/docs/roadmap/reports/big-upgrade-report-85.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `cycle85-release-prioritization-closeout` command to score Cycle 85 readiness from Cycle 84 evidence narrative handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for release prioritization closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 85 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for release prioritization completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 85 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/roadmap/reports/big-upgrade-report-86.md
+++ b/docs/roadmap/reports/big-upgrade-report-86.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `cycle86-launch-readiness-closeout` command to score Cycle 86 readiness from Cycle 85 release prioritization handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for launch readiness closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 86 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for launch readiness completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 86 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/roadmap/reports/big-upgrade-report-87.md
+++ b/docs/roadmap/reports/big-upgrade-report-87.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `cycle87-governance-handoff-closeout` command to score Cycle 87 readiness from Cycle 86 launch readiness handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for governance handoff closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 87 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for governance handoff completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 87 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/roadmap/reports/big-upgrade-report-88.md
+++ b/docs/roadmap/reports/big-upgrade-report-88.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `cycle88-governance-priorities-closeout` command to score Cycle 88 readiness from Cycle 87 governance handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for governance priorities closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 88 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for governance priorities completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 88 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/roadmap/reports/big-upgrade-report-89.md
+++ b/docs/roadmap/reports/big-upgrade-report-89.md
@@ -3,8 +3,8 @@
 ## What shipped
 
 - Added `cycle89-governance-scale-closeout` command to score Cycle 89 readiness from Cycle 88 governance handoff artifacts.
-- Added deterministic pack emission and execution evidence generation for governance scale closeout proof.
-- Added strict contract validation script and tests that enforce Cycle 89 closeout quality gates and handoff integrity.
+- Added deterministic pack emission and execution evidence generation for governance scale completion report proof.
+- Added strict contract validation script and tests that enforce Cycle 89 completion report quality gates and handoff integrity.
 
 ## Command lane
 

--- a/docs/roadmap/reports/big-upgrade-report-90.md
+++ b/docs/roadmap/reports/big-upgrade-report-90.md
@@ -4,7 +4,7 @@
 
 - Added `cycle90-phase3-wrap-publication-closeout` command to score Cycle 90 readiness from Cycle 89 governance scale artifacts.
 - Added deterministic pack emission and execution evidence generation for phase-3 wrap and publication proof.
-- Added strict contract validation script and tests that enforce Cycle 90 closeout quality gates and next-impact roadmap handoff integrity.
+- Added strict contract validation script and tests that enforce Cycle 90 completion report quality gates and next-impact roadmap handoff integrity.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-1.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-1.md
@@ -4,7 +4,7 @@
 
 - Added `continuous-upgrade-closeout-1` command to score Cycle 1 readiness from Cycle 90 publication artifacts.
 - Added deterministic pack emission and execution evidence generation for continuous upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 1 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 1 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-10.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-10.md
@@ -1,4 +1,4 @@
-# Cycle 10 — Continuous upgrade closeout lane report
+# Cycle 10 — Continuous upgrade completion report lane report
 
 ## Purpose
 Capture the active/public cycle 10 closeout surface with durable cycle-based wording.

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-11.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-11.md
@@ -1,4 +1,4 @@
-# Cycle 11 — Continuous upgrade closeout lane report
+# Cycle 11 — Continuous upgrade completion report lane report
 
 ## Purpose
 Capture the active/public cycle 11 closeout surface with durable cycle-based wording.

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-2.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-2.md
@@ -4,7 +4,7 @@
 
 - Added `continuous-upgrade-closeout-2` command to score Cycle 2 readiness from Cycle 1 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-2 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 2 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 2 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-3.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-3.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-3` command to score cycle 3 readiness from cycle 2 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-2 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 3 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 3 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-5.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-5.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-5` command to score cycle 5 readiness from cycle 4 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-5 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce cycle 5 closeout quality gates.
+- Added strict contract validation script and tests that enforce cycle 5 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-6.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-6.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-6` command to score cycle 6 readiness from cycle 5 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-6 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce cycle 6 closeout quality gates.
+- Added strict contract validation script and tests that enforce cycle 6 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-7.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-7.md
@@ -6,7 +6,7 @@
 
 - Added `continuous-upgrade-closeout-7` command to score cycle 7 readiness from cycle 6 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-7 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce cycle 7 closeout quality gates.
+- Added strict contract validation script and tests that enforce cycle 7 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-8.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-8.md
@@ -4,7 +4,7 @@
 
 - Added `continuous-upgrade-closeout-8` command to score Cycle 8 readiness from Cycle 7 continuous-upgrade artifacts.
 - Added deterministic pack emission and execution evidence generation for impact-8 continuous-upgrade proof.
-- Added strict contract validation script and tests that enforce Cycle 8 closeout quality gates.
+- Added strict contract validation script and tests that enforce Cycle 8 completion report quality gates.
 
 ## Command lane
 

--- a/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-9.md
+++ b/docs/roadmap/reports/continuous-upgrade-big-upgrade-report-9.md
@@ -1,4 +1,4 @@
-# Cycle 9 — Continuous upgrade closeout lane report
+# Cycle 9 — Continuous upgrade completion report lane report
 
 ## Purpose
 Capture the active/public cycle 9 closeout surface with durable cycle-based wording.

--- a/docs/roadmap/reports/ultra-upgrade-report-14.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-14.md
@@ -2,13 +2,13 @@
 
 ## Upgrade title
 
-**Cycle 14 big upgrade: week-two closeout engine with growth signals, week-over-week deltas, strict policy mode, and emitted blocker-remediation operating pack.**
+**Cycle 14 big upgrade: week-two completion report engine with growth signals, week-over-week deltas, strict policy mode, and emitted blocker-remediation operating pack.**
 
 ## Problem statement
 
 Week-two delivery (Cycles 8-13) was shippable, but maintainers still needed manual reporting for growth and blocker outcomes.
 
-The previous Cycle 14 implementation only mirrored week-one coverage and did not enforce growth-signal completeness or produce structured closeout artifacts for handoff.
+The previous Cycle 14 implementation only mirrored week-one coverage and did not enforce growth-signal completeness or produce structured completion report artifacts for handoff.
 
 ## Implementation scope
 
@@ -24,9 +24,9 @@ The previous Cycle 14 implementation only mirrored week-one coverage and did not
 - `docs/cli.md`
   - Updated `weekly-review` command examples and flags with Cycle 14 growth-signal and pack workflows.
 - `README.md`
-  - Upgraded Cycle 14 section with signal files, strict closeout run, and pack-generation command.
+  - Upgraded Cycle 14 section with signal files, strict completion report run, and pack-generation command.
 - `docs/index.md`
-  - Added Cycle 14 signal-driven command examples and links to closeout artifacts.
+  - Added Cycle 14 signal-driven command examples and links to completion report artifacts.
 - `scripts/check_weekly_review_artifact_contract.py`
   - Hardened Cycle 14 contract checks to include growth-signal and pack-file expectations.
 - `docs/artifacts/cycle14-growth-signals.json`
@@ -34,7 +34,7 @@ The previous Cycle 14 implementation only mirrored week-one coverage and did not
 - `docs/artifacts/cycle7-growth-signals.json`
   - Added baseline week-one growth signals for delta calculations.
 - `docs/artifacts/cycle14-weekly-pack/*`
-  - Added emitted Cycle 14 closeout operating pack files.
+  - Added emitted Cycle 14 completion report operating pack files.
 
 ## Validation checklist
 
@@ -46,7 +46,7 @@ The previous Cycle 14 implementation only mirrored week-one coverage and did not
 
 ## Artifact
 
-This document is the Cycle 14 closeout report for weekly review #2 with growth deltas and blocker-remediation pack outputs.
+This document is the Cycle 14 completion report for weekly review #2 with growth deltas and blocker-remediation pack outputs.
 
 ## Rollback plan
 

--- a/docs/roadmap/reports/ultra-upgrade-report-15.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-15.md
@@ -22,7 +22,7 @@ Cycle 15 now ships a **full GitHub Actions integration operating loop**:
   - failure recovery playbook.
 - Expanded emitted pack artifacts with strict/nightly workflows and distribution plan.
 - Strengthened tests for execute/evidence behavior and strict failure paths.
-- Hardened contract check script to enforce Cycle 15 closeout assets.
+- Hardened contract check script to enforce Cycle 15 completion report assets.
 
 ## Validation commands
 

--- a/docs/roadmap/reports/ultra-upgrade-report-19.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-19.md
@@ -23,4 +23,4 @@ python scripts/check_release_readiness_contract.py
 
 ## Closeout
 
-Cycle 19 now provides one release score, one strict gate lane, and one evidence bundle that can be attached directly to weekly closeout and release-candidate reviews.
+Cycle 19 now provides one release score, one strict gate lane, and one evidence bundle that can be attached directly to weekly completion report and release-candidate reviews.

--- a/docs/roadmap/reports/ultra-upgrade-report-21.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-21.md
@@ -9,7 +9,7 @@ Cycle 21 ships **weekly review #3** so teams can objectively track conversion im
 - Extended `sdetkit weekly-review` to support `--week 3` (Cycle 15-20 shipped window).
 - Added Cycle 21 growth-signal sample input for deterministic week-over-week deltas.
 - Added Cycle 20/21 documentation entries in README and docs index.
-- Added tests covering week-3 KPI behavior, growth-delta computation, and week-3 emitted closeout pack output.
+- Added tests covering week-3 KPI behavior, growth-delta computation, and week-3 emitted completion report pack output.
 
 ## Validation commands
 

--- a/docs/roadmap/reports/ultra-upgrade-report-22.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-22.md
@@ -8,7 +8,7 @@ Cycle 22 ships a deterministic **trust signal upgrade lane** so maintainers can 
 
 - Upgraded `sdetkit trust-assets` to a weighted trust matrix: badge visibility, policy-doc/link discoverability, and workflow/docs-index governance checks.
 - Added Cycle 22 integration doc + contract checks for required sections, commands, and generated artifacts.
-- Expanded Cycle 22 closeout pack outputs with trust action-plan guidance in addition to summary, scorecard, checklist, validation commands, and execution evidence.
+- Expanded Cycle 22 completion report pack outputs with trust action-plan guidance in addition to summary, scorecard, checklist, validation commands, and execution evidence.
 - Added README/docs index/CLI references and tests for command dispatch/help coverage.
 
 ## Validation commands

--- a/docs/roadmap/reports/ultra-upgrade-report-24.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-24.md
@@ -1,4 +1,4 @@
-# Cycle 24 ultra upgrade report — onboarding time-to-first-success closeout
+# Cycle 24 ultra upgrade report — onboarding time-to-first-success completion report
 
 ## What shipped
 

--- a/docs/roadmap/reports/ultra-upgrade-report-25.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-25.md
@@ -1,4 +1,4 @@
-# Cycle 25 ultra upgrade report — community activation closeout
+# Cycle 25 ultra upgrade report — community activation completion report
 
 ## What shipped
 

--- a/docs/roadmap/reports/ultra-upgrade-report-26.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-26.md
@@ -1,4 +1,4 @@
-# Cycle 26 ultra upgrade report — external contribution push closeout
+# Cycle 26 ultra upgrade report — external contribution push completion report
 
 ## What shipped
 

--- a/docs/roadmap/reports/ultra-upgrade-report-27.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-27.md
@@ -1,4 +1,4 @@
-# Cycle 27 ultra upgrade report — KPI audit closeout
+# Cycle 27 ultra upgrade report — KPI audit completion report
 
 ## What shipped
 

--- a/docs/roadmap/reports/ultra-upgrade-report-28.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-28.md
@@ -1,4 +1,4 @@
-# Cycle 28 ultra upgrade report — weekly review #4 closeout
+# Cycle 28 ultra upgrade report — weekly review #4 completion report
 
 ## What shipped
 

--- a/docs/roadmap/reports/ultra-upgrade-report-29.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-29.md
@@ -1,4 +1,4 @@
-# Cycle 29 ultra upgrade report — phase-1 hardening closeout
+# Cycle 29 ultra upgrade report — phase-1 hardening completion report
 
 ## What shipped
 

--- a/docs/roadmap/reports/ultra-upgrade-report-31.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-31.md
@@ -1,4 +1,4 @@
-# Cycle 31 ultra upgrade report — Phase-2 kickoff baseline closeout
+# Cycle 31 ultra upgrade report — Phase-2 kickoff baseline completion report
 
 ## What shipped
 

--- a/docs/roadmap/reports/ultra-upgrade-report-32.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-32.md
@@ -13,4 +13,4 @@ Cycle 32 hardens Phase-2 execution by turning release behavior into a determinis
 
 ## Cycle 33 handoff
 
-Cycle 32 is now closed with a locked cadence contract and ready handoff into Cycle 33 demo asset production.
+Cycle 32 is now closed with a locked cadence contract and ready handoff into Cycle 33 example asset production.

--- a/docs/roadmap/reports/ultra-upgrade-report-33.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-33.md
@@ -3,7 +3,7 @@
 ## What shipped
 
 - Added a new Cycle 33 command: `python -m sdetkit cycle33-demo-asset`.
-- Added strict scoring + contract checks for the first demo-production lane.
+- Added strict scoring + contract checks for the first example-production lane.
 - Added Cycle 33 artifact pack outputs for plan, script, board, and validation commands.
 
 ## Validation
@@ -16,4 +16,4 @@ python -m sdetkit cycle33-demo-asset --format json --strict
 
 ## Cycle 34 handoff
 
-Cycle 33 is closed with a locked demo-production contract and explicit handoff into Cycle 34 demo asset #2 pre-scope.
+Cycle 33 is closed with a locked example-production contract and explicit handoff into Cycle 34 example asset #2 pre-scope.

--- a/docs/roadmap/reports/ultra-upgrade-report-34.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-34.md
@@ -16,4 +16,4 @@ python -m sdetkit cycle34-demo-asset2 --format json --strict
 
 ## Cycle 35 handoff
 
-Cycle 34 is closed with a locked repo-audit demo-production contract and explicit handoff into Cycle 35 KPI instrumentation sequencing.
+Cycle 34 is closed with a locked repo-audit example-production contract and explicit handoff into Cycle 35 KPI instrumentation sequencing.

--- a/docs/roadmap/reports/ultra-upgrade-report-4.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-4.md
@@ -23,7 +23,7 @@ For Cycle 4, operators needed a single command that executes all built-in skills
 - `docs/cli.md`
   - Added `templates run-all` command reference.
 - `README.md`
-  - Added Cycle 4 ultra section for skills expansion and closeout checks.
+  - Added Cycle 4 ultra section for skills expansion and completion report checks.
 - `docs/index.md`
   - Added Cycle 4 ultra docs entry and quick-jump link.
 - `docs/artifacts/cycle4-skills-sample.md`

--- a/docs/roadmap/reports/ultra-upgrade-report-7.md
+++ b/docs/roadmap/reports/ultra-upgrade-report-7.md
@@ -6,7 +6,7 @@
 
 ## Problem statement
 
-Phase-1 work had six daily upgrades shipped, but no deterministic way to produce a weekly closeout summary from the repository itself.
+Phase-1 work had six daily upgrades shipped, but no deterministic way to produce a weekly completion report summary from the repository itself.
 
 This made weekly reporting manual and increased drift risk between what was delivered and what was communicated.
 
@@ -26,7 +26,7 @@ This made weekly reporting manual and increased drift risk between what was deli
 - `tests/test_cli_help_lists_subcommands.py`
   - Extended CLI help contract to include `weekly-review` in `sdetkit --help` output.
 - `README.md`
-  - Added Cycle 7 weekly review section with runnable command flow and closeout checks.
+  - Added Cycle 7 weekly review section with runnable command flow and completion report checks.
 - `docs/index.md`
   - Added Cycle 7 report link and execution bullets.
 - `docs/cli.md`
@@ -45,7 +45,7 @@ This made weekly reporting manual and increased drift risk between what was deli
 
 ## Artifact
 
-This document is the Cycle 7 artifact report for Weekly review #1 closeout and KPI checkpointing.
+This document is the Cycle 7 artifact report for Weekly review #1 completion report and KPI checkpointing.
 
 ## Rollback plan
 

--- a/docs/ultra-upgrade-report-14.md
+++ b/docs/ultra-upgrade-report-14.md
@@ -2,13 +2,13 @@
 
 ## Upgrade title
 
-**Cycle 14 big upgrade: week-two closeout engine with growth signals, week-over-week deltas, strict policy mode, and emitted blocker-remediation operating pack.**
+**Cycle 14 big upgrade: week-two completion report engine with growth signals, week-over-week deltas, strict policy mode, and emitted blocker-remediation operating pack.**
 
 ## Problem statement
 
 Week-two delivery (Cycles 8-13) was shippable, but maintainers still needed manual reporting for growth and blocker outcomes.
 
-The previous Cycle 14 implementation only mirrored week-one coverage and did not enforce growth-signal completeness or produce structured closeout artifacts for handoff.
+The previous Cycle 14 implementation only mirrored week-one coverage and did not enforce growth-signal completeness or produce structured completion report artifacts for handoff.
 
 ## Implementation scope
 
@@ -24,9 +24,9 @@ The previous Cycle 14 implementation only mirrored week-one coverage and did not
 - `docs/cli.md`
   - Updated `weekly-review` command examples and flags with Cycle 14 growth-signal and pack workflows.
 - `README.md`
-  - Upgraded Cycle 14 section with signal files, strict closeout run, and pack-generation command.
+  - Upgraded Cycle 14 section with signal files, strict completion report run, and pack-generation command.
 - `docs/index.md`
-  - Added Cycle 14 signal-driven command examples and links to closeout artifacts.
+  - Added Cycle 14 signal-driven command examples and links to completion report artifacts.
 - `scripts/check_weekly_review_artifact_contract.py`
   - Hardened Cycle 14 contract checks to include growth-signal and pack-file expectations.
 - `docs/artifacts/cycle14-growth-signals.json`
@@ -34,7 +34,7 @@ The previous Cycle 14 implementation only mirrored week-one coverage and did not
 - `docs/artifacts/cycle7-growth-signals.json`
   - Added baseline week-one growth signals for delta calculations.
 - `docs/artifacts/cycle14-weekly-pack/*`
-  - Added emitted Cycle 14 closeout operating pack files.
+  - Added emitted Cycle 14 completion report operating pack files.
 
 ## Validation checklist
 
@@ -46,7 +46,7 @@ The previous Cycle 14 implementation only mirrored week-one coverage and did not
 
 ## Artifact
 
-This document is the Cycle 14 closeout report for weekly review #2 with growth deltas and blocker-remediation pack outputs.
+This document is the Cycle 14 completion report for weekly review #2 with growth deltas and blocker-remediation pack outputs.
 
 ## Rollback plan
 

--- a/docs/ultra-upgrade-report-15.md
+++ b/docs/ultra-upgrade-report-15.md
@@ -22,7 +22,7 @@ Cycle 15 now ships a **full GitHub Actions integration operating loop**:
   - failure recovery playbook.
 - Expanded emitted pack artifacts with strict/nightly workflows and distribution plan.
 - Strengthened tests for execute/evidence behavior and strict failure paths.
-- Hardened contract check script to enforce Cycle 15 closeout assets.
+- Hardened contract check script to enforce Cycle 15 completion report assets.
 
 ## Validation commands
 

--- a/docs/ultra-upgrade-report-32.md
+++ b/docs/ultra-upgrade-report-32.md
@@ -13,4 +13,4 @@ Cycle 32 hardens Phase-2 execution by turning release behavior into a determinis
 
 ## Cycle 33 handoff
 
-Cycle 32 is now closed with a locked cadence contract and ready handoff into Cycle 33 demo asset production.
+Cycle 32 is now closed with a locked cadence contract and ready handoff into Cycle 33 example asset production.

--- a/docs/ultra-upgrade-report-33.md
+++ b/docs/ultra-upgrade-report-33.md
@@ -3,7 +3,7 @@
 ## What shipped
 
 - Added a new Cycle 33 command: `python -m sdetkit cycle33-demo-asset`.
-- Added strict scoring + contract checks for the first demo-production lane.
+- Added strict scoring + contract checks for the first example-production lane.
 - Added Cycle 33 artifact pack outputs for plan, script, board, and validation commands.
 
 ## Validation
@@ -16,4 +16,4 @@ python -m sdetkit cycle33-demo-asset --format json --strict
 
 ## Cycle 34 handoff
 
-Cycle 33 is closed with a locked demo-production contract and explicit handoff into Cycle 34 demo asset #2 pre-scope.
+Cycle 33 is closed with a locked example-production contract and explicit handoff into Cycle 34 example asset #2 pre-scope.

--- a/docs/ultra-upgrade-report-34.md
+++ b/docs/ultra-upgrade-report-34.md
@@ -16,4 +16,4 @@ python -m sdetkit cycle34-demo-asset2 --format json --strict
 
 ## Cycle 35 handoff
 
-Cycle 34 is closed with a locked repo-audit demo-production contract and explicit handoff into Cycle 35 KPI instrumentation sequencing.
+Cycle 34 is closed with a locked repo-audit example-production contract and explicit handoff into Cycle 35 KPI instrumentation sequencing.

--- a/docs/ultra-upgrade-report-4.md
+++ b/docs/ultra-upgrade-report-4.md
@@ -23,7 +23,7 @@ For Cycle 4, operators needed a single command that executes all built-in skills
 - `docs/cli.md`
   - Added `templates run-all` command reference.
 - `README.md`
-  - Added Cycle 4 ultra section for skills expansion and closeout checks.
+  - Added Cycle 4 ultra section for skills expansion and completion report checks.
 - `docs/index.md`
   - Added Cycle 4 ultra docs entry and quick-jump link.
 - `docs/artifacts/cycle4-skills-sample.md`


### PR DESCRIPTION
## Summary
- Continue professional naming cleanup in Markdown prose.
- Focus wave 2 on docs-only findings from archive/report/artifact-style documentation surfaces.
- Keep the change docs-only and preserve source/test/CLI/artifact/workflow compatibility.

## Why
- The cleanup plan still recommends `docs-only-cleanup` as the first safe slice.
- Wave 1 reduced the inventory from `1097` to `1069`; wave 2 continues reducing docs-only naming debt without touching public surfaces.

## Verification
- Docs-only guard: no non-Markdown files changed.
- `PYTHONPATH=src python -m pytest -q tests/test_docs_workflow_typos.py::test_docs_do_not_contain_accidental_duplicate_words tests/test_release_prioritization.py::test_release_prioritization_docs_page_matches_default_template`
- `python -m sdetkit professional-naming-inventory --root . --out build/sdetkit/professional-naming-inventory-after-docs-wave2.json --format text`
- `python -m sdetkit professional-naming-cleanup-plan --inventory-json build/sdetkit/professional-naming-inventory-after-docs-wave2.json --out build/sdetkit/professional-naming-cleanup-plan-after-docs-wave2.json --format text`
- `make proof-after-format`

## Risk
- Medium-low.
- Prose-only docs cleanup.
- No source code changes.
- No tests changed.
- No CLI removals.
- No artifact ID changes.
- No workflow changes.
- No JSON key changes.
- No compatibility migration claimed.
- Rollback: revert the Markdown prose replacements.
