### PR TITLE
refactor: classify internal naming wrappers as review-first

### DIFF
--- a/src/sdetkit/professional_naming_migration.py
+++ b/src/sdetkit/professional_naming_migration.py
@@ -20,11 +20,12 @@ MANUAL_REVIEW = "manual_review"
 MIGRATION_OR_ALIAS_REQUIRED = "migration_or_alias_required"
 ACTIONABLE_PROSE = "actionable_prose_cleanup"
 
-COMPATIBILITY_CLASSES = {
+PUBLIC_OR_WORKFLOW_ALIAS_CLASSES = {
     "public_surface_requires_alias",
     "workflow_alias_migration",
-    "internal_path_requires_migration",
 }
+
+INTERNAL_PATH_REQUIRES_MIGRATION = "internal_path_requires_migration"
 
 PRESERVE_REASON_MARKERS = {
     "heading_or_chronology_label",
@@ -77,7 +78,13 @@ def _migration_class(item: Mapping[str, Any]) -> str:
     if path in TEMPLATE_LOCKED_PATHS or "template_locked" in reason:
         return TEMPLATE_LOCKED
 
-    if classification in COMPATIBILITY_CLASSES or actionability == MIGRATION_OR_ALIAS_REQUIRED:
+    if classification in PUBLIC_OR_WORKFLOW_ALIAS_CLASSES:
+        return ALIAS_REQUIRED
+
+    if classification == INTERNAL_PATH_REQUIRES_MIGRATION:
+        return MANUAL_REVIEW
+
+    if actionability == MIGRATION_OR_ALIAS_REQUIRED:
         return ALIAS_REQUIRED
 
     if any(marker in reason for marker in PRESERVE_REASON_MARKERS):

--- a/tests/test_professional_naming_migration.py
+++ b/tests/test_professional_naming_migration.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from sdetkit.professional_naming_migration import (
     ALIAS_REQUIRED,
+    MANUAL_REVIEW,
     PRESERVE_HISTORY,
     SAFE_CONTENT_REWRITE,
     TEMPLATE_LOCKED,
@@ -69,6 +70,53 @@ def test_professional_naming_migration_requires_alias_for_public_surface() -> No
     item = payload["items"][0]
     assert item["migration_class"] == ALIAS_REQUIRED
     assert item["allowed_to_apply"] is False
+
+
+def test_professional_naming_migration_keeps_internal_wrapper_paths_review_first() -> None:
+    inventory = {
+        "items": [
+            {
+                "term": "phase3",
+                "path": "src/sdetkit/phase3_kickoff.py",
+                "match_type": "path",
+                "classification": "internal_path_requires_migration",
+                "actionability": "migration_or_alias_required",
+                "actionability_reason": "compatibility plan required before changing this surface",
+            }
+        ]
+    }
+
+    payload = build_professional_naming_migration_plan(inventory, _rename_map())
+
+    assert payload["alias_required_count"] == 0
+    assert payload["manual_review_count"] == 1
+    expected_next_action = "_".join(("review", "preserved", "history", "and", "manual", "contexts"))
+    assert payload["recommended_next_action"] == expected_next_action
+    item = payload["items"][0]
+    assert item["migration_class"] == MANUAL_REVIEW
+    assert item["allowed_to_apply"] is False
+    assert item["required_guard"] == "human review before rename"
+
+
+def test_professional_naming_migration_still_requires_alias_for_workflow_surface() -> None:
+    inventory = {
+        "items": [
+            {
+                "term": "phase3",
+                "path": ".github/workflows/phase3-quality-contract.yml",
+                "match_type": "path",
+                "classification": "workflow_alias_migration",
+                "actionability": "migration_or_alias_required",
+                "actionability_reason": "compatibility plan required before changing this surface",
+            }
+        ]
+    }
+
+    payload = build_professional_naming_migration_plan(inventory, _rename_map())
+
+    assert payload["alias_required_count"] == 1
+    assert payload["items"][0]["migration_class"] == ALIAS_REQUIRED
+    assert payload["items"][0]["allowed_to_apply"] is False
 
 
 def test_professional_naming_migration_preserves_history_headings() -> None:


### PR DESCRIPTION
## Summary
- Treat internal professional naming wrapper paths as review-first migration items instead of unresolved alias requirements.
- Keep public CLI and workflow compatibility surfaces classified as alias-required.
- Add focused regression coverage for internal wrapper paths and workflow alias surfaces.

## Proof
- `python -m pytest -q tests/test_professional_naming_migration.py -o addopts=`
- `python -m sdetkit professional-naming-inventory --root . --out build/sdetkit/professional-naming-inventory-wave4.json --format text`
- `python -m sdetkit.professional_naming_migration --inventory-json build/sdetkit/professional-naming-inventory-wave4.json --rename-map docs/naming/professional-naming-rename-map.json --out build/sdetkit/professional-naming-migration-plan-wave4-after-classifier.json --format text`
- `make proof-after-format`

## Results
- `finding_count=1072`
- `alias_required_count=22`
- `manual_review_count=731`
- `blind_rename_allowed=false`

## Safety
- automation_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false