### PR TITLE
feat(failure): strengthen failure vector extraction

### DIFF
--- a/src/sdetkit/failure_vector.py
+++ b/src/sdetkit/failure_vector.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import json
 import re
+from collections import Counter
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
 SCHEMA_VERSION = "sdetkit.failure_vector.v1"
+BUNDLE_SCHEMA_VERSION = "sdetkit.failure_vector.bundle.v1"
 
 PYTEST_NODE_RE = re.compile(r"FAILED\s+(?P<node>[^\s]+::[^\s]+)")
 PY_FILE_RE = re.compile(r"(?P<path>(?:src|tests)/[A-Za-z0-9_./-]+\.py)")
+MYPY_ERROR_RE = re.compile(r"(?P<path>(?:src|tests)/[A-Za-z0-9_./-]+\.py):\d+:\s+error:")
 RUFF_RULE_RE = re.compile(r"\b(?P<rule>[A-Z]\d{3})\b")
 EXIT_CODE_RE = re.compile(r"Process completed with exit code (?P<code>\d+)")
 
@@ -44,13 +48,14 @@ def extract_failure_vector(
     environment: str = "unknown",
 ) -> FailureVector:
     lines = [line.rstrip() for line in log_text.splitlines()]
-    first_line = _first_failing_line(lines)
+    failure_index = _first_failing_line_index(lines)
+    first_line = _line_at(lines, failure_index)
     failure_class = _classify_failure(log_text, first_line)
     affected_files = _affected_files(log_text, first_line)
 
     return FailureVector(
         check=check,
-        command="unknown",
+        command=_extract_command(lines, failure_index),
         exit_code=_extract_exit_code(log_text),
         failure_class=failure_class,
         risk=_risk_for_class(failure_class),
@@ -65,24 +70,78 @@ def extract_failure_vector(
     )
 
 
+def build_failure_vector_bundle(
+    log_paths: Sequence[str | Path],
+    *,
+    environment: str = "unknown",
+) -> dict[str, object]:
+    vectors = []
+    for raw_path in log_paths:
+        path = Path(raw_path)
+        vector = extract_failure_vector(
+            path.read_text(encoding="utf-8", errors="ignore"),
+            check=path.parent.name if path.parent.name else path.stem,
+            log_url=path.as_posix(),
+            environment=environment,
+        )
+        vectors.append(vector.to_dict())
+
+    by_class = Counter(str(vector["failure_class"]) for vector in vectors)
+    by_risk = Counter(str(vector["risk"]) for vector in vectors)
+
+    return {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "vector_schema_version": SCHEMA_VERSION,
+        "environment": environment,
+        "failure_vector_count": len(vectors),
+        "summary": {
+            "by_failure_class": dict(sorted(by_class.items())),
+            "by_risk": dict(sorted(by_risk.items())),
+            "safe_fix_candidate_count": sum(
+                1 for vector in vectors if bool(vector["safe_fix_candidate"])
+            ),
+            "review_first_count": sum(
+                1 for vector in vectors if not bool(vector["safe_fix_candidate"])
+            ),
+        },
+        "failure_vectors": vectors,
+    }
+
+
 def write_failure_vector(vector: FailureVector, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(vector.to_dict(), indent=2, sort_keys=True)
     path.write_text(payload + "\n", encoding="utf-8")
 
 
+def write_failure_vector_bundle(
+    log_paths: Sequence[str | Path],
+    path: Path,
+    *,
+    environment: str = "unknown",
+) -> dict[str, object]:
+    payload = build_failure_vector_bundle(log_paths, environment=environment)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
 def render_failure_vector_report(vector: FailureVector) -> str:
     safe = "yes" if vector.safe_fix_candidate else "no"
     local_repro = vector.local_repro_command or "none"
     first_line = vector.first_failing_line or "unknown"
+    affected = ", ".join(vector.affected_files) if vector.affected_files else "none"
     return "\n".join(
         [
             "# Failure Vector",
             "",
             f"- check: `{vector.check}`",
+            f"- command: `{vector.command}`",
             f"- class: `{vector.failure_class}`",
             f"- risk: `{vector.risk}`",
+            f"- scope: `{vector.scope}`",
             f"- safe_fix_candidate: `{safe}`",
+            f"- affected_files: `{affected}`",
             f"- first_failing_line: `{first_line}`",
             f"- local_repro_command: `{local_repro}`",
             "",
@@ -90,30 +149,98 @@ def render_failure_vector_report(vector: FailureVector) -> str:
     )
 
 
+def render_failure_vector_bundle_report(payload: dict[str, object]) -> str:
+    summary = payload.get("summary", {})
+    summary = summary if isinstance(summary, dict) else {}
+    by_class = summary.get("by_failure_class", {})
+    by_class = by_class if isinstance(by_class, dict) else {}
+
+    lines = [
+        "# Failure Vector Bundle",
+        "",
+        f"- schema_version: `{payload.get('schema_version', 'unknown')}`",
+        f"- failure_vector_count: `{payload.get('failure_vector_count', 0)}`",
+        f"- safe_fix_candidate_count: `{summary.get('safe_fix_candidate_count', 0)}`",
+        f"- review_first_count: `{summary.get('review_first_count', 0)}`",
+        "",
+        "## By failure class",
+        "",
+    ]
+
+    if by_class:
+        lines.extend(f"- `{name}`: `{count}`" for name, count in sorted(by_class.items()))
+    else:
+        lines.append("- none")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _line_at(lines: Sequence[str], index: int) -> str:
+    if index < 0 or index >= len(lines):
+        return ""
+    return lines[index].strip()
+
+
 def _first_failing_line(lines: list[str]) -> str:
-    needles = (
-        "FAILED ",
-        "ERROR ",
-        "AssertionError",
-        "Traceback",
-        "ruff format",
-        "ruff check",
-        "mypy",
-        "Merge conflict",
-        "CONFLICT ",
-        "npm ERR!",
-        "Process completed with exit code",
-    )
-    for line in lines:
+    return _line_at(lines, _first_failing_line_index(lines))
+
+
+def _first_failing_line_index(lines: Sequence[str]) -> int:
+    generic_index = -1
+
+    for index, line in enumerate(lines):
         stripped = line.strip()
-        if stripped and any(needle in stripped for needle in needles):
+        lowered = stripped.lower()
+
+        if not stripped:
+            continue
+
+        if stripped.startswith("FAILED "):
+            return index
+        if MYPY_ERROR_RE.search(stripped):
+            return index
+        if "would be reformatted" in lowered:
+            return index
+        if "ruff format" in lowered and "failed" in lowered:
+            return index
+        if RUFF_RULE_RE.search(stripped) and "-->" in "\n".join(lines[index : index + 4]):
+            return index
+        if stripped.startswith(("ERROR ", "ERROR:")):
+            return index
+        if stripped.startswith("Traceback"):
+            return index
+        if "merge conflict" in lowered or stripped.startswith("CONFLICT "):
+            return index
+        if "npm err!" in lowered:
+            return index
+        if "process completed with exit code" in lowered:
+            generic_index = index
+
+    return generic_index
+
+
+def _extract_command(lines: Sequence[str], failure_index: int) -> str:
+    upper_bound = failure_index if failure_index >= 0 else len(lines)
+
+    for line in reversed(lines[:upper_bound]):
+        stripped = line.strip()
+
+        if stripped.startswith("Run "):
+            return stripped.removeprefix("Run ").strip()
+        if "##[group]Run " in stripped:
+            return stripped.split("Run ", 1)[1].strip()
+        if stripped.startswith("$ "):
+            return stripped[2:].strip()
+        if "python -m " in stripped or "pytest" in stripped or "mypy" in stripped:
             return stripped
-    return ""
+
+    return "unknown"
 
 
 def _classify_failure(log_text: str, first_line: str) -> str:
     lowered = f"{first_line}\n{log_text}".lower()
-    if "ruff format" in lowered or "would reformat" in lowered:
+    if "ruff format" in lowered or "would reformat" in lowered or "would be reformatted" in lowered:
         return "formatter_only"
     if "ruff check" in lowered or RUFF_RULE_RE.search(first_line):
         return "lint"

--- a/tests/test_failure_vector_extraction.py
+++ b/tests/test_failure_vector_extraction.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
-from sdetkit.failure_vector import extract_failure_vector, write_failure_vector
+from sdetkit.failure_vector import (
+    build_failure_vector_bundle,
+    extract_failure_vector,
+    render_failure_vector_bundle_report,
+    render_failure_vector_report,
+    write_failure_vector,
+    write_failure_vector_bundle,
+)
 
 
 def test_failure_vector_extracts_first_pytest_failure() -> None:
@@ -70,4 +77,93 @@ def test_failure_vector_can_write_deterministic_json(tmp_path: Path) -> None:
 
     text = out.read_text(encoding="utf-8")
     assert '"schema_version": "sdetkit.failure_vector.v1"' in text
+    assert '"failure_class": "test"' in text
+
+
+def test_failure_vector_prefers_mypy_error_over_run_command() -> None:
+    log_text = """
+    Run python -m mypy src
+    src/sdetkit/example.py:10: error: Incompatible return value type
+    Process completed with exit code 1
+    """
+
+    vector = extract_failure_vector(log_text, check="mypy", environment="github_actions")
+
+    assert vector.command == "python -m mypy src"
+    assert vector.failure_class == "type"
+    assert vector.first_failing_line == (
+        "src/sdetkit/example.py:10: error: Incompatible return value type"
+    )
+    assert vector.affected_files == ("src/sdetkit/example.py",)
+    assert vector.local_repro_command == "python -m mypy src"
+
+
+def test_failure_vector_report_includes_command_scope_and_affected_files() -> None:
+    vector = extract_failure_vector(
+        "Run python -m mypy src\n"
+        "src/sdetkit/example.py:10: error: Incompatible return value type\n",
+        check="mypy",
+    )
+
+    report = render_failure_vector_report(vector)
+
+    assert "- command: `python -m mypy src`" in report
+    assert "- scope: `pr_owned_only`" in report
+    assert "- affected_files: `src/sdetkit/example.py`" in report
+
+
+def test_failure_vector_bundle_summarizes_multiple_logs(tmp_path: Path) -> None:
+    test_log = tmp_path / "pytest" / "ci.log"
+    lint_log = tmp_path / "lint" / "ci.log"
+    test_log.parent.mkdir()
+    lint_log.parent.mkdir()
+
+    test_log.write_text(
+        "Run python -m pytest -q\n"
+        "FAILED tests/test_widget.py::test_widget_contract - AssertionError\n"
+        "Process completed with exit code 1\n",
+        encoding="utf-8",
+    )
+    lint_log.write_text(
+        "Run python -m ruff format --check .\n"
+        "ruff format..............................................................Failed\n"
+        "tests/test_widget.py\n"
+        "1 file would be reformatted\n",
+        encoding="utf-8",
+    )
+
+    payload = build_failure_vector_bundle(
+        [test_log, lint_log],
+        environment="github_actions",
+    )
+
+    assert payload["schema_version"] == "sdetkit.failure_vector.bundle.v1"
+    assert payload["failure_vector_count"] == 2
+    assert payload["summary"]["by_failure_class"] == {
+        "formatter_only": 1,
+        "test": 1,
+    }
+    assert payload["summary"]["safe_fix_candidate_count"] == 1
+    assert payload["summary"]["review_first_count"] == 1
+
+    report = render_failure_vector_bundle_report(payload)
+    assert "# Failure Vector Bundle" in report
+    assert "- `formatter_only`: `1`" in report
+    assert "- `test`: `1`" in report
+
+
+def test_failure_vector_bundle_can_write_deterministic_json(tmp_path: Path) -> None:
+    log = tmp_path / "pytest" / "ci.log"
+    out = tmp_path / "build" / "sdetkit" / "failure-vectors.json"
+    log.parent.mkdir()
+    log.write_text(
+        "FAILED tests/test_widget.py::test_widget_contract - AssertionError\n",
+        encoding="utf-8",
+    )
+
+    payload = write_failure_vector_bundle([log], out, environment="local")
+
+    assert payload["failure_vector_count"] == 1
+    text = out.read_text(encoding="utf-8")
+    assert '"schema_version": "sdetkit.failure_vector.bundle.v1"' in text
     assert '"failure_class": "test"' in text


### PR DESCRIPTION
## Summary
- Prefer actual failure lines over wrapper command lines when extracting failure vectors.
- Capture the originating command for pytest, mypy, ruff, and wrapper logs.
- Add deterministic multi-log failure vector bundle JSON/report support.
- Extend tests for mypy first-failure selection, command capture, report fields, and bundle summaries.

## Verification
- python -m ruff check src/sdetkit/failure_vector.py tests/test_failure_vector_extraction.py --fix
- python -m pytest -q tests/test_failure_vector_extraction.py tests/test_ci_failure_extractor.py tests/test_pr_quality_failure_vector_report.py tests/test_diagnostic_vector_engine.py -o addopts=
- python -m ruff check src tests scripts
- python -m mypy --config-file pyproject.toml src
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Low.
- Extends existing failure vector extraction and tests.
- Does not change CI gates, CLI dispatch, or release contracts.