### PR TITLE
test(adoption): prove local external root smoke

### DIFF
--- a/src/sdetkit/adoption_learning.py
+++ b/src/sdetkit/adoption_learning.py
@@ -67,6 +67,10 @@ def _fixture_repo_matrix_present(repo_root: Path) -> bool:
     return EXPECTED_FIXTURE_REPOS <= present
 
 
+def _local_external_root_smoke_present(repo_root: Path) -> bool:
+    return (repo_root / "tests" / "test_adoption_local_external_root.py").is_file()
+
+
 def _detected_strengths(surface: dict[str, Any]) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     package_managers = set(_names(surface.get("package_managers")))
@@ -100,6 +104,7 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
     ci_systems = set(_names(surface.get("ci_systems")))
     review_unknowns = surface.get("review_first_unknowns")
     fixture_matrix_present = _fixture_repo_matrix_present(repo_root)
+    local_external_root_smoke_present = _local_external_root_smoke_present(repo_root)
 
     gaps: list[str] = []
     if languages <= {"python"} and not fixture_matrix_present:
@@ -108,7 +113,8 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
         gaps.append("add fixture coverage for non-GitHub CI providers")
     if not review_unknowns and not fixture_matrix_present:
         gaps.append("add fixtures that prove review-first unknown handling")
-    gaps.append("add local external-root smoke before public repo trials")
+    if not local_external_root_smoke_present:
+        gaps.append("add local external-root smoke before public repo trials")
     gaps.append("add public repo eligibility screen before using third-party repos")
     return gaps
 

--- a/tests/test_adoption_learning.py
+++ b/tests/test_adoption_learning.py
@@ -64,7 +64,7 @@ def test_adoption_learning_records_current_repo_self_baseline() -> None:
     assert "make proof-after-format" in payload["observed_surfaces"]["recommended_proof_commands"]
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "local external root smoke"
+    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
 
@@ -127,6 +127,6 @@ def test_adoption_learning_text_renderer_keeps_next_upgrade_visible() -> None:
 
     text = render_adoption_learning_text(payload)
 
-    assert "recommended_next_upgrade=local external root smoke" in text
+    assert "recommended_next_upgrade=public repo eligibility screen" in text
     assert "learning_gaps:" in text
     assert "- semantic_equivalence_proven=false" in text

