### PR TITLE
feat(report): surface SafetyGate decisions in failure-vector reports

### DIFF
--- a/src/sdetkit/failure_vector.py
+++ b/src/sdetkit/failure_vector.py
@@ -127,10 +127,17 @@ def write_failure_vector_bundle(
 
 
 def render_failure_vector_report(vector: FailureVector) -> str:
+    from sdetkit.safety_gate import evaluate_failure_vector
+
+    decision = evaluate_failure_vector(vector)
     safe = "yes" if vector.safe_fix_candidate else "no"
+    allowed = "yes" if decision.safe_fix_allowed else "no"
+    review_first = "yes" if decision.review_first else "no"
     local_repro = vector.local_repro_command or "none"
     first_line = vector.first_failing_line or "unknown"
     affected = ", ".join(vector.affected_files) if vector.affected_files else "none"
+    allowed_files = ", ".join(decision.allowed_files) if decision.allowed_files else "none"
+    proof_commands = ", ".join(decision.proof_commands) if decision.proof_commands else "none"
     return "\n".join(
         [
             "# Failure Vector",
@@ -144,6 +151,17 @@ def render_failure_vector_report(vector: FailureVector) -> str:
             f"- affected_files: `{affected}`",
             f"- first_failing_line: `{first_line}`",
             f"- local_repro_command: `{local_repro}`",
+            "",
+            "## SafetyGate Decision",
+            "",
+            f"- safe_fix_allowed: `{allowed}`",
+            f"- review_first: `{review_first}`",
+            f"- reason: `{decision.reason}`",
+            f"- allowed_files: `{allowed_files}`",
+            f"- proof_commands: `{proof_commands}`",
+            "- automation_allowed: `false`",
+            "- patch_application_allowed: `false`",
+            "- merge_authorized: `false`",
             "",
         ]
     )

--- a/src/sdetkit/safety_gate.py
+++ b/src/sdetkit/safety_gate.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
-
-from sdetkit.failure_vector import FailureVector
+from typing import Protocol
 
 SCHEMA_VERSION = "sdetkit.safety_gate.v1"
+
+
+class FailureVectorLike(Protocol):
+    failure_class: str
+    risk: str
+    scope: str
+    safe_fix_candidate: bool
+    affected_files: tuple[str, ...]
+    local_repro_command: str | None
+
 
 SAFE_FIX_CLASSES = frozenset({"formatter_only", "lint"})
 
@@ -39,7 +48,7 @@ class SafetyGateDecision:
         return payload
 
 
-def evaluate_failure_vector(vector: FailureVector) -> SafetyGateDecision:
+def evaluate_failure_vector(vector: FailureVectorLike) -> SafetyGateDecision:
     safe_fix_allowed = _safe_fix_allowed(vector)
 
     return SafetyGateDecision(
@@ -87,7 +96,7 @@ def render_safety_gate_decision_report(decision: SafetyGateDecision) -> str:
     )
 
 
-def _safe_fix_allowed(vector: FailureVector) -> bool:
+def _safe_fix_allowed(vector: FailureVectorLike) -> bool:
     return (
         vector.safe_fix_candidate
         and vector.failure_class in SAFE_FIX_CLASSES
@@ -97,7 +106,7 @@ def _safe_fix_allowed(vector: FailureVector) -> bool:
     )
 
 
-def _decision_reason(vector: FailureVector, safe_fix_allowed: bool) -> str:
+def _decision_reason(vector: FailureVectorLike, safe_fix_allowed: bool) -> str:
     if safe_fix_allowed:
         return "failure vector is low-risk, PR-owned, and mechanically eligible"
     if not vector.safe_fix_candidate:
@@ -113,7 +122,7 @@ def _decision_reason(vector: FailureVector, safe_fix_allowed: bool) -> str:
     return "failure vector does not satisfy SafetyGate eligibility"
 
 
-def _proof_commands(vector: FailureVector) -> tuple[str, ...]:
+def _proof_commands(vector: FailureVectorLike) -> tuple[str, ...]:
     commands: list[str] = []
     if vector.local_repro_command:
         commands.append(vector.local_repro_command)

--- a/tests/test_pr_quality_failure_vector_report.py
+++ b/tests/test_pr_quality_failure_vector_report.py
@@ -18,6 +18,11 @@ def test_pr_quality_failure_vector_report_renders_review_first_decision() -> Non
     assert "- risk: `high`" in report
     assert "- safe_fix_candidate: `no`" in report
     assert "- local_repro_command: `none`" in report
+    assert "## SafetyGate Decision" in report
+    assert "- safe_fix_allowed: `no`" in report
+    assert "- review_first: `yes`" in report
+    assert "failure_class 'unknown'" in report
+    assert "- automation_allowed: `false`" in report
 
 
 def test_pr_quality_failure_vector_report_renders_exact_pytest_repro() -> None:
@@ -34,3 +39,29 @@ def test_pr_quality_failure_vector_report_renders_exact_pytest_repro() -> None:
         "`PYTHONPATH=src python -m pytest -q "
         "tests/test_widget.py::test_widget_contract -o addopts=`" in report
     )
+
+
+def test_pr_quality_failure_vector_report_surfaces_safety_gate_safe_candidate() -> None:
+    vector = extract_failure_vector(
+        """
+        ruff format..............................................................Failed
+        tests/test_widget.py
+        1 file would be reformatted
+        """,
+        check="pre-commit / ruff format",
+    )
+
+    report = render_failure_vector_report(vector)
+
+    assert "- class: `formatter_only`" in report
+    assert "- safe_fix_candidate: `yes`" in report
+    assert "## SafetyGate Decision" in report
+    assert "- safe_fix_allowed: `yes`" in report
+    assert "- review_first: `no`" in report
+    assert "- allowed_files: `tests/test_widget.py`" in report
+    assert (
+        "- proof_commands: `python -m ruff format --check tests/test_widget.py, make proof-after-format`"
+        in report
+    )
+    assert "- patch_application_allowed: `false`" in report
+    assert "- merge_authorized: `false`" in report


### PR DESCRIPTION
## Summary
- Surface SafetyGate decisions directly in failure-vector reports.
- Show safe-fix allowed/review-first status, decision reason, allowed files, and proof commands.
- Keep report output explicitly non-authorizing for automation, patch application, and merge.

## Verification
- `python -m ruff check src/sdetkit/failure_vector.py tests/test_pr_quality_failure_vector_report.py --fix`
- `python -m pytest -q tests/test_pr_quality_failure_vector_report.py tests/test_safety_gate.py tests/test_failure_vector_extraction.py -o addopts=`
- `python -m mypy --config-file pyproject.toml src`
- `QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge`
- `make proof-after-format`
- final post-format focused proof:
  - `python -m pytest -q tests/test_pr_quality_failure_vector_report.py tests/test_safety_gate.py tests/test_failure_vector_extraction.py -o addopts=`

## Risk
- Low.
- Reporting-only change.
- No workflow, CLI, schema, patching, remediation, or merge authority change.

## Boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false