### PR TITLE
docs: clean professional naming prose sweep

### DIFF
--- a/docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.md
+++ b/docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.md
@@ -1,4 +1,4 @@
-Acceleration closeout summary
+Acceleration completion summary
 - Activation score: 51
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.md
+++ b/docs/artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.md
@@ -1,4 +1,4 @@
-Case Study Launch Closeout summary
+Case Study Launch Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-closeout-summary.md
+++ b/docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-closeout-summary.md
@@ -1,4 +1,4 @@
-Case Study Prep1 Closeout summary
+Case Study Prep1 Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/case-study-prep2-closeout-pack/case-study-prep2-closeout-summary.md
+++ b/docs/artifacts/case-study-prep2-closeout-pack/case-study-prep2-closeout-summary.md
@@ -1,4 +1,4 @@
-Case Study Prep 2 Closeout summary
+Case Study Prep 2 Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/case-study-prep3-closeout-pack/case-study-prep3-closeout-summary.md
+++ b/docs/artifacts/case-study-prep3-closeout-pack/case-study-prep3-closeout-summary.md
@@ -1,4 +1,4 @@
-Case Study Prep3 Closeout summary
+Case Study Prep3 Completion summary
 - Activation score: 49
 - Passed checks: 7
 - Failed checks: 7

--- a/docs/artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.md
+++ b/docs/artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.md
@@ -1,4 +1,4 @@
-Case Study Prep4 Closeout summary
+Case Study Prep4 Completion summary
 - Activation score: 54
 - Passed checks: 8
 - Failed checks: 6

--- a/docs/artifacts/community-program-closeout-pack/community-program-closeout-summary.md
+++ b/docs/artifacts/community-program-closeout-pack/community-program-closeout-summary.md
@@ -1,4 +1,4 @@
-Community Program Closeout summary
+Community Program Completion summary
 - Activation score: 36
 - Passed checks: 5
 - Failed checks: 8

--- a/docs/artifacts/community-touchpoint-closeout-pack/community-touchpoint-closeout-summary.md
+++ b/docs/artifacts/community-touchpoint-closeout-pack/community-touchpoint-closeout-summary.md
@@ -1,4 +1,4 @@
-Community Touchpoint Closeout summary
+Community Touchpoint Completion summary
 - Activation score: 69
 - Passed checks: 10
 - Failed checks: 4

--- a/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.md
+++ b/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.md
@@ -1,4 +1,4 @@
-Contributor Activation Closeout summary (legacy: )
+Contributor Activation Completion summary (legacy: )
 - Activation score: 48
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.md
+++ b/docs/artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.md
@@ -1,4 +1,4 @@
-Contributor Recognition Closeout summary
+Contributor Recognition Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/demo-asset-pack/demo-asset-summary.md
+++ b/docs/artifacts/demo-asset-pack/demo-asset-summary.md
@@ -16,7 +16,7 @@
 ## Misses
 -  strict continuity signal is missing.
 -  delivery board integrity is incomplete (needs >=5 items and /34 anchors).
-- Demo contract, quality checklist, or delivery board entries are missing.
+- Example contract, quality checklist, or delivery board entries are missing.
 
 ## Handoff actions
 - [ ] Re-run  cadence command and restore strict pass baseline before demo lock.

--- a/docs/artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.md
+++ b/docs/artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.md
@@ -1,4 +1,4 @@
-Distribution Scaling Closeout summary
+Distribution Scaling Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/docs-loop-closeout-pack-53/docs-loop-closeout-summary.md
+++ b/docs/artifacts/docs-loop-closeout-pack-53/docs-loop-closeout-summary.md
@@ -1,4 +1,4 @@
-Docs Loop Closeout summary (legacy: )
+Docs Loop Completion summary (legacy: )
 - Activation score: 41
 - Passed checks: 5
 - Failed checks: 9

--- a/docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.md
+++ b/docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.md
@@ -1,4 +1,4 @@
-Docs Loop Closeout summary (legacy: )
+Docs Loop Completion summary (legacy: )
 - Activation score: 41
 - Passed checks: 5
 - Failed checks: 9

