### PR TITLE
feat(report): expose failure bundle safety summary

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1480,9 +1480,20 @@ def write_comment_body(
             bundle,
             failure_bundle_out_dir,
         )
+        manifest = _as_dict(bundle.get("manifest"))
         failure_bundle_result = {
             "out_dir": failure_bundle_out_dir.as_posix(),
             "files": [item.as_posix() for item in written_bundle_paths],
+            "report_path": (failure_bundle_out_dir / "failure-bundle.md").as_posix(),
+            "safety_summary": {
+                "review_first": bool(manifest.get("review_first", False)),
+                "safe_fix_allowed": bool(manifest.get("safe_fix_allowed", False)),
+                "reporting_only": True,
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
         }
 
     status = _string(action_report.get("status") or "unknown")

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2385,3 +2385,83 @@ def test_action_report_security_review_signal_diagnoses_stale_only_findings() ->
     assert "blocked only while stale review comments remain unresolved" in body
     assert "refresh code scanning or resolve stale review comments" in body
     assert "wait_for_code_scanning_refresh" in body
+
+
+def test_write_comment_body_surfaces_failure_bundle_safety_summary(tmp_path: Path) -> None:
+    action_path = _write_json(
+        tmp_path / "action-report.json",
+        {
+            "status": "safe_fix_available",
+            "primary_blocker": {},
+            "automation": {
+                "attempted": False,
+                "allowed": True,
+                "reason": "safe fix planning is allowed, but not applied by this report",
+            },
+            "recommended_actions": ["Run the listed proof before any merge decision."],
+            "proof_commands": ["python -m pre_commit run -a"],
+            "safe_fix_available": True,
+        },
+    )
+    intelligence_path = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "checks_seen": 3,
+            "failed_checks": [
+                {
+                    "name": "ruff",
+                    "safe_to_auto_fix": True,
+                    "review_first": False,
+                    "first_failure": {
+                        "line": "I001 Import block is un-sorted or un-formatted",
+                        "line_number": 12,
+                        "tool": "ruff",
+                        "kind": "lint",
+                    },
+                    "diagnosis": {
+                        "owner_files": ["tests/test_widget.py"],
+                    },
+                }
+            ],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+    )
+    out = tmp_path / "comment.md"
+    bundle_out = tmp_path / "failure-bundle"
+
+    result = report.write_comment_body(
+        action_report_path=action_path,
+        check_intelligence_path=intelligence_path,
+        out=out,
+        failure_bundle_out_dir=bundle_out,
+        pr_number=1606,
+        head_sha="head-sha",
+        base_sha="base-sha",
+    )
+
+    failure_bundle = result["failure_bundle"]
+    safety_summary = failure_bundle["safety_summary"]
+
+    assert failure_bundle["out_dir"] == bundle_out.as_posix()
+    assert failure_bundle["report_path"] == (bundle_out / "failure-bundle.md").as_posix()
+    assert failure_bundle["files"] == [
+        (bundle_out / "manifest.json").as_posix(),
+        (bundle_out / "failure-bundle.json").as_posix(),
+        (bundle_out / "failure-bundle.md").as_posix(),
+    ]
+    assert safety_summary == {
+        "review_first": False,
+        "safe_fix_allowed": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    markdown = (bundle_out / "failure-bundle.md").read_text(encoding="utf-8")
+    assert "# Current-head failure evidence bundle" in markdown
+    assert "- Safe fix allowed: `true`" in markdown
+    assert "- Review first: `false`" in markdown


### PR DESCRIPTION
## Summary
- Expose a non-authorizing `failure_bundle.safety_summary` in PR-quality action-report output.
- Include review-first and safe-fix-allowed flags from the current-head failure bundle manifest.
- Include explicit reporting-only boundaries for automation, patch application, merge authorization, and semantic equivalence.

## Verification
- `python -m ruff check src/sdetkit/pr_quality_action_report.py tests/test_pr_quality_action_report.py --fix`
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_current_head_failure_bundle.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=`
- `python -m mypy --config-file pyproject.toml src`
- `QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge`
- `make proof-after-format`
- final focused proof:
  - `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_current_head_failure_bundle.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=`

## Risk
- Low.
- JSON result/reporting metadata only.
- No workflow, CLI behavior, remediation, patching, or merge authority change.

## Boundary
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false