### PR TITLE
feat(adoption): render operator readiness report

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -681,7 +681,7 @@ Then use stability-aware command discovery:
     )
     adoption_surface.add_argument("--root", default=".")
     adoption_surface.add_argument("--out", default="build/sdetkit/adoption-surface.json")
-    adoption_surface.add_argument("--format", choices=["json", "text"], default="json")
+    adoption_surface.add_argument("--format", choices=["json", "text", "report"], default="json")
 
     issue_queue_classifier = sub.add_parser(
         "issue-queue-classifier",

--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -429,6 +429,95 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     }
 
 
+def _format_named_items(items: object) -> list[str]:
+    if not isinstance(items, list) or not items:
+        return ["- none detected"]
+
+    lines: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name", "unknown"))
+        confidence = item.get("confidence")
+        suffix = f" ({confidence})" if confidence else ""
+        lines.append(f"- {name}{suffix}")
+    return lines or ["- none detected"]
+
+
+def _format_proof_commands(items: object) -> list[str]:
+    if not isinstance(items, list) or not items:
+        return ["- none recommended"]
+
+    lines: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        command = str(item.get("command", "")).strip()
+        if not command:
+            continue
+        surface = str(item.get("surface", "unknown"))
+        purpose = str(item.get("purpose", "unknown"))
+        auto_run = str(item.get("auto_run_allowed", False)).lower()
+        lines.append(
+            f"- `{command}` — surface={surface}; purpose={purpose}; auto_run_allowed={auto_run}"
+        )
+    return lines or ["- none recommended"]
+
+
+def render_adoption_surface_report(payload: dict[str, Any]) -> str:
+    identity = payload.get("repo_identity")
+    repo_identity = identity if isinstance(identity, dict) else {}
+    operator_summary = payload.get("operator_summary")
+    summary = operator_summary if isinstance(operator_summary, dict) else {}
+
+    lines = [
+        "# SDETKit adoption readiness report",
+        "",
+        "## Repository",
+        f"- name: {repo_identity.get('name', 'unknown')}",
+        f"- git_detected: {str(repo_identity.get('git_detected', False)).lower()}",
+        f"- is_current_sdetkit_repo: {str(repo_identity.get('is_current_sdetkit_repo', False)).lower()}",
+        f"- remote_url: {repo_identity.get('remote_url', '')}",
+        "",
+        "## Detected languages",
+        *_format_named_items(payload.get("detected_languages")),
+        "",
+        "## Package managers",
+        *_format_named_items(payload.get("package_managers")),
+        "",
+        "## Test runners",
+        *_format_named_items(payload.get("test_runners")),
+        "",
+        "## CI systems",
+        *_format_named_items(payload.get("ci_systems")),
+        "",
+        "## Security tools",
+        *_format_named_items(payload.get("security_tools")),
+        "",
+        "## Recommended proof commands",
+        *_format_proof_commands(payload.get("recommended_proof_commands")),
+        "",
+        "## Review-first unknowns",
+        *(
+            [f"- {item}" for item in payload.get("review_first_unknowns", [])]
+            if payload.get("review_first_unknowns")
+            else ["- none"]
+        ),
+        "",
+        "## Operator summary",
+        f"- status: {summary.get('status', 'unknown')}",
+        f"- next_action: {summary.get('next_action', '')}",
+        "",
+        "## Authority boundary",
+        f"- automation_allowed: {str(payload.get('automation_allowed', True)).lower()}",
+        f"- patch_application_allowed: {str(payload.get('patch_application_allowed', True)).lower()}",
+        f"- merge_authorized: {str(payload.get('merge_authorized', True)).lower()}",
+        f"- semantic_equivalence_proven: {str(payload.get('semantic_equivalence_proven', True)).lower()}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def write_adoption_surface_artifact(
     *,
     repo_root: str | Path = ".",
@@ -489,13 +578,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--out", default="build/sdetkit/adoption-surface.json")
-    parser.add_argument("--format", choices=["json", "text"], default="json")
+    parser.add_argument("--format", choices=["json", "text", "report"], default="json")
     ns = parser.parse_args(list(argv) if argv is not None else None)
 
     summary = write_adoption_surface_artifact(repo_root=ns.root, out=ns.out)
 
     if ns.format == "json":
         sys.stdout.write(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    elif ns.format == "report":
+        payload = json.loads(Path(summary["adoption_surface_json"]).read_text(encoding="utf-8"))
+        sys.stdout.write(render_adoption_surface_report(payload) + "\n")
     else:
         sys.stdout.write(f"adoption_surface_json={summary['adoption_surface_json']}\n")
         sys.stdout.write(f"automation_allowed={str(summary['automation_allowed']).lower()}\n")

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -283,3 +283,68 @@ def test_adoption_surface_payload_validator_rejects_authority_escalation() -> No
     }
 
     assert validate_adoption_surface_payload(payload) == ["automation_allowed must be false"]
+
+
+def test_adoption_surface_report_renders_operator_readiness_summary(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
+    _write(tmp_path / ".pre-commit-config.yaml", "repos: []\n")
+    _write(tmp_path / "package.json", json.dumps({"name": "demo", "scripts": {"build": "tsc"}}))
+    out = tmp_path / "adoption-surface.json"
+
+    from sdetkit.adoption_surface import main
+
+    rc = main(["--root", str(tmp_path), "--out", str(out), "--format", "report"])
+
+    assert rc == 0
+    report = capsys.readouterr().out
+    assert "# SDETKit adoption readiness report" in report
+    assert "## Detected languages" in report
+    assert "- python (high)" in report
+    assert "- javascript_typescript (medium)" in report
+    assert "## Recommended proof commands" in report
+    assert "`python -m pytest -q -o addopts=`" in report
+    assert "auto_run_allowed=false" in report
+    assert "## Review-first unknowns" in report
+    assert (
+        "JavaScript/TypeScript package manifest detected but test command is not proven" in report
+    )
+    assert "## Authority boundary" in report
+    assert "- automation_allowed: false" in report
+    assert "- patch_application_allowed: false" in report
+    assert "- merge_authorized: false" in report
+    assert "- semantic_equivalence_proven: false" in report
+
+
+def test_adoption_surface_cli_dispatch_renders_operator_report(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(tmp_path / "requirements-test.txt", "pytest==9.0.3\n")
+    _write(tmp_path / "package.json", json.dumps({"name": "demo", "scripts": {"build": "tsc"}}))
+    out = tmp_path / "adoption-surface.json"
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-surface",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--format",
+            "report",
+        ]
+    )
+
+    assert rc == 0
+    report = capsys.readouterr().out
+    assert "# SDETKit adoption readiness report" in report
+    assert "## Recommended proof commands" in report
+    assert "auto_run_allowed=false" in report
+    assert "- patch_application_allowed: false" in report


### PR DESCRIPTION
## Summary
- Add a Markdown-style operator readiness report for `sdetkit adoption-surface`.
- Include repository identity, detected surfaces, recommended proof commands, review-first unknowns, operator next action, and authority boundary.
- Extend root CLI dispatch so `python -m sdetkit adoption-surface --format report` works through the public entrypoint.
- Add focused regression coverage for direct module rendering and root CLI dispatch.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format report`
- `make proof-after-format`
- `git diff --check`

## Risk
- Low.
- Public surface: additive `--format report` option for adoption-surface.
- Rollback: revert this PR.

## Boundary
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- recommended proof commands remain manual/review-first