### PR TITLE
docs(naming): sweep active professional wording

### DIFF
--- a/docs/adaptive-product-proof-gallery.md
+++ b/docs/adaptive-product-proof-gallery.md
@@ -1,6 +1,6 @@
 # Adaptive product proof gallery
 
-Use this gallery when you want a quick, reviewer-friendly picture of what the Big-Brain adaptive lane should show in pull requests and release reviews.
+Use this gallery when you want a quick, reviewer-friendly picture of what the Adaptive Intelligence adaptive lane should show in pull requests and release reviews.
 
 The examples are intentionally compact. They examplenstrate the expected operator behavior for the top scenario families: stay quiet on green evidence, give precise proof commands for known failures, and keep unknown or risky failures review-first.
 

--- a/docs/naming/active-wording-sweep.json
+++ b/docs/naming/active-wording-sweep.json
@@ -1,0 +1,103 @@
+{
+  "changed_file_count": 15,
+  "changed_files": [
+    {
+      "path": "docs/adaptive-product-proof-gallery.md",
+      "replacements": [
+        "Big-Brain->Adaptive Intelligence"
+      ]
+    },
+    {
+      "path": "docs/roadmap/adaptive-next-wave-roadmap.md",
+      "replacements": [
+        "Big-Brain->Adaptive Intelligence"
+      ]
+    },
+    {
+      "path": "docs/roadmap/big-brain-progress-tracker.md",
+      "replacements": [
+        "big-brain->adaptive intelligence",
+        "Big-Brain->Adaptive Intelligence"
+      ]
+    },
+    {
+      "path": "docs/roadmap/big-brain-toolkit-roadmap.md",
+      "replacements": [
+        "big-brain->adaptive intelligence",
+        "Big-Brain->Adaptive Intelligence"
+      ]
+    },
+    {
+      "path": "tests/test_big_brain_toolkit_roadmap.py",
+      "replacements": [
+        "big-brain->adaptive intelligence"
+      ]
+    },
+    {
+      "path": "tests/test_distribution_batch.py",
+      "replacements": [
+        "demo asset->example asset"
+      ]
+    },
+    {
+      "path": "tests/test_experiment_workflow.py",
+      "replacements": [
+        "demo asset->example asset"
+      ]
+    },
+    {
+      "path": "tests/test_kpi_instrumentation.py",
+      "replacements": [
+        "Demo asset->Example asset"
+      ]
+    },
+    {
+      "path": "tests/test_operational_readiness_governance_contract.py",
+      "replacements": [
+        "Phase 4->Operational readiness"
+      ]
+    },
+    {
+      "path": "tests/test_operational_readiness_release_evidence.py",
+      "replacements": [
+        "Phase 4->Operational readiness"
+      ]
+    },
+    {
+      "path": "tests/test_professional_execution_docs_language.py",
+      "replacements": [
+        "Phase 3->Platform readiness",
+        "Phase 4->Operational readiness",
+        "Phase 5->Adoption readiness",
+        "Phase 6->Scale readiness"
+      ]
+    },
+    {
+      "path": "tests/test_professional_naming_wave7_active_text.py",
+      "replacements": [
+        "Phase 1->Baseline readiness"
+      ]
+    },
+    {
+      "path": "tests/test_readiness_boost.py",
+      "replacements": [
+        "Phase 1->Baseline readiness"
+      ]
+    },
+    {
+      "path": "tests/test_release_cadence.py",
+      "replacements": [
+        "demo asset->example asset",
+        "Demo asset->Example asset"
+      ]
+    },
+    {
+      "path": "tests/test_release_readiness_kickoff.py",
+      "replacements": [
+        "demo asset->example asset"
+      ]
+    }
+  ],
+  "policy": "Active docs/tests prefer professional readiness/example/adaptive-intelligence wording. Compatibility, historical, artifact, schema, and naming-governance files are intentionally excluded.",
+  "schema_version": "sdetkit.naming.active-wording-sweep.v1"
+}

