### PR TITLE
feat(memory): surface SafetyGate evidence in RepoMemory

### DIFF
--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -180,6 +180,47 @@ def _controlled_candidate_validation(evidence: Mapping[str, Any]) -> JsonObject:
     }
 
 
+def _safety_gate_evidence(pattern_insights: Mapping[str, Any]) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    payload = _as_dict(pattern_insights.get("safety_gate_evidence"))
+    if not payload:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "trajectory.safety_gate",
+            "record_count": 0,
+            "review_first_count": 0,
+            "safe_fix_allowed_count": 0,
+            "reporting_only_count": 0,
+            "report_paths": [],
+            "decision_boundary": denied,
+        }
+
+    boundary = _as_dict(payload.get("decision_boundary"))
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    if expanded:
+        raise ValueError("SafetyGate evidence expands authority: " + ", ".join(expanded))
+
+    return {
+        "collection_status": _string(payload.get("collection_status")) or "collected",
+        "status": _string(payload.get("status")) or "safety_gate_evidence_observed",
+        "source": _string(payload.get("source")) or "trajectory.safety_gate",
+        "record_count": _int(payload.get("record_count")),
+        "review_first_count": _int(payload.get("review_first_count")),
+        "safe_fix_allowed_count": _int(payload.get("safe_fix_allowed_count")),
+        "reporting_only_count": _int(payload.get("reporting_only_count")),
+        "report_paths": [
+            _string(item) for item in _as_list(payload.get("report_paths")) if _string(item)
+        ],
+        "decision_boundary": denied,
+    }
+
+
 def _proof_commands(benchmark_report: Mapping[str, Any]) -> list[str]:
     commands: set[str] = set()
     for scenario in _as_list(benchmark_report.get("scenarios")):
