### PR TITLE
ci: make dependency auto-merge helper best effort

### DIFF
--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -23,6 +23,9 @@ jobs:
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        # Keep this helper best-effort: repository auto-merge may be disabled
+        # while protected-branch manual merge remains the authority.
+        continue-on-error: true
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d  # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_dependency_auto_merge_workflow.py
+++ b/tests/test_dependency_auto_merge_workflow.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "dependency-auto-merge.yml"
+
+
+def test_dependency_auto_merge_helper_is_best_effort() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    action = (
+        "uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d"
+    )
+
+    assert action in text
+    assert "continue-on-error: true" in text
+    assert "repository auto-merge may be disabled" in text


### PR DESCRIPTION
## Summary
- Keep the dependency auto-merge helper best-effort when repository auto-merge is disabled.
- Add a workflow guard test so the behavior stays intentional.

## Why
- The auto-merge action can fail with: GraphQL: Auto merge is not allowed for this repository.
- Manual protected-branch merge remains the authority.

## Verification
- `python -m pytest -q tests/test_dependency_auto_merge_workflow.py -o addopts=`
- `make proof-after-format`

## Risk
- Low.
- Rollback: remove the workflow continue-on-error line and test.

Refs #1518