### PR TITLE
feat(adoption): profile external repo readiness read-only

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -22,8 +22,14 @@ REQUIRED_LIST_FIELDS = (
 
 REQUIRED_FALSE_FIELDS = (
     "automation_allowed",
+    "patch_application_allowed",
     "merge_authorized",
     "semantic_equivalence_proven",
+)
+
+REQUIRED_OBJECT_FIELDS = (
+    "repo_identity",
+    "operator_summary",
 )
 
 IGNORED_PARTS = {
@@ -101,6 +107,8 @@ def _add_proof_command(
             "command": command,
             "confidence": confidence,
             "purpose": purpose,
+            "executes_untrusted_code": True,
+            "auto_run_allowed": False,
         }
     )
 
@@ -138,6 +146,58 @@ def _quality_proof_command(root: Path) -> str:
     if _make_target_exists(root, "proof-after-format"):
         return "make proof-after-format"
     return "python -m pre_commit run -a"
+
+
+def _sanitize_remote_url(url: str) -> str:
+    if "://" not in url or "@" not in url:
+        return url
+    scheme, rest = url.split("://", 1)
+    return f"{scheme}://{rest.rsplit('@', 1)[-1]}"
+
+
+def _git_detected(root: Path) -> bool:
+    return (root / ".git").exists()
+
+
+def _git_remote_url(root: Path) -> str:
+    config = root / ".git" / "config"
+    if not config.is_file():
+        return ""
+
+    in_origin = False
+    for raw_line in config.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[remote "):
+            in_origin = '"origin"' in line or "'origin'" in line
+            continue
+        if in_origin and line.startswith("url ="):
+            return _sanitize_remote_url(line.split("=", 1)[1].strip())
+    return ""
+
+
+def _is_current_sdetkit_repo(root: Path) -> bool:
+    try:
+        return root.resolve() == Path.cwd().resolve()
+    except OSError:
+        return False
+
+
+def _repo_identity(root: Path) -> dict[str, Any]:
+    return {
+        "name": root.resolve().name if root.exists() else root.name,
+        "is_current_sdetkit_repo": _is_current_sdetkit_repo(root),
+        "git_detected": _git_detected(root),
+        "remote_url": _git_remote_url(root),
+    }
+
+
+def _operator_summary() -> dict[str, str]:
+    return {
+        "status": "read_only_profile_generated",
+        "next_action": (
+            "Review detected surfaces and manually run trusted proof commands in the target repo."
+        ),
+    }
 
 
 def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
@@ -348,7 +408,8 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "repo_root": ".",
+        "repo_root": root.as_posix(),
+        "repo_identity": _repo_identity(root),
         "detected_languages": sorted(detected_languages, key=lambda item: item["name"]),
         "package_managers": sorted(package_managers, key=lambda item: item["name"]),
         "test_runners": sorted(test_runners, key=lambda item: item["name"]),
@@ -360,7 +421,9 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             key=lambda item: (item["surface"], item["command"]),
         ),
         "review_first_unknowns": sorted(set(review_first_unknowns)),
+        "operator_summary": _operator_summary(),
         "automation_allowed": False,
+        "patch_application_allowed": False,
         "merge_authorized": False,
         "semantic_equivalence_proven": False,
     }
@@ -379,6 +442,7 @@ def write_adoption_surface_artifact(
         "schema_version": payload["schema_version"],
         "adoption_surface_json": out_path.as_posix(),
         "automation_allowed": payload["automation_allowed"],
+        "patch_application_allowed": payload["patch_application_allowed"],
         "merge_authorized": payload["merge_authorized"],
         "semantic_equivalence_proven": payload["semantic_equivalence_proven"],
     }
@@ -395,6 +459,10 @@ def validate_adoption_surface_payload(payload: object) -> list[str]:
     for field in REQUIRED_LIST_FIELDS:
         if not isinstance(payload.get(field), list):
             errors.append(f"{field} must be a list")
+
+    for field in REQUIRED_OBJECT_FIELDS:
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{field} must be an object")
 
     for field in REQUIRED_FALSE_FIELDS:
         if payload.get(field) is not False:
@@ -431,6 +499,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         sys.stdout.write(f"adoption_surface_json={summary['adoption_surface_json']}\n")
         sys.stdout.write(f"automation_allowed={str(summary['automation_allowed']).lower()}\n")
+        sys.stdout.write(
+            f"patch_application_allowed={str(summary['patch_application_allowed']).lower()}\n"
+        )
         sys.stdout.write(f"merge_authorized={str(summary['merge_authorized']).lower()}\n")
         sys.stdout.write(
             f"semantic_equivalence_proven={str(summary['semantic_equivalence_proven']).lower()}\n"

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -45,6 +45,7 @@ def test_adoption_surface_detects_python_github_security_and_proof_commands(
 
     assert payload["schema_version"] == SCHEMA_VERSION
     assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False
     assert payload["semantic_equivalence_proven"] is False
     assert "python" in _names(payload["detected_languages"])
@@ -143,6 +144,44 @@ def test_adoption_surface_detects_multi_language_evidence_without_running_comman
     assert payload["artifact_surfaces"] == [{"name": "coverage", "paths": ["coverage.xml"]}]
 
 
+def test_adoption_surface_profiles_external_repo_readiness_without_authority(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
+    _write(
+        tmp_path / ".git" / "config",
+        '[remote "origin"]\n    url = https://token@example.com/org/repo.git\n',
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert payload["repo_root"] == tmp_path.as_posix()
+    assert payload["repo_identity"] == {
+        "name": tmp_path.name,
+        "is_current_sdetkit_repo": False,
+        "git_detected": True,
+        "remote_url": "https://example.com/org/repo.git",
+    }
+    assert payload["operator_summary"] == {
+        "status": "read_only_profile_generated",
+        "next_action": (
+            "Review detected surfaces and manually run trusted proof commands in the target repo."
+        ),
+    }
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+    assert all(
+        command["auto_run_allowed"] is False for command in payload["recommended_proof_commands"]
+    )
+    assert all(
+        command["executes_untrusted_code"] is True
+        for command in payload["recommended_proof_commands"]
+    )
+
+
 def test_adoption_surface_module_writes_deterministic_artifact(
     tmp_path: Path,
     capsys,
@@ -161,6 +200,7 @@ def test_adoption_surface_module_writes_deterministic_artifact(
     assert stdout["adoption_surface_json"] == out.as_posix()
     assert payload["schema_version"] == SCHEMA_VERSION
     assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False
     assert payload["semantic_equivalence_proven"] is False
 
@@ -234,7 +274,10 @@ def test_adoption_surface_payload_validator_rejects_authority_escalation() -> No
         "artifact_surfaces": [],
         "recommended_proof_commands": [],
         "review_first_unknowns": [],
+        "repo_identity": {},
+        "operator_summary": {},
         "automation_allowed": True,
+        "patch_application_allowed": False,
         "merge_authorized": False,
         "semantic_equivalence_proven": False,
     }


### PR DESCRIPTION
## Summary
- Add external-repo readiness identity fields to the adoption-surface payload.
- Add operator summary output for read-only profile generation.
- Mark recommended proof commands as executing target code and never auto-runnable.
- Preserve all authority boundaries, including patch_application_allowed=false.
- Add focused regression coverage for external repo readiness and CLI text boundary output.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format text`
- `make proof-after-format`
- `git diff --check`

## Risk
- Low.
- Public surface: adoption-surface JSON/text output expands with read-only fields.
- Rollback: revert this PR.

## Boundary
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no target repo commands are executed automatically
- no target repo mutation is introduced