@@ -599,6 +640,7 @@ def build_repo_memory_profile(
     controlled_validation = _controlled_candidate_validation(
         controlled_candidate_validation_evidence or {}
     )
+    safety_gate_evidence = _safety_gate_evidence(pattern_insights)
     benchmark_proven = _benchmark_contract_proven(benchmark_report)
     live_proven = _live_contract_proven(live_report)
     safe_fix_history = _safe_fix_history(
@@ -654,6 +696,7 @@ def build_repo_memory_profile(
             "live_benchmark_status": _string(live_report.get("status")),
             "live_report_mode": _string(live_report.get("report_mode")),
             "live_contract_proven": live_proven,
+            "safety_gate_evidence_record_count": _int(safety_gate_evidence.get("record_count")),
         },
         "command_profile": {
             "source": "replayable_benchmark_harness",
@@ -692,6 +735,7 @@ def build_repo_memory_profile(
         "known_safe_candidate_count": len(supported_candidates),
         "live_safe_candidate_count": len(live_supported_candidates),
         "controlled_candidate_validation": controlled_validation,
+        "safety_gate_evidence": safety_gate_evidence,
         "flaky_test_registry": flaky_registry,
         "escalation_rules": _escalation_rules(),
         "unproven_boundaries": unproven_boundaries,
@@ -718,6 +762,8 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
     provenance = _as_dict(profile.get("proof_provenance"))
     failure_patterns = _as_dict(profile.get("failure_patterns"))
     controlled = _as_dict(profile.get("controlled_candidate_validation"))
+    safety_gate = _as_dict(profile.get("safety_gate_evidence"))
+    safety_boundary = _as_dict(safety_gate.get("decision_boundary"))
     flaky = _as_dict(profile.get("flaky_test_registry"))
     flaky_source = _as_dict(flaky.get("source"))
     boundary = _as_dict(profile.get("decision_boundary"))
@@ -854,6 +900,36 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
     lines.extend(
         [
             "",
+            "## SafetyGate trajectory evidence",
+            "",
+            f"- Collection status: `{_string(safety_gate.get('collection_status'))}`",
+            f"- Status: `{_string(safety_gate.get('status'))}`",
+            f"- Records: `{_int(safety_gate.get('record_count'))}`",
+            f"- Safe-fix allowed records: `{_int(safety_gate.get('safe_fix_allowed_count'))}`",
+            f"- Review-first records: `{_int(safety_gate.get('review_first_count'))}`",
+            f"- Reporting-only records: `{_int(safety_gate.get('reporting_only_count'))}`",
+            (
+                "- Automation allowed by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('automation_allowed'))).lower()}`"
+            ),
+            (
+                "- Patch application allowed by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('merge_authorized'))).lower()}`"
+            ),
+            (
+                "- Semantic equivalence proven by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+        ]
+    )
+
+    lines.extend(
+        [
+            "",
             "## Flaky test registry",
             "",
             f"- Collection status: `{_string(flaky.get('collection_status'))}`",
@@ -971,6 +1047,9 @@ def main(argv: list[str] | None = None) -> int:
                     "controlled_candidate_validation_status": profile[
                         "controlled_candidate_validation"
                     ]["status"],
+                    "safety_gate_evidence_record_count": profile["safety_gate_evidence"][
+                        "record_count"
+                    ],
                 },
                 indent=2,
                 sort_keys=True,

--- a/src/sdetkit/trajectory_pattern_insights.py
+++ b/src/sdetkit/trajectory_pattern_insights.py
@@ -98,6 +98,58 @@ def _safe_fix_patterns(
     ]
 
 
+def _safety_gate_evidence(rows: list[JsonObject]) -> JsonObject:
+    safety_rows = [
+        _as_dict(row.get("safety_gate")) for row in rows if _as_dict(row.get("safety_gate"))
+    ]
+    if not safety_rows:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "trajectory.safety_gate",
+            "record_count": 0,
+            "review_first_count": 0,
+            "safe_fix_allowed_count": 0,
+            "reporting_only_count": 0,
+            "report_paths": [],
+            "decision_boundary": {
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        }
+
+    return {
+        "collection_status": "collected",
+        "status": "safety_gate_evidence_observed",
+        "source": "trajectory.safety_gate",
+        "record_count": len(safety_rows),
+        "review_first_count": sum(1 for row in safety_rows if _bool(row.get("review_first"))),
+        "safe_fix_allowed_count": sum(
+            1 for row in safety_rows if _bool(row.get("safe_fix_allowed"))
+        ),
+        "reporting_only_count": sum(1 for row in safety_rows if _bool(row.get("reporting_only"))),
+        "report_paths": sorted(
+            {
+                _string(row.get("report_path"))
+                for row in safety_rows
+                if _string(row.get("report_path"))
+            }
+        ),
+        "decision_boundary": {
+            "automation_allowed": any(_bool(row.get("automation_allowed")) for row in safety_rows),
+            "patch_application_allowed": any(
+                _bool(row.get("patch_application_allowed")) for row in safety_rows
+            ),
+            "merge_authorized": any(_bool(row.get("merge_authorized")) for row in safety_rows),
+            "semantic_equivalence_proven": any(
+                _bool(row.get("semantic_equivalence_proven")) for row in safety_rows
+            ),
+        },
+    }
+
+
 def _operator_focus(
     *,
     record_count: int,
@@ -198,6 +250,7 @@ def build_pattern_insights(
         "dominant_action": _dominant(actions, total=len(rows)),
         "recurring_review_first_surfaces": recurring_review_surfaces,
         "recurring_safe_fix_patterns": recurring_safe_fixes,
+        "safety_gate_evidence": _safety_gate_evidence(rows),
         "operator_focus": _operator_focus(
             record_count=len(rows),
             recurring_review_surfaces=recurring_review_surfaces,
@@ -211,6 +264,8 @@ def build_pattern_insights(
 def render_pattern_markdown(insights: Mapping[str, Any]) -> str:
     history = _as_dict(insights.get("history_summary"))
     focus = _as_dict(insights.get("operator_focus"))
+    safety_gate = _as_dict(insights.get("safety_gate_evidence"))
+    boundary = _as_dict(safety_gate.get("decision_boundary"))
 
     lines = [
         "# Trajectory pattern insights",
@@ -258,6 +313,28 @@ def render_pattern_markdown(insights: Mapping[str, Any]) -> str:
             )
     else:
         lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## SafetyGate evidence",
+            "",
+            f"- Collection status: `{_string(safety_gate.get('collection_status'))}`",
+            f"- Status: `{_string(safety_gate.get('status'))}`",
+            f"- Records: `{int(safety_gate.get('record_count', 0) or 0)}`",
+            f"- Safe-fix allowed records: `{int(safety_gate.get('safe_fix_allowed_count', 0) or 0)}`",
+            f"- Review-first records: `{int(safety_gate.get('review_first_count', 0) or 0)}`",
+            f"- Reporting-only records: `{int(safety_gate.get('reporting_only_count', 0) or 0)}`",
+            (
+                "- Automation allowed by SafetyGate evidence: "
+                f"`{str(_bool(boundary.get('automation_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by SafetyGate evidence: "
+                f"`{str(_bool(boundary.get('merge_authorized'))).lower()}`"
+            ),
+        ]
+    )
 
     lines.extend(
         [

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -751,3 +751,76 @@ def test_repo_memory_rejects_controlled_scenario_semantic_equivalence_claim() ->
         assert "scenario expands authority" in str(exc)
     else:
         raise AssertionError("expected semantic-equivalence-claiming scenario to be rejected")
+
+
+def test_repo_memory_surfaces_safety_gate_evidence_without_authority() -> None:
+    insights = _pattern_insights()
+    insights["safety_gate_evidence"] = {
+        "collection_status": "collected",
+        "status": "safety_gate_evidence_observed",
+        "source": "trajectory.safety_gate",
+        "record_count": 1,
+        "safe_fix_allowed_count": 1,
+        "review_first_count": 0,
+        "reporting_only_count": 1,
+        "report_paths": ["build/pr-quality/failure-bundle/failure-bundle.md"],
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+    profile = build_repo_memory_profile(
+        pattern_insights=insights,
+        benchmark_report=_benchmark_report(),
+        live_benchmark_report=_live_benchmark_report(),
+    )
+
+    safety_gate = profile["safety_gate_evidence"]
+    assert profile["inputs"]["safety_gate_evidence_record_count"] == 1
+    assert safety_gate["collection_status"] == "collected"
+    assert safety_gate["safe_fix_allowed_count"] == 1
+    assert safety_gate["review_first_count"] == 0
+    assert safety_gate["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    markdown = render_markdown(profile)
+    assert "## SafetyGate trajectory evidence" in markdown
+    assert "Safe-fix allowed records: `1`" in markdown
+    assert "Automation allowed by SafetyGate evidence: `false`" in markdown
+    assert "Merge authorized by SafetyGate evidence: `false`" in markdown
+
+
+def test_repo_memory_rejects_authority_expanding_safety_gate_evidence() -> None:
+    insights = _pattern_insights()
+    insights["safety_gate_evidence"] = {
+        "collection_status": "collected",
+        "status": "safety_gate_evidence_observed",
+        "source": "trajectory.safety_gate",
+        "record_count": 1,
+        "safe_fix_allowed_count": 1,
+        "review_first_count": 0,
+        "reporting_only_count": 1,
+        "decision_boundary": {
+            "automation_allowed": True,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=insights,
+            benchmark_report=_benchmark_report(),
+        )
+    except ValueError as exc:
+        assert "SafetyGate evidence expands authority: automation_allowed" in str(exc)
+    else:
+        raise AssertionError("expected authority-expanding SafetyGate evidence to fail")

--- a/tests/test_trajectory_pattern_insights.py
+++ b/tests/test_trajectory_pattern_insights.py
@@ -184,3 +184,40 @@ def test_pattern_insights_cli_accepts_multiple_trajectory_files(
     printed = json.loads(capsys.readouterr().out)
     assert printed["insights"]["record_count"] == 5
     assert printed["insights"]["recurring_review_first_surfaces"][0]["value"] == "pr_quality"
+
+
+def test_pattern_insights_summarizes_safety_gate_evidence() -> None:
+    rows = _records()[:1]
+    rows[0]["safety_gate"] = {
+        "source": "failure_bundle.safety_summary",
+        "review_first": False,
+        "safe_fix_allowed": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "report_path": "build/pr-quality/failure-bundle/failure-bundle.md",
+    }
+
+    insights = build_pattern_insights(rows, minimum_repeat=1)
+    safety_gate = insights["safety_gate_evidence"]
+
+    assert safety_gate["collection_status"] == "collected"
+    assert safety_gate["status"] == "safety_gate_evidence_observed"
+    assert safety_gate["record_count"] == 1
+    assert safety_gate["safe_fix_allowed_count"] == 1
+    assert safety_gate["review_first_count"] == 0
+    assert safety_gate["reporting_only_count"] == 1
+    assert safety_gate["report_paths"] == ["build/pr-quality/failure-bundle/failure-bundle.md"]
+    assert safety_gate["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    markdown = render_pattern_markdown(insights)
+    assert "## SafetyGate evidence" in markdown
+    assert "Safe-fix allowed records: `1`" in markdown
+    assert "Automation allowed by SafetyGate evidence: `false`" in markdown


### PR DESCRIPTION
## Summary
- Summarize trajectory SafetyGate evidence in trajectory pattern insights.
- Surface SafetyGate evidence counts in RepoMemory profiles and markdown.
- Reject SafetyGate evidence that attempts to expand automation, patch application, merge authorization, or semantic equivalence authority.

## Verification
- `python -m ruff check src/sdetkit/trajectory_pattern_insights.py src/sdetkit/repo_memory.py tests/test_trajectory_pattern_insights.py tests/test_repo_memory.py --fix`
- `python -m pytest -q tests/test_trajectory_pattern_insights.py tests/test_repo_memory.py tests/test_trajectory_store.py tests/test_pr_quality_action_report.py -o addopts=`
- `python -m mypy --config-file pyproject.toml src`
- `QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge`
- `make proof-after-format`
- final post-format focused proof:
  - `python -m pytest -q tests/test_trajectory_pattern_insights.py tests/test_repo_memory.py tests/test_trajectory_store.py tests/test_pr_quality_action_report.py -o addopts=`

## Risk
- Low.
- Reporting/profile metadata only.
- No workflow, remediation, patching, command execution, or merge authority change.

## Boundary
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false