--- a/docs/artifacts/ecosystem-priorities-closeout-pack/ecosystem-priorities-closeout-summary.md
+++ b/docs/artifacts/ecosystem-priorities-closeout-pack/ecosystem-priorities-closeout-summary.md
@@ -1,4 +1,4 @@
-Ecosystem Priorities Closeout summary
+Ecosystem Priorities Completion summary
 - Activation score: 69
 - Passed checks: 10
 - Failed checks: 4

--- a/docs/artifacts/execution-prioritization-closeout-pack-50/execution-prioritization-closeout-summary.md
+++ b/docs/artifacts/execution-prioritization-closeout-pack-50/execution-prioritization-closeout-summary.md
@@ -1,4 +1,4 @@
- execution prioritization closeout summary
+ execution prioritization completion summary
 - Activation score: 51
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/experiment-lane-pack/experiment-lane-summary.md
+++ b/docs/artifacts/experiment-lane-pack/experiment-lane-summary.md
@@ -12,11 +12,11 @@
 - Distribution closeout delivery board checklist items: `5`
 
 ## Wins
-- Distribution closeout delivery board integrity validated with 5 checklist items.
+- Distribution completion delivery board integrity validated with 5 checklist items.
 - Experiment contract + quality checklist is fully locked for execution.
 
 ## Misses
-- Distribution closeout strict continuity signal is missing.
+- Distribution completion strict continuity signal is missing.
 
 ## Handoff actions
 - [ ] Re-run distribution closeout command and restore strict pass baseline before experiment lane lock.

--- a/docs/artifacts/governance-handoff-closeout-pack/governance-handoff-closeout-summary.md
+++ b/docs/artifacts/governance-handoff-closeout-pack/governance-handoff-closeout-summary.md
@@ -1,4 +1,4 @@
- governance handoff closeout summary
+ governance handoff completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/governance-priorities-closeout-pack/governance-priorities-closeout-summary.md
+++ b/docs/artifacts/governance-priorities-closeout-pack/governance-priorities-closeout-summary.md
@@ -1,4 +1,4 @@
- governance priorities closeout summary
+ governance priorities completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/governance-scale-closeout-pack/governance-scale-closeout-summary.md
+++ b/docs/artifacts/governance-scale-closeout-pack/governance-scale-closeout-summary.md
@@ -1,4 +1,4 @@
- governance scale closeout summary
+ governance scale completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/integration-expansion-closeout-pack/integration-expansion-closeout-summary.md
+++ b/docs/artifacts/integration-expansion-closeout-pack/integration-expansion-closeout-summary.md
@@ -1,4 +1,4 @@
-Integration Expansion Closeout summary
+Integration Expansion Completion summary
 - Activation score: 45
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.md
+++ b/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.md
@@ -1,4 +1,4 @@
-Integration Expansion 2 Closeout summary
+Integration Expansion 2 Completion summary
 - Activation score: 37
 - Passed checks: 5
 - Failed checks: 9

--- a/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.md
+++ b/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.md
@@ -1,4 +1,4 @@
-Integration Expansion3 Closeout summary
+Integration Expansion3 Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.md
+++ b/docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.md
@@ -1,4 +1,4 @@
-Integration Expansion4 Closeout summary
+Integration Expansion4 Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/issue-pack-8/gfi-06.md
+++ b/docs/artifacts/issue-pack-8/gfi-06.md
@@ -8,4 +8,4 @@
 
 1. Contributing docs include explicit docs/artifacts/dayX-* naming guidance.
 2. Examples include at least one markdown artifact path.
-3. Language remains beginner-friendly and concise.
+3. Language remains introductory-friendly and concise.

--- a/docs/artifacts/kpi-instrumentation-pack-35/kpi-instrumentation-summary-35.md
+++ b/docs/artifacts/kpi-instrumentation-pack-35/kpi-instrumentation-summary-35.md
@@ -15,7 +15,7 @@
 - Name 34 continuity is strict-pass with activation score=100.0.
 - Name 34 delivery board integrity validated with 5 checklist items.
 - KPI instrumentation contract + quality checklist is fully locked for execution.
