### PR TITLE
refactor(naming): add professional Makefile quality aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PHASE2_BASELINE_PRE_EXTRACTION ?= docs/artifacts/release-readiness-hotspot-basel
 BUSINESS_EXECUTION_OPERATOR ?= sherif69-sa
 
 .PHONY: bootstrap max brutal venv runtime-install first-proof-install install ci-deps-sync test cov lint fmt format-before-proof proof-after-format type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry upgrade-next operator-onramp operator-onramp-dry-run operator-onramp-verify onboarding-next doctor-remediate first-proof-freshness first-proof-ops-bundle-contract first-proof-ops-bundle-trend first-proof-ops-bundle-trend-report first-proof-execution-report first-proof-execution-contract first-proof-schema-contract upgrade-status-line first-proof-followup-ready followup-ready-metrics first-proof-dashboard first-proof-readiness-threshold followup-changelog plan-next-10 cleanup-first-proof-artifacts golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-fast ship-readiness-contract release-room release-room-fast portfolio-readiness premerge-release-room premerge-release-room-fast adaptive-scenario-db adaptive-postcheck owner-escalation-payload adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready premerge-finalize first-proof first-proof-local first-proof-contract first-proof-health-score first-proof-learn first-proof-control-tower first-proof-weekly-trend first-proof-trend-threshold first-proof-tests first-proof-tests-local first-proof-verify first-proof-verify-local gate-decision-summary gate-decision-summary-contract fit-check adoption-followup adoption-followup-contract adoption-control-loop adoption-control-loop-contract adoption-posture adoption-validate adoption-control-loop-full ops-followup ops-followup-contract ops-now ops-now-lite ops-next ops-premerge-next ops-premerge-next-fast phase1-baseline baseline-status phase1-next baseline-ops-snapshot phase1-dashboard baseline-weekly-pack phase1-control-loop baseline-run-all baseline-artifact-set baseline-telemetry baseline-readiness-signal baseline-followup-pass baseline-blocker-register baseline-run baseline-execution-core baseline-workflow baseline-flow-contract baseline-release-readiness-gate baseline-executive-report baseline-transition-plan baseline-complete baseline-completion-report phase-current phase-current-json release-readiness-start release-readiness-workflow release-readiness-status release-readiness-start-contract release-readiness-seed release-readiness-hotspot-baseline release-readiness-hotspot-delta release-readiness-complete release-readiness-progress release-readiness-surface-clarity phase3-dependency-radar quality-baseline-summary-fixture
-.PHONY: platform-readiness-quality-contract phase3-quality-report phase3-do-it operational-readiness-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract plan-status phase1-execute phase2-execute phase3-governance phase4-credibility real-workflow-daily real-workflow-daily-fast real-workflow-weekly real-workflow-premerge real-workflow-premerge-fast real-workflow ops-daily ops-daily-fast ops-weekly ops-premerge ops-premerge-fast ops-workflow
+.PHONY: platform-readiness-quality-contract platform-readiness-dependency-radar platform-readiness-quality-report platform-readiness-quality-run phase3-quality-report phase3-do-it operational-readiness-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract plan-status phase1-execute phase2-execute phase3-governance phase4-credibility real-workflow-daily real-workflow-daily-fast real-workflow-weekly real-workflow-premerge real-workflow-premerge-fast real-workflow ops-daily ops-daily-fast ops-weekly ops-premerge ops-premerge-fast ops-workflow
 .PHONY: business-execution-start business-execution-start-contract business-execution-go-gate business-execution-progress business-execution-progress-contract business-execution-next business-execution-next-contract business-execution-handoff business-execution-handoff-contract business-execution-escalation business-execution-escalation-contract business-execution-followup business-execution-followup-contract business-execution-continue business-execution-continue-contract business-execution-horizon business-execution-horizon-contract business-execution-inputs-contract business-execution-pipeline business-execution-week1-pipeline
 
 bootstrap: venv
