### PR TITLE
chore(deps): stage hypothesis upgrade

### DIFF
--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -3,7 +3,7 @@
 httpx==0.28.1
 build==1.5.0
 check-wheel-contents==0.6.3
-hypothesis==6.155.1
+hypothesis==6.155.2
 mkdocs==1.6.1
 mkdocs-material==9.7.6
 mypy==2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
   "twine==6.2.0"
 ]
 test = [
-  "hypothesis==6.155.1",
+  "hypothesis==6.155.2",
   "pre-commit==4.6.0",
   "PyYAML",
   "pytest",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.4.0
 pytest-xdist[psutil]==3.8.0
-hypothesis==6.155.1
+hypothesis==6.155.2
 PyYAML==6.0.3
 httpx==0.28.1
 ruff==0.15.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pytest==9.0.3
 pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.4.0
-hypothesis==6.155.1
+hypothesis==6.155.2
 mutmut==3.6.0
 build==1.5.0
 twine==6.2.0


### PR DESCRIPTION
## Summary
- Stage the quality-tooling `hypothesis` upgrade from `6.155.1` to `6.155.2`.
- Keep the pinned version aligned across `pyproject.toml`, `requirements.txt`, `requirements-test.txt`, and `constraints-ci.txt`.

## Why
- Live upgrade audit identified `hypothesis` as a quality-tooling watchlist stage-upgrade.
- After the patch, focused upgrade audit reports `hypothesis` is aligned at `6.155.2` with `manifest_action=none` and zero actionable packages.
- `mutmut` is already aligned at `3.6.0`; the combined audit reports zero actionable packages for both staged quality-tooling upgrades.

## Automation guard
- PR diff scope is limited to four dependency pin files.
- No open bot/dependency PRs were present before push.
- No open dependency-related remote branches were present before push.
- No open Dependabot alerts were present before push.
- Dependency auto-merge is scoped to `dependabot[bot]`, not this maintainer branch.

## Verification
- `python -m pip install -c constraints-ci.txt -r requirements-test.txt`
- `python - <<'PY' ... hypothesis.__version__ == "6.155.2" ... PY`
- `python -m pytest -q tests/test_textutil.py -o addopts=`
- `python -m pytest -q tests/test_validate_test_bootstrap.py tests/test_check_test_bootstrap_contract.py tests/test_test_bootstrap_validate_unit.py -o addopts=`
- `PYTHONPATH=src python -m sdetkit doctor --upgrade-audit --upgrade-audit-package hypothesis --format json --out build/quality-tooling-upgrades/doctor-hypothesis-after.json`
- `PYTHONPATH=src python -m sdetkit doctor --upgrade-audit --upgrade-audit-package mutmut --upgrade-audit-package hypothesis --format json --out build/quality-tooling-upgrades/doctor-mutmut-hypothesis-after-both.json`
- `bash quality.sh ci`
- `bash quality.sh cov`
- `make proof-after-format`

## Risk
- Low to medium.
- Quality-tooling dependency only.
- `hypothesis` is used only in test coverage (`tests/test_textutil.py` hotspot).
- No runtime code changes.
