### PR TITLE
docs(adoption): document operator readiness report

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -95,3 +95,27 @@ Use these in order:
 - [Real repo adoption proof](real-repo-adoption.md)
 - [Adoption examples](adoption-examples.md)
 - [Choose your path](choose-your-path.md)
+
+## Operator readiness report
+
+Use the adoption-surface report when you want a human-readable, review-first summary before running commands in an adopted repository:
+
+```bash
+python -m sdetkit adoption-surface \
+  --root . \
+  --out build/sdetkit/adoption-surface.json \
+  --format report
+```
+
+The report summarizes repository identity, detected languages, package managers, test runners, CI systems, security tools, recommended proof commands, review-first unknowns, and the authority boundary.
+
+The command is intentionally read-only. Recommended proof commands are listed for the operator to review and run manually; they are not auto-run by SDETKit.
+
+Authority boundary:
+
+```text
+automation_allowed=false
+patch_application_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -211,3 +211,13 @@ python -m sdetkit boost scan . --index-out build/sdetkit-index --evidence-dir bu
 - [Versioning and support posture](versioning-and-support.md)
 - [Command taxonomy](command-taxonomy.md)
 - [Umbrella architecture](architecture/umbrella-kits.md)
+
+### `sdetkit adoption-surface --format report`
+
+Render a Markdown-style operator readiness report while also writing the deterministic adoption-surface JSON artifact:
+
+```bash
+python -m sdetkit adoption-surface --root . --out build/sdetkit/adoption-surface.json --format report
+```
+
+Use this report for review-first adoption planning. It does not authorize automation, patch application, merging, or semantic-equivalence claims.


### PR DESCRIPTION
## Summary
- Document the adoption-surface operator readiness report.
- Add the `python -m sdetkit adoption-surface --format report` usage path.
- Clarify that the report is read-only and review-first.
- Document the authority boundary for automation, patch application, merge authorization, and semantic equivalence.

## Verification
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_mkdocs_exclude_docs_scope.py -o addopts=`
- `python -m pytest -q tests/test_adoption_surface.py -o addopts=`
- `make proof-after-format`
- `git diff --check`

## Risk
- Low.
- Docs only.
- Rollback: revert this PR.

## Boundary
- documentation_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false