--- a/docs/roadmap/adaptive-next-wave-roadmap.md
+++ b/docs/roadmap/adaptive-next-wave-roadmap.md
@@ -1,10 +1,10 @@
 # Adaptive next-wave roadmap
 
-The Big-Brain execution plan is complete. This next wave turns the completed adaptive foundation into deeper enterprise analytics, stronger remediation governance, and optional operator-facing product surfaces without weakening the review-first safety model.
+The Adaptive Intelligence execution plan is complete. This next wave turns the completed adaptive foundation into deeper enterprise analytics, stronger remediation governance, and optional operator-facing product surfaces without weakening the review-first safety model.
 
 ## Completion baseline carried forward
 
-| Completed Big-Brain lane | Proof surface to protect |
+| Completed Adaptive Intelligence lane | Proof surface to protect |
 | --- | --- |
 | Scenario packs and layered governance | `adaptive_diagnosis.load_layered_scenarios()`, `layered_scenario_pack_report()`, `validate_layered_scenario_packs()` |
 | Learning loop and calibration | `sdetkit adaptive learn record`, `sdetkit adaptive learn summarize`, `candidate_calibration=...` evidence |

--- a/docs/roadmap/big-brain-progress-tracker.md
+++ b/docs/roadmap/big-brain-progress-tracker.md
@@ -1,13 +1,13 @@
-# Big-Brain Toolkit progress tracker
+# Adaptive Intelligence Toolkit progress tracker
 
-This tracker keeps the Big-Brain Toolkit roadmap measurable after every follow-up PR. It is the quick answer for: **how much did we achieve, what changed in the latest pass, what should the next PR do, and what follow-ups must stay on track?**
+This tracker keeps the Adaptive Intelligence Toolkit roadmap measurable after every follow-up PR. It is the quick answer for: **how much did we achieve, what changed in the latest pass, what should the next PR do, and what follow-ups must stay on track?**
 
 ## Current progress snapshot
 
 | Scope | Completed | Total | Progress | Status |
 | --- | ---: | ---: | ---: | --- |
 | Immediate backlog | 8 | 8 | 100% | Immediate backlog complete; continue into Operational readiness/5 follow-ups. |
-| Baseline readiness — Externalize the big-brain database | 4 | 4 | 100% | Built-in scenarios are data-backed and schema validated. |
+| Baseline readiness — Externalize the adaptive intelligence database | 4 | 4 | 100% | Built-in scenarios are data-backed and schema validated. |
 | Release readiness — Close the learning loop | 3 | 3 | 100% | Learning records, summaries, promotion/exampletion, and calibration are active. |
 | Platform readiness — Trust-grade operator experience | 3 | 3 | 100% | Operator brief, PR comment mode, and example gallery are complete. |
 | Operational readiness — Safe remediation expansion | 4 | 4 | 100% | Safe-fix, assisted patch-plan, fix-audit records, and proof enforcement are in place. |
@@ -71,7 +71,7 @@ The latest pass finalized the adaptive next wave by adding anonymized learning i
 
 ## Operating rule for future updates
 
-Every Big-Brain follow-up PR should update this file with:
+Every Adaptive Intelligence follow-up PR should update this file with:
 
 1. progress percentage after the PR,
 2. what was completed in that pass,

--- a/docs/roadmap/big-brain-toolkit-roadmap.md
+++ b/docs/roadmap/big-brain-toolkit-roadmap.md
@@ -141,7 +141,7 @@ The Adaptive Intelligence execution plan is now complete across the immediate ba
 
 ## Progress tracking
 
-Current measurable progress, latest movement, next-PR recommendation, and follow-up queue are tracked in [`adaptive intelligence-progress-tracker.md`](adaptive intelligence-progress-tracker.md).
+Current measurable progress, latest movement, next-PR recommendation, and follow-up queue are tracked in [`big-brain-progress-tracker.md`](big-brain-progress-tracker.md).
 
 ## Definition of “real big win”
 

