### PR TITLE
feat(trajectory): record failure bundle SafetyGate evidence

### DIFF
--- a/src/sdetkit/trajectory_store.py
+++ b/src/sdetkit/trajectory_store.py
@@ -43,6 +43,45 @@ def _string_list(value: Any) -> list[str]:
     return sorted({_string(item) for item in _as_list(value) if _string(item)})
 
 
+def _failure_bundle_safety_evidence(value: Mapping[str, Any] | None) -> JsonObject:
+    payload = _as_dict(value)
+    if not payload:
+        return {}
+
+    failure_bundle = _as_dict(payload.get("failure_bundle"))
+    if failure_bundle:
+        payload = failure_bundle
+
+    summary = _as_dict(payload.get("safety_summary"))
+    if not summary:
+        manifest = _as_dict(payload.get("manifest"))
+        if manifest:
+            summary = {
+                "review_first": manifest.get("review_first", False),
+                "safe_fix_allowed": manifest.get("safe_fix_allowed", False),
+                "reporting_only": True,
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            }
+
+    if not summary:
+        return {}
+
+    return {
+        "source": "failure_bundle.safety_summary",
+        "review_first": _bool(summary.get("review_first")),
+        "safe_fix_allowed": _bool(summary.get("safe_fix_allowed")),
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "report_path": _string(payload.get("report_path")),
+    }
+
+
 def _slug(value: str) -> str:
     slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.lower()).strip("-")
     return slug or "unknown"
@@ -268,6 +307,7 @@ def build_pr_quality_trajectory_records(
     check_intelligence: Mapping[str, Any],
     evidence_narrative: Mapping[str, Any] | None = None,
     safe_fix_outcome: Mapping[str, Any] | None = None,
+    failure_bundle: Mapping[str, Any] | None = None,
     repo: str = "",
     branch: str = "",
     commit_sha: str = "",
@@ -275,6 +315,7 @@ def build_pr_quality_trajectory_records(
     generated_at: str = DEFAULT_GENERATED_AT,
 ) -> list[JsonObject]:
     outcome = _as_dict(safe_fix_outcome)
+    failure_bundle_safety = _failure_bundle_safety_evidence(failure_bundle)
     automation = _as_dict(action_report.get("automation"))
     default_proof_commands = _string_list(action_report.get("proof_commands"))
     records: list[JsonObject] = []
@@ -373,6 +414,7 @@ def build_pr_quality_trajectory_records(
                         or check.get("title")
                     ),
                 },
