### PR TITLE
docs(naming): professionalize execution terminology

### DIFF
--- a/docs/operations-execution-guide.md
+++ b/docs/operations-execution-guide.md
@@ -1,11 +1,11 @@
 # Sequential execution operator guide
 
-If you already completed planning for all 6 phases, execute only one phase at a time with this rule:
+If you already completed planning for all readiness stages, execute only one stage at a time with this rule:
 
-1. Finish current phase exit criteria.
+1. Finish current readiness-stage exit criteria.
 2. Publish evidence artifacts.
-3. Freeze phase status.
-4. Start next phase kickoff.
+3. Freeze readiness-stage status.
+4. Start next readiness-stage kickoff.
 
 ## Current focus: baseline
 
@@ -41,39 +41,39 @@ If you want machine-readable output for automation:
 make operations-current-json
 ```
 
-## Phase completion contract
+## Readiness-stage completion contract
 
-Before promoting a phase from active to complete:
+Before promoting a readiness stage from active to complete:
 
 - Canonical truth lane artifacts exist and are readable.
 - Exit criteria are all explicitly marked pass.
 - Remaining work is moved to either:
-  - the next phase backlog, or
+  - the next readiness-stage backlog, or
   - an expansion options backlog.
 
 ## Weekly operating cadence (recommended)
 
 - **Monday:** Plan (scope, KPI, risks)
 - **Wednesday:** Build + validate checkpoint
-- **Friday:** Operationalize + expand backlog + phase status update
+- **Friday:** Operationalize + expand backlog + readiness-stage status update
 
-## Phase gate decision record template
+## Readiness-stage decision record template
 
-For each phase completion report, record:
+For each readiness-stage completion report, record:
 
-- Phase id and name
+- Stage id and name
 - Date
 - Exit criteria pass/fail status
 - Blocking risks
 - Canonical artifacts produced
-- Go/No-go decision for next phase
+- Go/No-go decision for the next readiness stage
 
 Keeping this format constant makes trend reporting and investor review easier.
 
 
 ## After baseline is completed
 
-Run `make operations-finalize` to archive the previous strategic plan snapshot and remove baseline from the active phase queue, then advance `current_phase` to release readiness.
+Run `make operations-finalize` to archive the previous strategic plan snapshot and remove baseline from the active readiness queue, then advance the `current_phase` state field to release readiness.
 
 Use `make operations-snapshot` each week to publish:
 
@@ -110,7 +110,7 @@ After baseline is truly complete, run `make operations-cleanup-plan` to archive 
 Use `make operations-quality-gate` to decide if release readiness can start, based on finish signal + artifact contract.
 
 
-Use `make operations-executive-report` to produce a one-page status for leadership handoff and phase decision meetings.
+Use `make operations-executive-report` to produce a one-page status for leadership handoff and readiness decision meetings.
 
 
 Use `make operations-flow-contract` to ensure the documented command path and Makefile targets stay in sync.

--- a/docs/operations-execution-plan.md
+++ b/docs/operations-execution-plan.md
@@ -1,6 +1,6 @@
 # Execution plan for major upgrades
 
-Run this plan in sequence and ship concrete outputs in every phase.
+Run this plan in sequence and ship concrete outputs in every readiness stage.
 
 ## Program guardrails
 
@@ -10,10 +10,10 @@ Run this plan in sequence and ship concrete outputs in every phase.
 
 ---
 
-## baseline — Build the baseline execution lane
+## Baseline readiness — Build the baseline evidence lane
 
 ### Mission
-Stand up a baseline lane that always produces machine-readable evidence and immediately flags environment/tooling drift.
+Stand up a baseline evidence lane that always produces machine-readable evidence and immediately flags environment/tooling drift.
 
 ### Do this
 - Lock environment contracts (Python/toolchain expectations).
@@ -22,7 +22,7 @@ Stand up a baseline lane that always produces machine-readable evidence and imme
 - Publish a weekly baseline report.
 
 ### Execute now
-1. Run the baseline lane:
+1. Run the baseline evidence lane:
    - `make operations-baseline`
    - `make operations-status`
    - `make operations-next-action`
@@ -82,7 +82,7 @@ Cut onboarding confusion while preserving advanced operational power.
 
 ---
 
-## Phase 3 — Expand the quality engine
+## Quality governance — Expand the quality engine
 
 ### Mission
 Upgrade checks into a stronger execution engine with better recommendations and richer evidence payloads.
@@ -113,7 +113,7 @@ Upgrade checks into a stronger execution engine with better recommendations and 
 
 ---
 
-## Phase 4 — Enforce enterprise governance
+## Operational governance — Enforce enterprise governance
 
 ### Mission
 Turn technical capability into enterprise-grade confidence with explicit governance and audit evidence.
@@ -144,7 +144,7 @@ Turn technical capability into enterprise-grade confidence with explicit governa
 
 ---
 
-## Phase 5 — Scale ecosystem integrations
+## Ecosystem readiness — Scale integrations
 
 ### Mission
 Scale integrations and extension surfaces without destabilizing core release-confidence guarantees.
@@ -175,7 +175,7 @@ Scale integrations and extension surfaces without destabilizing core release-con
 
 ---
 
-## Phase 6 — Operationalize metrics and commercialization
+## Metrics readiness — Operationalize metrics and commercialization
 
 ### Mission
 Convert technical progress into repeatable business outcomes and reporting-ready metrics for operators, buyers, and investors.
@@ -205,9 +205,9 @@ Convert technical progress into repeatable business outcomes and reporting-ready
 
 ---
 
-## Phase control loop (run every phase)
+## Readiness control loop (run every stage)
 
-Run the same control loop in every phase:
+Run the same control loop in every readiness stage:
 
 1. Plan: set targets, risks, and metrics.
 2. Execute: ship lane automation and deliverables.

--- a/docs/professional-naming-debt-register.md
+++ b/docs/professional-naming-debt-register.md
@@ -96,3 +96,11 @@ Current sweep policy:
 - do not rewrite generated evidence for line count
 - do not change schema identifiers without a migration contract
 - do not rename historical closeout reports as part of public command sweeps
+
+## Execution docs terminology progress
+
+The active execution-plan and execution-guide documentation now prefers readiness-stage,
+quality-governance, operational-governance, ecosystem-readiness, and metrics-readiness
+language in visible headings and navigation labels.
+
+Compatibility command names, generated artifact paths, and state-field names remain stable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,8 +191,8 @@ nav:
       - License: license.md
   - Advanced:
       - Execution programs:
-          - Phase-by-phase execution plan: operations-execution-plan.md
-          - Phase execution one-by-one: operations-execution-guide.md
+          - Upgrade execution plan: operations-execution-plan.md
+          - Sequential execution guide: operations-execution-guide.md
           - Repo health dashboard: repo-health-dashboard.md
           - Business execution hub: business_execution/index.md
           - Business execution — program master plan: business_execution/00-program-master-plan.md

--- a/tests/test_professional_execution_docs_language.py
+++ b/tests/test_professional_execution_docs_language.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+MKDOCS = Path("mkdocs.yml")
+EXECUTION_PLAN = Path("docs/operations-execution-plan.md")
+EXECUTION_GUIDE = Path("docs/operations-execution-guide.md")
+
+
+def test_mkdocs_execution_nav_uses_professional_labels() -> None:
+    text = MKDOCS.read_text(encoding="utf-8")
+
+    assert "Upgrade execution plan: operations-execution-plan.md" in text
+    assert "Sequential execution guide: operations-execution-guide.md" in text
+
+    assert "Phase-by-phase execution plan: operations-execution-plan.md" not in text
+    assert "Phase execution one-by-one: operations-execution-guide.md" not in text
+
+
+def test_execution_plan_uses_professional_stage_headings() -> None:
+    text = EXECUTION_PLAN.read_text(encoding="utf-8")
+
+    required = [
+        "## Baseline readiness — Build the baseline evidence lane",
+        "## Quality governance — Expand the quality engine",
+        "## Operational governance — Enforce enterprise governance",
+        "## Ecosystem readiness — Scale integrations",
+        "## Metrics readiness — Operationalize metrics and commercialization",
+        "## Readiness control loop (run every stage)",
+    ]
+
+    banned = [
+        "## Phase 3 — Expand the quality engine",
+        "## Phase 4 — Enforce enterprise governance",
+        "## Phase 5 — Scale ecosystem integrations",
+        "## Phase 6 — Operationalize metrics and commercialization",
+        "## Phase control loop (run every phase)",
+    ]
+
+    for phrase in required:
+        assert phrase in text
+
+    for phrase in banned:
+        assert phrase not in text
+
+
+def test_execution_guide_prefers_readiness_stage_language() -> None:
+    text = EXECUTION_GUIDE.read_text(encoding="utf-8")
+
+    required = [
+        "readiness stages",
+        "readiness-stage exit criteria",
+        "Readiness-stage completion contract",
+        "Readiness-stage decision record template",
+        "active readiness queue",
+    ]
+
+    banned = [
+        "all 6 phases",
+        "one phase at a time",
+        "Phase completion contract",
+        "Phase gate decision record template",
+        "active phase queue",
+    ]
+
+    for phrase in required:
+        assert phrase in text
+
+    for phrase in banned:
+        assert phrase not in text


### PR DESCRIPTION
## Summary
- Replace active execution docs and navigation labels that expose phase-era wording.
- Keep filenames, commands, artifact paths, and compatibility names stable.
- Add regression tests for professional execution docs language.

## Verification
- python -m pytest -q tests/test_professional_execution_docs_language.py -o addopts=
- make proof-after-format

## Risk
- Low.
- Docs/navigation/test-only change.
- No generated artifacts or public command removals.