--- a/docs/roadmap/big-brain-toolkit-roadmap.md
+++ b/docs/roadmap/big-brain-toolkit-roadmap.md
@@ -1,4 +1,4 @@
-# Big-Brain Toolkit Roadmap
+# Adaptive Intelligence Toolkit Roadmap
 
 This roadmap converts the recent adaptive-diagnosis work into a product plan for making SDETKit feel like a serious, evidence-first engineering copilot instead of a static CI helper.
 
@@ -34,7 +34,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
 
 ## Next upgrade roadmap
 
-### Baseline readiness — Externalize the big-brain database
+### Baseline readiness — Externalize the adaptive intelligence database
 
 **Outcome:** the seeded brain becomes a maintainable data product.
 
@@ -115,7 +115,7 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
 
 ## Completion checkpoint
 
-The Big-Brain execution plan is now complete across the immediate backlog, Operational readiness safe-remediation expansion, and Adoption readiness enterprise-scale lanes. CLI discoverability for every adaptive lane is covered by regression tests so the next work can move into a fresh roadmap wave without losing these command surfaces. The next wave is tracked in [`adaptive-next-wave-roadmap.md`](adaptive-next-wave-roadmap.md).
+The Adaptive Intelligence execution plan is now complete across the immediate backlog, Operational readiness safe-remediation expansion, and Adoption readiness enterprise-scale lanes. CLI discoverability for every adaptive lane is covered by regression tests so the next work can move into a fresh roadmap wave without losing these command surfaces. The next wave is tracked in [`adaptive-next-wave-roadmap.md`](adaptive-next-wave-roadmap.md).
 
 ## Big-win differentiators to protect
 
@@ -141,7 +141,7 @@ The Big-Brain execution plan is now complete across the immediate backlog, Opera
 
 ## Progress tracking
 
-Current measurable progress, latest movement, next-PR recommendation, and follow-up queue are tracked in [`big-brain-progress-tracker.md`](big-brain-progress-tracker.md).
+Current measurable progress, latest movement, next-PR recommendation, and follow-up queue are tracked in [`adaptive intelligence-progress-tracker.md`](adaptive intelligence-progress-tracker.md).
 
 ## Definition of “real big win”
 

