### PR TITLE
refactor(naming): route canonical commands to professional modules

### DIFF
--- a/src/sdetkit/legacy_adapters/workflow_aliases.py
+++ b/src/sdetkit/legacy_adapters/workflow_aliases.py
@@ -68,7 +68,21 @@ def professional_canonical_command_for(command: str) -> str:
     return canonical
 
 
+_PHASE_MODULE_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    ("sdetkit.phase1_", "sdetkit.baseline_"),
+    ("sdetkit.phase2_", "sdetkit.release_readiness_"),
+    ("sdetkit.phase3_", "sdetkit.platform_readiness_"),
+)
+
+
+def professional_canonical_module_for(module: str) -> str:
+    for legacy_prefix, replacement_prefix in _PHASE_MODULE_REPLACEMENTS:
+        if module.startswith(legacy_prefix):
+            return replacement_prefix + module.removeprefix(legacy_prefix)
+    return module
+
+
 CANONICAL_CLOSEOUT_COMMAND_MODULES: dict[str, str] = {
-    professional_canonical_command_for(command): module
+    professional_canonical_command_for(command): professional_canonical_module_for(module)
     for command, module in LEGACY_CLOSEOUT_COMMAND_MODULES.items()
 }

--- a/tests/test_professional_naming_compatibility_aliases.py
+++ b/tests/test_professional_naming_compatibility_aliases.py
@@ -7,6 +7,7 @@ from sdetkit.legacy_adapters.workflow_aliases import (
     CANONICAL_CLOSEOUT_COMMAND_MODULES,
     LEGACY_CLOSEOUT_COMMAND_MODULES,
     professional_canonical_command_for,
+    professional_canonical_module_for,
 )
 
 
@@ -15,9 +16,13 @@ def test_professional_canonical_closeout_commands_preserve_modules() -> None:
     canonical = "release-readiness-hardening-completion-report"
 
     assert professional_canonical_command_for(legacy) == canonical
+    assert professional_canonical_module_for("sdetkit.phase2_hardening") == (
+        "sdetkit.release_readiness_hardening"
+    )
     assert LEGACY_CLOSEOUT_COMMAND_MODULES[legacy] == "sdetkit.phase2_hardening"
-    assert CANONICAL_CLOSEOUT_COMMAND_MODULES[canonical] == "sdetkit.phase2_hardening"
-    assert LEGACY_COMMAND_MODULES[legacy] == LEGACY_COMMAND_MODULES[canonical]
+    assert CANONICAL_CLOSEOUT_COMMAND_MODULES[canonical] == ("sdetkit.release_readiness_hardening")
+    assert LEGACY_COMMAND_MODULES[legacy] == "sdetkit.phase2_hardening"
+    assert LEGACY_COMMAND_MODULES[canonical] == "sdetkit.release_readiness_hardening"
 
 
 def test_professional_canonical_command_aliases_are_registered() -> None:
@@ -25,8 +30,14 @@ def test_professional_canonical_command_aliases_are_registered() -> None:
         "acceleration-completion-report": "sdetkit.acceleration",
         "scale-completion-report": "sdetkit.scale",
         "release-prioritization-completion-report": "sdetkit.release_prioritization",
+        "release-readiness-hardening-completion-report": ("sdetkit.release_readiness_hardening"),
+        "release-readiness-wrap-handoff-completion-report": (
+            "sdetkit.release_readiness_wrap_handoff"
+        ),
+        "platform-readiness-preplan-completion-report": ("sdetkit.platform_readiness_preplan"),
+        "platform-readiness-kickoff-completion-report": ("sdetkit.platform_readiness_kickoff"),
         "platform-readiness-wrap-publication-completion-report": (
-            "sdetkit.phase3_wrap_publication"
+            "sdetkit.platform_readiness_wrap_publication"
         ),
     }
 


### PR DESCRIPTION
## Summary
- Route professional completion-report command aliases to professional module names.
- Keep legacy closeout command names mapped to legacy compatibility modules.
- Strengthen naming compatibility tests for release-readiness and platform-readiness command aliases.

## Why
- Canonical command names should expose production-grade module names.
- Legacy phase/closeout command names remain compatible while new operator-facing surfaces prefer professional naming.

## Verification
- `python -m pytest -q tests/test_professional_naming_compatibility_aliases.py tests/test_professional_naming_implementation_paths.py -o addopts=`
- `python - <<'PY' ... professional command alias routing ok ... PY`
- `make proof-after-format`

## Risk
- Low.
- Compatibility preserved: legacy commands still resolve to legacy wrapper modules.
- Rollback: revert this PR.