### PR TITLE
docs(naming): add example paths for demo assets

### DIFF
--- a/docs/artifacts/demo-asset-pack/demo-asset-summary.md
+++ b/docs/artifacts/demo-asset-pack/demo-asset-summary.md
@@ -1,24 +1,3 @@
-#  demo asset summary
+# Moved: example documentation
 
-- Activation score: **46**
-- Passed checks: **6**
-- Failed checks: **8**
-- Critical failures: **release_cadence_strict_baseline**
-
-## Release-cadence continuity
-
--  activation score: `65.0`
--  checks evaluated: `14`
--  delivery board checklist items: `5`
-
-## Wins
-
-## Misses
--  strict continuity signal is missing.
--  delivery board integrity is incomplete (needs >=5 items and /34 anchors).
-- Example contract, quality checklist, or delivery board entries are missing.
-
-## Handoff actions
-- [ ] Re-run  cadence command and restore strict pass baseline before demo lock.
-- [ ] Repair  delivery board entries to include  and  anchors.
-- [ ] Complete all  contract lines, quality checklist entries, and delivery board tasks in docs.
+This compatibility page preserves the legacy public path. The professional page is now [`example-asset-summary.md`](../../artifacts/example-asset-pack/example-asset-summary.md).

--- a/docs/artifacts/demo-asset-pack/demo-delivery-board.md
+++ b/docs/artifacts/demo-asset-pack/demo-delivery-board.md
@@ -1,7 +1,3 @@
-#  delivery board
+# Moved: example documentation
 
-- [ ]  script draft committed
-- [ ]  first cut rendered
-- [ ]  final cut + caption copy approved
-- [ ]  demo asset #2 backlog pre-scoped
-- [ ]  KPI instrumentation plan updated
+This compatibility page preserves the legacy public path. The professional page is now [`example-delivery-board.md`](../../artifacts/example-asset-pack/example-delivery-board.md).

--- a/docs/artifacts/demo-asset-pack/demo-script.md
+++ b/docs/artifacts/demo-asset-pack/demo-script.md
@@ -1,11 +1,3 @@
-#  demo script
+# Moved: example documentation
 
-## Hook (0-10s)
-- Pain point + why this matters now
-
-## Command lane (10-45s)
-- Run: `python -m sdetkit doctor --json`
-- Highlight key output fields
-
-## Value proof + CTA (45-90s)
-- Trust signal + docs link + next step
+This compatibility page preserves the legacy public path. The professional page is now [`example-script.md`](../../artifacts/example-asset-pack/example-script.md).

--- a/docs/artifacts/demo-sample-2.md
+++ b/docs/artifacts/demo-sample-2.md
@@ -1,29 +1,3 @@
-# Demo path (target: ~60 seconds)
+# Moved: example documentation
 