-- Name 35 KPI instrumentation closeout is fully complete and ready for Name 36 distribution execution.
+- Name 35 KPI instrumentation completion is fully complete and ready for Name 36 distribution execution.
 
 ## Misses
 - No misses recorded.

--- a/docs/artifacts/launch-readiness-closeout-pack/launch-readiness-closeout-summary.md
+++ b/docs/artifacts/launch-readiness-closeout-pack/launch-readiness-closeout-summary.md
@@ -1,4 +1,4 @@
- launch readiness closeout summary
+ launch readiness completion summary
 - Activation score: 50
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.md
+++ b/docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.md
@@ -1,4 +1,4 @@
-Optimization Closeout Foundation optimization closeout summary
+Optimization Completion Foundation optimization completion summary
 - Activation score: 51
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/optimization-closeout-foundation-pack/optimization-plan.md
+++ b/docs/artifacts/optimization-closeout-foundation-pack/optimization-plan.md
@@ -1,3 +1,3 @@
 # Optimization Closeout Foundation Optimization Plan
 
-- Objective: close Optimization Closeout Foundation with measurable quality and throughput gains.
+- Objective: close Optimization Completion Foundation with measurable quality and throughput gains.

--- a/docs/artifacts/optimization-closeout-pack-42/optimization-plan-42.md
+++ b/docs/artifacts/optimization-closeout-pack-42/optimization-plan-42.md
@@ -1,3 +1,3 @@
 # Optimization Closeout Foundation Optimization Plan
 
-- Objective: close Optimization Closeout Foundation with measurable quality and throughput gains.
+- Objective: close Optimization Completion Foundation with measurable quality and throughput gains.

--- a/docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.md
+++ b/docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.md
@@ -1,4 +1,4 @@
-Phase3 Kickoff Closeout summary
+Phase3 Kickoff Completion summary
 - Activation score: 29
 - Passed checks: 4
 - Failed checks: 9

--- a/docs/artifacts/phase3-wrap-publication-closeout-pack/phase3-wrap-publication-closeout-summary.md
+++ b/docs/artifacts/phase3-wrap-publication-closeout-pack/phase3-wrap-publication-closeout-summary.md
@@ -1,4 +1,4 @@
- phase-3 wrap publication closeout summary
+ phase-3 wrap publication completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/release-prioritization-closeout-pack/release-prioritization-closeout-summary.md
+++ b/docs/artifacts/release-prioritization-closeout-pack/release-prioritization-closeout-summary.md
@@ -1,4 +1,4 @@
- release prioritization closeout summary
+ release prioritization completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/reliability-evidence-pack-sample.md
+++ b/docs/artifacts/reliability-evidence-pack-sample.md
@@ -5,4 +5,4 @@
 - Gate status: **pass**
 
 ## Recommendations
-- Reliability posture is strong; keep current CI and closeout operating cadence.
+- Reliability posture is strong; keep current CI and completion operating cadence.

--- a/docs/artifacts/scale-closeout-pack/scale-closeout-summary.md
+++ b/docs/artifacts/scale-closeout-pack/scale-closeout-summary.md
@@ -1,4 +1,4 @@
-Scale closeout summary
+Scale completion summary
 - Activation score: 51
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/scale-upgrade-closeout-pack/scale-upgrade-closeout-summary.md
+++ b/docs/artifacts/scale-upgrade-closeout-pack/scale-upgrade-closeout-summary.md
@@ -1,4 +1,4 @@
-Scale Upgrade Closeout summary
+Scale Upgrade Completion summary
 - Activation score: 61
 - Passed checks: 9
 - Failed checks: 5

--- a/docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.md
+++ b/docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.md
@@ -1,4 +1,4 @@
-Trust Assets Refresh Closeout summary
+Trust Assets Refresh Completion summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8

--- a/docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.md
+++ b/docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.md
@@ -1,4 +1,4 @@
-Weekly Review Closeout summary
+Weekly Review Completion summary
 - Activation score: 55
 - Passed checks: 8
 - Failed checks: 6

--- a/docs/artifacts/weekly-review-pack/weekly-review-kpi-rollup.md
+++ b/docs/artifacts/weekly-review-pack/weekly-review-kpi-rollup.md
@@ -16,8 +16,8 @@
 - External contribution stayed healthy (100.0).
 
 ## Misses