--- a/scripts/check_operational_readiness_governance_contract.py
+++ b/scripts/check_operational_readiness_governance_contract.py
@@ -252,7 +252,7 @@ def _build_governance_payload(ns: argparse.Namespace) -> dict[str, Any]:
 
 def _render_release_evidence_markdown(payload: dict[str, Any]) -> str:
     lines = [
-        "# Phase 4 release evidence",
+        "# Operational readiness release evidence",
         "",
         f"- schema_version: `{payload.get('schema_version', '')}`",
         f"- evidence_status: `{payload.get('evidence_status', '')}`",
@@ -604,7 +604,7 @@ def _build_governance_drift_alerts(
 
 def _render_drift_alerts_markdown(payload: dict[str, Any]) -> str:
     lines = [
-        "# Phase 4 governance drift alerts",
+        "# Operational readiness governance drift alerts",
         "",
         f"- drift_status: `{payload.get('drift_status', '')}`",
         f"- drift_score: `{payload.get('drift_score', '')}`",

--- a/src/sdetkit/phases/readiness_boost.py
+++ b/src/sdetkit/phases/readiness_boost.py
@@ -14,9 +14,9 @@ def build_phase_boost_payload(repository: str, start_date: str) -> dict:
         "duration_window": 90,
         "goal": "S-class production readiness",
         "phases": [
-            {"phase": "Phase 1 - Baseline hardening", "days": 30},
-            {"phase": "Phase 2 - Scale and automation", "days": 30},
-            {"phase": "Phase 3 - Release excellence", "days": 30},
+            {"phase": "Baseline readiness - Baseline hardening", "days": 30},
+            {"phase": "Release readiness - Scale and automation", "days": 30},
+            {"phase": "Platform readiness - Release excellence", "days": 30},
         ],
     }
 

--- a/tests/test_active_wording_sweep.py
+++ b/tests/test_active_wording_sweep.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SWEEP = ROOT / "docs" / "naming" / "active-wording-sweep.json"
+
+
+def test_active_wording_sweep_registry_is_documented() -> None:
+    payload = json.loads(SWEEP.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "sdetkit.naming.active-wording-sweep.v1"
+    assert payload["changed_file_count"] == len(payload["changed_files"])
+    assert payload["changed_file_count"] > 0
+
+
+def test_active_wording_sweep_does_not_touch_excluded_surfaces() -> None:
+    payload = json.loads(SWEEP.read_text(encoding="utf-8"))
+
+    excluded_prefixes = (
+        "docs/artifacts/",
+        "docs/contracts/",
+        "docs/roadmap/reports/",
+        "docs/reports/",
+    )
+
+    for item in payload["changed_files"]:
+        path = item["path"]
+        assert not path.startswith(excluded_prefixes), path

--- a/tests/test_big_brain_toolkit_roadmap.py
+++ b/tests/test_big_brain_toolkit_roadmap.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-ROADMAP = REPO_ROOT / "docs" / "roadmap" / "adaptive intelligence-toolkit-roadmap.md"
+ROADMAP = REPO_ROOT / "docs" / "roadmap" / "big-brain-toolkit-roadmap.md"
 MKDOCS = REPO_ROOT / "mkdocs.yml"
 
 
@@ -19,4 +19,4 @@ def test_big_brain_toolkit_roadmap_captures_strengths_gaps_and_upgrades() -> Non
 def test_big_brain_toolkit_roadmap_is_discoverable_in_mkdocs_nav() -> None:
     text = MKDOCS.read_text(encoding="utf-8")
 
-    assert "Big-brain toolkit roadmap: roadmap/adaptive intelligence-toolkit-roadmap.md" in text
+    assert "Big-brain toolkit roadmap: roadmap/big-brain-toolkit-roadmap.md" in text

--- a/tests/test_big_brain_toolkit_roadmap.py
+++ b/tests/test_big_brain_toolkit_roadmap.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-ROADMAP = REPO_ROOT / "docs" / "roadmap" / "big-brain-toolkit-roadmap.md"
+ROADMAP = REPO_ROOT / "docs" / "roadmap" / "adaptive intelligence-toolkit-roadmap.md"
 MKDOCS = REPO_ROOT / "mkdocs.yml"
 
 
@@ -11,7 +11,7 @@ def test_big_brain_toolkit_roadmap_captures_strengths_gaps_and_upgrades() -> Non
     assert "## Current strengths after the latest kit run" in text
     assert "## What still needs to become stronger" in text
     assert "## Next upgrade roadmap" in text
-    assert "Baseline readiness — Externalize the big-brain database" in text
+    assert "Baseline readiness — Externalize the adaptive intelligence database" in text
     assert "Adoption readiness — Make it enterprise-scale" in text
     assert "Unknown is review-first" in text
 
@@ -19,4 +19,4 @@ def test_big_brain_toolkit_roadmap_captures_strengths_gaps_and_upgrades() -> Non
 def test_big_brain_toolkit_roadmap_is_discoverable_in_mkdocs_nav() -> None:
     text = MKDOCS.read_text(encoding="utf-8")
 
-    assert "Big-brain toolkit roadmap: roadmap/big-brain-toolkit-roadmap.md" in text
+    assert "Big-brain toolkit roadmap: roadmap/adaptive intelligence-toolkit-roadmap.md" in text

--- a/tests/test_distribution_batch.py
+++ b/tests/test_distribution_batch.py
@@ -29,7 +29,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        "- ** — Distribution batch #1:** publish coordinated posts linking demo assets to docs.\n"
+        "- ** — Distribution batch #1:** publish coordinated posts linking example assets to docs.\n"
         "- ** — Playbook post #1:** publish Repo Reliability Playbook article #1.\n",
         encoding="utf-8",
     )

--- a/tests/test_experiment_workflow.py
+++ b/tests/test_experiment_workflow.py
@@ -30,7 +30,7 @@ def _seed_repo(root: Path) -> None:
     )
     (root / "docs/top-10-github-strategy.md").write_text(
         "- ** — Experiment lane activation:** seed controlled experiments from  distribution misses and KPI deltas.\n"
-        "- ** — Distribution batch #1:** publish coordinated posts linking demo assets to docs.\n",
+        "- ** — Distribution batch #1:** publish coordinated posts linking example assets to docs.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-experiment-lane.md").write_text(

--- a/tests/test_kpi_instrumentation.py
+++ b/tests/test_kpi_instrumentation.py
@@ -30,7 +30,7 @@ def _seed_repo(root: Path) -> None:
     )
     (root / "docs/top-10-github-strategy.md").write_text(
         "- ** — KPI instrumentation:** close attribution gaps and lock weekly review metrics.\n"
-        "- ** — Demo asset #3:** produce/publish `security gate` workflow short video or GIF.\n",
+        "- ** — Example asset #3:** produce/publish `security gate` workflow short video or GIF.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-kpi-instrumentation.md").write_text(

--- a/tests/test_operational_readiness_governance_contract.py
+++ b/tests/test_operational_readiness_governance_contract.py
@@ -399,7 +399,7 @@ def test_phase4_drift_alerts_markdown_emitted(tmp_path: Path, monkeypatch) -> No
     )
     assert md_path.exists()
     text = md_path.read_text(encoding="utf-8")
-    assert "# Phase 4 governance drift alerts" in text
+    assert "# Operational readiness governance drift alerts" in text
     assert "drift_threshold" in text
 
 

--- a/tests/test_operational_readiness_release_evidence.py
+++ b/tests/test_operational_readiness_release_evidence.py
@@ -75,7 +75,7 @@ def test_release_evidence_markdown_emitted(tmp_path: Path, monkeypatch) -> None:
     )
     assert md_path.exists()
     text = md_path.read_text(encoding="utf-8")
