### PR TITLE
feat(safety): add failure-vector safety gate

### DIFF
--- a/src/sdetkit/safety_gate.py
+++ b/src/sdetkit/safety_gate.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from sdetkit.failure_vector import FailureVector
+
+SCHEMA_VERSION = "sdetkit.safety_gate.v1"
+
+SAFE_FIX_CLASSES = frozenset({"formatter_only", "lint"})
+
+GENERAL_BLOCKED_ACTIONS = (
+    "delete or weaken tests",
+    "skip CI or verifier checks",
+    "edit workflow gates to hide the failure",
+    "modify files outside allowed_files",
+)
+
+
+@dataclass(frozen=True)
+class SafetyGateDecision:
+    failure_class: str
+    risk: str
+    scope: str
+    safe_fix_allowed: bool
+    review_first: bool
+    reason: str
+    allowed_files: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    proof_commands: tuple[str, ...]
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["allowed_files"] = list(self.allowed_files)
+        payload["blocked_actions"] = list(self.blocked_actions)
+        payload["proof_commands"] = list(self.proof_commands)
+        return payload
+
+
+def evaluate_failure_vector(vector: FailureVector) -> SafetyGateDecision:
+    safe_fix_allowed = _safe_fix_allowed(vector)
+
+    return SafetyGateDecision(
+        failure_class=vector.failure_class,
+        risk=vector.risk,
+        scope=vector.scope,
+        safe_fix_allowed=safe_fix_allowed,
+        review_first=not safe_fix_allowed,
+        reason=_decision_reason(vector, safe_fix_allowed),
+        allowed_files=vector.affected_files if safe_fix_allowed else (),
+        blocked_actions=GENERAL_BLOCKED_ACTIONS,
+        proof_commands=_proof_commands(vector),
+    )
+
+
+def write_safety_gate_decision(decision: SafetyGateDecision, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(decision.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def render_safety_gate_decision_report(decision: SafetyGateDecision) -> str:
+    allowed = "yes" if decision.safe_fix_allowed else "no"
+    review_first = "yes" if decision.review_first else "no"
+    allowed_files = ", ".join(decision.allowed_files) if decision.allowed_files else "none"
+    proof_commands = ", ".join(decision.proof_commands) if decision.proof_commands else "none"
+
+    return "\n".join(
+        [
+            "# Safety Gate Decision",
+            "",
+            f"- schema_version: `{decision.schema_version}`",
+            f"- failure_class: `{decision.failure_class}`",
+            f"- risk: `{decision.risk}`",
+            f"- scope: `{decision.scope}`",
+            f"- safe_fix_allowed: `{allowed}`",
+            f"- review_first: `{review_first}`",
+            f"- reason: `{decision.reason}`",
+            f"- allowed_files: `{allowed_files}`",
+            f"- proof_commands: `{proof_commands}`",
+            "",
+        ]
+    )
+
+
+def _safe_fix_allowed(vector: FailureVector) -> bool:
+    return (
+        vector.safe_fix_candidate
+        and vector.failure_class in SAFE_FIX_CLASSES
+        and vector.risk == "low"
+        and vector.scope == "pr_owned_only"
+        and bool(vector.affected_files)
+    )
+
+
+def _decision_reason(vector: FailureVector, safe_fix_allowed: bool) -> str:
+    if safe_fix_allowed:
+        return "failure vector is low-risk, PR-owned, and mechanically eligible"
+    if not vector.safe_fix_candidate:
+        return (
+            f"failure_class {vector.failure_class!r} is review-first or not mechanically eligible"
+        )
+    if not vector.affected_files:
+        return "safe candidate lacks affected files, so patch scope cannot be verified"
+    if vector.scope != "pr_owned_only":
+        return f"scope {vector.scope!r} is not eligible for mechanical remediation"
+    if vector.risk != "low":
+        return f"risk {vector.risk!r} requires human review"
+    return "failure vector does not satisfy SafetyGate eligibility"
+
+
+def _proof_commands(vector: FailureVector) -> tuple[str, ...]:
+    commands: list[str] = []
+    if vector.local_repro_command:
+        commands.append(vector.local_repro_command)
+    commands.append("make proof-after-format")
+    return tuple(commands)

--- a/tests/test_safety_gate.py
+++ b/tests/test_safety_gate.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from sdetkit.failure_vector import extract_failure_vector
+from sdetkit.safety_gate import (
+    evaluate_failure_vector,
+    render_safety_gate_decision_report,
+    write_safety_gate_decision,
+)
+
+
+def test_safety_gate_allows_formatter_only_pr_owned_vector() -> None:
+    vector = extract_failure_vector(
+        """
+        ruff format..............................................................Failed
+        tests/test_widget.py
+        1 file would be reformatted
+        """,
+        check="pre-commit / ruff format",
+    )
+
+    decision = evaluate_failure_vector(vector)
+
+    assert decision.schema_version == "sdetkit.safety_gate.v1"
+    assert decision.safe_fix_allowed is True
+    assert decision.review_first is False
+    assert decision.allowed_files == ("tests/test_widget.py",)
+    assert decision.proof_commands == (
+        "python -m ruff format --check tests/test_widget.py",
+        "make proof-after-format",
+    )
+
+
+def test_safety_gate_allows_import_sort_lint_only_when_vector_is_safe_candidate() -> None:
+    vector = extract_failure_vector(
+        """
+        Run python -m ruff check tests/test_widget.py
+        I001 [*] Import block is un-sorted or un-formatted
+         --> tests/test_widget.py:1:1
+        Process completed with exit code 1
+        """,
+        check="ruff",
+    )
+
+    decision = evaluate_failure_vector(vector)
+
+    assert vector.failure_class == "lint"
+    assert vector.safe_fix_candidate is True
+    assert decision.safe_fix_allowed is True
+    assert decision.allowed_files == ("tests/test_widget.py",)
+
+
+def test_safety_gate_blocks_unknown_failure_review_first() -> None:
+    vector = extract_failure_vector(
+        """
+        custom quality wrapper returned an unexpected integrity result
+        Process completed with exit code 42
+        """,
+        check="quality wrapper",
+    )
+
+    decision = evaluate_failure_vector(vector)
+
+    assert decision.safe_fix_allowed is False
+    assert decision.review_first is True
+    assert decision.allowed_files == ()
+    assert "unknown" in decision.reason
+
+
+def test_safety_gate_blocks_safe_candidate_without_scope() -> None:
+    vector = extract_failure_vector(
+        """
+        ruff format..............................................................Failed
+        1 file would be reformatted
+        """,
+        check="pre-commit / ruff format",
+    )
+
+    decision = evaluate_failure_vector(vector)
+
+    assert vector.safe_fix_candidate is True
+    assert vector.scope == "unknown"
+    assert decision.safe_fix_allowed is False
+    assert "affected files" in decision.reason
+
+
+def test_safety_gate_report_and_json_are_deterministic(tmp_path: Path) -> None:
+    vector = extract_failure_vector(
+        """
+        ruff format..............................................................Failed
+        tests/test_widget.py
+        1 file would be reformatted
+        """,
+        check="pre-commit / ruff format",
+    )
+    decision = evaluate_failure_vector(vector)
+    out = tmp_path / "build" / "sdetkit" / "safety-gate-decision.json"
+
+    write_safety_gate_decision(decision, out)
+    report = render_safety_gate_decision_report(decision)
+
+    text = out.read_text(encoding="utf-8")
+    assert '"schema_version": "sdetkit.safety_gate.v1"' in text
+    assert '"safe_fix_allowed": true' in text
+    assert "# Safety Gate Decision" in report
+    assert "- safe_fix_allowed: `yes`" in report
+    assert "- allowed_files: `tests/test_widget.py`" in report


### PR DESCRIPTION
## Summary
- Add a first-class SafetyGate decision contract for FailureVector evidence.
- Allow only low-risk, PR-owned formatter/import-sort candidates.
- Keep unknown, broad, dependency, release, security, type, and test failures review-first.
- Emit deterministic JSON/report helpers for future PRReporter integration.

## Why
- FailureVector extraction now exists; the next product step is an explicit safety boundary before any remediation planning.

## Verification
- `python -m ruff check src/sdetkit/safety_gate.py tests/test_safety_gate.py --fix`
- `python -m pytest -q tests/test_safety_gate.py tests/test_failure_vector_extraction.py -o addopts=`
- `python -m mypy --config-file pyproject.toml src`
- `QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge`
- `make proof-after-format`

## Risk
- Low-medium.
- Adds internal API and tests only.
- No workflow, CLI, release, schema, or auto-fix authority change.
- Rollback: remove `src/sdetkit/safety_gate.py` and `tests/test_safety_gate.py`.

## Boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false