--  summary missing or below closeout target.
--  KPI summary missing or below closeout target.
+-  summary missing or below completion target.
+-  KPI summary missing or below completion target.
 
 ## Corrective actions
 - [ ] Re-run  pack generation and restore summary JSON for traceability.

--- a/docs/artifacts/weekly-review-pack/weekly-review-wins-misses-actions.md
+++ b/docs/artifacts/weekly-review-pack/weekly-review-wins-misses-actions.md
@@ -4,8 +4,8 @@
 - External contribution stayed healthy (100.0).
 
 ## Misses
--  summary missing or below closeout target.
--  KPI summary missing or below closeout target.
+-  summary missing or below completion target.
+-  KPI summary missing or below completion target.
 
 ## Corrective actions
 - [ ] Re-run  pack generation and restore summary JSON for traceability.

--- a/docs/artifacts/weekly-review-sample-14.md
+++ b/docs/artifacts/weekly-review-sample-14.md
@@ -33,6 +33,6 @@
 
 ## Next-week focus
 
-- Name 15: refine multi-channel distribution loop for documentation and demos.
+- Name 15: refine multi-channel distribution loop for documentation and examples.
 - Name 16: publish adoption-ready workflow templates with copy/paste CI variants.
 - Name 17: capture week-over-week quality + contribution deltas in one evidence pack.

--- a/docs/artifacts/wrap-pack-30/phase1-wrap-summary-30.md
+++ b/docs/artifacts/wrap-pack-30/phase1-wrap-summary-30.md
@@ -13,7 +13,7 @@
 - Average score: `100.0`
 
 ## Wins
-- Names 27-29 closeout artifacts loaded successfully (avg=100.0).
+- Names 27-29 completion artifacts loaded successfully (avg=100.0).
 - Phase-2 backlog locked with 8 actionable checklist items.
 - Name 30 wrap is release-ready and can hand off into Phase-2 kickoff.
 

--- a/docs/big-upgrade-report-53.md
+++ b/docs/big-upgrade-report-53.md
@@ -7,7 +7,7 @@ Close Cycle 53 with a high-confidence docs-loop optimization lane that turns Cyc
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 53 CLI lane: `cycle53-docs-loop-closeout`.
-- Added strict docs-loop contract checks for cross-links between demos, playbooks, and CLI docs.
+- Added strict docs-loop contract checks for cross-links between examples, playbooks, and CLI docs.
 - Added artifact-pack emission for docs-loop brief, cross-link map, KPI scorecard, and execution logs.
 - Added deterministic execution evidence capture for repeatable completion report verification.
 

--- a/docs/business_execution/02-pricing-logic-v1.md
+++ b/docs/business_execution/02-pricing-logic-v1.md
@@ -324,7 +324,7 @@ For every deal, log:
 - Discount details
 - Objections
 - Win/loss outcome
-- Lessons for model revision
+- Guides for model revision
 
 ---
 

--- a/docs/business_execution/03-gtm-30-day-operating-calendar.md
+++ b/docs/business_execution/03-gtm-30-day-operating-calendar.md
@@ -97,7 +97,7 @@ Deliverables:
 - Create objection-response notes.
 
 Deliverables:
-- Demo script v1
+- Example script v1
 - Objection log v1
 
 ### Day 5

--- a/docs/integrations-demo-asset.md
+++ b/docs/integrations-demo-asset.md
@@ -24,7 +24,7 @@ python scripts/check_demo_asset_contract.py
 
 ## Demo production contract
 
-- Demo owner: one accountable editor and one backup reviewer are assigned.
+- Example owner: one accountable editor and one backup reviewer are assigned.
 - Target format: publish both MP4 clip and GIF teaser for social/docs embedding.
 - Runtime SLA: main example duration stays between 45 and 90 seconds.
 - Narrative shape: pain -> command -> output -> value CTA must appear in order.
@@ -52,4 +52,4 @@ Lane weighted score (0-100):
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
 - Lane continuity and strict baseline carryover: 35 points.