@@ -571,6 +571,12 @@ release-readiness-progress: venv
 release-readiness-surface-clarity: venv
 	@bash -lc '. .venv/bin/activate && python scripts/check_operator_essentials_contract.py --format json'
 
+platform-readiness-dependency-radar: phase3-dependency-radar
+
+platform-readiness-quality-report: phase3-quality-report
+
+platform-readiness-quality-run: platform-readiness-quality-report
+
 phase3-dependency-radar: install
 	@bash -lc '. .venv/bin/activate && python scripts/platform_readiness_dependency_radar.py --policy-json config/dependency_slo_policy.json --out docs/artifacts/phase3-dependency-radar-$(DATE_TAG).json'
 
@@ -707,8 +713,8 @@ powerfuel-merge-ready: powerfuel-contract
 .PHONY: governance-contract-check ecosystem-contract-check metrics-contract-check
 
 quality-contract-check: platform-readiness-quality-contract
-quality-contract-report: phase3-quality-report
-quality-contract-run: phase3-do-it
+quality-contract-report: platform-readiness-quality-report
+quality-contract-run: platform-readiness-quality-run
 
 operations-baseline: phase1-baseline
 operations-status: phase1-status

--- a/tests/test_makefile_professional_naming_aliases.py
+++ b/tests/test_makefile_professional_naming_aliases.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MAKEFILE = Path("Makefile")
+
+
+def _target_dependencies(target: str) -> list[str]:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(target)}:([^\n]*)$", text, re.MULTILINE)
+    assert match is not None, f"missing Makefile target: {target}"
+    return match.group(1).split()
+
+
+def test_platform_readiness_quality_aliases_are_primary_makefile_surface() -> None:
+    assert _target_dependencies("platform-readiness-dependency-radar") == [
+        "phase3-dependency-radar"
+    ]
+    assert _target_dependencies("platform-readiness-quality-report") == ["phase3-quality-report"]
+    assert _target_dependencies("platform-readiness-quality-run") == [
+        "platform-readiness-quality-report"
+    ]
+
+
+def test_neutral_quality_contract_aliases_use_professional_targets() -> None:
+    assert _target_dependencies("quality-contract-report") == ["platform-readiness-quality-report"]
+    assert _target_dependencies("quality-contract-run") == ["platform-readiness-quality-run"]
+
+
+def test_legacy_phase3_do_it_remains_compatibility_only() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+
+    assert "phase3-do-it: platform-readiness-quality-contract" in text
+    assert "phase3-do-it is deprecated; use phase3-quality-report" in text
+    assert text.index("platform-readiness-quality-run:") < text.index("phase3-do-it:")

--- a/tests/test_production_workflow_naming_aliases.py
+++ b/tests/test_production_workflow_naming_aliases.py
@@ -7,8 +7,8 @@ MAKEFILE = ROOT / "Makefile"
 
 ALIASES = {
     "quality-contract-check": "platform-readiness-quality-contract",
-    "quality-contract-report": "phase3-quality-report",
-    "quality-contract-run": "phase3-do-it",
+    "quality-contract-report": "platform-readiness-quality-report",
+    "quality-contract-run": "platform-readiness-quality-run",
     "operations-baseline": "phase1-baseline",
     "operations-status": "phase1-status",
     "operations-next-action": "phase1-next",
@@ -39,7 +39,7 @@ ALIASES = {
 }
 
 
-def test_production_workflow_aliases_point_to_legacy_targets() -> None:
+def test_production_workflow_aliases_point_to_supported_targets() -> None:
     makefile = MAKEFILE.read_text(encoding="utf-8")
 
     for alias, target in ALIASES.items():


### PR DESCRIPTION
## Summary
- Add professional Makefile aliases for platform-readiness quality workflows.
- Route neutral quality-contract aliases through professional targets.
- Keep legacy phase3 targets available for compatibility.

## Verification
- python -m pytest -q tests/test_makefile_professional_naming_aliases.py -o addopts=
- make proof-after-format

## Risk
- Low.
- Makefile alias-only change.
- Legacy phase3 targets remain available.