### PR TITLE
docs: align active professional naming navigation

### DIFF
--- a/docs/integrations-baseline-hardening.md
+++ b/docs/integrations-baseline-hardening.md
@@ -1,6 +1,6 @@
 # Operational readiness hardening
 
-Lane closes Phase-1 by hardening top entry pages, removing stale guidance, and publishing a deterministic completion report lane.
+Lane closes Baseline by hardening top entry pages, removing stale guidance, and publishing a deterministic completion report lane.
 
 ## Why Lane exists
 
@@ -18,9 +18,9 @@ Lane closes Phase-1 by hardening top entry pages, removing stale guidance, and p
 ## Lane command lane
 
 ```bash
-python -m sdetkit phase1-hardening --format json --strict
-python -m sdetkit phase1-hardening --emit-pack-dir docs/artifacts/phase1-hardening-pack --format json --strict
-python -m sdetkit phase1-hardening --execute --evidence-dir docs/artifacts/phase1-hardening-pack/evidence --format json --strict
+python -m sdetkit baseline-hardening --format json --strict
+python -m sdetkit baseline-hardening --emit-pack-dir docs/artifacts/baseline-hardening-pack --format json --strict
+python -m sdetkit baseline-hardening --execute --evidence-dir docs/artifacts/baseline-hardening-pack/evidence --format json --strict
 python scripts/check_phase1_hardening_contract.py
 ```
 
@@ -31,7 +31,7 @@ Lane weighted score (0-100):
 - Docs contract and command-lane completeness: 35 points.
 - Entry-page discoverability + strategy alignment: 35 points.
 - Stale marker elimination in top pages: 20 points.
-- Artifact/report wiring for Phase-1 closeout: 10 points.
+- Artifact/report wiring for baseline closeout: 10 points.
 
 ## Entry page polish checklist
 

--- a/docs/integrations-baseline-wrap.md
+++ b/docs/integrations-baseline-wrap.md
@@ -1,25 +1,25 @@
 # Operational readiness handoff
 
-Lane closes Phase-1 with a hard evidence wrap-up and locks the first Phase-2 execution backlog.
+Lane closes Baseline with a hard evidence wrap-up and locks the first Release readiness execution backlog.
 
 ## Why Lane matters
 
 - Consolidates readiness results from Cycles 27-29 into a single handoff packet.
-- Prevents ambiguous next steps by publishing a deterministic Phase-2 backlog contract.
+- Prevents ambiguous next steps by publishing a deterministic release readiness backlog contract.
 - Produces an auditable launch artifact for maintainers and collaborators.
 
 ## Required inputs (Cycles 27-29)
 
 - `docs/artifacts/kpi-audit-pack/kpi-audit-summary.json`
 - `docs/artifacts/weekly-review-pack/weekly-review-summary.json`
-- `docs/artifacts/phase1-hardening-pack/phase1-hardening-summary.json` (primary)
+- `docs/artifacts/baseline-hardening-pack/baseline-hardening-summary.json` (primary)
 
 ## Lane command lane
 
 ```bash
-python -m sdetkit phase1-wrap --format json --strict
-python -m sdetkit phase1-wrap --emit-pack-dir docs/artifacts/phase1-wrap-pack --format json --strict
-python -m sdetkit phase1-wrap --execute --evidence-dir docs/artifacts/phase1-wrap-pack/evidence --format json --strict
+python -m sdetkit baseline-wrap --format json --strict
+python -m sdetkit baseline-wrap --emit-pack-dir docs/artifacts/baseline-wrap-pack --format json --strict
+python -m sdetkit baseline-wrap --execute --evidence-dir docs/artifacts/baseline-wrap-pack/evidence --format json --strict
 python scripts/check_phase1_wrap_contract.py
 ```
 
@@ -30,9 +30,9 @@ Lane weighted score (0-100):
 - Docs contract + command lane completeness: 30 points.
 - Discoverability and strategy alignment (README/docs index/top-10): 25 points.
 - Input artifact availability (Cycles 27-29): 25 points.
