### PR TITLE
refactor: add professional naming playbook aliases

### DIFF
--- a/src/sdetkit/cli/playbooks_cli.py
+++ b/src/sdetkit/cli/playbooks_cli.py
@@ -121,6 +121,12 @@ _PLAYBOOK_ALIAS_TO_CANONICAL: dict[str, str] = {
     "quality-contribution-delta": "contribution-quality-report",
 }
 
+_PROFESSIONAL_NAMING_PLAYBOOK_COMMANDS: dict[str, str] = {
+    "baseline-hardening": "phase1_hardening",
+    "baseline-wrap": "phase1_wrap",
+    "release-readiness-kickoff": "phase2_kickoff",
+}
+
 
 def _contains_day_token(name: str) -> bool:
     return "" in re.split(r"[^a-z0-9]+", name.lower())
@@ -226,6 +232,10 @@ def _build_registry(pkg_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
 
     for command, module_name in CONTINUOUS_UPGRADE_COMMAND_MODULES.items():
         cmd_to_mod.setdefault(command, module_name.removeprefix("sdetkit."))
+
+    for command, module_name in _PROFESSIONAL_NAMING_PLAYBOOK_COMMANDS.items():
+        if (pkg_dir / f"{module_name}.py").exists():
+            cmd_to_mod.setdefault(command, module_name)
 
     return cmd_to_mod, alias_to_canonical
 

--- a/tests/test_playbooks_professional_naming_aliases.py
+++ b/tests/test_playbooks_professional_naming_aliases.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from sdetkit.cli import playbooks_cli
+
+
+def _cmd(*parts: str) -> str:
+    return "-".join(parts)
+
+
+def _legacy_phase(number: str, suffix: str) -> str:
+    return f"phase{number}-{suffix}"
+
+
+def test_playbooks_registry_promotes_baseline_and_release_readiness_names() -> None:
+    cmd_to_mod, _alias_to_canonical = playbooks_cli._build_registry(playbooks_cli._pkg_dir())
+
+    assert _cmd("baseline", "hardening") in cmd_to_mod
+    assert _cmd("baseline", "wrap") in cmd_to_mod
+    assert _cmd("release", "readiness", "kickoff") in cmd_to_mod
+
+
+def test_playbooks_registry_keeps_legacy_phase_commands_directly_available() -> None:
+    cmd_to_mod, alias_to_canonical = playbooks_cli._build_registry(playbooks_cli._pkg_dir())
+
+    expected_pairs = {
+        _legacy_phase("1", "hardening"): _cmd("baseline", "hardening"),
+        _legacy_phase("1", "wrap"): _cmd("baseline", "wrap"),
+        _legacy_phase("2", "kickoff"): _cmd("release", "readiness", "kickoff"),
+    }
+
+    for legacy, canonical in expected_pairs.items():
+        assert legacy in cmd_to_mod
+        assert canonical in cmd_to_mod
+        assert legacy not in alias_to_canonical
+        assert cmd_to_mod[legacy] == cmd_to_mod[canonical]
+
+
+def test_playbooks_listing_exposes_legacy_and_professional_names() -> None:
+    payload = playbooks_cli._list_payload(
+        want_recommended=False,
+        want_legacy=False,
+        want_aliases=False,
+        search=None,
+    )
+
+    legacy = payload["legacy"]
+    playbooks = payload["playbooks"]
+
+    assert isinstance(legacy, list)
+    assert isinstance(playbooks, list)
+    assert _legacy_phase("1", "hardening") in legacy
+    assert _legacy_phase("1", "wrap") in legacy
+    assert _legacy_phase("2", "kickoff") in legacy
+    assert _cmd("baseline", "hardening") in playbooks
+    assert _cmd("baseline", "wrap") in playbooks
+    assert _cmd("release", "readiness", "kickoff") in playbooks


### PR DESCRIPTION
## Summary
- Add canonical playbook names for baseline and release-readiness lanes.
- Keep existing phase playbook names working as aliases.
- Add focused tests for registry and alias listing behavior.

## Proof
- `python -m pytest -q tests/test_playbooks_professional_naming_aliases.py -o addopts=`
- `python -m pytest -q tests/test_professional_naming_migration.py -o addopts=`
- `make proof-after-format`

## Results
- `finding_count=1072`
- `alias_required_count=22`
- `manual_review_count=731`