### PR TITLE
chore(deps): raise twilio floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ telegram = [
   "python-telegram-bot>=22.7,<23"
 ]
 whatsapp = [
-  "twilio>=9.10.5,<10"
+  "twilio>=9.10.9,<10"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- Raise the optional WhatsApp/Twilio dependency floor from `twilio>=9.10.5,<10` to `twilio>=9.10.9,<10`.

## Why
- Live upgrade audit identified Twilio as the only allowed actionable dependency lane.
- After the patch, the focused Twilio upgrade audit reports zero actionable packages and keeps Twilio on the policy-covered watchlist.

## Verification
- `python -m pytest -q tests/test_notify_plugins.py tests/test_notify_plugins_extra.py -o addopts=`
- `PYTHONPATH=src python -m sdetkit doctor --upgrade-audit --upgrade-audit-package twilio --format json --out build/next/doctor-twilio-after.json`
- `make proof-after-format`

## Risk
- Low.
- Optional dependency floor only.
- No runtime code changes.
- No public command behavior changes.
