### PR TITLE
refactor(naming): add schema version aliases

### DIFF
--- a/docs/naming/schema-version-aliases.json
+++ b/docs/naming/schema-version-aliases.json
@@ -1,0 +1,273 @@
+{
+  "alias_count": 30,
+  "aliases": [
+    {
+      "legacy": "sdetkit.phase1_baseline.v1",
+      "professional": "sdetkit.baseline_baseline.v1",
+      "sample_sources": [
+        "scripts/baseline_lane.sh",
+        "scripts/check_baseline_summary_contract.py",
+        "scripts/seed_quality_baseline_summary_fixture.py",
+        "tests/test_ecosystem_readiness_contract.py",
+        "tests/test_metrics_readiness_contract.py",
+        "tests/test_platform_readiness_baseline_history_persist.py",
+        "tests/test_platform_readiness_followup_pass_determinism.py",
+        "tests/test_platform_readiness_quality_contract.py",
+        "tests/test_platform_readiness_remediation_payload_v2.py",
+        "tests/test_platform_readiness_trend_delta.py"
+      ],
+      "source_count": 11
+    },
+    {
+      "legacy": "sdetkit.phase2-hotspot-baseline.v1",
+      "professional": "sdetkit.release-readiness-hotspot-baseline.v1",
+      "sample_sources": [
+        "docs/artifacts/phase2-hotspot-baseline-2026-04-24.json",
+        "docs/artifacts/phase2-hotspot-baseline-pre-extraction-2026-04-24.json",
+        "docs/artifacts/release-readiness-hotspot-baseline-2026-04-24.json",
+        "docs/artifacts/release-readiness-hotspot-baseline-pre-extraction-2026-04-24.json"
+      ],
+      "source_count": 4
+    },
+    {
+      "legacy": "sdetkit.phase2-hotspot-delta.v1",
+      "professional": "sdetkit.release-readiness-hotspot-delta.v1",
+      "sample_sources": [
+        "docs/artifacts/phase2-hotspot-delta-2026-04-24.json",
+        "docs/artifacts/release-readiness-hotspot-delta-2026-04-24.json"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase2.doctor-behavior.v1",
+      "professional": "sdetkit.release_readiness.doctor-behavior.v1",
+      "sample_sources": [
+        "docs/contracts/phase2-doctor-behavior-contract.v1.json"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase2.repo-behavior.v1",
+      "professional": "sdetkit.release_readiness.repo-behavior.v1",
+      "sample_sources": [
+        "docs/contracts/phase2-repo-behavior-contract.v1.json"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase3-dependency-radar.v1",
+      "professional": "sdetkit.platform-readiness-dependency-radar.v1",
+      "sample_sources": [
+        "docs/artifacts/phase3-dependency-radar-2026-04-24.json",
+        "docs/artifacts/platform-readiness-dependency-radar-2026-04-24.json",
+        "scripts/platform_readiness_dependency_radar.py"
+      ],
+      "source_count": 3
+    },
+    {
+      "legacy": "sdetkit.phase3_adaptive_planning.v1",
+      "professional": "sdetkit.platform_readiness_adaptive_planning.v1",
+      "sample_sources": [
+        "scripts/platform_readiness_quality_engine.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase3_baseline_history.v1",
+      "professional": "sdetkit.platform_readiness_baseline_history.v1",
+      "sample_sources": [
+        "scripts/platform_readiness_persist_baseline_history.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase3_next_pass.v1",
+      "professional": "sdetkit.platform_readiness_next_pass.v1",
+      "sample_sources": [
+        "scripts/platform_readiness_quality_engine.py",
+        "tests/test_platform_readiness_quality_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase3_quality_contract.v1",
+      "professional": "sdetkit.platform_readiness_quality_contract.v1",
+      "sample_sources": [
+        "scripts/check_platform_readiness_quality_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase3_remediation.v2",
+      "professional": "sdetkit.platform_readiness_remediation.v2",
+      "sample_sources": [
+        "scripts/platform_readiness_quality_engine.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase3_trend_delta.v1",
+      "professional": "sdetkit.platform_readiness_trend_delta.v1",
+      "sample_sources": [
+        "scripts/platform_readiness_quality_engine.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase4_compliance_overlay.v1",
+      "professional": "sdetkit.operational_readiness_compliance_overlay.v1",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase4_compliance_overlay_pack.v1",
+      "professional": "sdetkit.operational_readiness_compliance_overlay_pack.v1",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py",
+        "tests/test_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase4_governance_adherence.v1",
+      "professional": "sdetkit.operational_readiness_governance_adherence.v1",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py",
+        "tests/test_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase4_governance_contract.v1",
+      "professional": "sdetkit.operational_readiness_governance_contract.v1",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py",
+        "tests/test_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase4_governance_contract.v2",
+      "professional": "sdetkit.operational_readiness_governance_contract.v2",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py",
+        "tests/test_ecosystem_readiness_contract.py",
+        "tests/test_metrics_readiness_contract.py",
+        "tests/test_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 4
+    },
+    {
+      "legacy": "sdetkit.phase4_governance_drift_alerts.v1",
+      "professional": "sdetkit.operational_readiness_governance_drift_alerts.v1",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py",
+        "tests/test_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase4_policy_as_code_template.v1",
+      "professional": "sdetkit.operational_readiness_policy_as_code_template.v1",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py",
+        "tests/test_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase4_release_evidence.v1",
+      "professional": "sdetkit.operational_readiness_release_evidence.v1",
+      "sample_sources": [
+        "scripts/check_operational_readiness_governance_contract.py",
+        "tests/test_operational_readiness_governance_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase5_ecosystem_contract.v1",
+      "professional": "sdetkit.adoption_readiness_ecosystem_contract.v1",
+      "sample_sources": [
+        "scripts/check_ecosystem_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase5_ecosystem_contract.v2",
+      "professional": "sdetkit.adoption_readiness_ecosystem_contract.v2",
+      "sample_sources": [
+        "scripts/check_ecosystem_readiness_contract.py",
+        "tests/test_metrics_readiness_contract.py"
+      ],
+      "source_count": 2
+    },
+    {
+      "legacy": "sdetkit.phase5_ecosystem_drift_alerts.v1",
+      "professional": "sdetkit.adoption_readiness_ecosystem_drift_alerts.v1",
+      "sample_sources": [
+        "scripts/check_ecosystem_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase5_ecosystem_reliability.v1",
+      "professional": "sdetkit.adoption_readiness_ecosystem_reliability.v1",
+      "sample_sources": [
+        "scripts/check_ecosystem_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase5_partner_packaging.v1",
+      "professional": "sdetkit.adoption_readiness_partner_packaging.v1",
+      "sample_sources": [
+        "scripts/check_ecosystem_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase6_commercial_scorecard.v1",
+      "professional": "sdetkit.scale_readiness_commercial_scorecard.v1",
+      "sample_sources": [
+        "scripts/check_metrics_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase6_kpi_snapshot.v1",
+      "professional": "sdetkit.scale_readiness_kpi_snapshot.v1",
+      "sample_sources": [
+        "scripts/check_metrics_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase6_metrics_contract.v1",
+      "professional": "sdetkit.scale_readiness_metrics_contract.v1",
+      "sample_sources": [
+        "scripts/check_metrics_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase6_metrics_contract.v2",
+      "professional": "sdetkit.scale_readiness_metrics_contract.v2",
+      "sample_sources": [
+        "scripts/check_metrics_readiness_contract.py"
+      ],
+      "source_count": 1
+    },
+    {
+      "legacy": "sdetkit.phase6_metrics_drift_alerts.v1",
+      "professional": "sdetkit.scale_readiness_metrics_drift_alerts.v1",
+      "sample_sources": [
+        "scripts/check_metrics_readiness_contract.py"
+      ],
+      "source_count": 1
+    }
+  ],
+  "policy": "Legacy schema_version values remain accepted. Professional schema_version values are aliases and must canonicalize back to legacy values for compatibility.",
+  "schema_version": "sdetkit.naming.schema-version-aliases.v1"
+}

--- a/src/sdetkit/schema_version_aliases.py
+++ b/src/sdetkit/schema_version_aliases.py
@@ -1,0 +1,95 @@
+"""Schema-version compatibility aliases for professional naming migration."""
+
+from __future__ import annotations
+
+SCHEMA_VERSION_ALIASES: dict[str, str] = {
+    "sdetkit.phase1_baseline.v1": "sdetkit.baseline_baseline.v1",
+    "sdetkit.phase2-hotspot-baseline.v1": "sdetkit.release-readiness-hotspot-baseline.v1",
+    "sdetkit.phase2-hotspot-delta.v1": "sdetkit.release-readiness-hotspot-delta.v1",
+    "sdetkit.phase2.doctor-behavior.v1": "sdetkit.release_readiness.doctor-behavior.v1",
+    "sdetkit.phase2.repo-behavior.v1": "sdetkit.release_readiness.repo-behavior.v1",
+    "sdetkit.phase3-dependency-radar.v1": "sdetkit.platform-readiness-dependency-radar.v1",
+    "sdetkit.phase3_adaptive_planning.v1": "sdetkit.platform_readiness_adaptive_planning.v1",
+    "sdetkit.phase3_baseline_history.v1": "sdetkit.platform_readiness_baseline_history.v1",
+    "sdetkit.phase3_next_pass.v1": "sdetkit.platform_readiness_next_pass.v1",
+    "sdetkit.phase3_quality_contract.v1": "sdetkit.platform_readiness_quality_contract.v1",
+    "sdetkit.phase3_remediation.v2": "sdetkit.platform_readiness_remediation.v2",
+    "sdetkit.phase3_trend_delta.v1": "sdetkit.platform_readiness_trend_delta.v1",
+    "sdetkit.phase4_compliance_overlay.v1": "sdetkit.operational_readiness_compliance_overlay.v1",
+    "sdetkit.phase4_compliance_overlay_pack.v1": "sdetkit.operational_readiness_compliance_overlay_pack.v1",
+    "sdetkit.phase4_governance_adherence.v1": "sdetkit.operational_readiness_governance_adherence.v1",
+    "sdetkit.phase4_governance_contract.v1": "sdetkit.operational_readiness_governance_contract.v1",
+    "sdetkit.phase4_governance_contract.v2": "sdetkit.operational_readiness_governance_contract.v2",
+    "sdetkit.phase4_governance_drift_alerts.v1": "sdetkit.operational_readiness_governance_drift_alerts.v1",
+    "sdetkit.phase4_policy_as_code_template.v1": "sdetkit.operational_readiness_policy_as_code_template.v1",
+    "sdetkit.phase4_release_evidence.v1": "sdetkit.operational_readiness_release_evidence.v1",
+    "sdetkit.phase5_ecosystem_contract.v1": "sdetkit.adoption_readiness_ecosystem_contract.v1",
+    "sdetkit.phase5_ecosystem_contract.v2": "sdetkit.adoption_readiness_ecosystem_contract.v2",
+    "sdetkit.phase5_ecosystem_drift_alerts.v1": "sdetkit.adoption_readiness_ecosystem_drift_alerts.v1",
+    "sdetkit.phase5_ecosystem_reliability.v1": "sdetkit.adoption_readiness_ecosystem_reliability.v1",
+    "sdetkit.phase5_partner_packaging.v1": "sdetkit.adoption_readiness_partner_packaging.v1",
+    "sdetkit.phase6_commercial_scorecard.v1": "sdetkit.scale_readiness_commercial_scorecard.v1",
+    "sdetkit.phase6_kpi_snapshot.v1": "sdetkit.scale_readiness_kpi_snapshot.v1",
+    "sdetkit.phase6_metrics_contract.v1": "sdetkit.scale_readiness_metrics_contract.v1",
+    "sdetkit.phase6_metrics_contract.v2": "sdetkit.scale_readiness_metrics_contract.v2",
+    "sdetkit.phase6_metrics_drift_alerts.v1": "sdetkit.scale_readiness_metrics_drift_alerts.v1",
+}
+
+PROFESSIONAL_SCHEMA_VERSION_ALIASES: dict[str, str] = {
+    "sdetkit.baseline_baseline.v1": "sdetkit.phase1_baseline.v1",
+    "sdetkit.release-readiness-hotspot-baseline.v1": "sdetkit.phase2-hotspot-baseline.v1",
+    "sdetkit.release-readiness-hotspot-delta.v1": "sdetkit.phase2-hotspot-delta.v1",
+    "sdetkit.release_readiness.doctor-behavior.v1": "sdetkit.phase2.doctor-behavior.v1",
+    "sdetkit.release_readiness.repo-behavior.v1": "sdetkit.phase2.repo-behavior.v1",
+    "sdetkit.platform-readiness-dependency-radar.v1": "sdetkit.phase3-dependency-radar.v1",
+    "sdetkit.platform_readiness_adaptive_planning.v1": "sdetkit.phase3_adaptive_planning.v1",
+    "sdetkit.platform_readiness_baseline_history.v1": "sdetkit.phase3_baseline_history.v1",
+    "sdetkit.platform_readiness_next_pass.v1": "sdetkit.phase3_next_pass.v1",
+    "sdetkit.platform_readiness_quality_contract.v1": "sdetkit.phase3_quality_contract.v1",
+    "sdetkit.platform_readiness_remediation.v2": "sdetkit.phase3_remediation.v2",
+    "sdetkit.platform_readiness_trend_delta.v1": "sdetkit.phase3_trend_delta.v1",
+    "sdetkit.operational_readiness_compliance_overlay.v1": "sdetkit.phase4_compliance_overlay.v1",
+    "sdetkit.operational_readiness_compliance_overlay_pack.v1": "sdetkit.phase4_compliance_overlay_pack.v1",
+    "sdetkit.operational_readiness_governance_adherence.v1": "sdetkit.phase4_governance_adherence.v1",
+    "sdetkit.operational_readiness_governance_contract.v1": "sdetkit.phase4_governance_contract.v1",
+    "sdetkit.operational_readiness_governance_contract.v2": "sdetkit.phase4_governance_contract.v2",
+    "sdetkit.operational_readiness_governance_drift_alerts.v1": "sdetkit.phase4_governance_drift_alerts.v1",
+    "sdetkit.operational_readiness_policy_as_code_template.v1": "sdetkit.phase4_policy_as_code_template.v1",
+    "sdetkit.operational_readiness_release_evidence.v1": "sdetkit.phase4_release_evidence.v1",
+    "sdetkit.adoption_readiness_ecosystem_contract.v1": "sdetkit.phase5_ecosystem_contract.v1",
+    "sdetkit.adoption_readiness_ecosystem_contract.v2": "sdetkit.phase5_ecosystem_contract.v2",
+    "sdetkit.adoption_readiness_ecosystem_drift_alerts.v1": "sdetkit.phase5_ecosystem_drift_alerts.v1",
+    "sdetkit.adoption_readiness_ecosystem_reliability.v1": "sdetkit.phase5_ecosystem_reliability.v1",
+    "sdetkit.adoption_readiness_partner_packaging.v1": "sdetkit.phase5_partner_packaging.v1",
+    "sdetkit.scale_readiness_commercial_scorecard.v1": "sdetkit.phase6_commercial_scorecard.v1",
+    "sdetkit.scale_readiness_kpi_snapshot.v1": "sdetkit.phase6_kpi_snapshot.v1",
+    "sdetkit.scale_readiness_metrics_contract.v1": "sdetkit.phase6_metrics_contract.v1",
+    "sdetkit.scale_readiness_metrics_contract.v2": "sdetkit.phase6_metrics_contract.v2",
+    "sdetkit.scale_readiness_metrics_drift_alerts.v1": "sdetkit.phase6_metrics_drift_alerts.v1",
+}
+
+
+def professional_schema_version(schema_version: str) -> str:
+    """Return the professional alias for a legacy schema version when known."""
+    return SCHEMA_VERSION_ALIASES.get(schema_version, schema_version)
+
+
+def legacy_schema_version(schema_version: str) -> str:
+    """Return the legacy canonical schema version for a professional alias when known."""
+    return PROFESSIONAL_SCHEMA_VERSION_ALIASES.get(schema_version, schema_version)
+
+
+def accepted_schema_versions(schema_version: str) -> tuple[str, ...]:
+    """Return all accepted schema-version spellings for a schema contract."""
+    professional = professional_schema_version(schema_version)
+    legacy = legacy_schema_version(schema_version)
+    versions = []
+    for value in (legacy, professional, schema_version):
+        if value not in versions:
+            versions.append(value)
+    return tuple(versions)
+
+
+def schema_versions_compatible(left: str, right: str) -> bool:
+    """Return whether two schema-version spellings refer to the same contract."""
+    return legacy_schema_version(left) == legacy_schema_version(right)

--- a/tests/test_ecosystem_readiness_contract.py
+++ b/tests/test_ecosystem_readiness_contract.py
@@ -13,6 +13,7 @@ from scripts import check_ecosystem_readiness_contract as contract
 from scripts import check_operational_readiness_governance_contract as phase4_contract
 from scripts import check_platform_readiness_quality_contract as phase3_contract
 from scripts import check_release_readiness_start_summary_contract as phase2_contract
+from sdetkit.schema_version_aliases import schema_versions_compatible
 
 EXPECTED_GATE_CHECK_IDS = [
     "schema_completeness",
@@ -154,7 +155,9 @@ def test_phase5_regression_contracts_for_phase1_to_phase4_unchanged() -> None:
     assert "operational-readiness-governance-contract" in makefile_text
     assert "phase5-ecosystem-contract" in makefile_text
 
-    assert phase1_contract.REQUIRED_TOP_LEVEL["schema_version"] == "sdetkit.phase1_baseline.v1"
+    assert schema_versions_compatible(
+        phase1_contract.REQUIRED_TOP_LEVEL["schema_version"], "sdetkit.phase1_baseline.v1"
+    )
     assert phase2_contract.EXPECTED_SCHEMA == "sdetkit.release_readiness_start_workflow.v1"
     assert callable(phase3_contract.main)
     assert phase4_contract.SCHEMA_VERSION == "sdetkit.phase4_governance_contract.v2"

--- a/tests/test_metrics_readiness_contract.py
+++ b/tests/test_metrics_readiness_contract.py
@@ -13,6 +13,7 @@ from scripts import check_metrics_readiness_contract as contract
 from scripts import check_operational_readiness_governance_contract as phase4_contract
 from scripts import check_platform_readiness_quality_contract as phase3_contract
 from scripts import check_release_readiness_start_summary_contract as phase2_contract
+from sdetkit.schema_version_aliases import schema_versions_compatible
 
 EXPECTED_PHASE6_GATE_CHECK_IDS = [
     "schema_completeness",
@@ -342,7 +343,9 @@ def test_phase6_legacy_cli_args_subprocess_smoke(tmp_path: Path) -> None:
 
 
 def test_phase6_regression_contracts_phase1_to_phase5_unchanged() -> None:
-    assert phase1_contract.REQUIRED_TOP_LEVEL["schema_version"] == "sdetkit.phase1_baseline.v1"
+    assert schema_versions_compatible(
+        phase1_contract.REQUIRED_TOP_LEVEL["schema_version"], "sdetkit.phase1_baseline.v1"
+    )
     assert phase2_contract.EXPECTED_SCHEMA == "sdetkit.release_readiness_start_workflow.v1"
     assert callable(phase3_contract.main)
     assert phase4_contract.SCHEMA_VERSION == "sdetkit.phase4_governance_contract.v2"

--- a/tests/test_platform_readiness_quality_contract.py
+++ b/tests/test_platform_readiness_quality_contract.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from scripts import check_platform_readiness_quality_contract as contract
+from sdetkit.schema_version_aliases import schema_versions_compatible
 
 
 def _write_summary(path: Path, checks: list[dict[str, object]]) -> Path:
@@ -60,7 +61,7 @@ def test_phase3_quality_contract_positive_path(tmp_path: Path) -> None:
     assert (out_dir / "phase3-trend-delta.json").exists()
     assert (out_dir / "phase3-next-pass-handoff.json").exists()
     payload = json.loads((out_dir / "phase3-next-pass-handoff.json").read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "sdetkit.phase3_next_pass.v1"
+    assert schema_versions_compatible(payload["schema_version"], "sdetkit.phase3_next_pass.v1")
 
 
 def test_phase3_quality_contract_missing_summary_fails(tmp_path: Path) -> None:

--- a/tests/test_quality_contract_local_fixture_dx.py
+++ b/tests/test_quality_contract_local_fixture_dx.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from sdetkit.schema_version_aliases import schema_versions_compatible
+
 ROOT = Path(__file__).resolve().parents[1]
 SEED_SCRIPT = ROOT / "scripts" / "seed_quality_baseline_summary_fixture.py"
 
@@ -23,7 +25,7 @@ def test_seed_phase1_baseline_summary_fixture_writes_contract_shape(tmp_path: Pa
     assert json.loads(result.stdout)["seeded"] is True
 
     payload = json.loads(summary.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "sdetkit.phase1_baseline.v1"
+    assert schema_versions_compatible(payload["schema_version"], "sdetkit.phase1_baseline.v1")
     assert payload["generated_at_utc"] == "2026-04-19T00:00:00Z"
     assert payload["out_dir"] == "build/phase1-baseline"
     assert payload["ok"] is False

--- a/tests/test_schema_version_aliases.py
+++ b/tests/test_schema_version_aliases.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.schema_version_aliases import (
+    SCHEMA_VERSION_ALIASES,
+    accepted_schema_versions,
+    legacy_schema_version,
+    professional_schema_version,
+    schema_versions_compatible,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+ALIASES = ROOT / "docs" / "naming" / "schema-version-aliases.json"
+
+
+def test_schema_version_alias_registry_matches_docs() -> None:
+    payload = json.loads(ALIASES.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "sdetkit.naming.schema-version-aliases.v1"
+    assert payload["alias_count"] == len(payload["aliases"])
+    assert payload["alias_count"] > 0
+
+    documented = {item["legacy"]: item["professional"] for item in payload["aliases"]}
+
+    assert documented == SCHEMA_VERSION_ALIASES
+
+
+def test_professional_schema_versions_are_compatibility_aliases() -> None:
+    for legacy, professional in SCHEMA_VERSION_ALIASES.items():
+        assert professional_schema_version(legacy) == professional
+        assert legacy_schema_version(professional) == legacy
+        assert schema_versions_compatible(legacy, professional)
+        assert schema_versions_compatible(professional, legacy)
+        assert legacy in accepted_schema_versions(legacy)
+        assert professional in accepted_schema_versions(legacy)
+
+
+def test_unknown_schema_version_is_stable() -> None:
+    unknown = "sdetkit.unrelated-contract.v1"
+
+    assert professional_schema_version(unknown) == unknown
+    assert legacy_schema_version(unknown) == unknown
+    assert accepted_schema_versions(unknown) == (unknown,)
+    assert schema_versions_compatible(unknown, unknown)


### PR DESCRIPTION
## Summary
- Add a professional schema-version alias registry for legacy phase schema contracts.
- Preserve legacy schema_version values as canonical compatibility spellings.
- Add helpers to resolve professional aliases back to legacy schemas.
- Add tests proving aliases are documented, reversible, and accepted.

## Verification
- python -m ruff check src tests scripts
- python -m mypy --config-file pyproject.toml src
- python -m pytest -q tests/test_schema_version_aliases.py tests/test_platform_readiness_quality_contract.py tests/test_quality_contract_local_fixture_dx.py tests/test_ecosystem_readiness_contract.py tests/test_metrics_readiness_contract.py tests/test_owned_surface_hygiene_contract.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Medium.
- Schema names are contracts, so this PR adds aliases instead of renaming legacy schema_version values.
- Existing artifacts remain compatible.