### PR TITLE
docs(naming): inventory public docs path rename candidates

### DIFF
--- a/docs/naming/public-docs-path-rename-inventory.json
+++ b/docs/naming/public-docs-path-rename-inventory.json
@@ -1,0 +1,122 @@
+{
+  "records": [
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-1.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-10.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-11.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-2.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-3.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-4.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-5.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-6.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-7.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-8.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Continuous upgrade delivery workflow",
+      "path": "docs/integrations-continuous-upgrade-closeout-9.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Optimization foundation workflow",
+      "path": "docs/integrations-optimization-closeout-foundation.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    },
+    {
+      "classification": "needs_review",
+      "first_heading": "# Scale upgrade workflow",
+      "path": "docs/integrations-scale-upgrade-closeout.md",
+      "recommended_action": "rename_with_redirect_or_preserve_as_legacy_reference",
+      "tokens": [
+        "closeout"
+      ]
+    }
+  ],
+  "schema_version": "sdetkit.public-docs-path-rename-inventory.v1"
+}

--- a/docs/naming/public-docs-path-rename-inventory.md
+++ b/docs/naming/public-docs-path-rename-inventory.md
@@ -1,0 +1,20 @@
+# Public docs path rename inventory
+
+This inventory identifies active public docs paths/headings that still contain legacy naming.
+It is planning-only: no public docs paths are renamed in this PR.
+
+| Path | Heading | Tokens | Recommended action |
+| --- | --- | --- | --- |
+| `docs/integrations-continuous-upgrade-closeout-1.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-10.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-11.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-2.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-3.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-4.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-5.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-6.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-7.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-8.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-continuous-upgrade-closeout-9.md` | # Continuous upgrade delivery workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-optimization-closeout-foundation.md` | # Optimization foundation workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |
+| `docs/integrations-scale-upgrade-closeout.md` | # Scale upgrade workflow | closeout | rename_with_redirect_or_preserve_as_legacy_reference |


### PR DESCRIPTION
## Summary
- Add a planning inventory for active public docs paths/headings that still contain legacy naming.
- Identify 13 closeout-related public docs path candidates for future redirect-backed cleanup.
- Keep this PR planning-only with no file renames.

## Verification
- python -m pytest -q tests/test_professional_naming_migration.py tests/test_owned_surface_hygiene_contract.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Low.
- Inventory docs only.
- No CLI, schema, workflow, Makefile, artifact, or path rename changes.