--- a/tests/test_adoption_local_external_root.py
+++ b/tests/test_adoption_local_external_root.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from sdetkit.adoption_learning import build_adoption_learning_payload
+from sdetkit.adoption_surface import (
+    discover_adoption_surface,
+    render_adoption_surface_report,
+    write_adoption_surface_artifact,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _snapshot_tree(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        rel = path.relative_to(root).as_posix()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _make_owned_external_repo(root: Path) -> None:
+    _write(root / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(root / "requirements-test.txt", "pytest==9.0.3\n")
+    _write(
+        root / ".git" / "config",
+        '[remote "origin"]\n    url = https://token@example.com/org/owned-demo.git\n',
+    )
+
+
+def test_local_external_root_surface_is_read_only_and_not_current_repo(
+    tmp_path: Path,
+) -> None:
+    external_root = tmp_path / "owned_external_repo"
+    _make_owned_external_repo(external_root)
+    before = _snapshot_tree(external_root)
+    out = tmp_path / "artifacts" / "adoption-surface.json"
+
+    summary = write_adoption_surface_artifact(repo_root=external_root, out=out)
+
+    assert _snapshot_tree(external_root) == before
+    assert out.is_file()
+    assert not out.is_relative_to(external_root)
+    assert summary["adoption_surface_json"] == out.as_posix()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["repo_root"] == external_root.as_posix()
+    assert payload["repo_identity"] == {
+        "name": "owned_external_repo",
+        "is_current_sdetkit_repo": False,
+        "git_detected": True,
+        "remote_url": "https://example.com/org/owned-demo.git",
+    }
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+    assert all(
+        command["auto_run_allowed"] is False for command in payload["recommended_proof_commands"]
+    )
+
+
+def test_local_external_root_report_keeps_operator_boundary(tmp_path: Path) -> None:
+    external_root = tmp_path / "owned_external_repo"
+    _make_owned_external_repo(external_root)
+
+    report = render_adoption_surface_report(discover_adoption_surface(external_root))
+
+    assert "# SDETKit adoption readiness report" in report
+    assert "- name: owned_external_repo" in report
+    assert "- is_current_sdetkit_repo: false" in report
+    assert "- git_detected: true" in report
+    assert "- remote_url: https://example.com/org/owned-demo.git" in report
+    assert "- python (high)" in report
+    assert "auto_run_allowed=false" in report
+    assert "- patch_application_allowed: false" in report
+
+
+def test_local_external_root_cli_dispatch_writes_artifact_outside_target(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    external_root = tmp_path / "owned_external_repo"
+    _make_owned_external_repo(external_root)
+    before = _snapshot_tree(external_root)
+    out = tmp_path / "artifacts" / "adoption-surface.json"
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-surface",
+            "--root",
+            str(external_root),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert _snapshot_tree(external_root) == before
+    assert "adoption_surface_json=" in stdout
+    assert payload["repo_identity"]["is_current_sdetkit_repo"] is False
+    assert payload["repo_identity"]["remote_url"] == "https://example.com/org/owned-demo.git"
+
+
+def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -> None:
+    payload = build_adoption_learning_payload(Path("."))
+
+    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
+    assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
+    assert (
+        "add public repo eligibility screen before using third-party repos"
+        in payload["learning_gaps"]
+    )
+    assert payload["authority_boundary"]["automation_allowed"] is False
+    assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -194,13 +194,17 @@ def test_adoption_surface_fixture_reports_remain_operator_readable(fixture: str)
 def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "local external root smoke"
+    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "local external root smoke"
+    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
     assert "add fixture coverage for non-GitHub CI providers" not in payload["learning_gaps"]
     assert "add fixtures that prove review-first unknown handling" not in payload["learning_gaps"]
-    assert "add local external-root smoke before public repo trials" in payload["learning_gaps"]
+    assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
+    assert (
+        "add public repo eligibility screen before using third-party repos"
+        in payload["learning_gaps"]
+    )
 
 
 def test_fixture_matrix_proves_review_first_unknown_handling() -> None:


### PR DESCRIPTION
## Summary
- Add owned local external-root smoke coverage for adoption-surface.
- Prove SDETKit can inspect a repo outside its checkout while keeping `is_current_sdetkit_repo=false`.
- Prove target repo content is unchanged after adoption-surface artifact generation.
- Prove remote URLs are sanitized before reporting.
- Advance adoption-learning after local external-root smoke exists: the next recommended upgrade becomes public repo eligibility screen.

## Verification
- `python -m pytest -q tests/test_adoption_local_external_root.py tests/test_adoption_surface_fixture_matrix.py tests/test_adoption_surface.py tests/test_adoption_learning.py -o addopts=`
- `python -m sdetkit adoption-surface --root /tmp/sdetkit-local-external-root-smoke/owned_python_repo --out build/sdetkit/local-external-adoption-surface.json --format report`
- `python -m sdetkit adoption-learning --root . --surface-json build/sdetkit/adoption-surface.json --out build/sdetkit/adoption-learning.json --format text`
- `make proof-after-format`
- `git diff --check`

## Learning Result
- Local external-root smoke is now proven.
- SDETKit can inspect an owned repo outside its checkout read-only.
- The target repo remains unchanged.
- Self-adoption learning advances to: public repo eligibility screen.

## Risk
- Low.
- Test-only plus learning-transition logic.
- No dependency install.
- No target repo command execution.
- No external/public repo usage.
- Rollback: revert this PR.

## Boundary
- owned_local_external_repo_only=true
- learning_only=true
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false