### PR TITLE
docs(naming): add professional operational docs paths

### DIFF
--- a/docs/artifacts/live-adoption/product-proof-post-1072/docs-example-proof-summary.md
+++ b/docs/artifacts/live-adoption/product-proof-post-1072/docs-example-proof-summary.md
@@ -318,9 +318,9 @@ None.
 | `docs/cli.md` | 30 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit doctor --enterprise --format md` |
 | `docs/cli.md` | 32 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit doctor --enterprise-rerun-failed --json` |
 | `docs/cli.md` | 35 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit doctor --enterprise-rerun-high --json` |
-| `docs/cli.md` | 39 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit doctor --enterprise-next-pass-only` |
-| `docs/cli.md` | 40 | `docs-command-needs-fixture-or-policy-review` | `- CI-friendly status mode: `python -m sdetkit doctor --enterprise-next-pass-only --enterprise-next-pass-exit-code` |
-| `docs/cli.md` | 43 | `docs-command-needs-fixture-or-policy-review` | `- markdown-friendly output: `python -m sdetkit doctor --enterprise-next-pass-only --format md` |
+| `docs/cli.md` | 39 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit doctor --enterprise-follow-up-only` |
+| `docs/cli.md` | 40 | `docs-command-needs-fixture-or-policy-review` | `- CI-friendly status mode: `python -m sdetkit doctor --enterprise-follow-up-only --enterprise-follow-up-exit-code` |
+| `docs/cli.md` | 43 | `docs-command-needs-fixture-or-policy-review` | `- markdown-friendly output: `python -m sdetkit doctor --enterprise-follow-up-only --format md` |
 | `docs/cli.md` | 115 | `docs-command-needs-fixture-or-policy-review` | `python -m sdetkit --no-legacy-hint phase1-hardening` |
 | `docs/cli.md` | 118 | `docs-command-needs-fixture-or-policy-review` | `SDETKIT_LEGACY_HINTS=0 python -m sdetkit phase1-hardening` |
 | `docs/cli.md` | 126 | `docs-command-needs-fixture-or-policy-review` | `python -m sdetkit legacy migrate-hint phase1-hardening` |
@@ -599,7 +599,7 @@ None.
 | `docs/omnichannel-mcp-bridge.md` | 24 | `docs-command-needs-fixture-or-policy-review` | `sdetkit agent serve \` |
 | `docs/operator-essentials.md` | 10 | `docs-command-needs-fixture-or-policy-review` | `2. `python -m sdetkit gate release --format json --out build/release-preflight.json` |
 | `docs/operator-essentials.md` | 22 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit review . --no-workspace --format operator-json` |
-| `docs/operator-essentials.md` | 24 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit doctor --enterprise-next-pass-only --enterprise-next-pass-exit-code` |
+| `docs/operator-essentials.md` | 24 | `docs-command-needs-fixture-or-policy-review` | `- `python -m sdetkit doctor --enterprise-follow-up-only --enterprise-follow-up-exit-code` |
 | `docs/ops.md` | 3 | `docs-command-needs-fixture-or-policy-review` | `sdetkit ops init` bootstraps `.sdetkit/` with config, policies, playbooks, cache, and out folders.` |
 | `docs/patch-harness.md` | 11 | `docs-command-needs-fixture-or-policy-review` | `sdetkit patch spec.json` |
 | `docs/patch-harness.md` | 12 | `safe-dry-run-candidate-not-in-allowlist` | `sdetkit patch spec.json --dry-run` |

--- a/docs/professional-naming-debt-register.md
+++ b/docs/professional-naming-debt-register.md
@@ -9,11 +9,11 @@ New public surfaces should use durable production names.
 Avoid new names containing:
 
 - `phase1`, `phase2`, `phase3`, `phase4`, `phase5`, `phase6`
-- `do-it`
+- `execute`
 - `closeout`
-- `finish-signal`
-- `retire-plan`
-- `next-pass`
+- `completion-signal`
+- `deprecation-plan`
+- `follow-up`
 - `gate-phase2`
 - `lesson`
 - `tutorial`
@@ -35,9 +35,9 @@ Existing legacy names may remain when they are public compatibility surfaces, ge
 | phase 6 / phase6 | metrics contract |
 | closeout | completion, evidence pack, delivery summary, release evidence |
 | demo | product proof, example workflow, sample output |
-| next-pass | follow-up, handoff, remediation plan |
-| finish-signal | readiness signal |
-| retire-plan | migration plan |
+| follow-up | follow-up, handoff, remediation plan |
+| completion-signal | readiness signal |
+| deprecation-plan | migration plan |
 | gate-phase2 | readiness gate |
 | big upgrade report | upgrade assessment report |
 | ultra upgrade report | implementation report |
@@ -86,8 +86,8 @@ The public Makefile surface now prefers professional names for baseline, operati
 release-readiness, platform-readiness, adoption-readiness, and scale-readiness lanes.
 
 Compatibility aliases remain available for transition-era `phase1`, `phase2`, `phase3`,
-`phase5`, `phase6`, `phase-current`, `do-it`, `finish-signal`, `next-pass`, and
-`retire-plan` names where removal would break existing users or historical automation.
+`phase5`, `phase6`, `phase-current`, `execute`, `completion-signal`, `follow-up`, and
+`deprecation-plan` names where removal would break existing users or historical automation.
 
 Current sweep policy:
 


### PR DESCRIPTION
## Summary
- Add professional docs paths and wording for legacy operational naming such as next-pass, finish-signal, retire-plan, and do-it.
- Preserve legacy public paths as compatibility stubs where paths changed.
- Keep this wave limited to docs/artifact markdown surfaces.

## Verification
- python -m pytest -q tests/test_professional_naming_migration.py tests/test_owned_surface_hygiene_contract.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Medium-low.
- Docs/artifact paths only, with compatibility stubs.
- No CLI, schema, workflow, Makefile, or Python module rename.