### PR TITLE
chore(deps): stage mutmut upgrade

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,7 +9,7 @@ httpx==0.28.1
 ruff==0.15.16
 mypy==2.1.0
 pre-commit==4.6.0
-mutmut==3.5.0
+mutmut==3.6.0
 
 # Security scanner transitive dependency floors
 idna==3.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.4.0
 hypothesis==6.155.1
-mutmut==3.5.0
+mutmut==3.6.0
 build==1.5.0
 twine==6.2.0
 

--- a/tests/test_mutation_workflow_dependency_contract.py
+++ b/tests/test_mutation_workflow_dependency_contract.py
@@ -10,6 +10,6 @@ def test_mutation_workflow_uses_requirements_test_for_mutmut() -> None:
     workflow = MUTATION_WORKFLOW.read_text(encoding="utf-8")
     requirements = REQUIREMENTS_TEST.read_text(encoding="utf-8")
 
-    assert "mutmut==3.5.0" in requirements
+    assert "mutmut==3.6.0" in requirements
     assert "python -m pip install -c constraints-ci.txt -r requirements-test.txt" in workflow
     assert "python -m pip install mutmut" not in workflow


### PR DESCRIPTION
## Summary
- Stage the quality-tooling `mutmut` upgrade from `3.5.0` to `3.6.0`.
- Keep the mutation workflow dependency contract aligned with `requirements-test.txt`.

## Why
- Live upgrade audit identified `mutmut` as the top backlog-watchlist quality-tooling stage-upgrade.
- After the patch, focused upgrade audit reports `mutmut` is aligned at `3.6.0` with `manifest_action=none` and zero actionable packages.

## Verification
- `python -m pytest -q tests/test_mutation_workflow_dependency_contract.py tests/test_workflow_dependency_install_contract.py -o addopts=`
- `PYTHONPATH=src python -m sdetkit doctor --upgrade-audit --upgrade-audit-package mutmut --format json --out build/quality-tooling-upgrades/doctor-mutmut-after-revert.json`
- `bash quality.sh ci`
- `bash quality.sh cov`
- `make proof-after-format`

## Risk
- Low to medium.
- Quality-tooling dependency only.
- No runtime code changes.
- `mutmut` is declared-only in repo Python usage.
