### PR TITLE
docs: audit cycle and impact naming patterns

### DIFF
--- a/docs/professional-naming-cycle-impact-audit.md
+++ b/docs/professional-naming-cycle-impact-audit.md
@@ -1,0 +1,74 @@
+# Professional naming audit: cycle and impact patterns
+
+## Purpose
+
+This is a read-only audit for numbered cycle and impact terminology that appears in historical reports, artifact paths, command examples, and prose.
+
+This audit does not authorize renames, compatibility migrations, public surface changes, artifact slug changes, workflow changes, JSON key changes, or command changes.
+
+## Current decision
+
+```text
+rename_allowed=false
+compatibility_migration_allowed=false
+public_surface_changes_allowed=false
+automation_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+```
+
+## Why this needs audit before cleanup
+
+The terminology appears across mixed surfaces:
+
+- historical chronology labels,
+- generated or archived report names,
+- artifact slugs and proof identifiers,
+- command examples,
+- prose-only documentation wording,
+- duplicated report mirrors.
+
+A broad text replacement would risk changing compatibility-bound references or historical evidence.
+
+## Classification model
+
+| Class | Meaning | Current action |
+| --- | --- | --- |
+| historical_chronology_label | Numbered labels used to preserve sequence or history. | Keep or defer. |
+| artifact_slug_or_proof_id | Path, generated artifact name, proof id, or report slug. | Compatibility plan required. |
+| command_example_or_cli_surface | CLI command, script command, Make target, or copied terminal lane. | Do not touch without alias and tests. |
+| prose_only_wording | Human prose where wording is not a path, command, slug, heading contract, or generated evidence. | Candidate for future docs cleanup. |
+| duplicated_report_mirror | Same historical/report content mirrored across multiple docs locations. | Consider later consolidation, not rename-first cleanup. |
+
+## Surfaces to inspect
+
+Initial candidate families for inspection:
+
+```text
+docs/big-upgrade-report-*.md
+docs/continuous-upgrade-big-upgrade-report-*.md
+docs/roadmap/reports/*
+docs/ultra-upgrade-report-*.md
+docs/impact-*-ultra-upgrade-report.md
+docs/artifacts/**
+```
+
+## Future cleanup rule
+
+Future edits may only touch entries classified as `prose_only_wording`.
+
+Before any rename or replacement, the PR must prove:
+
+```text
+reference_scan_done=true
+public_surface_change=false
+artifact_slug_change=false
+command_example_change=false
+json_key_change=false
+workflow_change=false
+compatibility_plan_present_if_needed=true
+```
+
+## Recommended next slice after this audit
+
+Use this audit to select a small prose-only cleanup wave. Keep compatibility-bound paths, command examples, artifact ids, chronology headings, and report filenames unchanged unless a later migration plan explicitly covers aliases, docs, tests, and rollback.


### PR DESCRIPTION
## Summary
- Add a read-only professional naming audit for numbered cycle and impact terminology.
- Classify mixed surfaces before any future cleanup wave.
- Preserve compatibility by making no renames, source changes, workflow changes, artifact slug changes, command changes, or JSON key changes.

## Why
- `Cycle X` and `impact-X` appear across historical chronology labels, artifact/proof identifiers, command examples, report mirrors, and prose-only wording.
- A broad replacement would risk changing compatibility-bound references or historical evidence.
- This PR creates a safe classification point before selecting any future prose-only cleanup slice.

## Verification
- `PYTHONPATH=src python -m pytest -q tests/test_docs_workflow_typos.py::test_docs_do_not_contain_accidental_duplicate_words tests/test_release_prioritization.py::test_release_prioritization_docs_page_matches_default_template`
- `python -m sdetkit professional-naming-inventory --root . --out build/sdetkit/professional-naming-inventory-after-cycle-impact-audit.json --format text`
- `python -m sdetkit professional-naming-cleanup-plan --inventory-json build/sdetkit/professional-naming-inventory-after-cycle-impact-audit.json --out build/sdetkit/professional-naming-cleanup-plan-after-cycle-impact-audit.json --format text`
- `make proof-after-format`

Proof result from local WSL2:
- focused tests: 2 passed
- naming inventory finding_count: 1047
- cleanup plan slice_count: 6
- recommended_first_slice: docs-only-cleanup
- proof-after-format: passed
- pre-commit hooks: passed
- mypy: passed

## Risk
- Low.
- Docs-only, read-only audit.
- Rollback: delete `docs/professional-naming-cycle-impact-audit.md`.

## Compatibility
- No public surface changes.
- No compatibility migration claimed.
- `rename_allowed=false`
- `compatibility_migration_allowed=false`
- `public_surface_changes_allowed=false`
- `automation_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`