-- Locked Phase-2 backlog quality: 20 points.
+- Locked release readiness backlog quality: 20 points.
 
-## Locked Phase-2 backlog
+## Locked release readiness backlog
 
 - [ ] Lane baseline metrics + weekly targets
 - [ ] Lane release cadence + changelog checklist

--- a/docs/integrations-community-program-workflow.md
+++ b/docs/integrations-community-program-workflow.md
@@ -11,7 +11,7 @@ Lane ships a major community-program upgrade that converts Lane kickoff evidence
 ## Required inputs (Lane)
 
 - `docs/artifacts/platform-readiness-kickoff-completion-report-pack/platform-readiness-kickoff-completion-report-summary.json`
-- `docs/artifacts/platform-readiness-kickoff-completion-report-pack/phase3-kickoff-delivery-board.md`
+- `docs/artifacts/platform-readiness-kickoff-completion-report-pack/platform-readiness-kickoff-delivery-board.md`
 
 ## Community Program Closeout command lane (legacy)
 
@@ -25,7 +25,7 @@ python scripts/check_community_program_closeout_contract.py
 ## Community program execution contract
 
 - Single owner + backup reviewer are assigned for Lane community office-hours execution and moderation safety.
-- This lane references Lane Phase-3 kickoff outcomes, trust guardrails, and KPI continuity evidence.
+- This lane references Lane platform readiness kickoff outcomes, trust guardrails, and KPI continuity evidence.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane completion report records office-hours cadence, participation rules, moderation SOPs, and Lane onboarding priorities.
 

--- a/docs/integrations-continuous-upgrade-closeout-1.md
+++ b/docs/integrations-continuous-upgrade-closeout-1.md
@@ -8,10 +8,10 @@ Lane starts the next impact by converting phase-3 wrap publication outcomes into
 - Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
 - Creates a deterministic handoff from Lane completion report into the continuous-upgrade backlog.
 
-## Required inputs (Phase-3 wrap publication)
+## Required inputs (platform readiness wrap publication)
 
 - `docs/artifacts/platform-readiness-wrap-publication-completion-report-pack/platform-readiness-wrap-publication-completion-report-summary.json`
-- `docs/artifacts/platform-readiness-wrap-publication-completion-report-pack/phase3-wrap-publication-delivery-board.md`
+- `docs/artifacts/platform-readiness-wrap-publication-completion-report-pack/platform-readiness-wrap-publication-delivery-board.md`
 - `docs/roadmap/plans/continuous-upgrade-plan-1.json`
 
 ## Command lane

--- a/docs/integrations-example-asset.md
+++ b/docs/integrations-example-asset.md
@@ -16,9 +16,9 @@ Lane closes the first distribution-ready example asset, turning Lane release rea
 ## Lane command lane
 
 ```bash
-python -m sdetkit demo-asset --format json --strict
-python -m sdetkit demo-asset --emit-pack-dir docs/artifacts/demo-asset-pack --format json --strict
-python -m sdetkit demo-asset --execute --evidence-dir docs/artifacts/demo-asset-pack/evidence --format json --strict
+python -m sdetkit example-asset --format json --strict
+python -m sdetkit example-asset --emit-pack-dir docs/artifacts/example-asset-pack --format json --strict
+python -m sdetkit example-asset --execute --evidence-dir docs/artifacts/example-asset-pack/evidence --format json --strict
 python scripts/check_demo_asset_contract.py
 ```
 

--- a/docs/integrations-example-asset2.md
+++ b/docs/integrations-example-asset2.md
@@ -10,15 +10,15 @@ Lane closes the second distribution-ready example asset by translating repositor
 
 ## Required inputs (Lane)
 
