### PR TITLE
feat(score): classify operator step errors

### DIFF
--- a/src/sdetkit/patch_scorer.py
+++ b/src/sdetkit/patch_scorer.py
@@ -188,7 +188,54 @@ STEP_ERROR_CATEGORIES = [
     "unsafe_authority_request",
     "false_success_claim",
     "premature_completion",
+    "wrong_helper_name",
+    "wrong_marker_patch",
+    "unsupported_helper_signature",
+    "accidental_public_cli_drift",
+    "authority_expansion_attempt",
+    "skipped_post_format_proof",
 ]
+
+OPERATOR_MISSTEP_CODE_TO_CATEGORY = {
+    "wrong_helper_name": "wrong_helper_name",
+    "wrong_marker_patch": "wrong_marker_patch",
+    "unsupported_helper_signature": "unsupported_helper_signature",
+    "accidental_public_cli_drift": "accidental_public_cli_drift",
+    "authority_expansion_attempt": "authority_expansion_attempt",
+    "skipped_post_format_proof": "skipped_post_format_proof",
+}
+
+
+def _int_from(value: Any, *, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _operator_misstep_flags(proposed_patch: Mapping[str, Any]) -> list[JsonObject]:
+    flags: list[JsonObject] = []
+    for item in _as_list(proposed_patch.get("operator_missteps")):
+        raw = _as_dict(item)
+        code = _string(raw.get("code")).lower().strip()
+        category = OPERATOR_MISSTEP_CODE_TO_CATEGORY.get(code)
+        if not category and code in STEP_ERROR_CATEGORIES:
+            category = code
+        if not category:
+            continue
+
+        blocking = _bool(raw.get("blocking"))
+        flag = _risk_flag(
+            category.upper(),
+            _string(raw.get("message")) or f"Operator misstep recorded: {category}.",
+            blocking=blocking,
+            penalty=_int_from(raw.get("penalty"), default=100 if blocking else 0),
+            files=_string_list(raw.get("files")),
+        )
+        flag["step_error_category"] = category
+        flag["source"] = "operator_misstep"
+        flags.append(flag)
+    return flags
 
 
 def _authority_claimed(payload: Mapping[str, Any]) -> bool:
@@ -216,6 +263,13 @@ def _step_error_taxonomy(flags: list[JsonObject]) -> JsonObject:
         categories.append("skipped_proof")
     if "UNSAFE_AUTHORITY_REQUEST" in codes:
         categories.append("unsafe_authority_request")
+    if "SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION" in codes:
+        categories.append("authority_expansion_attempt")
+
+    for flag in flags:
+        category = _string(flag.get("step_error_category"))
+        if category in STEP_ERROR_CATEGORIES and category not in categories:
+            categories.append(category)
 
     return {
         "schema_version": STEP_ERROR_TAXONOMY_SCHEMA_VERSION,
@@ -328,6 +382,7 @@ def score_patch(
     changed_files = _string_list(proposed_patch.get("changed_files"))
     proposed_authority_claimed = _authority_claimed(proposed_patch)
     flags: list[JsonObject] = []
+    flags.extend(_operator_misstep_flags(proposed_patch))
 
     if proposed_authority_claimed:
         flags.append(

--- a/tests/test_patch_scorer.py
+++ b/tests/test_patch_scorer.py
@@ -306,3 +306,96 @@ def test_patch_scorer_blocks_authority_expanding_safetygate_evidence() -> None:
         item["code"] == "SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION" and item["blocking"] is True
         for item in payload["risk_flags"]
     )
+
+
+def test_patch_scorer_classifies_operator_missteps_without_authority() -> None:
+    payload = score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "format-patch",
+            "changed_files": ["src/sdetkit/example.py"],
+            "operator_missteps": [
+                {
+                    "code": "wrong_helper_name",
+                    "message": "Used a helper name that does not exist in the current test file.",
+                },
+                {
+                    "code": "unsupported_helper_signature",
+                    "message": "Called a local helper with an unsupported keyword argument.",
+                },
+            ],
+        },
+        pattern_insights=_matching_safe_insights(),
+    )
+
+    assert payload["decision"]["status"] == "candidate_for_protected_verification"
+    assert payload["decision"]["automation_allowed"] is False
+    assert payload["score"] == 100
+    assert payload["step_error_taxonomy"]["primary_category"] == "wrong_helper_name"
+    assert payload["step_error_taxonomy"]["observed_categories"] == [
+        "wrong_helper_name",
+        "unsupported_helper_signature",
+    ]
+    assert {
+        flag["step_error_category"]
+        for flag in payload["risk_flags"]
+        if flag.get("source") == "operator_misstep"
+    } == {"wrong_helper_name", "unsupported_helper_signature"}
+    assert all(
+        flag["blocking"] is False
+        for flag in payload["risk_flags"]
+        if flag.get("source") == "operator_misstep"
+    )
+
+
+def test_patch_scorer_blocks_declared_public_cli_drift_misstep() -> None:
+    payload = score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "format-patch",
+            "changed_files": ["src/sdetkit/example.py"],
+            "operator_missteps": [
+                {
+                    "code": "accidental_public_cli_drift",
+                    "message": "A broad replacement changed a public CLI default.",
+                    "blocking": True,
+                    "penalty": 100,
+                    "files": ["src/sdetkit/pr_quality_action_report.py"],
+                }
+            ],
+        },
+        pattern_insights=_matching_safe_insights(),
+    )
+
+    assert payload["score"] == 0
+    assert payload["decision"]["status"] == "blocked_review_first"
+    assert payload["decision"]["automation_allowed"] is False
+    assert payload["step_error_taxonomy"]["primary_category"] == "accidental_public_cli_drift"
+    assert payload["step_error_taxonomy"]["observed_categories"] == ["accidental_public_cli_drift"]
+    assert any(
+        flag["code"] == "ACCIDENTAL_PUBLIC_CLI_DRIFT"
+        and flag["blocking"] is True
+        and flag["files"] == ["src/sdetkit/pr_quality_action_report.py"]
+        for flag in payload["risk_flags"]
+    )
+
+
+def test_patch_scorer_maps_safetygate_authority_violation_to_step_error_taxonomy() -> None:
+    insights = _safetygate_safe_insights()
+    insights["safety_gate_evidence"]["decision_boundary"]["merge_authorized"] = True
+
+    payload = score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "format-patch",
+            "changed_files": ["src/sdetkit/example.py"],
+        },
+        pattern_insights=insights,
+    )
+
+    assert payload["decision"]["status"] == "blocked_review_first"
+    assert "authority_expansion_attempt" in payload["step_error_taxonomy"]["observed_categories"]
+    assert any(
+        flag["code"] == "SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION" and flag["blocking"] is True
+        for flag in payload["risk_flags"]
+    )