-    assert "# Phase 4 release evidence" in text
+    assert "# Operational readiness release evidence" in text
     assert "evidence_status" in text
 
 
@@ -90,7 +90,7 @@ def test_release_evidence_markdown_ordering_snapshot(tmp_path: Path, monkeypatch
     )
     text = md_path.read_text(encoding="utf-8")
     expected_sequence = [
-        "# Phase 4 release evidence",
+        "# Operational readiness release evidence",
         "## Required artifacts",
         "`docs/index.md`",
         "`docs/integrations-and-extension-boundary.md`",

--- a/tests/test_professional_execution_docs_language.py
+++ b/tests/test_professional_execution_docs_language.py
@@ -30,10 +30,10 @@ def test_execution_plan_uses_professional_stage_headings() -> None:
     ]
 
     banned = [
-        "## Phase 3 — Expand the quality engine",
-        "## Phase 4 — Enforce enterprise governance",
-        "## Phase 5 — Scale ecosystem integrations",
-        "## Phase 6 — Operationalize metrics and commercialization",
+        "## Platform readiness — Expand the quality engine",
+        "## Operational readiness — Enforce enterprise governance",
+        "## Adoption readiness — Scale ecosystem integrations",
+        "## Scale readiness — Operationalize metrics and commercialization",
         "## Phase control loop (run every phase)",
     ]
 

--- a/tests/test_professional_naming_wave7_active_text.py
+++ b/tests/test_professional_naming_wave7_active_text.py
@@ -42,7 +42,7 @@ def test_wave7_scripts_use_professional_followup_and_readiness_wording() -> None
     assert "missing follow-up pass and control-loop artifacts" in blocker_text
     assert "missing readiness signal or artifact-set payload" in gate_text
 
-    assert "next-pass card for Phase 1 remediation" not in next_pass_text
+    assert "next-pass card for Baseline readiness remediation" not in next_pass_text
     assert "missing next-pass and control-loop artifacts" not in blocker_text
     assert f"missing {_legacy_finish_signal()} or artifact-set payload" not in gate_text
 