-- `docs/artifacts/demo-asset-pack/demo-asset-summary.json`
-- `docs/artifacts/demo-asset-pack/demo-delivery-board.md`
+- `docs/artifacts/example-asset-pack/example-asset-summary.json`
+- `docs/artifacts/example-asset-pack/example-delivery-board.md`
 
 ## Lane command lane
 
 ```bash
-python -m sdetkit demo-asset2 --format json --strict
-python -m sdetkit demo-asset2 --emit-pack-dir docs/artifacts/demo-asset2-pack --format json --strict
-python -m sdetkit demo-asset2 --execute --evidence-dir docs/artifacts/demo-asset2-pack/evidence --format json --strict
+python -m sdetkit example-asset2 --format json --strict
+python -m sdetkit example-asset2 --emit-pack-dir docs/artifacts/example-asset2-pack --format json --strict
+python -m sdetkit example-asset2 --execute --evidence-dir docs/artifacts/example-asset2-pack/evidence --format json --strict
 python scripts/check_demo_asset2_contract.py
 ```
 

--- a/docs/integrations-kpi-instrumentation.md
+++ b/docs/integrations-kpi-instrumentation.md
@@ -10,8 +10,8 @@ Lane closes the week with a hardened KPI operating loop that ties growth narrati
 
 ## Required inputs (Lane)
 
-- `docs/artifacts/demo-asset2-pack/demo-asset2-summary.json`
-- `docs/artifacts/demo-asset2-pack/demo-asset2-delivery-board.md`
+- `docs/artifacts/example-asset2-pack/example-asset2-summary.json`
+- `docs/artifacts/example-asset2-pack/example-asset2-delivery-board.md`
 
 ## Lane command lane
 

--- a/docs/integrations-platform-readiness-kickoff-workflow.md
+++ b/docs/integrations-platform-readiness-kickoff-workflow.md
@@ -1,19 +1,19 @@
 # Quality governance kickoff workflow
 
-Lane ships a major Phase-3 kickoff upgrade that converts Lane wrap evidence into a strict baseline for ecosystem + trust execution.
+Lane ships a major platform readiness kickoff upgrade that converts Lane wrap evidence into a strict baseline for ecosystem + trust execution.
 
-## Why Phase3 Kickoff Closeout matters
+## Why Platform Readiness Kickoff matters
 
-- Converts Lane completion report evidence into repeatable Phase-3 execution loops.
+- Converts Lane completion report evidence into repeatable Platform readiness execution loops.
 - Protects trust outcomes with ownership, command proof, and KPI rollback guardrails.
 - Produces a deterministic handoff from Lane kickoff into Lane community program setup.
 
 ## Required inputs (Lane)
 
 - `docs/artifacts/release-readiness-wrap-handoff-completion-report-pack/release-readiness-wrap-handoff-completion-report-summary.json`
-- `docs/artifacts/release-readiness-wrap-handoff-completion-report-pack/phase2-wrap-handoff-delivery-board.md`
+- `docs/artifacts/release-readiness-wrap-handoff-completion-report-pack/release-readiness-wrap-handoff-delivery-board.md`
 
-## Phase3 Kickoff Closeout command lane (legacy)
+## Platform Readiness Kickoff command lane (legacy)
 
 ```bash
 python -m sdetkit platform-readiness-kickoff-completion-report --format json --strict
@@ -22,14 +22,14 @@ python -m sdetkit platform-readiness-kickoff-completion-report --execute --evide
 python scripts/check_phase3_kickoff_closeout_contract.py
 ```
 
-## Phase-3 kickoff execution contract
+## platform readiness kickoff execution contract
 
-- Single owner + backup reviewer are assigned for Lane Phase-3 kickoff execution and trust-signal triage.
-- This lane references Lane Phase-2 wrap outcomes, risks, and KPI continuity evidence.
+- Single owner + backup reviewer are assigned for Lane platform readiness kickoff execution and trust-signal triage.
+- This lane references Lane release readiness wrap outcomes, risks, and KPI continuity evidence.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
-- Lane completion report records Phase-3 baseline activation, trust KPI owners, and Lane community program priorities.
+- Lane completion report records Platform readiness baseline activation, trust KPI owners, and Lane community program priorities.
 
-## Phase-3 kickoff quality checklist
+## platform readiness kickoff quality checklist
 
 - [ ] Includes baseline snapshot, owner map, KPI guardrails, and rollback strategy
 - [ ] Every section has owner, review window, KPI threshold, and risk flag
