### PR TITLE
feat: extract failed check logs into failure vectors

### DIFF
--- a/src/sdetkit/ci_failure_extractor.py
+++ b/src/sdetkit/ci_failure_extractor.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.ci_failure_extractor.v1"
+DEFAULT_OUT = "build/sdetkit/failed-check-logs.json"
+
+PATH_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.(?:py|md|yml|yaml|toml|ini|cfg|txt|sh))"
+)
+PYTEST_FAILED_RE = re.compile(r"^FAILED\s+(?P<nodeid>\S+)")
+EXIT_CODE_RE = re.compile(r"(?:exit code|exited with code)\s+(?P<code>\d+)", re.IGNORECASE)
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _first_nonempty(*values: object) -> str:
+    for value in values:
+        text = _text(value)
+        if text:
+            return text
+    return ""
+
+
+def _extract_exit_code(lines: Sequence[str]) -> int | str:
+    for line in reversed(lines):
+        match = EXIT_CODE_RE.search(line)
+        if match:
+            return int(match.group("code"))
+    return "unknown"
+
+
+def _extract_command(lines: Sequence[str], failure_index: int) -> str:
+    for line in reversed(lines[: max(failure_index, 0)]):
+        stripped = line.strip()
+        if stripped.startswith("Run "):
+            return stripped.removeprefix("Run ").strip()
+        if stripped.startswith("$ "):
+            return stripped[2:].strip()
+        if "python -m " in stripped or "pytest" in stripped or "mypy" in stripped:
+            return stripped
+    return "unknown"
+
+
+def _failure_signal_index(lines: Sequence[str]) -> int:
+    generic_index = -1
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        lower = stripped.lower()
+
+        if not stripped:
+            continue
+        if "process completed with exit code" in lower:
+            generic_index = index
+            continue
+        if stripped.startswith("FAILED "):
+            return index
+        if re.search(r":[0-9]+:\s+error:", stripped):
+            return index
+        if "ruff format" in lower and "failed" in lower:
+            return index
+        if "would be reformatted" in lower:
+            return index
+        if "resolutionimpossible" in lower or "no matching distribution found" in lower:
+            return index
+        if "merge conflict" in lower or stripped.startswith("CONFLICT "):
+            return index
+        if stripped.startswith("ERROR ") or stripped.startswith("ERROR:"):
+            return index
+
+    return generic_index if generic_index >= 0 else 0
+
+
+def _classify(line: str, full_text: str) -> tuple[str, str, bool, bool, str]:
+    haystack = f"{line}\n{full_text}".lower()
+
+    if "merge conflict" in haystack or "<<<<<<<" in haystack or "conflict " in haystack:
+        return "workflow", "merge_conflict", False, True, "Merge conflict requires human review"
+
+    if "ruff format" in haystack or "would be reformatted" in haystack:
+        return "formatting", "formatter_only", True, False, ""
+
+    if "ruff" in haystack and ("failed" in haystack or "error" in haystack):
+        return "formatting", "lint", False, False, ""
+
+    if "mypy" in haystack or re.search(r":[0-9]+:\s+error:", line):
+        return "type_contract", "type", False, True, "Type contract failures are review-first"
+
+    if line.strip().startswith("FAILED ") or "pytest" in haystack or "assertionerror" in haystack:
+        return "test", "test", False, False, ""
+
+    if "resolutionimpossible" in haystack or "no matching distribution found" in haystack:
+        return (
+            "dependency",
+            "dependency",
+            False,
+            True,
+            "Dependency failures require review-first alignment",
+        )
+
+    return "unknown", "unknown", False, True, "Unknown failure requires log review"
+
+
+def _affected_files(line: str) -> list[str]:
+    paths = {match.group("path") for match in PATH_RE.finditer(line)}
+    node_match = PYTEST_FAILED_RE.match(line.strip())
+    if node_match:
+        node_id = node_match.group("nodeid")
+        file_part = node_id.split("::", 1)[0]
+        if file_part:
+            paths.add(file_part)
+    return sorted(paths)
+
+
+def _failing_test(line: str) -> str:
+    match = PYTEST_FAILED_RE.match(line.strip())
+    return match.group("nodeid") if match else "unknown"
+
+
+def extract_log_text(
+    text: str,
+    *,
+    check_name: str = "raw-ci-log",
+    log_path: str = "",
+) -> dict[str, Any]:
+    lines = text.splitlines()
+    failure_index = _failure_signal_index(lines)
+    first_line = lines[failure_index].strip() if lines else "no log lines found"
+    surface, failure_class, safe_to_auto_fix, review_first, reason = _classify(first_line, text)
+    affected_files = _affected_files(first_line)
+    command = _extract_command(lines, failure_index)
+    exit_code = _extract_exit_code(lines)
+
+    if not affected_files and failure_class == "unknown":
+        affected_files = []
+
+    title_by_class = {
+        "formatter_only": "Formatter-only failure extracted from CI log",
+        "lint": "Lint failure extracted from CI log",
+        "type": "Type contract failure extracted from CI log",
+        "test": "Test failure extracted from CI log",
+        "dependency": "Dependency failure extracted from CI log",
+        "merge_conflict": "Merge conflict extracted from CI log",
+        "unknown": "Unknown failure extracted from CI log",
+    }
+
+    record: dict[str, Any] = {
+        "name": check_name,
+        "check": check_name,
+        "command": command,
+        "exit_code": exit_code,
+        "log_path": log_path,
+        "first_failure_line": first_line,
+        "first_failure": {
+            "line": first_line,
+            "line_number": failure_index + 1 if lines else 0,
+            "tool": _first_nonempty(failure_class, "unknown"),
+            "kind": failure_class,
+        },
+        "diagnosis": {
+            "title": title_by_class.get(failure_class, "Failure extracted from CI log"),
+            "surface": surface,
+            "confidence": "medium" if failure_class != "unknown" else "low",
+        },
+        "failure_class": failure_class,
+        "affected_files": affected_files,
+        "failing_file": affected_files[0] if affected_files else "unknown",
+        "failing_test": _failing_test(first_line),
+        "safe_to_auto_fix": safe_to_auto_fix,
+        "review_first": review_first,
+        "safe_remediation": {
+            "safe_to_auto_fix": safe_to_auto_fix,
+            "strategy": "run_pre_commit"
+            if safe_to_auto_fix
+            else "review_first"
+            if review_first
+            else "rerun_focused_proof",
+            "reason": reason,
+        },
+    }
+    return record
+
+
+def build_failed_check_logs(log_paths: Sequence[str | Path]) -> dict[str, Any]:
+    records = []
+    for raw_path in log_paths:
+        path = Path(raw_path)
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        records.append(
+            extract_log_text(
+                text,
+                check_name=path.parent.name if path.parent.name else path.stem,
+                log_path=path.as_posix(),
+            )
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "failed_check_count": len(records),
+        "failed_checks": records,
+        "summary": {
+            "safe_to_auto_fix_count": sum(1 for record in records if record["safe_to_auto_fix"]),
+            "review_first_count": sum(1 for record in records if record["review_first"]),
+            "unknown_count": sum(1 for record in records if record["failure_class"] == "unknown"),
+        },
+    }
+
+
+def write_failed_check_logs(log_paths: Sequence[str | Path], out: str | Path) -> dict[str, Any]:
+    payload = build_failed_check_logs(log_paths)
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.ci_failure_extractor")
+    parser.add_argument("--log", action="append", required=True, help="Raw CI log file to extract")
+    parser.add_argument("--out", default=DEFAULT_OUT)
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        payload = write_failed_check_logs(args.log, args.out)
+    except OSError as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"failed_check_logs_json={args.out}")
+        print(f"failed_check_count={payload['failed_check_count']}")
+        print(f"safe_to_auto_fix_count={payload['summary']['safe_to_auto_fix_count']}")
+        print(f"review_first_count={payload['summary']['review_first_count']}")
+        print(f"unknown_count={payload['summary']['unknown_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/ci_failures/pytest_assertion/ci_log.txt
+++ b/tests/fixtures/ci_failures/pytest_assertion/ci_log.txt
@@ -1,0 +1,4 @@
+Run python -m pytest -q tests/test_widget.py -o addopts=
+============================= test session starts =============================
+FAILED tests/test_widget.py::test_widget_contract - AssertionError: expected stable evidence
+Error: Process completed with exit code 1.

--- a/tests/test_ci_failure_extractor.py
+++ b/tests/test_ci_failure_extractor.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.ci_failure_extractor import build_failed_check_logs, main
+from sdetkit.diagnostic_vector_engine import build_diagnostic_vector
+
+
+def test_ci_failure_extractor_turns_pytest_log_into_failure_vector() -> None:
+    log_path = Path("tests/fixtures/ci_failures/pytest_assertion/ci_log.txt")
+
+    payload = build_failed_check_logs([log_path])
+
+    assert payload["schema_version"] == "sdetkit.ci_failure_extractor.v1"
+    assert payload["failed_check_count"] == 1
+    record = payload["failed_checks"][0]
+    assert record["first_failure_line"].startswith(
+        "FAILED tests/test_widget.py::test_widget_contract"
+    )
+    assert record["failure_class"] == "test"
+    assert record["affected_files"] == ["tests/test_widget.py"]
+
+    vector_payload = build_diagnostic_vector(failed_check_logs=payload)
+    vector = vector_payload["failure_vectors"][0]
+    assert vector["failure_class"] == "test"
+    assert vector["failing_file"] == "tests/test_widget.py"
+    assert vector["failing_test"] == "tests/test_widget.py::test_widget_contract"
+
+
+def test_ci_failure_extractor_marks_formatter_only_as_safe_candidate(tmp_path: Path) -> None:
+    log_path = tmp_path / "format-log.txt"
+    log_path.write_text(
+        "Run python -m pre_commit run -a\n"
+        "ruff format..............................Failed\n"
+        "1 file would be reformatted\n"
+        "Error: Process completed with exit code 1.\n",
+        encoding="utf-8",
+    )
+
+    payload = build_failed_check_logs([log_path])
+    record = payload["failed_checks"][0]
+
+    assert record["failure_class"] == "formatter_only"
+    assert record["safe_to_auto_fix"] is True
+    assert record["review_first"] is False
+
+    vector_payload = build_diagnostic_vector(failed_check_logs=payload)
+    vector = vector_payload["failure_vectors"][0]
+    assert vector["safe_fix_candidate"] is True
+    assert vector["failure_class"] == "formatter_only"
+
+
+def test_ci_failure_extractor_marks_mypy_as_review_first(tmp_path: Path) -> None:
+    log_path = tmp_path / "mypy-log.txt"
+    log_path.write_text(
+        "Run python -m mypy src\n"
+        "src/sdetkit/example.py:10: error: Incompatible return value type\n"
+        "Error: Process completed with exit code 1.\n",
+        encoding="utf-8",
+    )
+
+    payload = build_failed_check_logs([log_path])
+    record = payload["failed_checks"][0]
+
+    assert record["failure_class"] == "type"
+    assert record["review_first"] is True
+    assert record["affected_files"] == ["src/sdetkit/example.py"]
+
+    vector_payload = build_diagnostic_vector(failed_check_logs=payload)
+    vector = vector_payload["failure_vectors"][0]
+    assert vector["review_first"] is True
+    assert vector["risk_surface"] == "type_contract"
+
+
+def test_ci_failure_extractor_cli_writes_failed_check_logs(tmp_path: Path, capsys) -> None:
+    log_path = tmp_path / "unknown-log.txt"
+    out = tmp_path / "failed-check-logs.json"
+    log_path.write_text("Error: Process completed with exit code 1.\n", encoding="utf-8")
+
+    rc = main(["--log", str(log_path), "--out", str(out), "--format", "text"])
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "failed_check_logs_json=" in stdout
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["summary"]["unknown_count"] == 1
+    assert payload["failed_checks"][0]["review_first"] is True


### PR DESCRIPTION
## Summary
- Add a deterministic raw CI failure log extractor.
- Emit structured `failed_check_logs` payloads that feed the existing diagnostic vector engine.
- Cover pytest assertion, formatter-only, mypy/type-contract, and unknown failure log cases with fixture-driven tests.

## Why
- The repo already has `diagnostic_vector_engine` and canonical `failure-vector.json` output.
- The missing upstream piece is a local parser that turns raw CI log text into the `failed_check_logs` input the engine already accepts.
- This keeps the next roadmap step local, deterministic, and file-backed without adding cloud/API/queue behavior.

## Verification
- `python -m pytest -q tests/test_ci_failure_extractor.py tests/test_diagnostic_vector_engine.py -o addopts=`
- `python -m sdetkit.ci_failure_extractor --log tests/fixtures/ci_failures/pytest_assertion/ci_log.txt --out build/sdetkit/failed-check-logs.json --format text`
- `python -m sdetkit.diagnostic_vector_engine --failed-check-logs build/sdetkit/failed-check-logs.json --out-dir build/sdetkit/ci-log-diagnostics --format json`
- `make proof-after-format`

Proof result from local WSL2:
- tests: 15 passed
- failed_check_count: 1
- safe_to_auto_fix_count: 0
- review_first_count: 0
- unknown_count: 0
- diagnostic vector diagnosis_count: 1
- failure_vector_count: 1
- primary_surface: test
- primary_action: rerun_proof
- proof-after-format: passed
- pre-commit hooks: passed
- mypy: passed

## Risk
- Medium-low.
- Additive module and tests.
- No workflow changes.
- No external service dependency.
- No automation or merge authority added.

## Compatibility
- Existing diagnostic vector engine behavior is reused, not replaced.
- New extractor writes `sdetkit.ci_failure_extractor.v1` payloads with `failed_checks` records.
- `automation_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`