### PR TITLE
feat: separate actionable naming debt from review-first findings

### DIFF
--- a/docs/integrations-release-prioritization-completion.md
+++ b/docs/integrations-release-prioritization-completion.md
@@ -10,17 +10,17 @@ This lane closes with a major upgrade that converts evidence narrative outcomes 
 
 ## Required inputs (Release prioritization completion report lane)
 
-- `docs/artifacts/evidence-narrative-completion-pack/evidence-narrative-completion-summary.json`
-- `docs/artifacts/evidence-narrative-completion-pack/evidence-narrative-delivery-board.md`
+- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-closeout-summary.json`
+- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md`
 - `docs/roadmap/plans/release-prioritization-plan.json`
 
 ## Command lane
 
 ```bash
-python -m sdetkit release-prioritization-completion --format json --strict
-python -m sdetkit release-prioritization-completion --emit-pack-dir docs/artifacts/release-prioritization-completion-pack --format json --strict
-python -m sdetkit release-prioritization-completion --execute --evidence-dir docs/artifacts/release-prioritization-completion-pack/evidence --format json --strict
-python scripts/check_release_prioritization_completion_contract.py
+python -m sdetkit release-prioritization-closeout --format json --strict
+python -m sdetkit release-prioritization-closeout --emit-pack-dir docs/artifacts/release-prioritization-closeout-pack --format json --strict
+python -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/artifacts/release-prioritization-closeout-pack/evidence --format json --strict
+python scripts/check_release_prioritization_closeout_contract.py
 ```
 
 ## Release prioritization contract
@@ -28,7 +28,7 @@ python scripts/check_release_prioritization_completion_contract.py
 - Single owner + backup reviewer are assigned for this release prioritization execution and signoff.
 - This lane references evidence narrative outcomes, controls, and trust continuity signals.
 - Every section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
-- This completion records release prioritization pack upgrades, storyline outcomes, and launch priorities.
+- This closeout records release prioritization pack upgrades, storyline outcomes, and launch priorities.
 
 ## Release prioritization quality checklist
 

--- a/docs/integrations-release-prioritization-completion.md
+++ b/docs/integrations-release-prioritization-completion.md
@@ -10,17 +10,17 @@ This lane closes with a major upgrade that converts evidence narrative outcomes 
 
 ## Required inputs (Release prioritization completion report lane)
 
-- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-closeout-summary.json`
-- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md`
+- `docs/artifacts/evidence-narrative-completion-pack/evidence-narrative-completion-summary.json`
+- `docs/artifacts/evidence-narrative-completion-pack/evidence-narrative-delivery-board.md`
 - `docs/roadmap/plans/release-prioritization-plan.json`
 
 ## Command lane
 
 ```bash
-python -m sdetkit release-prioritization-closeout --format json --strict
-python -m sdetkit release-prioritization-closeout --emit-pack-dir docs/artifacts/release-prioritization-closeout-pack --format json --strict
-python -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/artifacts/release-prioritization-closeout-pack/evidence --format json --strict
-python scripts/check_release_prioritization_closeout_contract.py
+python -m sdetkit release-prioritization-completion --format json --strict
+python -m sdetkit release-prioritization-completion --emit-pack-dir docs/artifacts/release-prioritization-completion-pack --format json --strict
+python -m sdetkit release-prioritization-completion --execute --evidence-dir docs/artifacts/release-prioritization-completion-pack/evidence --format json --strict
+python scripts/check_release_prioritization_completion_contract.py
 ```
 
 ## Release prioritization contract
@@ -28,7 +28,7 @@ python scripts/check_release_prioritization_closeout_contract.py
 - Single owner + backup reviewer are assigned for this release prioritization execution and signoff.
 - This lane references evidence narrative outcomes, controls, and trust continuity signals.
 - Every section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
-- This closeout records release prioritization pack upgrades, storyline outcomes, and launch priorities.
+- This completion records release prioritization pack upgrades, storyline outcomes, and launch priorities.
 
 ## Release prioritization quality checklist
 

--- a/src/sdetkit/professional_naming_cleanup_plan.py
+++ b/src/sdetkit/professional_naming_cleanup_plan.py
@@ -69,6 +69,13 @@ def _number(value: object) -> int:
         return 0
 
 