-- Demo contract lock + delivery board readiness: 15 points.
+- Example contract lock + delivery board readiness: 15 points.

--- a/docs/integrations-demo-asset2.md
+++ b/docs/integrations-demo-asset2.md
@@ -24,7 +24,7 @@ python scripts/check_demo_asset2_contract.py
 
 ## Repo-audit production contract
 
-- Demo owner: one accountable editor and one backup reviewer are assigned.
+- Example owner: one accountable editor and one backup reviewer are assigned.
 - Target format: publish both MP4 clip and GIF teaser for social/docs embedding.
 - Runtime SLA: main example duration stays between 60 and 120 seconds.
 - Narrative shape: repo risk -> audit command -> findings -> remediation CTA must appear in order.

--- a/docs/integrations-documentation-loop-workflow.md
+++ b/docs/integrations-documentation-loop-workflow.md
@@ -1,6 +1,6 @@
 # Documentation governance workflow
 
-Lane closes with a major docs loop optimization upgrade that converts Lane narrative evidence into deterministic cross-link execution across demos, playbooks, and CLI docs.
+Lane closes with a major docs loop optimization upgrade that converts Lane narrative evidence into deterministic cross-link execution across examples, playbooks, and CLI docs.
 
 ## Why Lane matters
 

--- a/docs/integrations-growth-campaign-workflow.md
+++ b/docs/integrations-growth-campaign-workflow.md
@@ -48,7 +48,7 @@ python scripts/check_growth_campaign_closeout_contract.py
 
 ## Scoring model
 
-Growth Campaign Closeout weighted score (0-100):
+Growth Campaign Completion weighted score (0-100):
 
 - Contract + command lane integrity (35)
 - Lane continuity baseline quality (35)

--- a/docs/integrations-integration-feedback-workflow.md
+++ b/docs/integrations-integration-feedback-workflow.md
@@ -48,7 +48,7 @@ python scripts/check_integration_feedback_closeout_contract.py
 
 ## Scoring model
 
-Integration Feedback Closeout weighted score (0-100):
+Integration Feedback Completion weighted score (0-100):
 
 - Contract + command lane integrity (35)
 - Lane continuity baseline quality (35)

--- a/docs/integrations-optimization-closeout-foundation.md
+++ b/docs/integrations-optimization-closeout-foundation.md
@@ -1,6 +1,6 @@
 # Optimization foundation workflow
 
-Optimization Closeout Foundation closes the lane with a major optimization upgrade that converts Lane expansion outcomes into deterministic remediation loops.
+Optimization Completion Foundation closes the lane with a major optimization upgrade that converts Lane expansion outcomes into deterministic remediation loops.
 
 ## Why Optimization Closeout Foundation matters
 
@@ -24,10 +24,10 @@ python scripts/check_optimization_closeout_contract.py
 
 ## Optimization completion report contract
 
-- Single owner + backup reviewer are assigned for Optimization Closeout Foundation optimization lane execution and KPI follow-up.
-- The Optimization Closeout Foundation optimization lane references Lane expansion winners and misses with deterministic remediation loops.
-- Every Optimization Closeout Foundation section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.
-- Optimization Closeout Foundation completion report records optimization learnings and Lane acceleration priorities.
+- Single owner + backup reviewer are assigned for Optimization Completion Foundation optimization lane execution and KPI follow-up.
+- The Optimization Completion Foundation optimization lane references Lane expansion winners and misses with deterministic remediation loops.
+- Every Optimization Completion Foundation section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.
+- Optimization Completion Foundation completion report records optimization learnings and Lane acceleration priorities.
 
 ## Optimization quality checklist
 
@@ -47,7 +47,7 @@ python scripts/check_optimization_closeout_contract.py
 
 ## Scoring model
 
-Optimization Closeout Foundation weighted score (0-100):
+Optimization Completion Foundation weighted score (0-100):
 
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.

--- a/docs/integrations-trust-faq-expansion-workflow.md
+++ b/docs/integrations-trust-faq-expansion-workflow.md
@@ -48,7 +48,7 @@ python scripts/check_trust_faq_expansion_closeout_contract.py
 
 ## Scoring model
 
