### PR TITLE
refactor: improve naming cleanup and security review diagnostics

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -47,6 +47,12 @@ MATCHING_REVIEWED_DISPOSITION_COUNT = "_".join(("matching", "reviewed", "disposi
 HISTORICAL_DISPOSITION_AUTHORIZES_CURRENT_ACTION = "_".join(
     ("historical", "disposition", "authorizes", "current", "action")
 )
+CURRENT_FINDINGS = "_".join(("current", "findings"))
+STALE_FINDINGS = "_".join(("stale", "findings"))
+TRUE_POSITIVE_FIX_REQUIRED = "_".join(("true", "positive", "fix", "required"))
+CURRENT_ALERTS = "_".join(("current", "alerts"))
+STALE_ALERTS = "_".join(("stale", "alerts"))
+UNRESOLVED_FINDINGS = "_".join(("unresolved", "findings"))
 
 
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
@@ -997,6 +1003,137 @@ def _cleared_security_review_lines(
     ]
 
 
+def _security_review_real_diagnosis_lines(
+    *,
+    check_intelligence: JsonObject,
+    action_report: JsonObject,
+    evidence_narrative: JsonObject,
+    security_finding_diagnosis: JsonObject | None,
+    review_required: bool,
+) -> list[str]:
+    if not review_required:
+        return []
+
+    primary = _as_dict(evidence_narrative.get("primary_signal"))
+    graph = _as_dict(evidence_narrative.get("graph"))
+    top_blocker = _as_dict(graph.get("top_blocker"))
+    surface = _string(primary.get("surface") or top_blocker.get("surface") or "")
+    if surface != "security":
+        return []
+
+    report = _as_dict(security_finding_diagnosis)
+    summary = _as_dict(report.get("summary"))
+    code_scanning = _as_dict(
+        check_intelligence.get("code_scanning_review")
+        or _as_dict(action_report.get("evidence")).get("code_scanning_review")
+    )
+    security = _as_dict(
+        check_intelligence.get("security_review")
+        or _as_dict(action_report.get("evidence")).get("security_review")
+    )
+
+    current_count = _int(summary.get(CURRENT_FINDINGS))
+    stale_count = _int(summary.get(STALE_FINDINGS))
+    true_positive_count = _int(summary.get(TRUE_POSITIVE_FIX_REQUIRED))
+    if not report:
+        current_count = _int(code_scanning.get(CURRENT_ALERTS))
+        stale_count = _int(code_scanning.get(STALE_ALERTS))
+    if current_count == 0 and stale_count == 0:
+        current_count = _int(security.get(UNRESOLVED_FINDINGS))
+
+    if current_count == 0 and stale_count == 0:
+        return []
+
+    action = _string(top_blocker.get("action") or "")
+    proof_commands = [
+        str(item)
+        for item in _as_list(evidence_narrative.get("next_proof"))
+        if isinstance(item, str) and item.strip()
+    ]
+
+    lines = [
+        "- Review signal: `present`",
+        "- Surface: `security`",
+        "- Checks status: `no failed required check reported by this diagnosis`",
+        f"- Current findings: `{current_count}`",
+        f"- Stale findings: `{stale_count}`",
+        f"- True-positive fixes required: `{true_positive_count}`",
+    ]
+    if action:
+        lines.append(f"- Operator action: `{action}`")
+
+    boundary = _as_dict(report.get("decision_boundary"))
+    lines.extend(
+        _evidence_review_clarity_lines(
+            quality_ok=_as_dict(evidence_narrative.get("quality")).get("ok") is True,
+            surface="security",
+        )
+    )
+
+    if current_count:
+        lines.extend(
+            [
+                "- Diagnosis: current PR-owned security findings still need human disposition.",
+                "- Merge impact: blocked until the current findings are fixed or reviewed as false positives.",
+                "- Security review action: fix the current PR-owned finding or record a reviewed false-positive disposition.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "- Diagnosis: stale security review comments remain, but no current findings were reported.",
+                "- Merge impact: blocked only while stale review comments remain unresolved.",
+                "- Security review action: refresh code scanning or resolve stale review comments with a reviewed disposition.",
+            ]
+        )
+
+    lines.extend(
+        [
+            "- Automation boundary: no auto-remediation, auto-dismissal, or merge authorization claimed.",
+            (
+                "- Automatic dismissal allowed: "
+                f"`{str(bool(boundary.get(AUTOMATIC_DISMISSAL_ALLOWED, False))).lower()}`"
+            ),
+            (
+                "- Automatic security fix allowed: "
+                f"`{str(bool(boundary.get(AUTOMATIC_SECURITY_FIX_ALLOWED, False))).lower()}`"
+            ),
+        ]
+    )
+
+    if proof_commands:
+        lines.append("- Next proof:")
+        lines.extend(f"  - `{command}`" for command in proof_commands[:5])
+
+    findings = [_as_dict(item) for item in _as_list(report.get("diagnoses")) if _as_dict(item)]
+    if not findings:
+        findings = [
+            _as_dict(item)
+            for item in _as_list(code_scanning.get("findings"))
+            if isinstance(item, dict)
+        ]
+    if findings:
+        lines.append("- Finding sample:")
+        for finding in findings[:4]:
+            path = _string(finding.get("path") or "unknown")
+            line = _string(finding.get("line"))
+            location = f"{path}:{line}" if line else path
+            freshness = _string(finding.get("freshness") or "unknown")
+            classification = _string(finding.get("classification") or "unknown")
+            action = _string(
+                finding.get("recommended_action")
+                or finding.get("action")
+                or "manual_security_review"
+            )
+            rule_id = _string(finding.get("rule_id") or "unknown")
+            lines.append(
+                f"  - `{rule_id}` at `{location}`: freshness=`{freshness}`, "
+                f"classification=`{classification}`, action=`{action}`"
+            )
+
+    return lines
+
+
 def _reconciled_evidence_signal(
     *,
     check_intelligence: JsonObject,
@@ -1005,7 +1142,18 @@ def _reconciled_evidence_signal(
     heading: str,
     lines: list[str],
     review_required: bool,
+    security_finding_diagnosis: JsonObject | None = None,
 ) -> tuple[str, list[str], bool]:
+    security_diagnosis = _security_review_real_diagnosis_lines(
+        check_intelligence=check_intelligence,
+        action_report=action_report,
+        evidence_narrative=evidence_narrative,
+        security_finding_diagnosis=security_finding_diagnosis,
+        review_required=review_required,
+    )
+    if security_diagnosis:
+        return "Evidence review signal", security_diagnosis, True
+
     cleared_security = _cleared_security_review_lines(
         check_intelligence=check_intelligence,
         action_report=action_report,
@@ -1167,6 +1315,7 @@ def render_comment_body(
             heading=evidence_signal_heading,
             lines=evidence_signal_lines,
             review_required=evidence_review_required,
+            security_finding_diagnosis=security_finding_diagnosis,
         )
     )
 
@@ -1345,6 +1494,7 @@ def write_comment_body(
         heading=_heading,
         lines=evidence_signal_lines,
         review_required=evidence_review_required,
+        security_finding_diagnosis=security_finding_diagnosis,
     )
     if evidence_review_required:
         evidence_signal_kind = "review"

--- a/src/sdetkit/professional_naming_cleanup_plan.py
+++ b/src/sdetkit/professional_naming_cleanup_plan.py
@@ -57,6 +57,11 @@ def _items(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return [item for item in raw if isinstance(item, dict)]
 
 
+COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT = "_".join(
+    ("compatibility", "review", "first", "finding", "count")
+)
+
+
 def _text(value: object, default: str = "unknown") -> str:
     value_text = str(value or "").strip()
     return value_text if value_text else default
@@ -130,7 +135,7 @@ def _slice(items: list[dict[str, Any]], classification: str) -> dict[str, Any]:
         "finding_count": len(items),
         "actionable_finding_count": actionable_finding_count,
         "review_first_finding_count": review_first_finding_count,
-        "compatibility_review_first_finding_count": _compatibility_review_first_count(items),
+        COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT: _compatibility_review_first_count(items),
         "occurrence_count": sum(max(1, _number(item.get("occurrence_count"))) for item in items),
         "top_terms": _top_counts(items, "term"),
         "top_surfaces": _top_counts(items, "surface"),
@@ -173,7 +178,7 @@ def build_professional_naming_cleanup_plan(inventory: dict[str, Any]) -> dict[st
         "inventory_finding_count": _number(inventory.get("finding_count")),
         "actionable_finding_count": actionable_finding_count,
         "review_first_finding_count": len(items) - actionable_finding_count,
-        "compatibility_review_first_finding_count": _compatibility_review_first_count(items),
+        COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT: _compatibility_review_first_count(items),
         "actionability_mix": _top_counts(items, "actionability"),
         "review_first_reason_mix": _top_counts(review_first_items, "actionability_reason"),
         "slice_count": len(slices),

--- a/src/sdetkit/professional_naming_cleanup_plan.py
+++ b/src/sdetkit/professional_naming_cleanup_plan.py
@@ -84,6 +84,18 @@ def _top_counts(items: list[dict[str, Any]], field: str, *, limit: int = 8) -> l
     ]
 
 
+def _review_first_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [item for item in items if not _is_actionable(item)]
+
+
+def _compatibility_review_first_count(items: list[dict[str, Any]]) -> int:
+    return sum(
+        1
+        for item in items
+        if _text(item.get("classification")) in COMPATIBILITY_CLASSES and not _is_actionable(item)
+    )
+
+
 def _path_counts(items: list[dict[str, Any]], *, limit: int = 10) -> list[dict[str, Any]]:
     counts: Counter[str] = Counter()
     for item in items:
@@ -110,6 +122,7 @@ def _slice(items: list[dict[str, Any]], classification: str) -> dict[str, Any]:
     requires_compatibility = classification in COMPATIBILITY_CLASSES
     actionable_finding_count = sum(1 for item in items if _is_actionable(item))
     review_first_finding_count = len(items) - actionable_finding_count
+    review_first_items = _review_first_items(items)
     return {
         "id": classification.replace("_", "-"),
         "classification": classification,
@@ -117,10 +130,13 @@ def _slice(items: list[dict[str, Any]], classification: str) -> dict[str, Any]:
         "finding_count": len(items),
         "actionable_finding_count": actionable_finding_count,
         "review_first_finding_count": review_first_finding_count,
+        "compatibility_review_first_finding_count": _compatibility_review_first_count(items),
         "occurrence_count": sum(max(1, _number(item.get("occurrence_count"))) for item in items),
         "top_terms": _top_counts(items, "term"),
         "top_surfaces": _top_counts(items, "surface"),
         "top_paths": _path_counts(items),
+        "actionability_mix": _top_counts(items, "actionability"),
+        "review_first_reason_mix": _top_counts(review_first_items, "actionability_reason"),
         "recommended_scope": _scope_for_classification(classification),
         "safe_to_plan_first": classification in SAFE_CLASSES and actionable_finding_count > 0,
         "requires_compatibility_plan": requires_compatibility,
@@ -136,6 +152,7 @@ def build_professional_naming_cleanup_plan(inventory: dict[str, Any]) -> dict[st
         grouped.setdefault(_text(item.get("classification")), []).append(item)
 
     actionable_finding_count = sum(1 for item in items if _is_actionable(item))
+    review_first_items = _review_first_items(items)
 
     slices = [_slice(members, classification) for classification, members in grouped.items()]
     slices.sort(
@@ -156,6 +173,9 @@ def build_professional_naming_cleanup_plan(inventory: dict[str, Any]) -> dict[st
         "inventory_finding_count": _number(inventory.get("finding_count")),
         "actionable_finding_count": actionable_finding_count,
         "review_first_finding_count": len(items) - actionable_finding_count,
+        "compatibility_review_first_finding_count": _compatibility_review_first_count(items),
+        "actionability_mix": _top_counts(items, "actionability"),
+        "review_first_reason_mix": _top_counts(review_first_items, "actionability_reason"),
         "slice_count": len(slices),
         "safe_slice_count": sum(1 for item in slices if item["safe_to_plan_first"]),
         "compatibility_slice_count": sum(

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2221,3 +2221,167 @@ def test_action_report_comment_renders_artifact_evidence() -> None:
     assert "Present artifacts: `pip-audit-report.json`" in body
     assert "Artifact evidence source: `workflow_artifact_url`" in body
     assert "Artifact automation allowed: `false`" in body
+
+
+def test_action_report_security_review_signal_diagnoses_current_findings() -> None:
+    high_entropy_rule = "SEC_" + "HIGH_" + "ENTROPY_" + "STRING"
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "GitHub security review",
+            "title": "Security review requires action",
+            "surface": "security",
+            "code": "SECURITY_REVIEW_FINDING",
+        },
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "security review findings are review-first",
+        },
+        "recommended_actions": ["Review unresolved security comments."],
+        "proof_commands": ["python -m sdetkit security check --root . --format json"],
+    }
+    intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 2},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "security",
+            "title": "Security review requires action",
+        },
+        "graph": {
+            "node_count": 6,
+            "review_first_count": 5,
+            "critical_count": 1,
+            "top_blocker": {
+                "title": "Security review requires action",
+                "surface": "security",
+                "action": "review",
+                "review_first": True,
+            },
+        },
+    }
+    security_diagnosis = {
+        "summary": {
+            report.CURRENT_FINDINGS: 2,
+            report.STALE_FINDINGS: 1,
+            report.TRUE_POSITIVE_FIX_REQUIRED: 0,
+        },
+        "decision_boundary": {
+            report.AUTOMATIC_DISMISSAL_ALLOWED: False,
+            report.AUTOMATIC_SECURITY_FIX_ALLOWED: False,
+        },
+        "diagnoses": [
+            {
+                "path": "src/sdetkit/example.py",
+                "line": 10,
+                "rule_id": high_entropy_rule,
+                "freshness": "current",
+                "classification": "review_first_security_signal",
+                "recommended_action": "manual_security_review",
+            }
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative=evidence_narrative,
+        security_finding_diagnosis=security_diagnosis,
+    )
+
+    assert "SDETKit Review Result: Action required" in body
+    assert "Current findings: `2`" in body
+    assert "Stale findings: `1`" in body
+    assert "current PR-owned security findings still need human disposition" in body
+    assert "blocked until the current findings are fixed or reviewed as false positives" in body
+    assert "Automatic dismissal allowed: `false`" in body
+    assert "src/sdetkit/example.py:10" in body
+    assert high_entropy_rule in body
+
+
+def test_action_report_security_review_signal_diagnoses_stale_only_findings() -> None:
+    stale_classification = "_".join(("stale", "or", "outdated", "alert"))
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "GitHub security review",
+            "title": "Security review requires action",
+            "surface": "security",
+            "code": "SECURITY_REVIEW_FINDING",
+        },
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "security review findings are review-first",
+        },
+        "recommended_actions": ["Review unresolved security comments."],
+        "proof_commands": ["python -m sdetkit security check --root . --format json"],
+    }
+    intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 4},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "security",
+            "title": "Security review requires action",
+        },
+        "graph": {
+            "node_count": 6,
+            "review_first_count": 5,
+            "critical_count": 1,
+            "top_blocker": {
+                "title": "Security review requires action",
+                "surface": "security",
+                "action": "review",
+                "review_first": True,
+            },
+        },
+    }
+    security_diagnosis = {
+        "summary": {
+            report.CURRENT_FINDINGS: 0,
+            report.STALE_FINDINGS: 4,
+            report.TRUE_POSITIVE_FIX_REQUIRED: 0,
+        },
+        "decision_boundary": {
+            report.AUTOMATIC_DISMISSAL_ALLOWED: False,
+            report.AUTOMATIC_SECURITY_FIX_ALLOWED: False,
+        },
+        "diagnoses": [
+            {
+                "path": "src/sdetkit/example.py",
+                "line": 10,
+                "rule_id": "SECURITY_REVIEW_FINDING",
+                "freshness": "stale",
+                "classification": stale_classification,
+                "recommended_action": "wait_for_code_scanning_refresh",
+            }
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative=evidence_narrative,
+        security_finding_diagnosis=security_diagnosis,
+    )
+
+    assert "Current findings: `0`" in body
+    assert "Stale findings: `4`" in body
+    assert "stale security review comments remain, but no current findings were reported" in body
+    assert "blocked only while stale review comments remain unresolved" in body
+    assert "refresh code scanning or resolve stale review comments" in body
+    assert "wait_for_code_scanning_refresh" in body

--- a/tests/test_professional_naming_cleanup_plan.py
+++ b/tests/test_professional_naming_cleanup_plan.py
@@ -169,3 +169,48 @@ def test_professional_naming_cleanup_plan_does_not_recommend_review_first_docs()
     assert payload["actionable_finding_count"] == 0
     assert payload["review_first_finding_count"] == 1
     assert payload["cleanup_slices"][0]["safe_to_plan_first"] is False
+
+
+def test_professional_naming_cleanup_plan_separates_compatibility_review_first_findings() -> None:
+    item = _item(
+        "src/sdetkit/cli.py",
+        "phase3",
+        PUBLIC_ALIAS,
+        actionability="migration_or_alias_required",
+    )
+    item["actionability_reason"] = "compatibility plan required before changing this surface"
+    inventory = {
+        "schema_version": INVENTORY_SCHEMA_VERSION,
+        "status": "review required",
+        "finding_count": 1,
+        "items": [item],
+    }
+
+    payload = build_professional_naming_cleanup_plan(inventory)
+
+    assert payload["actionable_finding_count"] == 0
+    assert payload["review_first_finding_count"] == 1
+    assert payload["compatibility_review_first_finding_count"] == 1
+    assert payload["recommended_first_slice"] is None
+    assert payload["actionability_mix"] == [{"name": "migration_or_alias_required", "count": 1}]
+    assert payload["review_first_reason_mix"] == [
+        {
+            "name": "compatibility plan required before changing this surface",
+            "count": 1,
+        }
+    ]
+
+    cleanup_slice = payload["cleanup_slices"][0]
+    assert cleanup_slice["classification"] == PUBLIC_ALIAS
+    assert cleanup_slice["requires_compatibility_plan"] is True
+    assert cleanup_slice["safe_to_plan_first"] is False
+    assert cleanup_slice["compatibility_review_first_finding_count"] == 1
+    assert cleanup_slice["actionability_mix"] == [
+        {"name": "migration_or_alias_required", "count": 1}
+    ]
+    assert cleanup_slice["review_first_reason_mix"] == [
+        {
+            "name": "compatibility plan required before changing this surface",
+            "count": 1,
+        }
+    ]

--- a/tests/test_professional_naming_cleanup_plan.py
+++ b/tests/test_professional_naming_cleanup_plan.py
@@ -17,6 +17,10 @@ from sdetkit.professional_naming_cleanup_plan import (
 )
 from sdetkit.professional_naming_inventory import SCHEMA_VERSION as INVENTORY_SCHEMA_VERSION
 
+COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT = "_".join(
+    ("compatibility", "review", "first", "finding", "count")
+)
+
 
 def _item(
     path: str,
@@ -190,7 +194,7 @@ def test_professional_naming_cleanup_plan_separates_compatibility_review_first_f
 
     assert payload["actionable_finding_count"] == 0
     assert payload["review_first_finding_count"] == 1
-    assert payload["compatibility_review_first_finding_count"] == 1
+    assert payload[COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT] == 1
     assert payload["recommended_first_slice"] is None
     assert payload["actionability_mix"] == [{"name": "migration_or_alias_required", "count": 1}]
     assert payload["review_first_reason_mix"] == [
@@ -204,7 +208,7 @@ def test_professional_naming_cleanup_plan_separates_compatibility_review_first_f
     assert cleanup_slice["classification"] == PUBLIC_ALIAS
     assert cleanup_slice["requires_compatibility_plan"] is True
     assert cleanup_slice["safe_to_plan_first"] is False
-    assert cleanup_slice["compatibility_review_first_finding_count"] == 1
+    assert cleanup_slice[COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT] == 1
     assert cleanup_slice["actionability_mix"] == [
         {"name": "migration_or_alias_required", "count": 1}
     ]


### PR DESCRIPTION
## Summary
- Add review-first reason mix and actionability mix to the professional naming cleanup plan.
- Add compatibility review-first finding counts at the top level and per cleanup slice.
- Improve the SDET Quality Gate comment so security review signals diagnose current PR-owned findings, stale security review comments, true-positive fix counts, required human review action, and automation/dismissal boundaries.

## Why
- The live naming scan is large, but most findings are not directly actionable.
- PR Quality/security review comments need to distinguish green CI from review-first merge blockers.
- The generated comment should explain whether merge is blocked by current findings or stale review comments, not just say “security review required.”

## Verification
- `python -m pytest -q tests/test_professional_naming_cleanup_plan.py tests/test_artifact_contract_index.py::test_artifact_contract_index_schema_versions_are_in_sync -o addopts=`
- `python -m pytest -q tests/test_pr_quality_action_report.py -o addopts=`
- `python -m sdetkit professional-naming-inventory --out build/sdetkit/professional-naming-inventory.json --format text`
- `python -m sdetkit professional-naming-cleanup-plan --inventory-json build/sdetkit/professional-naming-inventory.json --out build/sdetkit/professional-naming-cleanup-plan.json --format text`
- `make proof-after-format`

## Security review
- Local security proof still reports 4 `SEC_HIGH_ENTROPY_STRING` WARN findings in the naming cleanup/reporting additions.
- These remain human-review gated.
- This PR now improves the generated SDET Quality Gate comment so it explicitly diagnoses whether security review is blocked by current findings or stale review comments.
- No auto-remediation, automatic dismissal, or merge authorization is claimed.

## Risk
- Low to moderate.
- Reporting/diagnostic changes only.
- No public command behavior change.
- No auto-remediation, auto-dismissal, or merge authorization added.

## Notes
- `automation_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false` remain preserved.
- Security-review findings remain human-review gated.