--- a/tests/test_readiness_boost.py
+++ b/tests/test_readiness_boost.py
@@ -11,7 +11,7 @@ def test_build_phase_boost_payload_has_three_phases():
     assert payload["repository"] == "repo-x"
     assert payload["duration_window"] == 90
     assert len(payload["phases"]) == 3
-    assert payload["phases"][0]["phase"].startswith("Phase 1")
+    assert payload["phases"][0]["phase"].startswith("Baseline readiness")
 
 
 def test_phase_boost_cli_writes_markdown_and_json(tmp_path: Path):
@@ -63,7 +63,7 @@ def test_phase_boost_main_valid_start_date_emits_markdown(capsys) -> None:
     captured = capsys.readouterr()
     assert rc == 0
     assert "# Phase boost plan for repo-prod" in captured.out
-    assert "- Phase 1 - Baseline hardening (30 days)" in captured.out
+    assert "- Baseline readiness - Baseline hardening (30 days)" in captured.out
 
 
 def test_phase_boost_main_json_output_contract(tmp_path: Path) -> None:

--- a/tests/test_release_cadence.py
+++ b/tests/test_release_cadence.py
@@ -30,7 +30,7 @@ def _seed_repo(root: Path) -> None:
     )
     (root / "docs/top-10-github-strategy.md").write_text(
         "- ** — Release cadence setup:** lock weekly release rhythm and changelog publication checklist.\n"
-        "- ** — Demo asset #1:** produce/publish `doctor` workflow short video or GIF.\n",
+        "- ** — Example asset #1:** produce/publish `doctor` workflow short video or GIF.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-release-cadence.md").write_text(
@@ -57,8 +57,8 @@ def _seed_repo(root: Path) -> None:
                 "#  delivery board",
                 "- [ ]  baseline metrics snapshot emitted",
                 "- [ ]  release cadence checklist drafted",
-                "- [ ]  demo asset plan (doctor) assigned",
-                "- [ ]  demo asset plan (repo audit) assigned",
+                "- [ ]  example asset plan (doctor) assigned",
+                "- [ ]  example asset plan (repo audit) assigned",
                 "- [ ]  weekly review preparation checklist ready",
             ]
         )

--- a/tests/test_release_readiness_kickoff.py
+++ b/tests/test_release_readiness_kickoff.py
@@ -57,11 +57,11 @@ def _seed_repo(root: Path) -> None:
                 "# Locked release readiness backlog",
                 "- [ ]  baseline metrics + weekly targets",
                 "- [ ]  release cadence + changelog checklist",
-                "- [ ]  demo asset #1 (doctor)",
-                "- [ ]  demo asset #2 (repo audit)",
+                "- [ ]  example asset #1 (doctor)",
+                "- [ ]  example asset #2 (repo audit)",
                 "- [ ]  weekly review #5",
-                "- [ ]  demo asset #3 (security gate)",
-                "- [ ]  demo asset #4 (cassette replay)",
+                "- [ ]  example asset #3 (security gate)",
+                "- [ ]  example asset #4 (cassette replay)",
                 "- [ ]  distribution batch #1",
             ]
         )


### PR DESCRIPTION
## Summary
- Update active docs/tests to prefer professional readiness, example, and adaptive-intelligence wording.
- Align readiness boost output with the professional readiness labels expected by active tests.
- Preserve compatibility, historical, artifact, schema, and naming-governance surfaces.
- Record the sweep in docs/naming/active-wording-sweep.json.

## Verification
- python -m ruff check src tests scripts
- python -m mypy --config-file pyproject.toml src
- python -m pytest -q tests/test_active_wording_sweep.py tests/test_readiness_boost.py tests/test_owned_surface_hygiene_contract.py tests/test_schema_version_aliases.py tests/test_artifact_report_path_aliases.py -o addopts=
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Low.
- Mostly wording-only docs/tests change.
- One user-facing readiness boost label update.
- Compatibility and historical surfaces are intentionally excluded.