@@ -37,9 +37,9 @@ python scripts/check_phase3_kickoff_closeout_contract.py
 - [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each trust KPI
 - [ ] Artifact pack includes kickoff brief, trust ledger, KPI scorecard, and execution log
 
-## Phase3 Kickoff Closeout delivery board (legacy)
+## Platform Readiness Kickoff delivery board (legacy)
 
-- [ ] Lane Phase-3 kickoff brief committed
+- [ ] Lane platform readiness kickoff brief committed
 - [ ] Lane kickoff reviewed with owner + backup
 - [ ] Lane trust ledger exported
 - [ ] Lane KPI scorecard snapshot exported
@@ -52,4 +52,4 @@ Lane weighted score (0-100):
 - Contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
 - Lane continuity and strict baseline carryover: 35 points.
-- Phase-3 kickoff contract lock + delivery board readiness: 15 points.
+- platform readiness kickoff contract lock + delivery board readiness: 15 points.

--- a/docs/integrations-platform-readiness-preplan-workflow.md
+++ b/docs/integrations-platform-readiness-preplan-workflow.md
@@ -1,19 +1,19 @@
 # Quality governance preplanning workflow
 
-Lane closes with a major Phase-3 pre-plan upgrade that turns Lane hardening outcomes into deterministic Lane execution priorities.
+Lane closes with a major platform readiness preplan upgrade that turns Lane hardening outcomes into deterministic Lane execution priorities.
 
 ## Why Lane matters
 
-- Converts Lane hardening evidence into repeatable Phase-3 planning loops.
+- Converts Lane hardening evidence into repeatable platform readiness planning loops.
 - Protects quality with ownership, command proof, and KPI rollback guardrails.
 - Produces a deterministic handoff from Lane completion report into Lane execution planning.
 
 ## Required inputs (Lane)
 
 - `docs/artifacts/release-readiness-hardening-completion-report-pack/release-readiness-hardening-completion-report-summary.json`
-- `docs/artifacts/release-readiness-hardening-completion-report-pack/phase2-hardening-delivery-board.md`
+- `docs/artifacts/release-readiness-hardening-completion-report-pack/release-readiness-hardening-delivery-board.md`
 
-## Phase3 Preplan Closeout command lane
+## Platform Readiness Preplan command lane
 
 ```bash
 python -m sdetkit platform-readiness-preplan-completion-report --format json --strict
@@ -22,14 +22,14 @@ python -m sdetkit platform-readiness-preplan-completion-report --execute --evide
 python scripts/check_phase3_preplan_closeout_contract.py
 ```
 
-## Phase-3 pre-plan contract
+## platform readiness preplan contract
 
-- Single owner + backup reviewer are assigned for Lane Phase-3 pre-plan execution and signal triage.
-- This lane references Lane Phase-2 hardening outcomes and unresolved risks.
+- Single owner + backup reviewer are assigned for Lane platform readiness preplan execution and signal triage.
+- This lane references Lane release readiness hardening outcomes and unresolved risks.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane completion report records pre-plan outcomes and Lane execution priorities.
 
-## Phase-3 pre-plan quality checklist
+## platform readiness preplan quality checklist
 
 - [ ] Includes priority digest, lane-level plan actions, and rollback strategy
 - [ ] Every section has owner, review window, KPI threshold, and risk flag
@@ -39,7 +39,7 @@ python scripts/check_phase3_preplan_closeout_contract.py
 
 ## Lane delivery board
 
-- [ ] Lane Phase-3 pre-plan brief committed
+- [ ] Lane platform readiness preplan brief committed
 - [ ] Lane pre-plan reviewed with owner + backup
 - [ ] Lane risk ledger exported
 - [ ] Lane KPI scorecard snapshot exported
@@ -52,4 +52,4 @@ Lane weighted score (0-100):
 - Contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
 - Lane continuity and strict baseline carryover: 35 points.
-- Phase-3 pre-plan contract lock + delivery board readiness: 15 points.
+- platform readiness preplan contract lock + delivery board readiness: 15 points.

--- a/docs/integrations-platform-readiness-wrap-publication-workflow.md
+++ b/docs/integrations-platform-readiness-wrap-publication-workflow.md
@@ -12,7 +12,7 @@ Lane closes with a major upgrade that converts Lane governance scale outcomes in
 
 - `docs/artifacts/governance-scale-closeout-pack/governance-scale-closeout-summary.json`
 - `docs/artifacts/governance-scale-closeout-pack/governance-scale-delivery-board.md`
-- `docs/roadmap/plans/phase3-wrap-publication-plan.json`
+- `docs/roadmap/plans/platform-readiness-wrap-publication-plan.json`
 
 ## Command lane
 
@@ -23,14 +23,14 @@ python -m sdetkit platform-readiness-wrap-publication-completion-report --execut
 python scripts/check_phase3_wrap_publication_closeout_contract.py
 ```
 
-## Phase-3 wrap publication contract
+## platform readiness wrap publication contract
 
 - Single owner + backup reviewer are assigned for Lane phase-3 wrap publication execution and signoff.
 - This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane completion report records phase-3 wrap publication outputs, final report publication status, and next-impact roadmap inputs.
 
-## Phase-3 wrap publication quality checklist
+## platform readiness wrap publication quality checklist
 
 - [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
 - [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag

--- a/docs/integrations-release-cadence.md
+++ b/docs/integrations-release-cadence.md
@@ -10,8 +10,8 @@ Lane converts Lane baseline goals into a repeatable release operating cadence wi
 
 ## Required inputs (Lane)
 
-- `docs/artifacts/phase2-kickoff-pack/phase2-kickoff-summary.json` (primary)
-- `docs/artifacts/phase2-kickoff-pack/phase2-kickoff-delivery-board.md` (primary)
+- `docs/artifacts/release-readiness-kickoff-pack/release-readiness-kickoff-summary.json` (primary)
+- `docs/artifacts/release-readiness-kickoff-pack/release-readiness-kickoff-delivery-board.md` (primary)
 
 ## Lane command lane
 

--- a/docs/integrations-release-readiness-hardening-workflow.md
+++ b/docs/integrations-release-readiness-hardening-workflow.md
@@ -1,6 +1,6 @@
 # Workflow hardening workflow
 
-Lane closes with a major Phase-2 hardening upgrade that turns Lane KPI deep-audit outcomes into deterministic execution hardening governance.
+Lane closes with a major release readiness hardening upgrade that turns Lane KPI deep-audit outcomes into deterministic execution hardening governance.
 
 ## Why Lane matters
 
@@ -13,7 +13,7 @@ Lane closes with a major Phase-2 hardening upgrade that turns Lane KPI deep-audi
 - `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json`
 - `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md`
 
-## Phase 2 Hardening Closeout command lane
+## Release Readiness Hardening command lane
 
 ```bash
 python -m sdetkit release-readiness-hardening-completion-report --format json --strict
@@ -22,14 +22,14 @@ python -m sdetkit release-readiness-hardening-completion-report --execute --evid
 python scripts/check_phase2_hardening_closeout_contract.py
 ```
 
-## Phase-2 hardening contract
+## release readiness hardening contract
 
-- Single owner + backup reviewer are assigned for Lane Phase-2 hardening execution and signal triage.
+- Single owner + backup reviewer are assigned for Lane release readiness hardening execution and signal triage.
 - The Lane references Lane KPI deep-audit outcomes and unresolved risks.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane completion report records hardening outcomes and Lane pre-plan priorities.
 
-## Phase-2 hardening quality checklist
+## release readiness hardening quality checklist
 
 - [ ] Includes friction-map digest, page hardening actions, and rollback strategy
 - [ ] Every section has owner, review window, KPI threshold, and risk flag
@@ -39,7 +39,7 @@ python scripts/check_phase2_hardening_closeout_contract.py
 
 ## Lane delivery board
 
-- [ ] Lane Phase-2 hardening brief committed
+- [ ] Lane release readiness hardening brief committed
 - [ ] Lane hardening plan reviewed with owner + backup
 - [ ] Lane risk ledger exported
 - [ ] Lane KPI scorecard snapshot exported
@@ -52,4 +52,4 @@ Lane weighted score (0-100):
 - Contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
 - Lane continuity and strict baseline carryover: 35 points.
-- Phase-2 hardening contract lock + delivery board readiness: 15 points.
+- release readiness hardening contract lock + delivery board readiness: 15 points.

--- a/docs/integrations-release-readiness-kickoff.md
+++ b/docs/integrations-release-readiness-kickoff.md
@@ -1,6 +1,6 @@
 # Workflow readiness baseline
 
-Lane starts Phase-2 with a measurable baseline carried over from Lane and a fixed weekly growth target set.
+Lane starts Release readiness with a measurable baseline carried over from Lane and a fixed weekly growth target set.
 
 ## Why Lane matters
 
@@ -10,22 +10,22 @@ Lane starts Phase-2 with a measurable baseline carried over from Lane and a fixe
 
 ## Required inputs (Lane)
 
-- `docs/artifacts/phase1-wrap-pack/phase1-wrap-summary.json` (primary)
-- `docs/artifacts/phase1-wrap-pack/phase1-wrap-phase2-backlog.md` (primary)
+- `docs/artifacts/baseline-wrap-pack/baseline-wrap-summary.json` (primary)
+- `docs/artifacts/baseline-wrap-pack/baseline-wrap-release-readiness-backlog.md` (primary)
 
 ## Lane command lane
 
 ```bash
-python -m sdetkit phase2-kickoff --format json --strict
-python -m sdetkit phase2-kickoff --emit-pack-dir docs/artifacts/phase2-kickoff-pack --format json --strict
-python -m sdetkit phase2-kickoff --execute --evidence-dir docs/artifacts/phase2-kickoff-pack/evidence --format json --strict
+python -m sdetkit release-readiness-kickoff --format json --strict
+python -m sdetkit release-readiness-kickoff --emit-pack-dir docs/artifacts/release-readiness-kickoff-pack --format json --strict
+python -m sdetkit release-readiness-kickoff --execute --evidence-dir docs/artifacts/release-readiness-kickoff-pack/evidence --format json --strict
 python scripts/check_phase2_kickoff_contract.py
 ```
 
 ## Baseline + weekly targets
 
 - Baseline source: Lane activation score and completion report rollup.
-- Week-1 Phase-2 target: maintain activation score >= 95 and preserve strict pass.
+- Week-1 Release readiness target: maintain activation score >= 95 and preserve strict pass.
 - Week-1 growth target: publish 3 external-facing assets and 1 KPI checkpoint.
 - Week-1 quality gate: every shipped action includes command evidence and a summary artifact.
 - Week-1 decision gate: if any target misses, publish corrective actions in the next weekly review.

--- a/docs/integrations-release-readiness-wrap-handoff.md
+++ b/docs/integrations-release-readiness-wrap-handoff.md
@@ -1,19 +1,19 @@
 # Workflow readiness handoff
 
-Lane closes with a major Phase-2 wrap + handoff upgrade that turns Lane pre-plan outcomes into deterministic Lane execution priorities.
+Lane closes with a major release readiness wrap handoff upgrade that turns Lane pre-plan outcomes into deterministic Lane execution priorities.
 
 ## Why Lane matters
 
-- Converts Lane pre-plan evidence into repeatable Phase-3 planning loops.
+- Converts Lane pre-plan evidence into repeatable platform readiness planning loops.
 - Protects quality with ownership, command proof, and KPI rollback guardrails.
 - Produces a deterministic handoff from Lane completion report into Lane execution planning.
 
 ## Required inputs (Lane)
 
 - `docs/artifacts/platform-readiness-preplan-completion-report-pack/platform-readiness-preplan-completion-report-summary.json`
-- `docs/artifacts/platform-readiness-preplan-completion-report-pack/phase3-preplan-delivery-board.md`
+- `docs/artifacts/platform-readiness-preplan-completion-report-pack/platform-readiness-preplan-delivery-board.md`
 
-## Phase 2 Wrap Handoff Closeout command lane
+## Release Readiness Wrap Handoff command lane
 
 ```bash
 python -m sdetkit release-readiness-wrap-handoff-completion-report --format json --strict
@@ -22,14 +22,14 @@ python -m sdetkit release-readiness-wrap-handoff-completion-report --execute --e
 python scripts/check_phase2_wrap_handoff_closeout_contract.py
 ```
 
-## Phase-2 wrap + handoff contract
+## release readiness wrap handoff contract
 
-- Single owner + backup reviewer are assigned for Lane Phase-2 wrap + handoff execution and signal triage.
-- The completion report lane references Phase-3 pre-plan outcomes and unresolved risks.
+- Single owner + backup reviewer are assigned for Lane release readiness wrap handoff execution and signal triage.
+- The completion report lane references platform readiness preplan outcomes and unresolved risks.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
-- Lane completion report records Phase-2 wrap outcomes and Lane execution priorities.
+- Lane completion report records Release readiness wrap outcomes and Lane execution priorities.
 
-## Phase-2 wrap + handoff quality checklist
+## release readiness wrap handoff quality checklist
 
 - [ ] Includes priority digest, lane-level plan actions, and rollback strategy
 - [ ] Every section has owner, review window, KPI threshold, and risk flag
@@ -39,7 +39,7 @@ python scripts/check_phase2_wrap_handoff_closeout_contract.py
 
 ## Lane delivery board
 
-- [ ] Lane Phase-2 wrap + handoff brief committed
+- [ ] Lane release readiness wrap handoff brief committed
 - [ ] Lane wrap reviewed with owner + backup
 - [ ] Lane risk ledger exported
 - [ ] Lane KPI scorecard snapshot exported
@@ -52,4 +52,4 @@ Lane weighted score (0-100):
 - Contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
 - Lane continuity and strict baseline carryover: 35 points.
-- Phase-2 wrap + handoff contract lock + delivery board readiness: 15 points.
+- release readiness wrap handoff contract lock + delivery board readiness: 15 points.

--- a/docs/integrations-weekly-review.md
+++ b/docs/integrations-weekly-review.md
@@ -4,7 +4,7 @@ Lane closes the weekly growth loop by consolidating Lane-27 outcomes into wins, 
 
 ## Who should run Lane
 
-- Maintainers preparing Phase-1 completion report and Lane hardening priorities.
+- Maintainers preparing Baseline completion report and Lane hardening priorities.
 - DevRel/community operators validating that activation efforts converted to contributions.
 - Engineering managers requiring an auditable weekly checkpoint before handoff.
 

--- a/tests/fixtures/professional_naming_legacy_surfaces.txt
+++ b/tests/fixtures/professional_naming_legacy_surfaces.txt
@@ -15,11 +15,5 @@ docs/integrations-continuous-upgrade-closeout-6.md :: path :: closeout :: docs/i
 docs/integrations-continuous-upgrade-closeout-7.md :: path :: closeout :: docs/integrations-continuous-upgrade-closeout-7.md
 docs/integrations-continuous-upgrade-closeout-8.md :: path :: closeout :: docs/integrations-continuous-upgrade-closeout-8.md
 docs/integrations-continuous-upgrade-closeout-9.md :: path :: closeout :: docs/integrations-continuous-upgrade-closeout-9.md
-docs/integrations-demo-asset.md :: path :: demo :: docs/integrations-demo-asset.md
-docs/integrations-demo-asset2.md :: path :: demo :: docs/integrations-demo-asset2.md
 docs/integrations-optimization-closeout-foundation.md :: path :: closeout :: docs/integrations-optimization-closeout-foundation.md
-docs/integrations-phase1-hardening.md :: path :: phase1 :: docs/integrations-phase1-hardening.md
-docs/integrations-phase1-wrap.md :: path :: phase1 :: docs/integrations-phase1-wrap.md
-docs/integrations-phase2-kickoff.md :: path :: phase2 :: docs/integrations-phase2-kickoff.md
-docs/integrations-phase2-wrap-handoff-completion.md :: path :: phase2 :: docs/integrations-phase2-wrap-handoff-completion.md
 docs/integrations-scale-upgrade-closeout.md :: path :: closeout :: docs/integrations-scale-upgrade-closeout.md

--- a/tests/test_professional_naming_docs_navigation_wave3.py
+++ b/tests/test_professional_naming_docs_navigation_wave3.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+CANONICAL_ACTIVE_DOCS = [
+    Path("docs/integrations-example-asset.md"),
+    Path("docs/integrations-example-asset2.md"),
+    Path("docs/integrations-platform-readiness-kickoff-workflow.md"),
+    Path("docs/integrations-platform-readiness-wrap-publication-workflow.md"),
+    Path("docs/integrations-baseline-hardening.md"),
+    Path("docs/integrations-baseline-wrap.md"),
+    Path("docs/integrations-release-readiness-kickoff.md"),
+    Path("docs/integrations-release-readiness-hardening-workflow.md"),
+    Path("docs/integrations-platform-readiness-preplan-workflow.md"),
+    Path("docs/integrations-release-readiness-wrap-handoff.md"),
+]
+
+RETIRED_ACTIVE_DOCS = [
+    Path("docs/integrations-demo-asset.md"),
+    Path("docs/integrations-demo-asset2.md"),
+    Path("docs/integrations-quality-governance-kickoff-workflow.md"),
+    Path("docs/integrations-publication-readiness-workflow.md"),
+    Path("docs/integrations-phase1-hardening.md"),
+    Path("docs/integrations-phase1-wrap.md"),
+    Path("docs/integrations-phase2-kickoff.md"),
+    Path("docs/integrations-workflow-readiness-hardening-workflow.md"),
+    Path("docs/integrations-quality-governance-preplanning-workflow.md"),
+    Path("docs/integrations-phase2-wrap-handoff-completion.md"),
+]
+
+LEGACY_ACTIVE_TOKENS = (
+    "Phase-1",
+    "Phase-2",
+    "Phase-3",
+    "phase1-",
+    "phase2-",
+    "phase3-",
+    "integrations-phase",
+    "demo-asset",
+    "demo-asset2",
+)
+
+
+def test_canonical_active_docs_pages_exist() -> None:
+    for path in CANONICAL_ACTIVE_DOCS:
+        assert path.exists(), path
+
+
+def test_retired_active_docs_pages_are_not_kept_as_live_pages() -> None:
+    for path in RETIRED_ACTIVE_DOCS:
+        assert not path.exists(), path
+
+
+def test_canonical_active_docs_pages_do_not_reintroduce_legacy_tokens() -> None:
+    for path in CANONICAL_ACTIVE_DOCS:
+        text = path.read_text(encoding="utf-8")
+        for token in LEGACY_ACTIVE_TOKENS:
+            assert token not in text, f"{path} contains {token!r}"
+
+
+def test_active_navigation_files_do_not_point_to_retired_integration_pages() -> None:
+    checked = [
+        Path("README.md"),
+        Path("docs/index.md"),
+        Path("docs/top-10-github-strategy.md"),
+        Path("mkdocs.yml"),
+    ]
+
+    retired_refs = [path.as_posix() for path in RETIRED_ACTIVE_DOCS]
+    for path in checked:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for ref in retired_refs:
+            assert ref not in text, f"{path} still points to {ref}"


### PR DESCRIPTION
## Summary
- Move active integration docs from transition-era names to canonical professional naming paths.
- Update active docs references for baseline, release readiness, platform readiness, and example asset pages.
- Add a guardrail test so active docs/navigation pages do not point back to retired live integration paths.

## Scope
- Active docs/navigation surfaces only.
- Historical reports, archived material, and generated evidence remain out of scope.

## Verification
- focused docs/navigation proof passed: 14 passed.
- naming inventory and migration plan generated.
- security check passed with error=0 and warn=0.
- branch is 1 commit ahead of main.