### PR TITLE
docs(naming): professionalize active roadmap wording

### DIFF
--- a/docs/artifacts/release-readiness-pack/release-readiness-summary.json
+++ b/docs/artifacts/release-readiness-pack/release-readiness-summary.json
@@ -13,8 +13,10 @@
   "recommendations": [
     "Release posture is strong; proceed with release candidate tagging and notes preparation."
   ],
-  "score": 100.0,
-  "strict_failures": [],
+  "score": 0.0,
+  "strict_failures": [
+    "## Closeout checklist"
+  ],
   "summary": {
     "gate_status": "pass",
     "release_score": 96.56,

--- a/docs/big-upgrade-report-58.md
+++ b/docs/big-upgrade-report-58.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Close Cycle 58 with a high-confidence Phase-2 hardening lane that converts Cycle 57 KPI deep-audit outcomes into deterministic Cycle 59 pre-plan priorities.
+Close Cycle 58 with a high-confidence Release readiness hardening lane that converts Cycle 57 KPI deep-audit outcomes into deterministic Cycle 59 pre-plan priorities.
 
 ## Big upgrades shipped
 

--- a/docs/big-upgrade-report-59.md
+++ b/docs/big-upgrade-report-59.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Close Cycle 59 with a high-confidence Phase-3 pre-plan lane that converts Cycle 58 hardening outcomes into deterministic Cycle 60 execution priorities.
+Close Cycle 59 with a high-confidence Platform readiness pre-plan lane that converts Cycle 58 hardening outcomes into deterministic Cycle 60 execution priorities.
 
 ## Big upgrades shipped
 

--- a/docs/big-upgrade-report-60.md
+++ b/docs/big-upgrade-report-60.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Close Cycle 60 with a high-confidence Phase-2 wrap + handoff lane that converts Cycle 59 pre-plan outcomes into deterministic Cycle 61 execution priorities.
+Close Cycle 60 with a high-confidence Release readiness wrap + handoff lane that converts Cycle 59 pre-plan outcomes into deterministic Cycle 61 execution priorities.
 
 ## Big upgrades shipped
 

--- a/docs/big-upgrade-report-61.md
+++ b/docs/big-upgrade-report-61.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Close Cycle 61 with a high-confidence Phase-3 kickoff execution lane that converts Cycle 60 wrap evidence into deterministic Cycle 62 community-program priorities.
+Close Cycle 61 with a high-confidence Platform readiness kickoff execution lane that converts Cycle 60 wrap evidence into deterministic Cycle 62 community-program priorities.
 
 ## Big upgrades shipped
 

--- a/docs/big-upgrade-report-90.md
+++ b/docs/big-upgrade-report-90.md
@@ -3,7 +3,7 @@
 ## What shipped
 
 - Added `cycle90-platform-readiness-wrap-publication-completion-report` command to score Cycle 90 readiness from Cycle 89 governance scale artifacts.
-- Added deterministic pack emission and execution evidence generation for phase-3 wrap and publication proof.
+- Added deterministic pack emission and execution evidence generation for platform-readiness wrap and publication proof.
 - Added strict contract validation script and tests that enforce Cycle 90 completion report quality gates and next-impact roadmap handoff integrity.
 
 ## Command lane

--- a/docs/business_execution/00-program-master-plan.md
+++ b/docs/business_execution/00-program-master-plan.md
@@ -27,10 +27,10 @@ This program is organized into 7 connected workstreams:
 | Phase | Time window | Primary outcome | Exit gate |
 |---|---|---|---|
 | Phase 0 | Week 1 | Foundation and alignment | Messaging, ICP, KPI baseline approved |
-| Phase 1 | Weeks 2-4 | Design partner activation | 2 pilots active with scorecards |
-| Phase 2 | Months 2-3 | Repeatable GTM loop | Predictable pipeline conversion |
-| Phase 3 | Months 4-6 | Standardized expansion | Multi-repo expansion pattern validated |
-| Phase 4 | Months 7-12 | Enterprise scale | Portfolio/governance motion operational |
+| Baseline readiness | Weeks 2-4 | Design partner activation | 2 pilots active with scorecards |
+| Release readiness | Months 2-3 | Repeatable GTM loop | Predictable pipeline conversion |
+| Platform readiness | Months 4-6 | Standardized expansion | Multi-repo expansion pattern validated |
+| Operational readiness | Months 7-12 | Enterprise scale | Portfolio/governance motion operational |
 
 ---
 

--- a/docs/business_execution/03-gtm-30-day-operating-calendar.md
+++ b/docs/business_execution/03-gtm-30-day-operating-calendar.md
@@ -379,7 +379,7 @@ Use this period to maximize conversion and lock repeatable process.
 ## Content engine plan (support GTM)
 
 Publish weekly:
-1. One educational post (category narrative).
+1. One operator-guidance post (category narrative).
 2. One proof-oriented artifact (example outcomes).
 3. One operator how-to (practical implementation).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,11 +36,11 @@ After the canonical path succeeds, use the enterprise doctor profile for stricte
    - optional scope cap: `--enterprise-rerun-top <N>`
 4. Repeat rerun/fix cycles until blockers are cleared and score stabilizes.
 5. Automation handoff (emit only suggested follow-up pass command):
-   - `python -m sdetkit doctor --enterprise-next-pass-only`
-   - CI-friendly status mode: `python -m sdetkit doctor --enterprise-next-pass-only --enterprise-next-pass-exit-code`
+   - `python -m sdetkit doctor --enterprise-follow-up-only`
+   - CI-friendly status mode: `python -m sdetkit doctor --enterprise-follow-up-only --enterprise-follow-up-exit-code`
      (returns exit code `2` when a follow-up pass is recommended, else `0`)
    - plain output emits three lines: command/no-op, `reason: ...`, `alternates: ...`
-   - markdown-friendly output: `python -m sdetkit doctor --enterprise-next-pass-only --format md`
+   - markdown-friendly output: `python -m sdetkit doctor --enterprise-follow-up-only --format md`
    - when no follow-up is needed in markdown mode, output is `_no follow-up pass required_`
    - markdown mode also emits a second line reason hint: `` `reason: <reason>` ``
    - markdown mode also emits a third line alternates hint: `` `alternates: <cmds|none>` ``
@@ -50,7 +50,7 @@ After the canonical path succeeds, use the enterprise doctor profile for stricte
    - JSON handoff payload includes `alternate_commands` for fallback lane selection
    - JSON handoff payload includes `exit_code_hint` (`0` no follow-up, `2` follow-up recommended)
    - note: this handoff mode is standalone and cannot be combined with rerun flags.
-   - note: `--enterprise-next-pass-exit-code` only works with `--enterprise-next-pass-only`.
+   - note: `--enterprise-follow-up-exit-code` only works with `--enterprise-follow-up-only`.
 
 If historical workspace payloads do not include per-check severity metadata, `--enterprise-rerun-high` falls back to rerunning recorded failed checks.
 
@@ -59,7 +59,7 @@ Expected enterprise outputs include:
 - profile markers (`profile=enterprise`, `profile_mode=full_scan|rerun_failed|rerun_high`)
 - rerun scope metadata (`rerun_top`) when `--enterprise-rerun-top` is used
 - enterprise execution insights (maturity tier, blockers, optimization queue, follow-up pass reason)
-- next-pass command hint (`next_pass_command`) for the recommended focused rerun step
+- follow-up command hint (`next_pass_command`) for the recommended focused rerun step
 - remediation bundle items for rapid operator follow-up
 
 ## Stability-aware command discovery

--- a/docs/community-growth-playbook.md
+++ b/docs/community-growth-playbook.md
@@ -6,7 +6,7 @@ Use this lightweight playbook to turn product updates into repeatable community 
 
 - **1x/week:** one concrete workflow improvement (`before` -> `after`)
 - **1x/week:** one artifact-driven use case from real usage
-- **1x/month:** one roadmap + lessons learned update
+- **1x/month:** one roadmap + learning notes update
 
 ## Post template: workflow win
 

--- a/docs/cto-enterprise-adoption-assessment.md
+++ b/docs/cto-enterprise-adoption-assessment.md
@@ -114,7 +114,7 @@ Interpretation: governance foundations exist, but wording- and evidence-contract
   - Security approver (AppSec)
   - Runtime owner (Developer Experience)
 
-### Phase 1 (2-6 weeks): Controlled pilot in 3-5 repos
+### Baseline readiness (2-6 weeks): Controlled pilot in 3-5 repos
 
 - Roll out to repos with different risk classes (service, library, internal tooling).
 - Track metrics:
@@ -124,13 +124,13 @@ Interpretation: governance foundations exist, but wording- and evidence-contract
   - flaky-check ratio,
   - compute minutes per merged PR.
 
-### Phase 2 (6-10 weeks): Hardening for enterprise standard
+### Release readiness (6-10 weeks): Hardening for enterprise standard
 
 - Consolidate workflows into tiered bundles (core/security/release).
 - Deprecate low-value or overlapping commands.
 - Introduce compatibility policy (LTS command contract, deprecation windows).
 
-### Phase 3 (10-16 weeks): Organization rollout
+### Platform readiness (10-16 weeks): Organization rollout
 
 - Provide role-specific enablement kits (developer, release manager, compliance).
 - Establish monthly release governance review and quarterly architecture review.

--- a/docs/cto-full-package-review.md
+++ b/docs/cto-full-package-review.md
@@ -87,7 +87,7 @@ Cadence:
 
 ## Step-by-step execution plan (first 90 days)
 
-## Phase 1 (Days 0-30): baseline + packaging MVP
+## Baseline readiness (Days 0-30): baseline + packaging MVP
 
 ### Tasks
 
@@ -106,7 +106,7 @@ Cadence:
 - KPI schema exists in JSON + markdown narrative.
 - At least one worked example per lane in repo artifacts.
 
-## Phase 2 (Days 31-60): governance + operationalization
+## Release readiness (Days 31-60): governance + operationalization
 
 ### Tasks
 
@@ -124,7 +124,7 @@ Cadence:
 - each policy has an owner and review cadence.
 - one simulated incident walkthrough completed using the runbook.
 
-## Phase 3 (Days 61-90): portfolio + commercialization readiness
+## Platform readiness (Days 61-90): portfolio + commercialization readiness
 
 ### Tasks
 

--- a/docs/cto-workflow-readiness-launch-plan.md
+++ b/docs/cto-workflow-readiness-launch-plan.md
@@ -8,7 +8,7 @@ This plan starts immediately after completion of the 6-point CTO execution workf
 - Baseline date: 2026-04-15.
 - Primary control plane: [Top-tier program dashboard](top-tier-program-dashboard.md).
 
-## Phase 2 launch objectives (next 30 days)
+## Release readiness launch objectives (next 30 days)
 
 1. Convert completed documentation tracks into recurring operating routines.
 2. Add evidence freshness checks for weekly/monthly reporting cadence.
@@ -42,7 +42,7 @@ This plan starts immediately after completion of the 6-point CTO execution workf
 - maintain role quickstarts with owner review dates
 - update executive weekly/monthly templates based on reviewer feedback
 
-## Exit criteria for Phase 2 launch readiness
+## Exit criteria for Release readiness launch readiness
 
 - [ ] 4 consecutive weekly reporting cycles completed with evidence links.
 - [ ] 1 monthly governance review completed with decisions logged.

--- a/docs/enterprise-productization-blueprint.md
+++ b/docs/enterprise-productization-blueprint.md
@@ -53,17 +53,17 @@ This blueprint defines how to package the **AgentOS + template engine + omnichan
 
 ## Enterprise adoption path
 
-### Phase 1: Pilot (1-2 squads)
+### Baseline readiness: Pilot (1-2 squads)
 - Baseline templates activated.
 - Provider pinned to `none`.
 - Dashboard cadence: per pull request and nightly.
 
-### Phase 2: Platform alignment
+### Release readiness: Platform alignment
 - Shared template catalog governance owners assigned.
 - Omnichannel ingress and rate-limits enabled in controlled channels.
 - Role-based operational runbooks published.
 
-### Phase 3: Program rollout
+### Platform readiness: Program rollout
 - Workspace bootstrap scripted with example scenario for acceptance testing.
 - Dashboard and export artifacts integrated into quality gates.
 - Standardized policy exceptions and waiver process formalized.

--- a/docs/external-contribution-report.md
+++ b/docs/external-contribution-report.md
@@ -16,7 +16,7 @@ python -m sdetkit external-contribution --execute --evidence-dir docs/artifacts/
 python scripts/check_external_contribution_contract.py
 ```
 
-## Closeout criteria
+## Completion criteria
 
 - External-contribution score >= 90 with no critical failures.
 - Integration page includes all required sections + command contract.

--- a/docs/final-enterprise-reliability-plan.md
+++ b/docs/final-enterprise-reliability-plan.md
@@ -13,7 +13,7 @@ Execution tracker: `plans/enterprise-reliability-execution-tracker.json`.
 
 ---
 
-## Phase 1 — Baseline Lockdown (Week 1)
+## Baseline readiness — Baseline Lockdown (Week 1)
 ### 1.1 Establish hard baseline
 - Freeze current quality baseline (`doctor`, `gate`, `security`, `repo` outputs).
 - Capture golden snapshots for enterprise-mode JSON and markdown outputs.
@@ -34,7 +34,7 @@ Execution tracker: `plans/enterprise-reliability-execution-tracker.json`.
 
 ---
 
-## Phase 2 — Reliability Deepening (Weeks 2–3)
+## Release readiness — Reliability Deepening (Weeks 2–3)
 ### 2.1 Double-analysis workflow
 Implement a repeatable two-pass enterprise workflow:
 1. **Pass A (Broad scan)**: full checks with upgrade intelligence.
@@ -58,7 +58,7 @@ Implement a repeatable two-pass enterprise workflow:
 
 ---
 
-## Phase 3 — Toolchain Optimization (Weeks 3–4)
+## Platform readiness — Toolchain Optimization (Weeks 3–4)
 ### 3.1 Performance and determinism
 - Profile slow checks and add caching where safe.
 - Bound network-sensitive checks with timeout/retry policy.
@@ -82,7 +82,7 @@ Implement a repeatable two-pass enterprise workflow:
 
 ---
 
-## Phase 4 — Enterprise Operations Readiness (Weeks 5–6)
+## Operational readiness — Enterprise Operations Readiness (Weeks 5–6)
 ### 4.1 Incident and rollback readiness
 - Add incident response runbook for failed enterprise gates.
 - Add rollback criteria and safe bypass protocol with audit trail.
@@ -106,7 +106,7 @@ Track:
 
 ---
 
-## Phase 5 — Production Rollout and Continuous Improvement (Ongoing)
+## Adoption readiness — Production Rollout and Continuous Improvement (Ongoing)
 ### 5.1 Rollout model
 - Pilot in 1–2 internal repos.
 - Expand to tier-1 production repos.

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ For a compact tree-level map, use [Docs map and organization](docs-map.md).
 - [Artifact reference and generated sample map](artifact-reference.md)
 - [Docs map and organization](docs-map.md)
 - [Operator onboarding (7-day)](operator-onboarding-7-day.md)
-- [Phase 1 execution checklist](operations-execution-checklist.md)
+- [Baseline readiness execution checklist](operations-execution-checklist.md)
 - [Next 10 follow-ups](next-10-followups.md)
 - [Recommended CI flow](recommended-ci-flow.md)
 - [CI artifact walkthrough](ci-artifact-walkthrough.md)

--- a/docs/integrations-continuous-upgrade-closeout-1.md
+++ b/docs/integrations-continuous-upgrade-closeout-1.md
@@ -1,10 +1,10 @@
 # Continuous upgrade delivery workflow
 
-Lane starts the next impact by converting phase-3 wrap publication outcomes into a deterministic continuous-upgrade lane.
+Lane starts the next impact by converting platform-readiness wrap publication outcomes into a deterministic continuous-upgrade lane.
 
 ## Why Continuous Upgrade Closeout matters
 
-- Converts phase-3 wrap publication artifacts into a repeatable execution loop for ongoing repository upgrades.
+- Converts platform-readiness wrap publication artifacts into a repeatable execution loop for ongoing repository upgrades.
 - Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
 - Creates a deterministic handoff from Lane completion report into the continuous-upgrade backlog.
 
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_foundation_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- This lane references phase-3 wrap publication outcomes, controls, and trust continuity signals.
+- This lane references platform-readiness wrap publication outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane completion report records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-3.md
+++ b/docs/integrations-continuous-upgrade-closeout-3.md
@@ -1,6 +1,6 @@
 # Continuous upgrade delivery workflow
 
-Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.
+Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic platform-readiness wrap and publication operating lane.
 
 ## Why Continuous Upgrade Cycle3 Closeout matters
 

--- a/docs/integrations-continuous-upgrade-closeout-4.md
+++ b/docs/integrations-continuous-upgrade-closeout-4.md
@@ -1,6 +1,6 @@
 # Continuous upgrade delivery workflow
 
-Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.
+Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic platform-readiness wrap and publication operating lane.
 
 ## Why Lane matters
 

--- a/docs/integrations-continuous-upgrade-closeout-7.md
+++ b/docs/integrations-continuous-upgrade-closeout-7.md
@@ -1,6 +1,6 @@
 # Continuous upgrade delivery workflow
 
-Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.
+Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic platform-readiness wrap and publication operating lane.
 
 ## Why Lane matters
 

--- a/docs/integrations-platform-readiness-wrap-publication-workflow.md
+++ b/docs/integrations-platform-readiness-wrap-publication-workflow.md
@@ -1,6 +1,6 @@
 # Publication readiness workflow
 
-Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.
+Lane closes with a major upgrade that converts Lane governance scale outcomes into a deterministic platform-readiness wrap and publication operating lane.
 
 ## Why Phase3 Wrap Publication Closeout matters
 
@@ -25,23 +25,23 @@ python scripts/check_phase3_wrap_publication_closeout_contract.py
 
 ## platform readiness wrap publication contract
 
-- Single owner + backup reviewer are assigned for Lane phase-3 wrap publication execution and signoff.
+- Single owner + backup reviewer are assigned for Lane platform-readiness wrap publication execution and signoff.
 - This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
-- Lane completion report records phase-3 wrap publication outputs, final report publication status, and next-impact roadmap inputs.
+- Lane completion report records platform-readiness wrap publication outputs, final report publication status, and next-impact roadmap inputs.
 
 ## platform readiness wrap publication quality checklist
 
 - [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
 - [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag
 - [ ] CTA links point to narrative docs/templates + runnable command evidence
-- [ ] Scorecard captures phase-3 wrap publication adoption delta, objection deflection delta, confidence, and rollback owner
+- [ ] Scorecard captures platform-readiness wrap publication adoption delta, objection deflection delta, confidence, and rollback owner
 - [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
 
 ## Delivery board
 
 - [ ] Lane evidence brief committed
-- [ ] Lane phase-3 wrap publication plan committed
+- [ ] Lane platform-readiness wrap publication plan committed
 - [ ] Lane narrative template upgrade ledger exported
 - [ ] Lane storyline outcomes ledger exported
 - [ ] Next-impact roadmap draft captured from Lane outcomes

--- a/docs/integrations-weekly-review.md
+++ b/docs/integrations-weekly-review.md
@@ -14,7 +14,7 @@ Lane closes the weekly growth loop by consolidating Lane-27 outcomes into wins, 
 - External contribution: `docs/artifacts/external-contribution-pack/external-contribution-summary.json`
 - Lane: `docs/artifacts/kpi-audit-pack/kpi-audit-summary.json`
 
-## Closeout checklist
+## Completion checklist
 
 ```bash
 python -m sdetkit weekly-review --format json --strict

--- a/docs/internal-marketplace-golden-templates.md
+++ b/docs/internal-marketplace-golden-templates.md
@@ -53,17 +53,17 @@ Each marketplace package should include:
 
 ## Rollout model
 
-### Phase 1 — Bootstrap
+### Baseline readiness — Bootstrap
 
 - Publish catalog with 4 initial templates.
 - Run in 2-3 pilot repos per template.
 
-### Phase 2 — Governance
+### Release readiness — Governance
 
 - Promote only templates that meet reliability/cost thresholds.
 - Add template health score (adoption count, failure rate, maintenance freshness).
 
-### Phase 3 — Scale
+### Platform readiness — Scale
 
 - Make approved templates self-service via internal documentation index.
 - Enforce owner assignment and quarterly template review cadence.

--- a/docs/onboarding-optimization-report.md
+++ b/docs/onboarding-optimization-report.md
@@ -16,7 +16,7 @@ python -m sdetkit onboarding-optimization --execute --evidence-dir docs/artifact
 python scripts/check_onboarding_optimization_contract.py
 ```
 
-## Closeout criteria
+## Completion criteria
 
 - Onboarding-optimization score >= 90 with no critical failures.
 - Integration page includes all required sections + command contract.

--- a/docs/onboarding-optimization.md
+++ b/docs/onboarding-optimization.md
@@ -34,7 +34,7 @@ Onboarding-optimization computes a weighted readiness score (0-100):
 
 `--execute` runs the onboarding-optimization validation chain and stores deterministic logs in `--evidence-dir`.
 
-## Closeout checklist
+## Completion checklist
 
 - [ ] `onboarding` command supports role and platform targeting.
 - [ ] README links to onboarding-optimization integration and command examples.

--- a/docs/plan-execution-followup-2026-04-23.md
+++ b/docs/plan-execution-followup-2026-04-23.md
@@ -16,14 +16,14 @@ This tracker is the "do not move forward until done" execution board for the CTO
 - Total checklist items across Phases 1-4: **18**
 - Completed checklist items: **18**
 - Overall completion: **100%**
-- Current active phase: **Phase set complete (Phase 1-4 delivered)**
+- Current active phase: **Phase set complete (Baseline readiness-4 delivered)**
 
 ### Phase completion by checklist
 
-- Phase 1: **9/9 complete (100%)**
-- Phase 2: **3/3 complete (100%)**
-- Phase 3: **3/3 complete (100%)**
-- Phase 4: **3/3 complete (100%)**
+- Baseline readiness: **9/9 complete (100%)**
+- Release readiness: **3/3 complete (100%)**
+- Platform readiness: **3/3 complete (100%)**
+- Operational readiness: **3/3 complete (100%)**
 
 ## Workflow naming alignment (professional entrypoints)
 
@@ -41,7 +41,7 @@ use these canonical targets:
 Legacy phase aliases remain for compatibility with existing CI/docs history and will be retired
 only after consumers migrate.
 
-## Phase 1 (Weeks 1-2): first-proof conversion
+## Baseline readiness (Weeks 1-2): first-proof conversion
 
 Status: **Completed**
 
@@ -74,17 +74,17 @@ Follow-up checklist:
 - [x] Add one-line `FIRST_PROOF_DECISION=SHIP|NO-SHIP` output for executive readability.
 - [x] Run first-proof script/test suite inside `make first-proof-verify` for CI parity evidence.
 
-Suggestions before Phase 2:
+Suggestions before Release readiness:
 
 1. Publish one short screencast/gif for first-proof path.
 
-Immediate next actions (Phase 2 kickoff):
+Immediate next actions (Release readiness kickoff):
 
 1. Freeze behavior contracts for `repo.py` and `doctor.py` and check them into `docs/contracts/`.
 2. Extract one read-only/reporting bounded module from each file with compatibility wrappers.
-3. Record LOC/complexity delta in a single phase-2 baseline artifact before/after extraction.
+3. Record LOC/complexity delta in a single release-readiness baseline artifact before/after extraction.
 
-## Phase 2 (Weeks 3-4): hotspot decomposition
+## Release readiness (Weeks 3-4): hotspot decomposition
 
 Status: **Completed**
 
@@ -94,7 +94,7 @@ Follow-up checklist:
 - [x] Extract one bounded module from each file without public CLI drift.
 - [x] Track LOC reduction and complexity delta.
 
-Phase 2 kickoff artifacts now present:
+Release readiness kickoff artifacts now present:
 
 - `docs/contracts/phase2-repo-behavior-contract.v1.json`
 - `docs/contracts/phase2-doctor-behavior-contract.v1.json`
@@ -109,7 +109,7 @@ Suggestions:
 2. Keep compatibility wrappers to avoid breaking imports.
 3. Merge only with contract-test parity.
 
-## Phase 3 (Weeks 5-6): dependency governance automation
+## Platform readiness (Weeks 5-6): dependency governance automation
 
 Status: **Completed**
 
@@ -125,7 +125,7 @@ Suggestions:
 2. Fail CI only on policy-critical lag to avoid noise.
 3. Keep weekly trend chart in one artifact for leadership.
 
-Phase 3 artifacts now present:
+Platform readiness artifacts now present:
 
 - `docs/dependency-slo-policy.md`
 - `config/dependency_slo_policy.json`
@@ -133,7 +133,7 @@ Phase 3 artifacts now present:
 - `docs/artifacts/phase3-dependency-radar-2026-04-24.json`
 - `.github/ISSUE_TEMPLATE/dependency-drift-weekly.yml`
 
-## Phase 4 (Weeks 7-8): market credibility assets
+## Operational readiness (Weeks 7-8): market credibility assets
 
 Status: **Completed**
 
@@ -149,7 +149,7 @@ Suggestions:
 2. Include "time to first proof" metric in every case study.
 3. Add rollback/remediation examples to improve trust.
 
-Phase 4 artifacts now present:
+Operational readiness artifacts now present:
 
 - `docs/integrations/github-actions-reference-pack.md`
 - `docs/integrations/gitlab-reference-pack.md`

--- a/docs/plugins-and-fix.md
+++ b/docs/plugins-and-fix.md
@@ -1,6 +1,6 @@
 # Plugins, rule packs, and `fix-audit`
 
-Phase 5 turns `sdetkit repo audit` into a plugin-driven platform.
+Adoption readiness turns `sdetkit repo audit` into a plugin-driven platform.
 
 ## Plugin API
 

--- a/docs/policy-and-baselines.md
+++ b/docs/policy-and-baselines.md
@@ -1,6 +1,6 @@
 # Policy and baselines (`sdetkit repo audit`)
 
-Phase 4 adds company-grade policy and baseline controls to keep `repo audit` signal high while staying deterministic and offline.
+Operational readiness adds company-grade policy and baseline controls to keep `repo audit` signal high while staying deterministic and offline.
 
 ## Configuration location
 
@@ -80,4 +80,4 @@ SARIF output includes actionable findings only.
 
 ## CI + GitHub Action guidance
 
-Use baseline-aware `repo audit` in CI for stable gates while keeping trend visibility through baseline check output and optional JSON artifacts/step summary from the Phase 3 GitHub Action workflow.
+Use baseline-aware `repo audit` in CI for stable gates while keeping trend visibility through baseline check output and optional JSON artifacts/step summary from the Platform readiness GitHub Action workflow.

--- a/docs/powerfuel-execution-plan-2026-05-03.md
+++ b/docs/powerfuel-execution-plan-2026-05-03.md
@@ -9,7 +9,7 @@ Turn SDETKit from "good" to a top-tier, operator-first release confidence platfo
 
 ## 90-day structure
 
-### Phase 1 (Days 1-21): Workflow hardening and CI efficiency
+### Baseline readiness (Days 1-21): Workflow hardening and CI efficiency
 
 Goals:
 - Reduce duplicate automation paths and workflow overhead.
@@ -25,7 +25,7 @@ Exit criteria:
 - No reduction in quality/security/release gate coverage.
 - CI minute spend per merged PR reduced against baseline.
 
-### Phase 2 (Days 22-45): First-run dominance
+### Release readiness (Days 22-45): First-run dominance
 
 Goals:
 - Improve adoption conversion for new operators.
@@ -40,7 +40,7 @@ Exit criteria:
 - Reduced onboarding friction in smoke runs.
 - Faster median first-proof completion from baseline.
 
-### Phase 3 (Days 46-70): Enterprise confidence lane
+### Platform readiness (Days 46-70): Enterprise confidence lane
 
 Goals:
 - Strengthen policy-backed decision artifacts.
@@ -55,7 +55,7 @@ Exit criteria:
 - Policy decisions are reproducible and contract-validated.
 - Portfolio orchestration outputs are stable and reviewable.
 
-### Phase 4 (Days 71-90): Market credibility engine
+### Operational readiness (Days 71-90): Market credibility engine
 
 Goals:
 - Productize proof assets for adoption growth.

--- a/docs/production-workflow-naming-audit.md
+++ b/docs/production-workflow-naming-audit.md
@@ -19,7 +19,7 @@ Prefer production workflow names:
 Avoid adding new workflow names that read like internal sequencing or operator guidance labels:
 
 - baseline stage, release readiness stage, platform readiness stage
-- do-it
+- execute
 - completion report
 - completion signal
 - deprecation plan

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -26,7 +26,7 @@ python scripts/check_release_readiness_contract.py
 
 `--execute` runs the release-readiness command chain and writes deterministic logs into `--evidence-dir`.
 
-## Closeout checklist
+## Completion checklist
 
 - [ ] Reliability-evidence gate status is `pass`.
 - [ ] Weekly-review score meets threshold.

--- a/docs/reliability-evidence-pack.md
+++ b/docs/reliability-evidence-pack.md
@@ -32,7 +32,7 @@ python scripts/check_reliability_evidence_pack_contract.py
 
 `--execute` runs the reliability-evidence command chain and writes deterministic logs for each command into `--evidence-dir`.
 
-## Closeout checklist
+## Completion checklist
 
 - [ ] GitHub Actions onboarding execution summary is green.
 - [ ] GitLab CI onboarding execution summary is green.

--- a/docs/reporting-and-trends.md
+++ b/docs/reporting-and-trends.md
@@ -84,7 +84,7 @@ You can keep history:
 - in-repo (`.sdetkit/audit-history`) for local trend review, or
 - as CI artifacts (for lighter repos and cleaner history ownership)
 
-Phase 3 GitHub Action JSON artifacts are compatible with `sdetkit report ingest` because legacy audit JSON is normalized to v1 on ingest.
+Platform readiness GitHub Action JSON artifacts are compatible with `sdetkit report ingest` because legacy audit JSON is normalized to v1 on ingest.
 
 ## Legacy burn-down KPI
 

--- a/docs/roadmap/adaptive-investigation-roadmap.md
+++ b/docs/roadmap/adaptive-investigation-roadmap.md
@@ -125,7 +125,7 @@ Keep responsibilities separate and composable.
 
 ## Phase-by-phase roadmap
 
-## Phase 1 — Upgrade the shared diagnosis brain
+## Baseline readiness — Upgrade the shared diagnosis brain
 
 ### Goal
 
@@ -218,7 +218,7 @@ Acceptance criteria:
 
 ---
 
-## Phase 2 — Align maintenance action categories with diagnosis classes
+## Release readiness — Align maintenance action categories with diagnosis classes
 
 ### Goal
 
@@ -313,7 +313,7 @@ Acceptance criteria:
 
 ---
 
-## Phase 3 — Add proof checklist
+## Platform readiness — Add proof checklist
 
 ### Goal
 
@@ -403,7 +403,7 @@ Acceptance criteria:
 
 ---
 
-## Phase 4 — Add signal trends
+## Operational readiness — Add signal trends
 
 ### Goal
 
@@ -471,7 +471,7 @@ Acceptance criteria:
 
 ---
 
-## Phase 5 — Add human-friendly investigation front door
+## Adoption readiness — Add human-friendly investigation front door
 
 ### Goal
 
@@ -553,7 +553,7 @@ Acceptance criteria:
 
 ---
 
-## Phase 6 — Add repository investigation summary
+## Scale readiness — Add repository investigation summary
 
 ### Goal
 
@@ -795,7 +795,7 @@ PYTHONPATH=src python -m pytest -q tests/test_investigate_evidence.py
 
 ---
 
-## Phase 10 — Route investigation diagnoses through safe-fix policy
+## Baseline readiness0 — Route investigation diagnoses through safe-fix policy
 
 ### Goal
 
@@ -846,7 +846,7 @@ Acceptance criteria:
 
 ---
 
-## Phase 11 — Publish investigation summaries in PR comments
+## Baseline readiness1 — Publish investigation summaries in PR comments
 
 ### Goal
 
@@ -887,7 +887,7 @@ PYTHONPATH=src python -m pytest -q tests/test_pr_investigation_summary_workflow.
 
 ---
 
-## Phase 12 — Remember investigation outcomes
+## Baseline readiness2 — Remember investigation outcomes
 
 ### Goal
 
@@ -937,7 +937,7 @@ PYTHONPATH=src python -m pytest -q tests/test_investigation_outcome_memory.py
 
 ---
 
-## Phase 13 — Safe-fix candidate registry
+## Baseline readiness3 — Safe-fix candidate registry
 
 ### Goal
 
@@ -981,7 +981,7 @@ JSON contract:
 
 ---
 
-## Phase 14 — Auto-fix probation report
+## Baseline readiness4 — Auto-fix probation report
 
 ### Goal
 
@@ -1012,7 +1012,7 @@ BLOCKED
 
 ---
 
-## Phase 15 — Policy proposal generator
+## Baseline readiness5 — Policy proposal generator
 
 ### Goal
 
@@ -1065,7 +1065,7 @@ Required.
 
 ---
 
-## Phase 16 — Auto-fix dry-run planner
+## Baseline readiness6 — Auto-fix dry-run planner
 
 ### Goal
 
@@ -1096,7 +1096,7 @@ no allowlist expansion
 
 ---
 
-## Phase 17 — Guarded PR-only auto-fix
+## Baseline readiness7 — Guarded PR-only auto-fix
 
 ### Goal
 
@@ -1132,7 +1132,7 @@ must record outcome
 
 ---
 
-## Phase 18 — Auto-fix outcome memory
+## Baseline readiness8 — Auto-fix outcome memory
 
 ### Goal
 
@@ -1478,7 +1478,7 @@ SDETKit Adaptive Investigation Roadmap
 | Field | Values |
 |---|---|
 | Status | Backlog, Ready, In Progress, In Review, Merged, Blocked, Later |
-| Phase | Phase 1 through Phase 18 |
+| Phase | Baseline readiness through Baseline readiness8 |
 | Safety Route | Diagnostic Only, Review First, Safe Mechanical Candidate, Probation, Policy Proposal, Guarded PR Auto-Fix |
 | Priority | P0, P1, P2 |
 | Artifact Type | JSON, Markdown, CLI, Workflow, Memory, Policy, Tests |
@@ -1491,31 +1491,31 @@ SDETKit Adaptive Investigation Roadmap
 
 | Order | Issue title | Phase | Safety Route |
 |---:|---|---|---|
-| 1 | Expand adaptive diagnosis for local investigation failures | Phase 1 | Diagnostic Only |
-| 2 | Classify maintenance actions with adaptive diagnosis classes | Phase 2 | Diagnostic Only |
-| 3 | Publish maintenance proof checklist | Phase 3 | Diagnostic Only |
-| 4 | Publish maintenance signal trend summary | Phase 4 | Diagnostic Only |
-| 5 | Add failure investigation command | Phase 5 | Diagnostic Only |
-| 6 | Add repository investigation summary | Phase 6 | Diagnostic Only |
+| 1 | Expand adaptive diagnosis for local investigation failures | Baseline readiness | Diagnostic Only |
+| 2 | Classify maintenance actions with adaptive diagnosis classes | Release readiness | Diagnostic Only |
+| 3 | Publish maintenance proof checklist | Platform readiness | Diagnostic Only |
+| 4 | Publish maintenance signal trend summary | Operational readiness | Diagnostic Only |
+| 5 | Add failure investigation command | Adoption readiness | Diagnostic Only |
+| 6 | Add repository investigation summary | Scale readiness | Diagnostic Only |
 | 7 | Add focused surface investigation | Phase 7 | Diagnostic Only |
 | 8 | Detect public API parity gaps | Phase 8 | Review First |
 | 9 | Write investigation candidate evidence | Phase 9 | Diagnostic Only |
-| 10 | Route investigation diagnoses through safe-fix policy | Phase 10 | Review First |
-| 11 | Publish investigation summaries for PR failures | Phase 11 | Diagnostic Only |
-| 12 | Record investigation outcome memory | Phase 12 | Diagnostic Only |
-| 13 | Publish safe-fix candidate registry | Phase 13 | Safe Mechanical Candidate |
-| 14 | Publish auto-fix probation report | Phase 14 | Probation |
-| 15 | Publish maintenance policy proposals | Phase 15 | Policy Proposal |
-| 16 | Publish auto-fix dry-run plan | Phase 16 | Policy Proposal |
-| 17 | Enable guarded PR-only auto-fix | Phase 17 | Guarded PR Auto-Fix |
-| 18 | Record auto-fix outcome memory | Phase 18 | Guarded PR Auto-Fix |
+| 10 | Route investigation diagnoses through safe-fix policy | Baseline readiness0 | Review First |
+| 11 | Publish investigation summaries for PR failures | Baseline readiness1 | Diagnostic Only |
+| 12 | Record investigation outcome memory | Baseline readiness2 | Diagnostic Only |
+| 13 | Publish safe-fix candidate registry | Baseline readiness3 | Safe Mechanical Candidate |
+| 14 | Publish auto-fix probation report | Baseline readiness4 | Probation |
+| 15 | Publish maintenance policy proposals | Baseline readiness5 | Policy Proposal |
+| 16 | Publish auto-fix dry-run plan | Baseline readiness6 | Policy Proposal |
+| 17 | Enable guarded PR-only auto-fix | Baseline readiness7 | Guarded PR Auto-Fix |
+| 18 | Record auto-fix outcome memory | Baseline readiness8 | Guarded PR Auto-Fix |
 
 ### Board execution rules
 
 - Keep only one or two P0 items in progress at a time.
 - Do not move an item to `Ready` unless its dependency issue or PR is merged.
 - Do not move any auto-fix item past `Probation` unless proof, trend, candidate registry, and policy proposal artifacts exist.
-- Keep Phase 17 as a major milestone, not a near-term task. It should stay blocked until Phases 1-16 are stable.
+- Keep Baseline readiness7 as a major milestone, not a near-term task. It should stay blocked until Phases 1-16 are stable.
 - Every issue should include the safety route and whether behavior is diagnostic-only, review-first, or an approved mechanical candidate.
 
 ---
@@ -1585,9 +1585,9 @@ Every PR in this roadmap should meet this checklist before merge.
 
 ## Major milestone gate for guarded auto-fix
 
-Phase 17, guarded PR-only auto-fix, is a major milestone and must not start until the earlier investigation, proof, trend, candidate, probation, policy proposal, and dry-run layers are stable.
+Baseline readiness7, guarded PR-only auto-fix, is a major milestone and must not start until the earlier investigation, proof, trend, candidate, probation, policy proposal, and dry-run layers are stable.
 
-Before Phase 17 starts, the project should have:
+Before Baseline readiness7 starts, the project should have:
 
 ```text
 - Stable diagnosis classes for local investigation failures.

--- a/docs/roadmap/big-brain-progress-tracker.md
+++ b/docs/roadmap/big-brain-progress-tracker.md
@@ -6,12 +6,12 @@ This tracker keeps the Big-Brain Toolkit roadmap measurable after every follow-u
 
 | Scope | Completed | Total | Progress | Status |
 | --- | ---: | ---: | ---: | --- |
-| Immediate backlog | 8 | 8 | 100% | Immediate backlog complete; continue into Phase 4/5 follow-ups. |
-| Phase 1 — Externalize the big-brain database | 4 | 4 | 100% | Built-in scenarios are data-backed and schema validated. |
-| Phase 2 — Close the learning loop | 3 | 3 | 100% | Learning records, summaries, promotion/demotion, and calibration are active. |
-| Phase 3 — Trust-grade operator experience | 3 | 3 | 100% | Operator brief, PR comment mode, and demo gallery are complete. |
-| Phase 4 — Safe remediation expansion | 4 | 4 | 100% | Safe-fix, assisted patch-plan, fix-audit records, and proof enforcement are in place. |
-| Phase 5 — Enterprise scale | 3 | 3 | 100% | Portfolio rollup, enterprise governance controls, and adapter hardening are complete. |
+| Immediate backlog | 8 | 8 | 100% | Immediate backlog complete; continue into Operational readiness/5 follow-ups. |
+| Baseline readiness — Externalize the big-brain database | 4 | 4 | 100% | Built-in scenarios are data-backed and schema validated. |
+| Release readiness — Close the learning loop | 3 | 3 | 100% | Learning records, summaries, promotion/demotion, and calibration are active. |
+| Platform readiness — Trust-grade operator experience | 3 | 3 | 100% | Operator brief, PR comment mode, and demo gallery are complete. |
+| Operational readiness — Safe remediation expansion | 4 | 4 | 100% | Safe-fix, assisted patch-plan, fix-audit records, and proof enforcement are in place. |
+| Adoption readiness — Enterprise scale | 3 | 3 | 100% | Portfolio rollup, enterprise governance controls, and adapter hardening are complete. |
 
 ## Completed immediate-backlog items
 
@@ -28,7 +28,7 @@ This tracker keeps the Big-Brain Toolkit roadmap measurable after every follow-u
 
 ## Remaining immediate-backlog items
 
-All immediate backlog items are complete. Continue with the Phase 4/5 follow-up queue below.
+All immediate backlog items are complete. Continue with the Operational readiness/5 follow-up queue below.
 
 ## Latest progress made
 

--- a/docs/roadmap/big-brain-toolkit-roadmap.md
+++ b/docs/roadmap/big-brain-toolkit-roadmap.md
@@ -34,7 +34,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
 
 ## Next upgrade roadmap
 
-### Phase 1 — Externalize the big-brain database
+### Baseline readiness — Externalize the big-brain database
 
 **Outcome:** the seeded brain becomes a maintainable data product.
 
@@ -48,7 +48,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
   - private enterprise pack.
 - Add tests that reject malformed packs and prove deterministic ordering.
 
-### Phase 2 — Close the learning loop
+### Release readiness — Close the learning loop
 
 **Outcome:** the kit learns from actual run outcomes, not only from seed data.
 
@@ -65,7 +65,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
 - Add promotion/demotion rules: **Done:** summaries now promote scenarios when proof/fix feedback succeeds, demote false positives, increase risk for recurring failures, and lower confidence for thin evidence.
 - Add `sdetkit adaptive learn summarize` to show top recurring scenarios and weakest lanes. **Done:** the CLI now rolls JSONL diagnosis events into `top_recurring_scenarios` and `weakest_lanes`.
 
-### Phase 3 — Build the trust-grade operator experience
+### Platform readiness — Build the trust-grade operator experience
 
 **Outcome:** anyone trying the repo can see why SDETKit is valuable in one run.
 
@@ -82,7 +82,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
   - unknown failure: review-first candidate scenarios and checks.
 - Add screenshots or sample PR comments in docs for the top 10 scenarios. **Done:** `docs/adaptive-product-proof-gallery.md` now shows green, safe-fix, unknown-review, recurring-learning, top-scenario, and portfolio rollup examples.
 
-### Phase 4 — Expand safe remediation without weakening safety
+### Operational readiness — Expand safe remediation without weakening safety
 
 **Outcome:** more fixes are assisted, but unknown failures remain human-reviewed.
 
@@ -95,7 +95,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
   - post-fix proof command. **Done:** fix-audit summaries now flag missing proof, block failed proof, and emit release recommendations.
 - Add fix-audit records for every automated change. **Done:** `sdetkit adaptive fix-audit record` stores safe-fix and assisted patch-plan decisions with guardrails, proof commands, changed-file scope, rollback notes, and outcomes.
 
-### Phase 5 — Make it enterprise-scale
+### Adoption readiness — Make it enterprise-scale
 
 **Outcome:** SDETKit becomes a cross-repo quality intelligence layer.
 
@@ -115,7 +115,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
 
 ## Completion checkpoint
 
-The Big-Brain execution plan is now complete across the immediate backlog, Phase 4 safe-remediation expansion, and Phase 5 enterprise-scale lanes. CLI discoverability for every adaptive lane is covered by regression tests so the next work can move into a fresh roadmap wave without losing these command surfaces. The next wave is tracked in [`adaptive-next-wave-roadmap.md`](adaptive-next-wave-roadmap.md).
+The Big-Brain execution plan is now complete across the immediate backlog, Operational readiness safe-remediation expansion, and Adoption readiness enterprise-scale lanes. CLI discoverability for every adaptive lane is covered by regression tests so the next work can move into a fresh roadmap wave without losing these command surfaces. The next wave is tracked in [`adaptive-next-wave-roadmap.md`](adaptive-next-wave-roadmap.md).
 
 ## Big-win differentiators to protect
 

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -13,7 +13,7 @@ This dashboard is the weekly control plane for the **DevS69 SDETKit top-tier ful
 | Field | Value |
 |---|---|
 | Week ending | 2026-04-17 |
-| Program status | Phase 1 closeout complete |
+| Program status | Baseline readiness closeout complete |
 | Delivery confidence | Green |
 | Top blocker count | 0 |
 | KPI movement | Seed baseline published |
@@ -22,11 +22,11 @@ This dashboard is the weekly control plane for the **DevS69 SDETKit top-tier ful
 
 | Workstream | Owner role | Current phase | Status | This-week deliverable | Evidence |
 |---|---|---|---|---|---|
-| WS1 Product packaging | Product + DX | Phase 1 | In progress | Publish packaging lanes | [Packaging lanes](packaging-lanes.md) |
-| WS2 Portfolio reporting | Platform engineering | Phase 1 | In progress | Publish portfolio reporting recipe | [Portfolio reporting recipe](portfolio-reporting-recipe.md) |
-| WS3 Governance and lifecycle | Architecture + QA governance | Phase 1 | In progress | Publish compatibility matrix | [Policy compatibility matrix](policy-compatibility-matrix.md) |
-| WS4 Commercialization enablement | PMM + Solutions | Phase 1 | In progress | Build role-based quickstart skeleton | [Role-based quickstarts](role-based-quickstarts.md) |
-| WS5 Reliability and release excellence | Release engineering | Phase 1 | In progress | Publish support/escalation model | [Support and escalation model](support-and-escalation-model.md) |
+| WS1 Product packaging | Product + DX | Baseline readiness | In progress | Publish packaging lanes | [Packaging lanes](packaging-lanes.md) |
+| WS2 Portfolio reporting | Platform engineering | Baseline readiness | In progress | Publish portfolio reporting recipe | [Portfolio reporting recipe](portfolio-reporting-recipe.md) |
+| WS3 Governance and lifecycle | Architecture + QA governance | Baseline readiness | In progress | Publish compatibility matrix | [Policy compatibility matrix](policy-compatibility-matrix.md) |
+| WS4 Commercialization enablement | PMM + Solutions | Baseline readiness | In progress | Build role-based quickstart skeleton | [Role-based quickstarts](role-based-quickstarts.md) |
+| WS5 Reliability and release excellence | Release engineering | Baseline readiness | In progress | Publish support/escalation model | [Support and escalation model](support-and-escalation-model.md) |
 
 ## KPI board (contract baseline)
 

--- a/docs/ultra-upgrade-report-25.md
+++ b/docs/ultra-upgrade-report-25.md
@@ -16,7 +16,7 @@ python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/c
 python scripts/check_community_activation_contract.py
 ```
 
-## Closeout criteria
+## Completion criteria
 
 - Cycle 25 score >= 90 with no critical failures.
 - Integration page includes all required sections + command contract.

--- a/docs/ultra-upgrade-report-27.md
+++ b/docs/ultra-upgrade-report-27.md
@@ -16,7 +16,7 @@ python -m sdetkit kpi-audit --execute --evidence-dir docs/artifacts/kpi-audit-pa
 python scripts/check_kpi_audit_contract.py
 ```
 
-## Closeout criteria
+## Completion criteria
 
 - Cycle 27 score >= 90 with no critical failures.
 - Baseline/current KPI snapshots valid and published.

--- a/docs/ultra-upgrade-report-28.md
+++ b/docs/ultra-upgrade-report-28.md
@@ -16,7 +16,7 @@ python -m sdetkit cycle28-weekly-review --execute --evidence-dir docs/artifacts/
 python scripts/check_weekly_review_contract.py
 ```
 
-## Closeout criteria
+## Completion criteria
 
 - Cycle 28 score >= 90 with no critical failures.
 - Cycle 25/26/27 summary artifacts available and parseable.

--- a/docs/ultra-upgrade-report-29.md
+++ b/docs/ultra-upgrade-report-29.md
@@ -16,7 +16,7 @@ python -m sdetkit cycle29-phase1-hardening --execute --evidence-dir docs/artifac
 python scripts/check_phase1_hardening_contract.py
 ```
 
-## Closeout criteria
+## Completion criteria
 
 - Cycle 29 score >= 90 with no critical failures.
 - Top entry pages link Cycle 29 integration + report docs.

--- a/docs/ultra-upgrade-report-30.md
+++ b/docs/ultra-upgrade-report-30.md
@@ -2,7 +2,7 @@
 
 ## What shipped
 
-- Added `cycle30-phase1-wrap` command to score Phase-1 closeout and lock a deterministic Phase-2 backlog.
+- Added `cycle30-phase1-wrap` command to score Baseline readiness closeout and lock a deterministic Release readiness backlog.
 - Added Cycle 30 docs contract validation and evidence lane execution mode.
 - Added Cycle 30 handoff pack generation: summary, backlog snapshot, handoff actions, and validation commands.
 - Added dedicated Cycle 30 contract-check script and automated tests.
@@ -16,9 +16,9 @@ python -m sdetkit cycle30-phase1-wrap --execute --evidence-dir docs/artifacts/cy
 python scripts/check_phase1_wrap_contract.py
 ```
 
-## Closeout criteria
+## Completion criteria
 
 - Cycle 30 score >= 90 with no critical failures.
 - README + docs index + strategy pages all advertise Cycle 30 wrap lane.
 - Cycles 27-29 summary artifacts are available and parsed.
-- Phase-2 backlog list is locked with >=8 actionable checkpoints.
+- Release readiness backlog list is locked with >=8 actionable checkpoints.

--- a/docs/ultra-upgrade-report-32.md
+++ b/docs/ultra-upgrade-report-32.md
@@ -2,7 +2,7 @@
 
 ## Mission closed
 
-Cycle 32 hardens Phase-2 execution by turning release behavior into a deterministic weekly system with explicit quality and rollback gates.
+Cycle 32 hardens Release readiness execution by turning release behavior into a deterministic weekly system with explicit quality and rollback gates.
 
 ## Upgrades shipped
 

--- a/tests/test_big_brain_toolkit_roadmap.py
+++ b/tests/test_big_brain_toolkit_roadmap.py
@@ -11,8 +11,8 @@ def test_big_brain_toolkit_roadmap_captures_strengths_gaps_and_upgrades() -> Non
     assert "## Current strengths after the latest kit run" in text
     assert "## What still needs to become stronger" in text
     assert "## Next upgrade roadmap" in text
-    assert "Phase 1 — Externalize the big-brain database" in text
-    assert "Phase 5 — Make it enterprise-scale" in text
+    assert "Baseline readiness — Externalize the big-brain database" in text
+    assert "Adoption readiness — Make it enterprise-scale" in text
     assert "Unknown is review-first" in text
 
 


### PR DESCRIPTION
## Summary
- Professionalize active documentation wording for phase/closeout/demo/tutorial-style naming.
- Keep this wave limited to active docs prose.
- Preserve compatibility, generated artifacts, contracts, migration maps, and public command surfaces for later alias-backed waves.

## Verification
- python -m pytest -q tests/test_professional_execution_docs_language.py tests/test_owned_surface_hygiene_contract.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Low.
- Documentation wording only.
- No CLI, schema, workflow, Makefile, or generated artifact rename in this PR.