### PR TITLE
feat(failure): emit failure vector CLI artifacts

### DIFF
--- a/src/sdetkit/ci_failure_extractor.py
+++ b/src/sdetkit/ci_failure_extractor.py
@@ -8,8 +8,15 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+from sdetkit.failure_vector import (
+    render_failure_vector_bundle_report,
+    write_failure_vector_bundle,
+)
+
 SCHEMA_VERSION = "sdetkit.ci_failure_extractor.v1"
 DEFAULT_OUT = "build/sdetkit/failed-check-logs.json"
+DEFAULT_FAILURE_VECTORS_OUT = "build/sdetkit/failure-vectors.json"
+DEFAULT_FAILURE_VECTORS_MD = "build/sdetkit/failure-vectors.md"
 
 PATH_RE = re.compile(
     r"(?P<path>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.(?:py|md|yml|yaml|toml|ini|cfg|txt|sh))"
@@ -222,10 +229,45 @@ def write_failed_check_logs(log_paths: Sequence[str | Path], out: str | Path) ->
     return payload
 
 
+def write_failure_vector_artifacts(
+    log_paths: Sequence[str | Path],
+    *,
+    json_out: str | Path = DEFAULT_FAILURE_VECTORS_OUT,
+    markdown_out: str | Path | None = None,
+    environment: str = "unknown",
+) -> dict[str, Any]:
+    payload = write_failure_vector_bundle(
+        log_paths,
+        Path(json_out),
+        environment=environment,
+    )
+
+    if markdown_out:
+        md_path = Path(markdown_out)
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text(render_failure_vector_bundle_report(payload) + "\n", encoding="utf-8")
+
+    return payload
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.ci_failure_extractor")
     parser.add_argument("--log", action="append", required=True, help="Raw CI log file to extract")
     parser.add_argument("--out", default=DEFAULT_OUT)
+    parser.add_argument(
+        "--failure-vectors-out",
+        default="",
+        help=(
+            "Optional JSON output path for deterministic failure-vector bundle "
+            f"(defaults to {DEFAULT_FAILURE_VECTORS_OUT} when markdown output is requested)"
+        ),
+    )
+    parser.add_argument(
+        "--failure-vectors-md",
+        default="",
+        help="Optional Markdown output path for deterministic failure-vector bundle summary",
+    )
+    parser.add_argument("--environment", default="unknown")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     return parser
 
@@ -234,18 +276,37 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(list(argv) if argv is not None else None)
     try:
         payload = write_failed_check_logs(args.log, args.out)
+        vector_payload = None
+        vectors_out = args.failure_vectors_out
+        if args.failure_vectors_md and not vectors_out:
+            vectors_out = DEFAULT_FAILURE_VECTORS_OUT
+        if vectors_out:
+            vector_payload = write_failure_vector_artifacts(
+                args.log,
+                json_out=vectors_out,
+                markdown_out=args.failure_vectors_md or None,
+                environment=args.environment,
+            )
     except OSError as exc:
         print(f"error={exc}", file=sys.stderr)
         return 2
 
     if args.format == "json":
-        print(json.dumps(payload, indent=2, sort_keys=True))
+        output: dict[str, Any] = {"failed_check_logs": payload}
+        if vector_payload is not None:
+            output["failure_vector_bundle"] = vector_payload
+        print(json.dumps(output, indent=2, sort_keys=True))
     else:
         print(f"failed_check_logs_json={args.out}")
         print(f"failed_check_count={payload['failed_check_count']}")
         print(f"safe_to_auto_fix_count={payload['summary']['safe_to_auto_fix_count']}")
         print(f"review_first_count={payload['summary']['review_first_count']}")
         print(f"unknown_count={payload['summary']['unknown_count']}")
+        if vector_payload is not None:
+            print(f"failure_vectors_json={vectors_out}")
+            if args.failure_vectors_md:
+                print(f"failure_vectors_md={args.failure_vectors_md}")
+            print(f"failure_vector_count={vector_payload['failure_vector_count']}")
     return 0
 
 

--- a/tests/test_ci_failure_extractor.py
+++ b/tests/test_ci_failure_extractor.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit.ci_failure_extractor import build_failed_check_logs, main
+from sdetkit.ci_failure_extractor import (
+    build_failed_check_logs,
+    main,
+    write_failure_vector_artifacts,
+)
 from sdetkit.diagnostic_vector_engine import build_diagnostic_vector
 
 
@@ -86,3 +90,74 @@ def test_ci_failure_extractor_cli_writes_failed_check_logs(tmp_path: Path, capsy
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["summary"]["unknown_count"] == 1
     assert payload["failed_checks"][0]["review_first"] is True
+
+
+def test_ci_failure_extractor_writes_failure_vector_artifacts(tmp_path: Path) -> None:
+    log_path = tmp_path / "pytest" / "ci.log"
+    vectors_out = tmp_path / "failure-vectors.json"
+    vectors_md = tmp_path / "failure-vectors.md"
+    log_path.parent.mkdir()
+    log_path.write_text(
+        "Run python -m pytest -q\n"
+        "FAILED tests/test_widget.py::test_widget_contract - AssertionError\n"
+        "Error: Process completed with exit code 1.\n",
+        encoding="utf-8",
+    )
+
+    payload = write_failure_vector_artifacts(
+        [log_path],
+        json_out=vectors_out,
+        markdown_out=vectors_md,
+        environment="github_actions",
+    )
+
+    assert payload["schema_version"] == "sdetkit.failure_vector.bundle.v1"
+    assert payload["failure_vector_count"] == 1
+    assert vectors_out.exists()
+    assert vectors_md.exists()
+    assert "# Failure Vector Bundle" in vectors_md.read_text(encoding="utf-8")
+
+
+def test_ci_failure_extractor_cli_can_emit_failure_vector_bundle(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    log_path = tmp_path / "mypy" / "ci.log"
+    failed_logs = tmp_path / "failed-check-logs.json"
+    vectors_out = tmp_path / "failure-vectors.json"
+    vectors_md = tmp_path / "failure-vectors.md"
+    log_path.parent.mkdir()
+    log_path.write_text(
+        "Run python -m mypy src\n"
+        "src/sdetkit/example.py:10: error: Incompatible return value type\n"
+        "Error: Process completed with exit code 1.\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--log",
+            str(log_path),
+            "--out",
+            str(failed_logs),
+            "--failure-vectors-out",
+            str(vectors_out),
+            "--failure-vectors-md",
+            str(vectors_md),
+            "--environment",
+            "github_actions",
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert f"failure_vectors_json={vectors_out}" in stdout
+    assert f"failure_vectors_md={vectors_md}" in stdout
+    assert "failure_vector_count=1" in stdout
+
+    vector_payload = json.loads(vectors_out.read_text(encoding="utf-8"))
+    assert vector_payload["environment"] == "github_actions"
+    assert vector_payload["failure_vectors"][0]["command"] == "python -m mypy src"
+    assert vector_payload["failure_vectors"][0]["failure_class"] == "type"


### PR DESCRIPTION
## Summary
- Extend the existing CI failure extractor CLI with optional deterministic failure-vector bundle outputs.
- Add JSON and Markdown artifact emission for operator triage.
- Preserve existing failed-check-log output behavior.
- Cover direct writer and CLI artifact behavior with tests.

## Verification
- python -m ruff check src/sdetkit/ci_failure_extractor.py tests/test_ci_failure_extractor.py --fix
- python -m pytest -q tests/test_ci_failure_extractor.py tests/test_failure_vector_extraction.py tests/test_pr_quality_failure_vector_report.py tests/test_diagnostic_vector_engine.py -o addopts=
- python -m ruff check src tests scripts
- python -m mypy --config-file pyproject.toml src
- QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge
- make proof-after-format

## Risk
- Low.
- Optional CLI flags only.
- Existing failed-check-log output remains unchanged.
- No workflow, gate, release, or schema-breaking changes.