### PR TITLE
refactor(naming): preserve review-locked migration references

### DIFF
--- a/docs/professional-naming-debt-register.md
+++ b/docs/professional-naming-debt-register.md
@@ -117,3 +117,9 @@ actionable while avoiding churn in compatibility evidence.
 The professional naming cleanup plan now reports review-locked naming governance
 references separately from generic review-first findings. This keeps governance
 evidence visible without recommending it as a direct cleanup slice.
+
+## Migration plan review-lock progress
+
+The professional naming migration plan now separates review-locked naming
+governance references from generic manual-review findings. This preserves naming
+governance evidence unless a dedicated migration plan explicitly owns the change.

--- a/src/sdetkit/professional_naming_migration.py
+++ b/src/sdetkit/professional_naming_migration.py
@@ -15,6 +15,7 @@ SAFE_CONTENT_REWRITE = "safe_content_rewrite"
 ALIAS_REQUIRED = "alias_required"
 PRESERVE_HISTORY = "preserve_history"
 TEMPLATE_LOCKED = "template_locked"
+REVIEW_LOCKED_REFERENCE = "review_locked_reference"
 MANUAL_REVIEW = "manual_review"
 
 MIGRATION_OR_ALIAS_REQUIRED = "migration_or_alias_required"
@@ -31,6 +32,9 @@ PRESERVE_REASON_MARKERS = {
     "heading_or_chronology_label",
     "command_path_link_schema_or_audit_context",
     "table_or_generated_matrix",
+}
+REVIEW_LOCKED_REASON_MARKERS = {
+    "review_locked_naming_governance_reference",
 }
 
 TEMPLATE_LOCKED_PATHS = {
@@ -78,6 +82,9 @@ def _migration_class(item: Mapping[str, Any]) -> str:
     if path in TEMPLATE_LOCKED_PATHS or "template_locked" in reason:
         return TEMPLATE_LOCKED
 
+    if reason in REVIEW_LOCKED_REASON_MARKERS:
+        return REVIEW_LOCKED_REFERENCE
+
     if classification in PUBLIC_OR_WORKFLOW_ALIAS_CLASSES:
         return ALIAS_REQUIRED
 
@@ -105,6 +112,7 @@ def _required_guard(migration_class: str) -> str:
         ALIAS_REQUIRED: "alias or compatibility shim plus tests",
         PRESERVE_HISTORY: "preserve historical evidence unless explicit migration plan exists",
         TEMPLATE_LOCKED: "template contract test must remain green",
+        REVIEW_LOCKED_REFERENCE: "preserve naming governance reference unless explicit migration plan exists",
         MANUAL_REVIEW: "human review before rename",
     }.get(migration_class, "human review before rename")
 
@@ -142,6 +150,7 @@ def build_professional_naming_migration_plan(
     by_class = Counter(row["migration_class"] for row in rows)
     safe_count = by_class.get(SAFE_CONTENT_REWRITE, 0)
     alias_count = by_class.get(ALIAS_REQUIRED, 0)
+    review_locked_count = by_class.get(REVIEW_LOCKED_REFERENCE, 0)
 
     if safe_count:
         recommended = "_".join(("apply", "safe", "content", "rewrite", "first"))
@@ -160,6 +169,7 @@ def build_professional_naming_migration_plan(
         "alias_required_count": alias_count,
         "preserve_history_count": by_class.get(PRESERVE_HISTORY, 0),
         "template_locked_count": by_class.get(TEMPLATE_LOCKED, 0),
+        "review_locked_reference_count": review_locked_count,
         "manual_review_count": by_class.get(MANUAL_REVIEW, 0),
         "by_migration_class": dict(sorted(by_class.items())),
         "recommended_next_action": recommended,
@@ -169,6 +179,7 @@ def build_professional_naming_migration_plan(
         "json_key_rename_without_alias": False,
         "artifact_slug_rename_without_redirect": False,
         "template_locked_rewrite": False,
+        "review_locked_reference_rewrite": False,
         "items": rows,
     }
 
@@ -204,6 +215,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"alias_required_count={payload['alias_required_count']}")
         print(f"preserve_history_count={payload['preserve_history_count']}")
         print(f"template_locked_count={payload['template_locked_count']}")
+        print(f"review_locked_reference_count={payload['review_locked_reference_count']}")
         print(f"manual_review_count={payload['manual_review_count']}")
         print(f"recommended_next_action={payload['recommended_next_action']}")
         print(f"blind_rename_allowed={str(payload['blind_rename_allowed']).lower()}")

--- a/tests/test_professional_naming_migration.py
+++ b/tests/test_professional_naming_migration.py
@@ -7,6 +7,7 @@ from sdetkit.professional_naming_migration import (
     ALIAS_REQUIRED,
     MANUAL_REVIEW,
     PRESERVE_HISTORY,
+    REVIEW_LOCKED_REFERENCE,
     SAFE_CONTENT_REWRITE,
     TEMPLATE_LOCKED,
     build_professional_naming_migration_plan,
@@ -204,3 +205,29 @@ def test_professional_naming_migration_cli_writes_plan(tmp_path: Path, capsys) -
     payload = json.loads(out_path.read_text(encoding="utf-8"))
     assert payload["safe_content_rewrite_count"] == 1
     assert payload["blind_rename_allowed"] is False
+
+
+def test_professional_naming_migration_preserves_review_locked_references() -> None:
+    inventory = {
+        "items": [
+            {
+                "term": "closeout",
+                "path": "docs/professional-naming-debt-register.md",
+                "match_type": "content",
+                "classification": "docs_only_cleanup",
+                "actionability": "review_first_context",
+                "actionability_reason": "review_locked_naming_governance_reference",
+            }
+        ]
+    }
+
+    payload = build_professional_naming_migration_plan(inventory, _rename_map())
+
+    assert payload["review_locked_reference_count"] == 1
+    assert payload["review_locked_reference_rewrite"] is False
+    assert payload["items"][0]["migration_class"] == REVIEW_LOCKED_REFERENCE
+    assert payload["items"][0]["allowed_to_apply"] is False
+    assert (
+        payload["items"][0]["required_guard"]
+        == "preserve naming governance reference unless explicit migration plan exists"
+    )


### PR DESCRIPTION
## Summary
- Classify review-locked naming governance references separately in migration plans.
- Preserve those references unless a dedicated migration plan owns the change.
- Add mapped regression coverage for Fast CI premerge.

## Verification
- python -m pytest -q tests/test_professional_naming_migration.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Low.
- Migration-plan reporting/test-only behavior.
- No public command, Makefile target, schema ID, or generated artifact changes.