### PR TITLE
fix: keep inspect cache noise out of review gates

### DIFF
--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -18,6 +18,22 @@ EXIT_OK = 0
 EXIT_FINDINGS = 2
 SUPPORTED_EXTENSIONS = {".csv", ".json"}
 SUPPORTED_CROSS_FILE_MODES = {"left_subset", "exact_match"}
+DEFAULT_EXCLUDED_DIRECTORY_PARTS = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".sdetkit",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "htmlcov",
+    "node_modules",
+}
 RULES_TEMPLATE: dict[str, Any] = {
     "files": {
         "orders.csv": {
@@ -435,6 +451,14 @@ def _recommendations(diagnostics: dict[str, int], has_record_ids: bool) -> list[
     return recs
 
 
+def _is_excluded_directory_scan_candidate(candidate: Path, *, root: Path) -> bool:
+    try:
+        parts = candidate.relative_to(root).parts
+    except ValueError:
+        parts = candidate.parts
+    return bool(DEFAULT_EXCLUDED_DIRECTORY_PARTS.intersection(parts))
+
+
 def _discover_supported_files(target: Path) -> tuple[list[Path], list[Path]]:
     if target.is_file():
         if target.suffix.lower() in SUPPORTED_EXTENSIONS:
@@ -443,8 +467,12 @@ def _discover_supported_files(target: Path) -> tuple[list[Path], list[Path]]:
 
     supported: list[Path] = []
     skipped: list[Path] = []
+    root = target.resolve()
     for candidate in sorted(target.rglob("*")):
         if not candidate.is_file():
+            continue
+        if _is_excluded_directory_scan_candidate(candidate.resolve(), root=root):
+            skipped.append(candidate)
             continue
         if candidate.suffix.lower() in SUPPORTED_EXTENSIONS:
             supported.append(candidate)

--- a/src/sdetkit/intelligence/review.py
+++ b/src/sdetkit/intelligence/review.py
@@ -789,24 +789,71 @@ def run_review(
         if inspect_rc == 0:
             healthy_controls.append("inspect evidence diagnostics are stable")
         else:
-            findings.append(
-                {
-                    "id": "review:inspect",
-                    "kind": "inspect",
-                    "severity": "high",
-                    "priority": 65,
-                    "why_it_matters": "inspect surfaced suspicious evidence or rule failures",
-                    "next_action": "Investigate inspect anomalies and resolve suspicious signals.",
-                    "message": "inspect reported findings",
-                }
+            inspect_judgment = inspect_payload.get("judgment", {})
+            if not isinstance(inspect_judgment, dict):
+                inspect_judgment = {}
+
+            inspect_severity = str(inspect_judgment.get("severity") or "high").lower()
+            inspect_status = str(inspect_judgment.get("status") or "fail").lower()
+            inspect_priority = int(inspect_judgment.get("priority_score") or 65)
+            inspect_recommendations = [
+                item
+                for item in inspect_judgment.get("recommendations", [])
+                if isinstance(item, dict)
+            ]
+            inspect_diagnostics = inspect_payload.get("summary", {}).get("diagnostics", {})
+            if not isinstance(inspect_diagnostics, dict):
+                inspect_diagnostics = {}
+            monitor_only_diagnostic_keys = {
+                "missing_value_columns",
+                "inconsistent_type_columns",
+            }
+            blocking_inspect_diagnostics = {
+                str(key): int(value)
+                for key, value in inspect_diagnostics.items()
+                if str(key) not in monitor_only_diagnostic_keys
+                and isinstance(value, int)
+                and value > 0
+            }
+            inspect_is_monitor_only = (
+                inspect_status in {"pass", "watch"}
+                and inspect_severity == "low"
+                and inspect_priority < selected_profile.fail_threshold
+                and not blocking_inspect_diagnostics
             )
-            prioritized_actions.append(
-                {
-                    "tier": "now",
-                    "priority": 65,
-                    "action": "Resolve inspect evidence anomalies and rerun review.",
-                }
-            )
+
+            if inspect_is_monitor_only:
+                healthy_controls.append("inspect evidence diagnostics are monitor-only")
+                for item in inspect_recommendations[:3]:
+                    prioritized_actions.append(
+                        {
+                            "tier": str(item.get("tier") or "monitor"),
+                            "priority": int(item.get("priority") or inspect_priority),
+                            "action": str(
+                                item.get("action")
+                                or "Monitor low-severity inspect evidence diagnostics."
+                            ),
+                        }
+                    )
+            else:
+                findings.append(
+                    {
+                        "id": "review:inspect",
+                        "kind": "inspect",
+                        "severity": inspect_severity,
+                        "priority": max(inspect_priority, 65),
+                        "why_it_matters": "inspect surfaced suspicious evidence or rule failures",
+                        "next_action": "Investigate inspect anomalies and resolve suspicious signals.",
+                        "message": "inspect reported findings",
+                    }
+                )
+                prioritized_actions.append(
+                    {
+                        "tier": "now",
+                        "priority": max(inspect_priority, 65),
+                        "action": "Resolve inspect evidence anomalies and rerun review.",
+                    }
+                )
 
     if "inspect-project" in baseline_checks:
         project_out = out_dir / "inspect-project"
@@ -847,8 +894,15 @@ def run_review(
                 }
             )
 
-    # contradictions as first-class product output (baseline signal set)
-    contradiction_graph = build_contradiction_clusters(findings=findings, detection=detection)
+    # contradictions as first-class product output (baseline signal set).
+    # Clean repo+data coexistence is useful during forensics/deep review, but
+    # normal release review should not fail solely because repo artifacts and
+    # low-severity evidence files coexist.
+    contradiction_graph = build_contradiction_clusters(
+        findings=findings,
+        detection=detection,
+        flag_repo_data_coexistence=selected_profile.name == "forensics" or adaptive_deep,
+    )
     conflicting.extend(contradiction_graph.get("flat_contradictions", []))
 
     baseline_confidence = investigation_confidence(

--- a/src/sdetkit/intelligence/review_engine.py
+++ b/src/sdetkit/intelligence/review_engine.py
@@ -326,13 +326,20 @@ def build_contradiction_graph(
     detection: dict[str, bool] | None = None,
     doctor_kind: str = "doctor",
     inspect_kind: str = "inspect",
+    flag_repo_data_coexistence: bool = True,
 ) -> list[dict[str, Any]]:
     graph: list[dict[str, Any]] = []
     has_doctor_failure = any(str(f.get("kind", "")) == doctor_kind for f in findings)
     has_inspect_failure = any(str(f.get("kind", "")) == inspect_kind for f in findings)
     repo_like = bool((detection or {}).get("repo_like", False))
     data_like = bool((detection or {}).get("data_like", False))
-    if repo_like and data_like and not has_doctor_failure and not has_inspect_failure:
+    if (
+        flag_repo_data_coexistence
+        and repo_like
+        and data_like
+        and not has_doctor_failure
+        and not has_inspect_failure
+    ):
         graph.append(
             {
                 "id": "review:conflict:repo-and-data-coexist",
@@ -370,8 +377,13 @@ def build_contradiction_clusters(
     *,
     findings: list[dict[str, Any]],
     detection: dict[str, bool] | None = None,
+    flag_repo_data_coexistence: bool = True,
 ) -> dict[str, Any]:
-    flat = build_contradiction_graph(findings=findings, detection=detection)
+    flat = build_contradiction_graph(
+        findings=findings,
+        detection=detection,
+        flag_repo_data_coexistence=flag_repo_data_coexistence,
+    )
     findings_by_kind: dict[str, list[dict[str, Any]]] = {}
     for item in findings:
         kind = str(item.get("kind", "unknown"))

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -304,3 +304,34 @@ def test_inspect_requires_path_in_normal_mode() -> None:
     assert run.returncode == 2
     assert run.stdout == ""
     assert run.stderr == "inspect: missing input path (or use --rules-template)\n"
+
+
+def test_inspect_directory_scan_excludes_local_tool_caches(tmp_path: Path) -> None:
+    data = tmp_path / "dataset.json"
+    data.write_text(json.dumps([{"id": "A1", "value": "kept"}]), encoding="utf-8")
+
+    mypy_cache = tmp_path / ".mypy_cache" / "3.10"
+    mypy_cache.mkdir(parents=True)
+    (mypy_cache / "module.meta.json").write_text(
+        json.dumps({"id": "CACHE_ONLY", "value": "generated"}),
+        encoding="utf-8",
+    )
+
+    pycache = tmp_path / "__pycache__"
+    pycache.mkdir()
+    (pycache / "generated.json").write_text(
+        json.dumps({"id": "PYCACHE_ONLY", "value": "generated"}),
+        encoding="utf-8",
+    )
+
+    rc = inspect_data.main([str(tmp_path), "--format", "json", "--out-dir", str(tmp_path / "out")])
+
+    assert rc == 0
+    payload = json.loads((tmp_path / "out" / "inspect.json").read_text(encoding="utf-8"))
+    assert payload["summary"]["files_analyzed"] == 1
+    assert payload["summary"]["skipped_file_count"] >= 2
+    assert payload["summary"]["diagnostics"]["cross_file_mismatches"] == 0
+    analyzed_paths = [report["path"] for report in payload["file_reports"]]
+    assert analyzed_paths == [str(data)]
+    assert all(".mypy_cache" not in path for path in analyzed_paths)
+    assert all("__pycache__" not in path for path in analyzed_paths)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -921,3 +921,62 @@ def test_cli_review_rejects_code_scanning_path_traversal(tmp_path: Path) -> None
 
     assert run.returncode != 0
     assert "code scanning file must be a single relative file name" in (run.stderr + run.stdout)
+
+
+def test_review_treats_low_severity_inspect_watch_as_monitor_signal(tmp_path: Path) -> None:
+    data = tmp_path / "events.csv"
+    data.write_text("id,type\nE1,\n", encoding="utf-8")
+
+    rc, payload, _, _ = review.run_review(
+        target=data,
+        out_dir=tmp_path / "out",
+        workspace_root=tmp_path / "workspace",
+        profile="release",
+        no_workspace=True,
+    )
+
+    assert rc == 0
+    assert payload["status"] == "pass"
+    assert "inspect evidence diagnostics are monitor-only" in payload["healthy_controls"]
+    assert not any(item.get("id") == "review:inspect" for item in payload["top_matters"])
+    assert not any(
+        item.get("action") == "Resolve inspect evidence anomalies and rerun review."
+        for item in payload["prioritized_actions"]
+    )
+
+
+def test_review_contradiction_graph_can_suppress_clean_repo_data_coexistence() -> None:
+    graph = review.build_contradiction_clusters(
+        findings=[],
+        detection={"repo_like": True, "data_like": True},
+        flag_repo_data_coexistence=False,
+    )
+
+    assert graph["flat_contradictions"] == []
+
+
+def test_forensics_review_keeps_repo_data_coexistence_verification_signal(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n",
+        encoding="utf-8",
+    )
+    (repo / "dataset.json").write_text(
+        json.dumps([{"id": "A1", "value": "ok"}]),
+        encoding="utf-8",
+    )
+
+    rc, payload, _, _ = review.run_review(
+        target=repo,
+        out_dir=tmp_path / "out",
+        workspace_root=tmp_path / "workspace",
+        profile="forensics",
+        no_workspace=True,
+    )
+
+    assert rc == 2
+    assert any(
+        item.get("id") == "review:conflict:repo-and-data-coexist"
+        for item in payload["conflicting_evidence"]
+    )


### PR DESCRIPTION
## Summary
- Exclude local/generated tool caches from `sdetkit inspect` directory scans.
- Prevent low-severity inspect watch signals from becoming release-blocking review findings.
- Keep repo/data coexistence as a forensics/deep-review verification signal, but stop treating clean coexistence as a normal release blocker.

## Why
- Live review failed because inspect scanned generated cache artifacts and produced noisy evidence diagnostics.
- After excluding caches, inspect reports no high-signal anomalies: no cross-file mismatches, no failed rule checks, and no suspicious rows.
- Remaining missing/inconsistent column signals are monitor-only and should not block release review.

## Verification
- `python -m pytest -q tests/test_inspect_data.py tests/test_review.py -o addopts=`
- `python -m sdetkit inspect . --format json`
- `PYTHONPATH=src python -m sdetkit review . --no-workspace --format json`
- `python -m sdetkit gate release --format json`
- `make proof-after-format`

## Risk
- Low.
- No public command removal.
- Inspect still scans explicit file inputs.
- Blocking inspect diagnostics such as cross-file mismatches, failed rules, suspicious rows, duplicate rows, and duplicate IDs remain blocking.