+                "safety_gate": failure_bundle_safety,
                 "fix": {
                     "allowed_strategy": action,
                     "patch_files": patch_files,
@@ -534,6 +576,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--check-intelligence", default="")
     parser.add_argument("--evidence-narrative", default="")
     parser.add_argument("--safe-fix-outcome", default="")
+    parser.add_argument("--failure-bundle", default="")
     parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--repo", default="")
     parser.add_argument("--branch", default="")
@@ -558,6 +601,7 @@ def main(argv: list[str] | None = None) -> int:
                 check_intelligence=_read_json(_optional_path(args.check_intelligence)),
                 evidence_narrative=_read_json(_optional_path(args.evidence_narrative)),
                 safe_fix_outcome=_read_json(_optional_path(args.safe_fix_outcome)),
+                failure_bundle=_read_json(_optional_path(args.failure_bundle)),
                 repo=args.repo,
                 branch=args.branch,
                 commit_sha=args.commit_sha,

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -479,3 +479,135 @@ def test_pr_quality_comment_can_show_green_evidence_review_trajectory_summary() 
     assert "Review-first decisions: `1`" in body
     assert "`evidence_review_required`=1" in body
     assert "`pr-quality-evidence-signal-evidence-review-signal`: action=`review`" in body
+
+
+def test_pr_quality_trajectory_records_carry_failure_bundle_safety_evidence() -> None:
+    from sdetkit.trajectory_store import build_pr_quality_trajectory_records
+
+    records = build_pr_quality_trajectory_records(
+        action_report={
+            "status": "safe_fix_available",
+            "automation": {
+                "allowed": True,
+                "reason": "safe fix planning is allowed, but not applied",
+            },
+            "proof_commands": ["python -m pre_commit run -a"],
+        },
+        check_intelligence={
+            "checks_seen": 1,
+            "failed_checks": [
+                {
+                    "name": "ruff",
+                    "safe_to_auto_fix": True,
+                    "review_first": False,
+                    "diagnosis": {
+                        "code": "RUFF_FIXABLE_LINT",
+                        "title": "Ruff fixable lint can be mechanically remediated",
+                    },
+                }
+            ],
+        },
+        failure_bundle={
+            "out_dir": "build/pr-quality/failure-bundle",
+            "report_path": "build/pr-quality/failure-bundle/failure-bundle.md",
+            "safety_summary": {
+                "review_first": False,
+                "safe_fix_allowed": True,
+                "reporting_only": True,
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        },
+        repo="sherif69-sa/DevS69-sdetkit",
+        branch="feat/trajectory-safetygate-summary-evidence",
+        commit_sha="abc123",
+        pr_number=1607,
+    )
+
+    assert len(records) == 1
+    safety_gate = records[0]["safety_gate"]
+    assert safety_gate == {
+        "source": "failure_bundle.safety_summary",
+        "review_first": False,
+        "safe_fix_allowed": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "report_path": "build/pr-quality/failure-bundle/failure-bundle.md",
+    }
+
+
+def test_pr_quality_trajectory_cli_accepts_failure_bundle_artifact(tmp_path: Path, capsys) -> None:
+    action_report = tmp_path / "action-report.json"
+    action_report.write_text(
+        json.dumps(
+            {
+                "status": "safe_fix_available",
+                "automation": {
+                    "allowed": True,
+                    "reason": "safe fix planning is allowed, but not applied",
+                },
+                "proof_commands": ["python -m pre_commit run -a"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    check_intelligence = tmp_path / "check-intelligence.json"
+    check_intelligence.write_text(
+        json.dumps(
+            {
+                "checks_seen": 1,
+                "failed_checks": [
+                    {
+                        "name": "ruff",
+                        "safe_to_auto_fix": True,
+                        "review_first": False,
+                        "diagnosis": {"code": "RUFF_FIXABLE_LINT"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    failure_bundle = tmp_path / "failure-bundle.json"
+    failure_bundle.write_text(
+        json.dumps(
+            {
+                "manifest": {
+                    "review_first": False,
+                    "safe_fix_allowed": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "trajectory.jsonl"
+
+    rc = main(
+        [
+            "--pr-quality-action-report",
+            str(action_report),
+            "--check-intelligence",
+            str(check_intelligence),
+            "--failure-bundle",
+            str(failure_bundle),
+            "--out",
+            str(out),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["summary"]["record_count"] == 1
+    record = json.loads(out.read_text(encoding="utf-8").splitlines()[0])
+    assert record["safety_gate"]["source"] == "failure_bundle.safety_summary"
+    assert record["safety_gate"]["safe_fix_allowed"] is True
+    assert record["safety_gate"]["review_first"] is False
+    assert record["safety_gate"]["automation_allowed"] is False
+    assert record["safety_gate"]["merge_authorized"] is False


### PR DESCRIPTION
## Summary
- Let PR-quality trajectory records carry non-authorizing failure-bundle SafetyGate evidence.
- Preserve review-first and safe-fix-allowed signals from `failure_bundle.safety_summary`.
- Add CLI support for passing a failure-bundle artifact into PR-quality trajectory generation.

## Verification
- `python -m ruff check src/sdetkit/trajectory_store.py tests/test_trajectory_store.py --fix`
- `python -m pytest -q tests/test_trajectory_store.py tests/test_pr_quality_action_report.py tests/test_current_head_failure_bundle.py -o addopts=`
- `python -m mypy --config-file pyproject.toml src`
- `QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge`
- `make proof-after-format`

## Risk
- Low.
- Trajectory metadata only.
- No PR comment rendering, workflow, remediation, patching, or merge authority change.

## Boundary
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false