### PR TITLE
refactor(naming): make baseline targets first class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -717,13 +717,6 @@ quality-contract-check: platform-readiness-quality-contract
 quality-contract-report: platform-readiness-quality-report
 quality-contract-run: platform-readiness-quality-run
 
-baseline-readiness-signal: phase1-finish-signal
-baseline-followup-pass: phase1-next-pass
-baseline-run: phase1-do-it
-baseline-transition-plan: phase1-retire-plan
-baseline-release-readiness-gate: phase1-gate-phase2
-baseline-completion-report: phase1-closeout
-
 operations-baseline: phase1-baseline
 operations-status: phase1-status
 operations-next-action: phase1-next

--- a/tests/test_makefile_baseline_operations_aliases.py
+++ b/tests/test_makefile_baseline_operations_aliases.py
@@ -28,19 +28,24 @@ def test_operations_aliases_route_through_baseline_names() -> None:
 
 
 def test_baseline_targets_are_first_class_professional_targets() -> None:
-    targets = (
-        "baseline-readiness-signal",
-        "baseline-followup-pass",
-        "baseline-run",
-        "baseline-transition-plan",
-        "baseline-release-readiness-gate",
-        "baseline-completion-report",
-    )
+    expected = {
+        "baseline-readiness-signal": ["venv"],
+        "baseline-followup-pass": ["venv"],
+        "baseline-run": [
+            "baseline-run-all",
+            "baseline-artifact-set",
+            "baseline-telemetry",
+            "baseline-readiness-signal",
+        ],
+        "baseline-transition-plan": ["venv"],
+        "baseline-release-readiness-gate": ["venv"],
+        "baseline-completion-report": ["venv"],
+    }
 
     banned_fragments = ("phase", "do-it", "closeout", "finish-signal", "next-pass", "retire-plan")
 
-    for target in targets:
-        deps = _target_dependencies(target)
-        assert deps, f"{target} should have an implementation dependency"
+    for target, deps in expected.items():
+        assert _target_dependencies(target) == deps
         for fragment in banned_fragments:
             assert fragment not in target
+            assert all(fragment not in dep for dep in deps)


### PR DESCRIPTION
## Summary
- Remove hidden legacy phase1 dependency aliases from baseline Makefile targets.
- Keep baseline targets as first-class professional targets.
- Strengthen baseline operations alias tests to reject legacy dependency fragments.

## Verification
- python -m pytest -q tests/test_makefile_baseline_operations_aliases.py tests/test_production_workflow_naming_aliases.py -o addopts=
- make proof-after-format

## Risk
- Low.
- Compatibility targets remain elsewhere.
- This only removes duplicate wrapper dependency lines that shadow first-class baseline targets.