-| Step | Command | Expected output snippets | Outcome |
-|---|---|---|---|
-| Health check | `python -m sdetkit doctor --format text` | `doctor score:`<br>`recommendations:` | Confirms repository hygiene and points to the highest-leverage fixes first. |
-| Repository audit | `python -m sdetkit repo audit --format text` | `Repo audit:`<br>`Result:` | Surfaces policy, CI, and governance gaps in a report-ready format. |
-| Security baseline | `python -m sdetkit security report --format text` | `security scan:`<br>`top findings:` | Produces a security-focused snapshot that can be attached to release reviews. |
-
-## Execution results
-
-| Step | Status | Exit code | Duration (s) | Missing snippets |
-|---|---|---:|---:|---|
-| Health check | pass | 0 | 0.624 | - |
-| Repository audit | pass | 0 | 1.086 | - |
-| Security baseline | pass | 0 | 1.909 | - |
-
-## SLA summary
-
-- Total duration: `3.619s`
-- Target: `60.0s`
-- Within target: `yes`
-
-## Demo tips
-
-- Use --execute when recording a live product demo so each step is validated.
-- Use --format markdown --output demo.md to save a shareable run artifact.
-- If a snippet check fails, rerun a single command manually and compare output with the expected markers.
-
-Related docs: [Docs fast start](../index.md#what-to-run-first), [repo audit](../repo-audit.md).
+This compatibility page preserves the legacy public path. The professional page is now [`example-sample-2.md`](../artifacts/example-sample-2.md).

--- a/docs/artifacts/example-asset-pack/example-asset-summary.md
+++ b/docs/artifacts/example-asset-pack/example-asset-summary.md
@@ -1,0 +1,24 @@
+#  example asset summary
+
+- Activation score: **46**
+- Passed checks: **6**
+- Failed checks: **8**
+- Critical failures: **release_cadence_strict_baseline**
+
+## Release-cadence continuity
+
+-  activation score: `65.0`
+-  checks evaluated: `14`
+-  delivery board checklist items: `5`
+
+## Wins
+
+## Misses
+-  strict continuity signal is missing.
+-  delivery board integrity is incomplete (needs >=5 items and /34 anchors).
+- Example contract, quality checklist, or delivery board entries are missing.
+
+## Handoff actions
+- [ ] Re-run  cadence command and restore strict pass baseline before example lock.
+- [ ] Repair  delivery board entries to include  and  anchors.
+- [ ] Complete all  contract lines, quality checklist entries, and delivery board tasks in docs.

--- a/docs/artifacts/example-asset-pack/example-delivery-board.md
+++ b/docs/artifacts/example-asset-pack/example-delivery-board.md
@@ -1,0 +1,7 @@
+#  delivery board
+
+- [ ]  script draft committed
+- [ ]  first cut rendered
+- [ ]  final cut + caption copy approved
+- [ ]  example asset #2 backlog pre-scoped
+- [ ]  KPI instrumentation plan updated

--- a/docs/artifacts/example-asset-pack/example-script.md
+++ b/docs/artifacts/example-asset-pack/example-script.md
@@ -1,0 +1,11 @@
+#  example script
+
+## Hook (0-10s)
+- Pain point + why this matters now
+
+## Command lane (10-45s)
+- Run: `python -m sdetkit doctor --json`
+- Highlight key output fields
+
+## Value proof + CTA (45-90s)
+- Trust signal + docs link + next step

--- a/docs/artifacts/example-sample-2.md
+++ b/docs/artifacts/example-sample-2.md
@@ -1,0 +1,29 @@
+# Example path (target: ~60 seconds)
+
+| Step | Command | Expected output snippets | Outcome |
+|---|---|---|---|
+| Health check | `python -m sdetkit doctor --format text` | `doctor score:`<br>`recommendations:` | Confirms repository hygiene and points to the highest-leverage fixes first. |
+| Repository audit | `python -m sdetkit repo audit --format text` | `Repo audit:`<br>`Result:` | Surfaces policy, CI, and governance gaps in a report-ready format. |
+| Security baseline | `python -m sdetkit security report --format text` | `security scan:`<br>`top findings:` | Produces a security-focused snapshot that can be attached to release reviews. |
+
+## Execution results
+
+| Step | Status | Exit code | Duration (s) | Missing snippets |
+|---|---|---:|---:|---|
+| Health check | pass | 0 | 0.624 | - |
+| Repository audit | pass | 0 | 1.086 | - |
+| Security baseline | pass | 0 | 1.909 | - |
+
+## SLA summary
+
+- Total duration: `3.619s`
+- Target: `60.0s`
+- Within target: `yes`
+
+## Example tips
+
+- Use --execute when recording a live product example so each step is validated.
+- Use --format markdown --output example.md to save a shareable run artifact.
+- If a snippet check fails, rerun a single command manually and compare output with the expected markers.
+
+Related docs: [Docs fast start](../index.md#what-to-run-first), [repo audit](../repo-audit.md).

--- a/docs/integrations-example-asset.md
+++ b/docs/integrations-example-asset.md
@@ -4,7 +4,7 @@ Lane closes the first distribution-ready example asset, turning Lane release rea
 
 ## Why Lane matters
 
-- Demonstrates real value with a concise `doctor` workflow narrative.
+- Examplenstrates real value with a concise `doctor` workflow narrative.
 - Creates a repeatable media pipeline (script → cut → publish → evidence).
 - Links each example claim to runnable CLI commands and docs for trust.
 
@@ -22,14 +22,14 @@ python -m sdetkit example-asset --execute --evidence-dir docs/artifacts/example-
 python scripts/check_example_asset_contract.py
 ```
 
-## Demo production contract
+## Example production contract
 
 - Example owner: one accountable editor and one backup reviewer are assigned.
 - Target format: publish both MP4 clip and GIF teaser for social/docs embedding.
 - Runtime SLA: main example duration stays between 45 and 90 seconds.
 - Narrative shape: pain -> command -> output -> value CTA must appear in order.
 
-## Demo quality checklist
+## Example quality checklist
 
 - [ ] Shows `python -m sdetkit doctor --json` execution with readable terminal output
 - [ ] Includes before/after or problem/solution framing in first 10 seconds


### PR DESCRIPTION
## Summary
- Add professional `example` documentation paths for demo asset surfaces.
- Preserve legacy demo paths as compatibility stubs where paths changed.
- Normalize demo wording to example in the renamed docs.

## Verification
- python -m pytest -q tests/test_professional_naming_migration.py tests/test_owned_surface_hygiene_contract.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Medium-low.
- Docs/artifact paths only, with compatibility stubs.
- No CLI, schema, workflow, Makefile, or Python module rename.