-Trust FAQ Expansion Closeout weighted score (0-100):
+Trust FAQ Expansion Completion weighted score (0-100):
 
 - Contract + command lane integrity (35)
 - Lane continuity baseline quality (35)

--- a/docs/investor-readiness-review-2026-04-18.md
+++ b/docs/investor-readiness-review-2026-04-18.md
@@ -36,7 +36,7 @@ The highest-value gap is not product vision; it is **operational signal clarity*
 
 - **Investor narrative strength: high** (clear problem/solution and packaging).
 - **Operational polish: medium** (lint/docs routing drift visible).
-- **Execution confidence for due diligence demos: medium-to-high** once quick hygiene fixes are applied.
+- **Execution confidence for due diligence examples: medium-to-high** once quick hygiene fixes are applied.
 
 ## Immediate actions (save time + money)
 

--- a/docs/module-rationalization-plan.md
+++ b/docs/module-rationalization-plan.md
@@ -94,7 +94,7 @@ Rationale: directly tied to release/governance/reliability decision contexts.
 
 ## Success criteria
 
-- Closeout-era module count reduced by >= 40% without Tier-A behavior changes.
+- Completion-era module count reduced by >= 40% without Tier-A behavior changes.
 - No CLI contract regressions on migrated commands.
 - Help/discovery surface simplified (fewer default/visible transition-era commands).
 

--- a/docs/roadmap/reports/big-upgrade-report-53.md
+++ b/docs/roadmap/reports/big-upgrade-report-53.md
@@ -7,7 +7,7 @@ Close Cycle 53 with a high-confidence docs-loop optimization lane that turns Cyc
 ## Big upgrades delivered
 
 - Added a dedicated Cycle 53 CLI lane: `cycle53-docs-loop-closeout`.
-- Added strict docs-loop contract checks for cross-links between demos, playbooks, and CLI docs.
+- Added strict docs-loop contract checks for cross-links between examples, playbooks, and CLI docs.
 - Added artifact-pack emission for docs-loop brief, cross-link map, KPI scorecard, and execution logs.
 - Added deterministic execution evidence capture for repeatable completion report verification.
 


### PR DESCRIPTION
## Summary
- Continue professional naming cleanup in Markdown prose after the cycle/impact audit guardrail.
- Consolidate wave 3 and the follow-up prose sweep into one PR on `docs/professional-naming-prose-cleanup-wave3`.
- Keep the change docs-only and preserve source/test/CLI/artifact/workflow/JSON compatibility.

## Why
- Previous waves reduced safe docs-only naming debt while preserving compatibility boundaries.
- This PR continues that cleanup pattern with a broader safe prose-only sweep rather than opening several tiny PRs.
- Remaining inventory still reports `compatibility_required=true`, so this PR does not claim full cleanup or rename authority.

## Verification
- `PYTHONPATH=src python -m pytest -q tests/test_docs_workflow_typos.py::test_docs_do_not_contain_accidental_duplicate_words tests/test_release_prioritization.py::test_release_prioritization_docs_page_matches_default_template`
- `python -m sdetkit professional-naming-inventory --root . --out build/sdetkit/professional-naming-inventory-after-docs-prose-sweep.json --format text`
- `python -m sdetkit professional-naming-cleanup-plan --inventory-json build/sdetkit/professional-naming-inventory-after-docs-prose-sweep.json --out build/sdetkit/professional-naming-cleanup-plan-after-docs-prose-sweep.json --format text`
- `make proof-after-format`

Proof result from local WSL2:
- focused tests: 2 passed
- naming inventory finding_count: 1047
- cleanup plan slice_count: 6
- recommended_first_slice: docs-only-cleanup
- proof-after-format: passed
- pre-commit hooks: passed
- mypy: passed

## Risk
- Medium-low.
- Prose-only docs cleanup.
- No source code changes.
- No tests changed.
- No CLI removals.
- No artifact ID changes.
- No workflow changes.
- No JSON key changes.
- No compatibility migration claimed.
- Rollback: revert the Markdown prose replacements.

## Compatibility
- `rename_allowed=false`
- `compatibility_migration_allowed=false`
- `public_surface_changes_allowed=false`
- `automation_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`