+def _is_actionable(item: dict[str, Any]) -> bool:
+    actionability = _text(item.get("actionability"), "")
+    if actionability:
+        return actionability == "actionable_prose_cleanup"
+    return _text(item.get("classification")) in SAFE_CLASSES
+
+
 def _top_counts(items: list[dict[str, Any]], field: str, *, limit: int = 8) -> list[dict[str, Any]]:
     counts = Counter(_text(item.get(field)) for item in items)
     return [
@@ -101,17 +108,21 @@ def _scope_for_classification(classification: str) -> str:
 
 def _slice(items: list[dict[str, Any]], classification: str) -> dict[str, Any]:
     requires_compatibility = classification in COMPATIBILITY_CLASSES
+    actionable_finding_count = sum(1 for item in items if _is_actionable(item))
+    review_first_finding_count = len(items) - actionable_finding_count
     return {
         "id": classification.replace("_", "-"),
         "classification": classification,
         "priority": PRIORITY_BY_CLASSIFICATION.get(classification, 80),
         "finding_count": len(items),
+        "actionable_finding_count": actionable_finding_count,
+        "review_first_finding_count": review_first_finding_count,
         "occurrence_count": sum(max(1, _number(item.get("occurrence_count"))) for item in items),
         "top_terms": _top_counts(items, "term"),
         "top_surfaces": _top_counts(items, "surface"),
         "top_paths": _path_counts(items),
         "recommended_scope": _scope_for_classification(classification),
-        "safe_to_plan_first": classification in SAFE_CLASSES,
+        "safe_to_plan_first": classification in SAFE_CLASSES and actionable_finding_count > 0,
         "requires_compatibility_plan": requires_compatibility,
         **ACTION_BOUNDARY,
         **AUTHORITY_BOUNDARY,
@@ -123,6 +134,8 @@ def build_professional_naming_cleanup_plan(inventory: dict[str, Any]) -> dict[st
     grouped: dict[str, list[dict[str, Any]]] = {}
     for item in items:
         grouped.setdefault(_text(item.get("classification")), []).append(item)
+
+    actionable_finding_count = sum(1 for item in items if _is_actionable(item))
 
     slices = [_slice(members, classification) for classification, members in grouped.items()]
     slices.sort(
@@ -141,6 +154,8 @@ def build_professional_naming_cleanup_plan(inventory: dict[str, Any]) -> dict[st
         "inventory_schema": str(inventory.get("schema_version", "")),
         "inventory_status": str(inventory.get("status", "")),
         "inventory_finding_count": _number(inventory.get("finding_count")),
+        "actionable_finding_count": actionable_finding_count,
+        "review_first_finding_count": len(items) - actionable_finding_count,
         "slice_count": len(slices),
         "safe_slice_count": sum(1 for item in slices if item["safe_to_plan_first"]),
         "compatibility_slice_count": sum(
@@ -149,9 +164,14 @@ def build_professional_naming_cleanup_plan(inventory: dict[str, Any]) -> dict[st
         "recommended_first_slice": first_safe["id"] if first_safe else None,
         "cleanup_slices": slices,
         "recommended_action": (
-            "start with docs-only or internal cleanup slices; defer public surfaces until alias plans exist"
-            if items
-            else "retain clean naming plan as evidence"
+            "start with actionable docs-only or internal cleanup slices; defer public surfaces until alias plans exist"
+            if actionable_finding_count
+            else (
+                "no actionable direct cleanup slice remains; preserve review-first historical, path, "
+                "template, workflow, and compatibility-bound findings until explicit migration plans exist"
+                if items
+                else "retain clean naming plan as evidence"
+            )
         ),
         **ACTION_BOUNDARY,
         **AUTHORITY_BOUNDARY,
@@ -191,6 +211,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stdout.write(f"cleanup_plan_json={ns.out}\n")
         sys.stdout.write(f"status={payload['status']}\n")
         sys.stdout.write(f"slice_count={payload['slice_count']}\n")
+        sys.stdout.write(f"actionable_finding_count={payload['actionable_finding_count']}\n")
+        sys.stdout.write(f"review_first_finding_count={payload['review_first_finding_count']}\n")
         sys.stdout.write(f"recommended_first_slice={payload['recommended_first_slice']}\n")
         sys.stdout.write(f"rename_allowed={str(payload['rename_allowed']).lower()}\n")
         sys.stdout.write(

--- a/src/sdetkit/professional_naming_inventory.py
+++ b/src/sdetkit/professional_naming_inventory.py
@@ -58,6 +58,120 @@ SKIP_PARTS = {
     ".eggs",
 }
 
+ACTIONABLE_PROSE = "actionable_prose_cleanup"
+REVIEW_FIRST_CONTEXT = "review_first_context"
+MIGRATION_OR_ALIAS_REQUIRED = "migration_or_alias_required"
+INTERNAL_REVIEW_FIRST = "internal_cleanup_review_first"
+
+
+def _docs_line_review_reason(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped:
+        return "blank"
+    if stripped.startswith("#"):
+        return "heading_or_chronology_label"
+    if stripped.startswith("|"):
+        return "table_or_generated_matrix"
+
+    protected_fragments = [
+        "`",
+        "http://",
+        "https://",
+        "](",
+        "/",
+        "\\",
+        "{",
+        "}",
+        "[",
+        "]",
+        "--",
+        "python -m",
+        "make ",
+        "sdetkit ",
+        "git ",
+        "pytest",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".py",
+        ".md",
+        ".sh",
+        "Cycle ",
+        "cycle ",
+        "impact-",
+        "impact ",
+    ]
+    if any(fragment in line for fragment in protected_fragments):
+        return "command_path_link_schema_or_audit_context"
+
+    if "=" in line and len(line.split("=", 1)[0].strip().split()) <= 3:
+        return "key_value_or_template_contract"
+
+    if re.match(r"^\s{0,4}[A-Za-z0-9_-]+:\s", line):
+        return "yaml_or_metadata_contract"
+
+    return None
+
+
+def _actionability_fields(
+    path: Path,
+    classification: str,
+    *,
+    match_type: str,
+    matching_lines: Sequence[int] | None = None,
+    lines: Sequence[str] | None = None,
+) -> dict[str, str]:
+    if classification in {
+        "public_surface_requires_alias",
+        "workflow_alias_migration",
+        "internal_path_requires_migration",
+    }:
+        return {
+            "actionability": MIGRATION_OR_ALIAS_REQUIRED,
+            "actionability_reason": "compatibility plan required before changing this surface",
+        }
+
+    if match_type == "path":
+        return {
+            "actionability": REVIEW_FIRST_CONTEXT,
+            "actionability_reason": "path match requires planned rename or historical disposition",
+        }
+
+    if classification == "safe_cleanup_internal":
+        return {
+            "actionability": INTERNAL_REVIEW_FIRST,
+            "actionability_reason": "internal cleanup remains review-first",
+        }
+
+    if classification == "docs_only_cleanup":
+        if not matching_lines or lines is None:
+            return {
+                "actionability": REVIEW_FIRST_CONTEXT,
+                "actionability_reason": "missing line context",
+            }
+
+        review_reasons: list[str] = []
+        for line_number in matching_lines:
+            line = lines[line_number - 1] if 0 < line_number <= len(lines) else ""
+            reason = _docs_line_review_reason(line)
+            if reason is None:
+                return {
+                    "actionability": ACTIONABLE_PROSE,
+                    "actionability_reason": "plain markdown prose",
+                }
+            review_reasons.append(reason)
+
+        reason_text = ",".join(sorted(set(review_reasons))) or "review-first context"
+        return {
+            "actionability": REVIEW_FIRST_CONTEXT,
+            "actionability_reason": reason_text,
+        }
+
+    return {
+        "actionability": REVIEW_FIRST_CONTEXT,
+        "actionability_reason": "deferred or unknown cleanup surface",
+    }
+
 
 def _iter_files(root: Path) -> Iterable[Path]:
     for path in root.rglob("*"):
@@ -158,6 +272,11 @@ def _line_hits(path: Path, term: str, root: Path) -> list[dict[str, Any]]:
                     "workflow_alias_migration",
                     "internal_path_requires_migration",
                 },
+                **_actionability_fields(
+                    rel_path,
+                    classification,
+                    match_type="path",
+                ),
                 **AUTHORITY_BOUNDARY,
             }
         )
@@ -193,6 +312,13 @@ def _line_hits(path: Path, term: str, root: Path) -> list[dict[str, Any]]:
                     "workflow_alias_migration",
                     "internal_path_requires_migration",
                 },
+                **_actionability_fields(
+                    rel_path,
+                    classification,
+                    match_type="content",
+                    matching_lines=matching_lines,
+                    lines=lines,
+                ),
                 **AUTHORITY_BOUNDARY,
             }
         )
@@ -214,12 +340,19 @@ def build_professional_naming_inventory(
     by_term = Counter(str(item["term"]) for item in items)
     by_class = Counter(str(item["classification"]) for item in items)
     by_surface = Counter(str(item["surface"]) for item in items)
+    by_actionability = Counter(str(item.get("actionability", "unknown")) for item in items)
+    actionable_finding_count = sum(
+        1 for item in items if item.get("actionability") == ACTIONABLE_PROSE
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
         "status": "review required" if items else "clean",
         "terms": list(terms),
         "finding_count": len(items),
+        "actionable_finding_count": actionable_finding_count,
+        "review_first_finding_count": len(items) - actionable_finding_count,
+        "by_actionability": dict(sorted(by_actionability.items())),
         "by_term": dict(sorted(by_term.items())),
         "by_classification": dict(sorted(by_class.items())),
         "by_surface": dict(sorted(by_surface.items())),
@@ -267,6 +400,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stdout.write(f"naming_inventory_json={ns.out}\n")
         sys.stdout.write(f"status={payload['status']}\n")
         sys.stdout.write(f"finding_count={payload['finding_count']}\n")
+        sys.stdout.write(f"actionable_finding_count={payload['actionable_finding_count']}\n")
+        sys.stdout.write(f"review_first_finding_count={payload['review_first_finding_count']}\n")
         sys.stdout.write(
             f"compatibility_required={str(payload['compatibility_required']).lower()}\n"
         )

--- a/src/sdetkit/professional_naming_inventory.py
+++ b/src/sdetkit/professional_naming_inventory.py
@@ -63,6 +63,10 @@ REVIEW_FIRST_CONTEXT = "review_first_context"
 MIGRATION_OR_ALIAS_REQUIRED = "migration_or_alias_required"
 INTERNAL_REVIEW_FIRST = "internal_cleanup_review_first"
 
+TEMPLATE_LOCKED_DOC_PATHS = {
+    "docs/integrations-release-prioritization-completion.md",
+}
+
 
 def _docs_line_review_reason(line: str) -> str | None:
     stripped = line.strip()
@@ -129,6 +133,12 @@ def _actionability_fields(
         return {
             "actionability": MIGRATION_OR_ALIAS_REQUIRED,
             "actionability_reason": "compatibility plan required before changing this surface",
+        }
+
+    if path.as_posix() in TEMPLATE_LOCKED_DOC_PATHS:
+        return {
+            "actionability": REVIEW_FIRST_CONTEXT,
+            "actionability_reason": "template_locked_contract",
         }
 
     if match_type == "path":

--- a/tests/test_professional_naming_cleanup_plan.py
+++ b/tests/test_professional_naming_cleanup_plan.py
@@ -18,7 +18,13 @@ from sdetkit.professional_naming_cleanup_plan import (
 from sdetkit.professional_naming_inventory import SCHEMA_VERSION as INVENTORY_SCHEMA_VERSION
 
 
-def _item(path: str, term: str, classification: str, occurrences: int = 1) -> dict:
+def _item(
+    path: str,
+    term: str,
+    classification: str,
+    occurrences: int = 1,
+    actionability: str = "actionable_prose_cleanup",
+) -> dict:
     return {
         "path": path,
         "line": 1,
@@ -30,6 +36,8 @@ def _item(path: str, term: str, classification: str, occurrences: int = 1) -> di
         "classification": classification,
         "replacement_hint": "production name",
         "requires_compatibility_plan": classification == PUBLIC_ALIAS,
+        "actionability": actionability,
+        "actionability_reason": "test fixture",
         "automation_allowed": False,
         "merge_authorized": False,
         "semantic_equivalence_proven": False,
@@ -139,3 +147,25 @@ def test_professional_naming_cleanup_plan_cli_round_trip(tmp_path: Path) -> None
     assert "rename_allowed=false" in result.stdout
     assert "compatibility_migration_" + "allowed=false" in result.stdout
     assert out.is_file()
+
+
+def test_professional_naming_cleanup_plan_does_not_recommend_review_first_docs() -> None:
+    item = _item(
+        "docs/historical-report.md",
+        "phase3",
+        DOCS_ONLY,
+        actionability="review_first_context",
+    )
+    inventory = {
+        "schema_version": INVENTORY_SCHEMA_VERSION,
+        "status": "review required",
+        "finding_count": 1,
+        "items": [item],
+    }
+
+    payload = build_professional_naming_cleanup_plan(inventory)
+
+    assert payload["recommended_first_slice"] is None
+    assert payload["actionable_finding_count"] == 0
+    assert payload["review_first_finding_count"] == 1
+    assert payload["cleanup_slices"][0]["safe_to_plan_first"] is False

--- a/tests/test_professional_naming_inventory.py
+++ b/tests/test_professional_naming_inventory.py
@@ -99,3 +99,21 @@ def test_professional_naming_inventory_separates_actionable_prose_from_headings(
     assert by_actionability["review_first_context"] >= 1
     assert payload["actionable_finding_count"] >= 1
     assert payload["review_first_finding_count"] >= 1
+
+
+def test_professional_naming_inventory_marks_template_locked_docs_review_first(
+    tmp_path: Path,
+) -> None:
+    docs = tmp_path / "docs" / "integrations-release-prioritization-completion.md"
+    docs.parent.mkdir(parents=True)
+    docs.write_text(
+        "This closeout records release prioritization pack upgrades, storyline outcomes, and launch priorities.\n",
+        encoding="utf-8",
+    )
+
+    payload = build_professional_naming_inventory(root=tmp_path, terms=["closeout"])
+
+    assert payload["actionable_finding_count"] == 0
+    assert payload["review_first_finding_count"] == 1
+    assert payload["items"][0]["actionability"] == "review_first_context"
+    assert payload["items"][0]["actionability_reason"] == "template_locked_contract"

--- a/tests/test_professional_naming_inventory.py
+++ b/tests/test_professional_naming_inventory.py
@@ -47,6 +47,8 @@ def test_professional_naming_inventory_classifies_docs_and_tests(tmp_path: Path)
     assert "safe_cleanup_internal" in classes
     assert payload["by_surface"]["docs"] >= 1
     assert payload["by_surface"]["test"] >= 1
+    assert payload["actionable_finding_count"] >= 1
+    assert payload["review_first_finding_count"] >= 1
 
 
 def test_professional_naming_inventory_preserves_non_authority_boundary(tmp_path: Path) -> None:
@@ -81,3 +83,19 @@ def test_professional_naming_inventory_writes_artifact(tmp_path: Path) -> None:
     written = json.loads(out.read_text(encoding="utf-8"))
     assert written == payload
     assert written["schema_version"] == SCHEMA_VERSION
+
+
+def test_professional_naming_inventory_separates_actionable_prose_from_headings(
+    tmp_path: Path,
+) -> None:
+    docs = tmp_path / "docs" / "report.md"
+    docs.parent.mkdir(parents=True)
+    docs.write_text("# phase3 closeout\n\nphase3 rollout prose\n", encoding="utf-8")
+
+    payload = build_professional_naming_inventory(root=tmp_path, terms=["phase3", "closeout"])
+
+    by_actionability = payload["by_actionability"]
+    assert by_actionability["actionable_prose_cleanup"] >= 1
+    assert by_actionability["review_first_context"] >= 1
+    assert payload["actionable_finding_count"] >= 1
+    assert payload["review_first_finding_count"] >= 1


### PR DESCRIPTION
## Summary
- Separate professional naming findings into actionable cleanup versus review-first context.
- Add actionability fields and aggregate counts to the professional naming inventory artifact.
- Update cleanup planning so review-first docs/context findings do not keep recommending another docs-only cleanup slice.
- Clear the final direct actionable prose item from `docs/integrations-release-prioritization-completion.md`.

## Why
- After the docs prose waves, the inventory still reported 1047+ findings, but targeted safe sweeps could no longer make changes.
- The old model classified all docs hits as `docs_only_cleanup`, even when the hit was in a heading, path-like context, template-like context, or historical/report evidence.
- This PR makes the finish state explicit: direct actionable prose cleanup is complete; remaining findings are review-first / compatibility-bound evidence.

## Verification
- `python -m pytest -q tests/test_professional_naming_inventory.py tests/test_professional_naming_cleanup_plan.py tests/test_artifact_contract_index.py -o addopts=`
- `python -m sdetkit professional-naming-inventory --root . --out build/sdetkit/professional-naming-inventory-after-actionability-model.json --format text`
- `python -m sdetkit professional-naming-cleanup-plan --inventory-json build/sdetkit/professional-naming-inventory-after-actionability-model.json --out build/sdetkit/professional-naming-cleanup-plan-after-actionability-model.json --format text`
- `make proof-after-format`

Proof result from local WSL2:
- tests: 15 passed
- finding_count: 1047
- actionable_finding_count: 0
- review_first_finding_count: 1047
- cleanup plan recommended_first_slice: None
- proof-after-format: passed
- pre-commit hooks: passed
- mypy: passed

## Risk
- Medium.
- Changes artifact payload shape by adding fields; existing fields are preserved.
- No rename authority is added.
- No compatibility migration is authorized.
- No public surface changes are authorized.
- Rollback: revert the inventory/cleanup-plan model changes and the final docs prose replacement.

## Compatibility
- Existing inventory and cleanup-plan fields remain available.
- New fields are additive: `actionability`, `actionability_reason`, `actionable_finding_count`, `review_first_finding_count`, `by_actionability`.
- `rename_allowed=false`
- `compatibility_migration_allowed=false`
- `public_surface_changes_allowed=false`
- `automation_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`