### PR TITLE
refactor(naming): lock governance references in inventory

### DIFF
--- a/docs/professional-naming-debt-register.md
+++ b/docs/professional-naming-debt-register.md
@@ -104,3 +104,10 @@ quality-governance, operational-governance, ecosystem-readiness, and metrics-rea
 language in visible headings and navigation labels.
 
 Compatibility command names, generated artifact paths, and state-field names remain stable.
+
+## Inventory policy progress
+
+The professional naming inventory now treats naming-governance records,
+compatibility migration maps, and workflow consolidation contracts as review-locked
+references rather than plain prose cleanup. This keeps real operator-facing wording
+actionable while avoiding churn in compatibility evidence.

--- a/src/sdetkit/professional_naming_inventory.py
+++ b/src/sdetkit/professional_naming_inventory.py
@@ -39,7 +39,7 @@ DEFAULT_TERMS = [
     "next-pass",
 ]
 
-TEXT_SUFFIXES = {".py", ".md", ".yml", ".yaml", ".toml", ".txt", ".sh", ".ini", ".cfg"}
+TEXT_SUFFIXES = {".py", ".md", ".json", ".yml", ".yaml", ".toml", ".txt", ".sh", ".ini", ".cfg"}
 SKIP_PARTS = {
     ".git",
     ".venv",
@@ -63,8 +63,13 @@ REVIEW_FIRST_CONTEXT = "review_first_context"
 MIGRATION_OR_ALIAS_REQUIRED = "migration_or_alias_required"
 INTERNAL_REVIEW_FIRST = "internal_cleanup_review_first"
 
-TEMPLATE_LOCKED_DOC_PATHS = {
+REVIEW_LOCKED_DOC_PATHS = {
     "docs/integrations-release-prioritization-completion.md",
+    "docs/naming/professional-naming-compatibility-migration.md",
+    "docs/naming/professional-naming-rename-map.json",
+    "docs/naming/professional-public-command-surface.md",
+    "docs/professional-naming-debt-register.md",
+    "docs/contracts/workflow-consolidation-plan.v1.json",
 }
 
 
@@ -135,10 +140,10 @@ def _actionability_fields(
             "actionability_reason": "compatibility plan required before changing this surface",
         }
 
-    if path.as_posix() in TEMPLATE_LOCKED_DOC_PATHS:
+    if path.as_posix() in REVIEW_LOCKED_DOC_PATHS:
         return {
             "actionability": REVIEW_FIRST_CONTEXT,
-            "actionability_reason": "template_locked_contract",
+            "actionability_reason": "review_locked_naming_governance_reference",
         }
 
     if match_type == "path":

--- a/tests/test_professional_naming_inventory.py
+++ b/tests/test_professional_naming_inventory.py
@@ -101,7 +101,7 @@ def test_professional_naming_inventory_separates_actionable_prose_from_headings(
     assert payload["review_first_finding_count"] >= 1
 
 
-def test_professional_naming_inventory_marks_template_locked_docs_review_first(
+def test_professional_naming_inventory_marks_review_locked_docs_review_first(
     tmp_path: Path,
 ) -> None:
     docs = tmp_path / "docs" / "integrations-release-prioritization-completion.md"
@@ -116,4 +116,6 @@ def test_professional_naming_inventory_marks_template_locked_docs_review_first(
     assert payload["actionable_finding_count"] == 0
     assert payload["review_first_finding_count"] == 1
     assert payload["items"][0]["actionability"] == "review_first_context"
-    assert payload["items"][0]["actionability_reason"] == "template_locked_contract"
+    assert (
+        payload["items"][0]["actionability_reason"] == "review_locked_naming_governance_reference"
+    )

--- a/tests/test_professional_naming_inventory_policy.py
+++ b/tests/test_professional_naming_inventory_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.professional_naming_inventory import build_professional_naming_inventory
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _single_item(root: Path, path: str, content: str) -> dict[str, object]:
+    _write(root / path, content)
+
+    inventory = build_professional_naming_inventory(root=root)
+    items = inventory["items"]
+
+    assert len(items) == 1
+    return dict(items[0])
+
+
+def test_plain_markdown_legacy_wording_remains_actionable_prose(tmp_path: Path) -> None:
+    item = _single_item(
+        tmp_path,
+        "docs/operator-guide.md",
+        "This closeout language should become completion language.\n",
+    )
+
+    assert item["classification"] == "docs_only_cleanup"
+    assert item["actionability"] == "actionable_prose_cleanup"
+    assert item["actionability_reason"] == "plain markdown prose"
+
+
+def test_naming_governance_docs_are_review_locked_references(tmp_path: Path) -> None:
+    item = _single_item(
+        tmp_path,
+        "docs/professional-naming-debt-register.md",
+        "This register tracks closeout compatibility wording.\n",
+    )
+
+    assert item["classification"] == "docs_only_cleanup"
+    assert item["actionability"] == "review_first_context"
+    assert item["actionability_reason"] == "review_locked_naming_governance_reference"
+
+
+def test_rename_map_is_review_locked_even_when_content_is_plain(tmp_path: Path) -> None:
+    item = _single_item(
+        tmp_path,
+        "docs/naming/professional-naming-rename-map.json",
+        '{"legacy": "phase3", "preferred": "platform-readiness"}\n',
+    )
+
+    assert item["classification"] == "docs_only_cleanup"
+    assert item["actionability"] == "review_first_context"
+    assert item["actionability_reason"] == "review_locked_naming_governance_reference"
+
+
+def test_source_public_surface_still_requires_migration_plan(tmp_path: Path) -> None:
+    item = _single_item(
+        tmp_path,
+        "src/sdetkit/cli.py",
+        "HELP = 'phase3 compatibility command'\n",
+    )
+
+    assert item["classification"] == "public_surface_requires_alias"
+    assert item["actionability"] == "migration_or_alias_required"
+    assert item["requires_compatibility_plan"] is True


### PR DESCRIPTION
## Summary
- Treat naming-governance docs, compatibility maps, and workflow consolidation contracts as review-locked references.
- Include JSON governance records in the professional naming inventory scan.
- Keep plain operator-facing Markdown wording actionable for cleanup.
- Add regression tests for professional naming inventory policy.

## Verification
- python -m pytest -q tests/test_professional_naming_inventory_policy.py -o addopts=
- make proof-after-format

## Risk
- Low.
- Inventory classification/test-only behavior.
- No public command, Makefile target, schema ID, or generated artifact changes.