### PR TITLE
feat(verifier): enforce SafetyGate evidence boundary

### DIFF
--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -25,6 +25,9 @@ PROOF_REQUIREMENTS_MISSING = "_".join(("PROOF", "REQUIREMENTS", "MISSING"))
 REQUIRED_PROOF_NOT_CAPTURED = "_".join(("REQUIRED", "PROOF", "NOT", "CAPTURED"))
 REQUIRED_PROOF_FAILED = "_".join(("REQUIRED", "PROOF", "FAILED"))
 SEMANTIC_EQUIVALENCE_NOT_PROVEN = "_".join(("SEMANTIC", "EQUIVALENCE", "NOT", "PROVEN"))
+SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION = "_".join(
+    ("SAFETYGATE", "EVIDENCE", "AUTHORITY", "VIOLATION")
+)
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -103,6 +106,46 @@ def _proof_passed(result: Mapping[str, Any]) -> bool:
     )
 
 
+def _safety_gate_evidence(evidence: Mapping[str, Any]) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    payload = _as_dict(evidence.get("safety_gate_evidence"))
+    if not payload:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "verification_evidence.safety_gate_evidence",
+            "record_count": 0,
+            "review_first_count": 0,
+            "safe_fix_allowed_count": 0,
+            "reporting_only_count": 0,
+            "report_paths": [],
+            "expanded_authority_fields": [],
+            "decision_boundary": denied,
+        }
+
+    boundary = _as_dict(payload.get("decision_boundary"))
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    return {
+        "collection_status": _string(payload.get("collection_status")) or "collected",
+        "status": _string(payload.get("status")) or "safety_gate_evidence_observed",
+        "source": _string(payload.get("source")) or "verification_evidence.safety_gate_evidence",
+        "record_count": _int(payload.get("record_count"), default=0),
+        "review_first_count": _int(payload.get("review_first_count"), default=0),
+        "safe_fix_allowed_count": _int(payload.get("safe_fix_allowed_count"), default=0),
+        "reporting_only_count": _int(payload.get("reporting_only_count"), default=0),
+        "report_paths": [
+            _string(item) for item in _as_list(payload.get("report_paths")) if _string(item)
+        ],
+        "expanded_authority_fields": expanded,
+        "decision_boundary": denied,
+    }
+
+
 def verify_candidate(
     *,
     patch_score: Mapping[str, Any],
@@ -116,6 +159,7 @@ def verify_candidate(
     evidence_files = _string_list(verification_evidence.get("changed_files"))
     proof_requirements = _string_list(patch_score.get("proof_requirements"))
     proof_results = _proof_results_by_command(verification_evidence)
+    safety_gate_evidence = _safety_gate_evidence(verification_evidence)
     findings: list[JsonObject] = []
 
     if _string(decision.get("status")) != "candidate_for_protected_verification" or not _bool(
@@ -135,6 +179,17 @@ def verify_candidate(
                 AUTOMATION_BOUNDARY_VIOLATION,
                 "PatchScorer output unexpectedly attempts to authorize automation.",
                 blocking=True,
+            )
+        )
+
+    expanded_safetygate_fields = _string_list(safety_gate_evidence.get("expanded_authority_fields"))
+    if expanded_safetygate_fields:
+        findings.append(
+            _finding(
+                SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION,
+                "SafetyGate evidence attempted to expand verifier authority.",
+                blocking=True,
+                files=expanded_safetygate_fields,
             )
         )
 
@@ -238,6 +293,7 @@ def verify_candidate(
         "observed_changed_files": evidence_files,
         "allowed_files": allowed_files,
         "proof_requirements": proof_requirements,
+        "safety_gate_evidence": safety_gate_evidence,
         "findings": findings,
         "decision": {
             "status": status,
@@ -257,6 +313,8 @@ def verify_candidate(
 
 def render_markdown(payload: Mapping[str, Any]) -> str:
     decision = _as_dict(payload.get("decision"))
+    safety_gate = _as_dict(payload.get("safety_gate_evidence"))
+    safety_boundary = _as_dict(safety_gate.get("decision_boundary"))
     findings = [_as_dict(item) for item in _as_list(payload.get("findings"))]
 
     lines = [
@@ -291,6 +349,36 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
             f"blocking=`{str(_bool(finding.get('blocking'))).lower()}` "
             f"{_string(finding.get('message'))}{suffix}"
         )
+
+    lines.extend(
+        [
+            "",
+            "## SafetyGate evidence",
+            "",
+            f"- Collection status: `{_string(safety_gate.get('collection_status'))}`",
+            f"- Status: `{_string(safety_gate.get('status'))}`",
+            f"- Records: `{_int(safety_gate.get('record_count'), default=0)}`",
+            f"- Safe-fix allowed records: `{_int(safety_gate.get('safe_fix_allowed_count'), default=0)}`",
+            f"- Review-first records: `{_int(safety_gate.get('review_first_count'), default=0)}`",
+            f"- Reporting-only records: `{_int(safety_gate.get('reporting_only_count'), default=0)}`",
+            (
+                "- Automation allowed by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('automation_allowed'))).lower()}`"
+            ),
+            (
+                "- Patch application allowed by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('merge_authorized'))).lower()}`"
+            ),
+            (
+                "- Semantic equivalence proven by SafetyGate evidence: "
+                f"`{str(_bool(safety_boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+        ]
+    )
 
     lines.extend(["", "## Required proof evaluated", ""])
     proof_requirements = _string_list(payload.get("proof_requirements"))

--- a/src/sdetkit/replayable_benchmark_harness.py
+++ b/src/sdetkit/replayable_benchmark_harness.py
@@ -341,8 +341,13 @@ def evaluate_scenario(
     verification_evidence = (
         dict(verification_evidence_override)
         if verification_evidence_override is not None
-        else declared_verification_evidence
+        else dict(declared_verification_evidence)
     )
+    if (
+        _string(safety_gate_evidence.get("collection_status")) == "collected"
+        and "safety_gate_evidence" not in verification_evidence
+    ):
+        verification_evidence["safety_gate_evidence"] = safety_gate_evidence
     evidence_source = (
         LIVE_EVIDENCE_SOURCE if verification_evidence_override is not None else "fixture_declared"
     )

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -12,6 +12,7 @@ from sdetkit.protected_verifier import (
     REQUIRED_PROOF_NOT_CAPTURED,
     SEMANTIC_EQUIVALENCE_NOT_PROVEN,
     main,
+    render_markdown,
     verify_candidate,
 )
 
@@ -71,7 +72,7 @@ def test_verifier_structurally_verifies_candidate_but_does_not_authorize() -> No
     ]
 
 
-def test_verifier_blocks_non_candidate_patch_score() -> None:
+def test_verifier_blocks_non_candidate_score() -> None:
     score = _candidate_score()
     score["decision"] = {
         "status": "blocked_review_first",
@@ -177,3 +178,79 @@ def test_verifier_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     assert saved["decision"]["automation_allowed"] is False
     assert "# Protected verifier result" in markdown
     assert "does not prove semantic equivalence" in markdown
+
+
+def test_protected_verifier_surfaces_safetygate_evidence_without_authority() -> None:
+    evidence = _passing_evidence()
+    evidence["safety_gate_evidence"] = {
+        "collection_status": "collected",
+        "status": "safety_gate_evidence_observed",
+        "source": "trajectory.safety_gate",
+        "record_count": 1,
+        "safe_fix_allowed_count": 1,
+        "review_first_count": 0,
+        "reporting_only_count": 1,
+        "report_paths": ["build/pr-quality/failure-bundle/failure-bundle.md"],
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+    payload = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence=evidence,
+    )
+
+    assert payload["decision"]["status"] == "structurally_verified_candidate"
+    assert payload["decision"]["automation_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    safety_gate = payload["safety_gate_evidence"]
+    assert safety_gate["collection_status"] == "collected"
+    assert safety_gate["safe_fix_allowed_count"] == 1
+    assert safety_gate["expanded_authority_fields"] == []
+    assert safety_gate["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    markdown = render_markdown(payload)
+    assert "## SafetyGate evidence" in markdown
+    assert "Safe-fix allowed records: `1`" in markdown
+    assert "Automation allowed by SafetyGate evidence: `false`" in markdown
+    assert "Merge authorized by SafetyGate evidence: `false`" in markdown
+
+
+def test_protected_verifier_blocks_authority_expanding_safetygate_evidence() -> None:
+    evidence = _passing_evidence()
+    evidence["safety_gate_evidence"] = {
+        "collection_status": "collected",
+        "status": "safety_gate_evidence_observed",
+        "source": "trajectory.safety_gate",
+        "record_count": 1,
+        "safe_fix_allowed_count": 1,
+        "review_first_count": 0,
+        "reporting_only_count": 1,
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": True,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+    payload = verify_candidate(
+        patch_score=_candidate_score(),
+        verification_evidence=evidence,
+    )
+
+    assert payload["decision"]["status"] == "blocked_review_first"
+    assert payload["safety_gate_evidence"]["expanded_authority_fields"] == ["merge_authorized"]
+    assert any(
+        item["code"] == "SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION" and item["blocking"] is True
+        for item in payload["findings"]
+    )

--- a/tests/test_replayable_benchmark_harness.py
+++ b/tests/test_replayable_benchmark_harness.py
@@ -317,3 +317,17 @@ def test_replayable_benchmark_rejects_authority_expanding_safetygate_evidence() 
         assert "SafetyGate benchmark evidence expands authority: merge_authorized" in str(exc)
     else:
         raise AssertionError("expected authority-expanding SafetyGate evidence to fail")
+
+
+def test_replayable_benchmark_passes_safetygate_evidence_into_protected_verifier() -> None:
+    scenario = load_scenarios([SAFETYGATE_EVIDENCE_PATH])[0]
+
+    result = evaluate_scenario(scenario)
+
+    verifier_safety_gate = result["protected_verifier_result"]["safety_gate_evidence"]
+    assert verifier_safety_gate["collection_status"] == "collected"
+    assert verifier_safety_gate["source"] == "trajectory.safety_gate"
+    assert verifier_safety_gate["safe_fix_allowed_count"] == 1
+    assert verifier_safety_gate["expanded_authority_fields"] == []
+    assert result["protected_verifier_result"]["decision"]["automation_allowed"] is False
+    assert result["protected_verifier_result"]["decision"]["merge_authorized"] is False


### PR DESCRIPTION
## Summary
- Let ProtectedVerifier surface read-only SafetyGate evidence from verification evidence.
- Block SafetyGate evidence that attempts to expand automation, patch application, merge authorization, or semantic equivalence authority.
- Pass SafetyGate evidence from replayable benchmark scenarios into ProtectedVerifier evidence.

## Verification
- `python -m ruff check src/sdetkit/protected_verifier.py src/sdetkit/replayable_benchmark_harness.py tests/test_protected_verifier.py tests/test_replayable_benchmark_harness.py --fix`
- `python -m pytest -q tests/test_protected_verifier.py tests/test_replayable_benchmark_harness.py -o addopts=`
- `python -m mypy --config-file pyproject.toml src`
- `QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge`
- `make proof-after-format`
- final post-format focused proof:
  - `python -m pytest -q tests/test_protected_verifier.py tests/test_replayable_benchmark_harness.py -o addopts=`

## Risk
- Low.
- Verifier/reporting metadata only.
- No workflow, remediation, patching, command execution, or merge authority change.

## Boundary
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false