### PR TITLE
chore(maintenance): suppress empty secret protection trackers

### DIFF
--- a/.github/workflows/secret-protection-review-bot.yml
+++ b/.github/workflows/secret-protection-review-bot.yml
@@ -195,6 +195,18 @@ jobs:
               }
             }
 
+            const hasOpenSecretAlerts = secretAlertsAvailable && secretAlerts.length > 0;
+            const hasBypassedSecretAlerts = secretAlertsAvailable && bypassedAlerts.length > 0;
+            const shouldOpenStandaloneIssue = hasOpenSecretAlerts || hasBypassedSecretAlerts;
+
+            if (!shouldOpenStandaloneIssue) {
+              console.log(
+                'No standalone secret protection review issue created: ' +
+                'live secret scanning found no open alerts or bypassed alerts.'
+              );
+              return;
+            }
+
             const existing = priorIssues.find((issue) => issue.title === title);
             if (existing) {
               await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });

--- a/.github/workflows/secret-protection-review-bot.yml
+++ b/.github/workflows/secret-protection-review-bot.yml
@@ -200,10 +200,10 @@ jobs:
             const shouldOpenStandaloneIssue = hasOpenSecretAlerts || hasBypassedSecretAlerts;
 
             if (!shouldOpenStandaloneIssue) {
-              console.log(
-                'No standalone secret protection review issue created: ' +
-                'live secret scanning found no open alerts or bypassed alerts.'
-              );
+              await core.summary
+                .addHeading('Secret protection review')
+                .addRaw('No standalone issue created: live secret scanning found no open alerts or bypassed alerts.')
+                .write();
               return;
             }
 

--- a/tests/test_secret_protection_review_workflow.py
+++ b/tests/test_secret_protection_review_workflow.py
@@ -47,7 +47,11 @@ def test_secret_protection_review_suppresses_empty_standalone_trackers() -> None
         "const shouldOpenStandaloneIssue = hasOpenSecretAlerts || hasBypassedSecretAlerts;" in text
     )
     assert "if (!shouldOpenStandaloneIssue)" in text
-    assert "No standalone secret protection review issue created" in text
+    assert (
+        "No standalone issue created: live secret scanning found no open alerts or bypassed alerts."
+        in text
+    )
+    assert "console.log(" not in text
 
     guard = text.index("if (!shouldOpenStandaloneIssue)")
     create_issue = text.index("await github.rest.issues.create({")

--- a/tests/test_secret_protection_review_workflow.py
+++ b/tests/test_secret_protection_review_workflow.py
@@ -33,3 +33,22 @@ def test_secret_protection_review_does_not_render_unavailable_secret_alerts_as_z
     )
     assert "`- Alert age buckets: \\`${secretAgeBuckets}\\``" in text
     assert "- Secret scanning alerts were unavailable for this run." in text
+
+
+def test_secret_protection_review_suppresses_empty_standalone_trackers() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const hasOpenSecretAlerts = secretAlertsAvailable && secretAlerts.length > 0;" in text
+    assert (
+        "const hasBypassedSecretAlerts = secretAlertsAvailable && bypassedAlerts.length > 0;"
+        in text
+    )
+    assert (
+        "const shouldOpenStandaloneIssue = hasOpenSecretAlerts || hasBypassedSecretAlerts;" in text
+    )
+    assert "if (!shouldOpenStandaloneIssue)" in text
+    assert "No standalone secret protection review issue created" in text
+
+    guard = text.index("if (!shouldOpenStandaloneIssue)")
+    create_issue = text.index("await github.rest.issues.create({")
+    assert guard < create_issue


### PR DESCRIPTION
## Summary
- Stop the secret protection review bot from opening standalone tracker issues when the live secret-scanning queue is clean.
- Keep standalone issues reserved for real open secret alerts or push-protection bypass follow-up.
- Add a workflow regression guard.

## Why
- #1568 was opened with unavailable/static review text, but live triage showed 0 open secret-scanning alerts.
- Clean weekly scans should stay in the rolling command center instead of creating noisy standalone issues.

## Verification
- `python -m pytest -q tests/test_secret_protection_review_workflow.py -o addopts=`
- `make proof-after-format`

Refs #1500