### PR TITLE
refactor(naming): report review-locked cleanup references

### DIFF
--- a/docs/professional-naming-debt-register.md
+++ b/docs/professional-naming-debt-register.md
@@ -111,3 +111,9 @@ The professional naming inventory now treats naming-governance records,
 compatibility migration maps, and workflow consolidation contracts as review-locked
 references rather than plain prose cleanup. This keeps real operator-facing wording
 actionable while avoiding churn in compatibility evidence.
+
+## Cleanup plan review-lock progress
+
+The professional naming cleanup plan now reports review-locked naming governance
+references separately from generic review-first findings. This keeps governance
+evidence visible without recommending it as a direct cleanup slice.

--- a/src/sdetkit/professional_naming_cleanup_plan.py
+++ b/src/sdetkit/professional_naming_cleanup_plan.py
@@ -60,6 +60,8 @@ def _items(payload: dict[str, Any]) -> list[dict[str, Any]]:
 COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT = "_".join(
     ("compatibility", "review", "first", "finding", "count")
 )
+REVIEW_LOCKED_NAMING_GOVERNANCE_REFERENCE = "review_locked_naming_governance_reference"
+REVIEW_LOCKED_REFERENCE_COUNT = "_".join(("review", "locked", "reference", "count"))
 
 
 def _text(value: object, default: str = "unknown") -> str:
@@ -101,6 +103,14 @@ def _compatibility_review_first_count(items: list[dict[str, Any]]) -> int:
     )
 
 
+def _review_locked_reference_count(items: list[dict[str, Any]]) -> int:
+    return sum(
+        1
+        for item in items
+        if _text(item.get("actionability_reason"), "") == REVIEW_LOCKED_NAMING_GOVERNANCE_REFERENCE
+    )
+
+
 def _path_counts(items: list[dict[str, Any]], *, limit: int = 10) -> list[dict[str, Any]]:
     counts: Counter[str] = Counter()
     for item in items:
@@ -136,6 +146,7 @@ def _slice(items: list[dict[str, Any]], classification: str) -> dict[str, Any]:
         "actionable_finding_count": actionable_finding_count,
         "review_first_finding_count": review_first_finding_count,
         COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT: _compatibility_review_first_count(items),
+        REVIEW_LOCKED_REFERENCE_COUNT: _review_locked_reference_count(items),
         "occurrence_count": sum(max(1, _number(item.get("occurrence_count"))) for item in items),
         "top_terms": _top_counts(items, "term"),
         "top_surfaces": _top_counts(items, "surface"),
@@ -179,6 +190,7 @@ def build_professional_naming_cleanup_plan(inventory: dict[str, Any]) -> dict[st
         "actionable_finding_count": actionable_finding_count,
         "review_first_finding_count": len(items) - actionable_finding_count,
         COMPATIBILITY_REVIEW_FIRST_FINDING_COUNT: _compatibility_review_first_count(items),
+        REVIEW_LOCKED_REFERENCE_COUNT: _review_locked_reference_count(items),
         "actionability_mix": _top_counts(items, "actionability"),
         "review_first_reason_mix": _top_counts(review_first_items, "actionability_reason"),
         "slice_count": len(slices),

--- a/tests/test_professional_naming_cleanup_plan.py
+++ b/tests/test_professional_naming_cleanup_plan.py
@@ -10,6 +10,8 @@ from sdetkit.professional_naming_cleanup_plan import (
     AUTHORITY_BOUNDARY,
     DOCS_ONLY,
     PUBLIC_ALIAS,
+    REVIEW_LOCKED_NAMING_GOVERNANCE_REFERENCE,
+    REVIEW_LOCKED_REFERENCE_COUNT,
     SAFE_INTERNAL,
     SCHEMA_VERSION,
     build_professional_naming_cleanup_plan,
@@ -217,4 +219,38 @@ def test_professional_naming_cleanup_plan_separates_compatibility_review_first_f
             "name": "compatibility plan required before changing this surface",
             "count": 1,
         }
+    ]
+
+
+def test_professional_naming_cleanup_plan_counts_review_locked_references() -> None:
+    item = _item(
+        "docs/professional-naming-debt-register.md",
+        "closeout",
+        DOCS_ONLY,
+        actionability="review_first_context",
+    )
+    item["actionability_reason"] = REVIEW_LOCKED_NAMING_GOVERNANCE_REFERENCE
+    inventory = {
+        "schema_version": INVENTORY_SCHEMA_VERSION,
+        "status": "review required",
+        "finding_count": 1,
+        "items": [item],
+    }
+
+    payload = build_professional_naming_cleanup_plan(inventory)
+
+    assert payload["actionable_finding_count"] == 0
+    assert payload["review_first_finding_count"] == 1
+    assert payload[REVIEW_LOCKED_REFERENCE_COUNT] == 1
+    assert payload["recommended_first_slice"] is None
+    assert payload["review_first_reason_mix"] == [
+        {"name": REVIEW_LOCKED_NAMING_GOVERNANCE_REFERENCE, "count": 1}
+    ]
+
+    cleanup_slice = payload["cleanup_slices"][0]
+    assert cleanup_slice["classification"] == DOCS_ONLY
+    assert cleanup_slice["safe_to_plan_first"] is False
+    assert cleanup_slice[REVIEW_LOCKED_REFERENCE_COUNT] == 1
+    assert cleanup_slice["review_first_reason_mix"] == [
+        {"name": REVIEW_LOCKED_NAMING_GOVERNANCE_REFERENCE, "count": 1}
     ]


### PR DESCRIPTION
## Summary
- Track review-locked naming governance references in cleanup-plan summaries and slices.
- Keep actionable cleanup recommendation behavior unchanged.
- Add mapped regression coverage for Fast CI premerge.

## Verification
- python -m pytest -q tests/test_professional_naming_cleanup_plan.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Low.
- Cleanup-plan reporting/test-only behavior.
- No public command, Makefile target, schema ID, or generated artifact changes.