### PR DESCRIPTION
## Summary
- Extend StepErrorTaxonomy with operator-misstep categories.
- Classify advisory operator missteps such as wrong helper names and unsupported helper signatures without granting authority.
- Allow declared blocking missteps such as accidental public CLI drift to force review-first.
- Map SafetyGate authority violations to `authority_expansion_attempt`.

## Verification
- `python -m ruff check src/sdetkit/patch_scorer.py tests/test_patch_scorer.py tests/test_pr_quality_action_report.py tests/test_trajectory_store.py tests/test_repo_memory.py --fix`
- `python -m pytest -q tests/test_patch_scorer.py tests/test_pr_quality_action_report.py tests/test_trajectory_store.py tests/test_repo_memory.py -o addopts=`
- `python -m mypy --config-file pyproject.toml src`
- `QUALITY_DIFF_BASE=origin/main bash scripts/quality.sh premerge`
- `make proof-after-format`
- final post-format focused proof:
  - `python -m pytest -q tests/test_patch_scorer.py tests/test_pr_quality_action_report.py tests/test_trajectory_store.py tests/test_repo_memory.py -o addopts=`

## Risk
- Low.
- Scoring/taxonomy metadata only.
- No workflow, remediation, patching, command execution, or merge authority change.

## Boundary
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false