### PR TITLE
feat(adoption): screen public repo eligibility

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -693,6 +693,26 @@ Then use stability-aware command discovery:
     adoption_learning.add_argument("--trial-name", default="self_adoption_baseline")
     adoption_learning.add_argument("--format", choices=["json", "text"], default="json")
 
+    public_repo_eligibility = sub.add_parser(
+        "public-repo-eligibility",
+        help="[Advanced but supported] Screen public repo eligibility for read-only trials",
+    )
+    public_repo_eligibility.add_argument("--repo-url", required=True)
+    public_repo_eligibility.add_argument("--license", dest="license_id", required=True)
+    public_repo_eligibility.add_argument(
+        "--out", default="build/sdetkit/public-repo-eligibility.json"
+    )
+    public_repo_eligibility.add_argument(
+        "--repo-size", choices=["small", "medium", "large", "huge"], default="small"
+    )
+    public_repo_eligibility.add_argument("--private", action="store_true")
+    public_repo_eligibility.add_argument("--owned-by-us", action="store_true")
+    public_repo_eligibility.add_argument("--has-no-ai-notice", action="store_true")
+    public_repo_eligibility.add_argument("--has-no-benchmark-notice", action="store_true")
+    public_repo_eligibility.add_argument("--has-security-sensitive-content", action="store_true")
+    public_repo_eligibility.add_argument("--has-malware-or-exploit-content", action="store_true")
+    public_repo_eligibility.add_argument("--format", choices=["json", "text"], default="json")
+
     issue_queue_classifier = sub.add_parser(
         "issue-queue-classifier",
         help="[Advanced but supported] Classify issue queue snapshots without mutation",
@@ -1421,6 +1441,33 @@ def main(argv: Sequence[str] | None = None) -> int:
         if str(ns.surface_json):
             forwarded.extend(["--surface-json", str(ns.surface_json)])
         return _run_module_main("sdetkit.adoption_learning", forwarded)
+
+    if ns.cmd == "public-repo-eligibility":
+        forwarded = [
+            "--repo-url",
+            str(ns.repo_url),
+            "--license",
+            str(ns.license_id),
+            "--out",
+            str(ns.out),
+            "--repo-size",
+            str(ns.repo_size),
+            "--format",
+            str(ns.format),
+        ]
+        if ns.private:
+            forwarded.append("--private")
+        if ns.owned_by_us:
+            forwarded.append("--owned-by-us")
+        if ns.has_no_ai_notice:
+            forwarded.append("--has-no-ai-notice")
+        if ns.has_no_benchmark_notice:
+            forwarded.append("--has-no-benchmark-notice")
+        if ns.has_security_sensitive_content:
+            forwarded.append("--has-security-sensitive-content")
+        if ns.has_malware_or_exploit_content:
+            forwarded.append("--has-malware-or-exploit-content")
+        return _run_module_main("sdetkit.adoption_public_repo_eligibility", forwarded)
 
     if ns.cmd == "issue-queue-classifier":
         forwarded = [

--- a/src/sdetkit/adoption_learning.py
+++ b/src/sdetkit/adoption_learning.py
@@ -71,6 +71,10 @@ def _local_external_root_smoke_present(repo_root: Path) -> bool:
     return (repo_root / "tests" / "test_adoption_local_external_root.py").is_file()
 
 
+def _public_repo_eligibility_screen_present(repo_root: Path) -> bool:
+    return (repo_root / "tests" / "test_adoption_public_repo_eligibility.py").is_file()
+
+
 def _detected_strengths(surface: dict[str, Any]) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     package_managers = set(_names(surface.get("package_managers")))
@@ -105,6 +109,7 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
     review_unknowns = surface.get("review_first_unknowns")
     fixture_matrix_present = _fixture_repo_matrix_present(repo_root)
     local_external_root_smoke_present = _local_external_root_smoke_present(repo_root)
+    public_repo_eligibility_screen_present = _public_repo_eligibility_screen_present(repo_root)
 
     gaps: list[str] = []
     if languages <= {"python"} and not fixture_matrix_present:
@@ -115,7 +120,10 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
         gaps.append("add fixtures that prove review-first unknown handling")
     if not local_external_root_smoke_present:
         gaps.append("add local external-root smoke before public repo trials")
-    gaps.append("add public repo eligibility screen before using third-party repos")
+    if not public_repo_eligibility_screen_present:
+        gaps.append("add public repo eligibility screen before using third-party repos")
+    else:
+        gaps.append("run first permissive public repo read-only trial")
     return gaps
 
 
@@ -126,6 +134,8 @@ def _recommended_next_upgrade(gaps: list[str]) -> str:
         return "local external root smoke"
     if any("public repo eligibility screen" in gap for gap in gaps):
         return "public repo eligibility screen"
+    if any("first permissive public repo read-only trial" in gap for gap in gaps):
+        return "first permissive public repo read-only trial"
     return "review learning gaps"
 
 

--- a/src/sdetkit/adoption_public_repo_eligibility.py
+++ b/src/sdetkit/adoption_public_repo_eligibility.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.public_repo_eligibility.v1"
+
+PERMISSIVE_LICENSES = frozenset(
+    {
+        "MIT",
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "ISC",
+        "Unlicense",
+        "CC0-1.0",
+    }
+)
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _normalized_license(value: str) -> str:
+    aliases = {
+        "apache": "Apache-2.0",
+        "apache2": "Apache-2.0",
+        "apache-2": "Apache-2.0",
+        "bsd-2": "BSD-2-Clause",
+        "bsd-3": "BSD-3-Clause",
+        "cc0": "CC0-1.0",
+        "mit": "MIT",
+        "isc": "ISC",
+        "unlicense": "Unlicense",
+    }
+    stripped = value.strip()
+    return aliases.get(stripped.lower(), stripped)
+
+
+def _valid_repo_url(url: str) -> bool:
+    return url.startswith("https://github.com/") or url.startswith("https://gitlab.com/")
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def evaluate_public_repo_eligibility(
+    *,
+    repo_url: str,
+    license_id: str,
+    is_public: bool = True,
+    repo_size: str = "small",
+    has_no_ai_notice: bool = False,
+    has_no_benchmark_notice: bool = False,
+    has_security_sensitive_content: bool = False,
+    has_malware_or_exploit_content: bool = False,
+    owned_by_us: bool = False,
+) -> dict[str, Any]:
+    normalized_license = _normalized_license(license_id)
+    blocked_reasons: list[str] = []
+    reasons: list[str] = []
+
+    if not repo_url.strip():
+        blocked_reasons.append("missing repo_url")
+    elif not _valid_repo_url(repo_url):
+        blocked_reasons.append("repo_url must be a supported public forge URL")
+    else:
+        reasons.append("repo_url is a supported forge URL")
+
+    if not is_public:
+        blocked_reasons.append("repo must be public for public read-only trials")
+    else:
+        reasons.append("repo is public")
+
+    if owned_by_us:
+        reasons.append("repo is owned or controlled by the operator")
+    elif normalized_license in PERMISSIVE_LICENSES:
+        reasons.append(f"license is permissive: {normalized_license}")
+    elif not normalized_license:
+        blocked_reasons.append("license is missing")
+    else:
+        blocked_reasons.append(f"license is not in permissive allowlist: {normalized_license}")
+
+    if repo_size not in {"small", "medium"}:
+        blocked_reasons.append(f"repo size is not suitable for first trial: {repo_size}")
+    else:
+        reasons.append(f"repo size is suitable: {repo_size}")
+
+    if has_no_ai_notice:
+        blocked_reasons.append("repo contains no-AI usage notice")
+    if has_no_benchmark_notice:
+        blocked_reasons.append("repo contains no-benchmark usage notice")
+    if has_security_sensitive_content:
+        blocked_reasons.append("repo appears security-sensitive")
+    if has_malware_or_exploit_content:
+        blocked_reasons.append("repo appears to contain malware or exploit content")
+
+    allowed = not blocked_reasons
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repo_url": repo_url,
+        "license_detected": normalized_license,
+        "owned_by_us": owned_by_us,
+        "is_public": is_public,
+        "repo_size": repo_size,
+        "allowed_for_read_only_trial": allowed,
+        "reasons": reasons,
+        "blocked_reasons": blocked_reasons,
+        "rules": {
+            "read_only_trial_only": True,
+            "no_dependency_install": True,
+            "no_test_execution": True,
+            "no_target_repo_mutation": True,
+            "no_pr_or_issue_opened_on_target": True,
+            "no_endorsement_claim": True,
+        },
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "authority_boundary": _authority_boundary(),
+    }
+
+
+def write_public_repo_eligibility_artifact(
+    *,
+    repo_url: str,
+    license_id: str,
+    out: str | Path = "build/sdetkit/public-repo-eligibility.json",
+    is_public: bool = True,
+    repo_size: str = "small",
+    has_no_ai_notice: bool = False,
+    has_no_benchmark_notice: bool = False,
+    has_security_sensitive_content: bool = False,
+    has_malware_or_exploit_content: bool = False,
+    owned_by_us: bool = False,
+) -> dict[str, Any]:
+    payload = evaluate_public_repo_eligibility(
+        repo_url=repo_url,
+        license_id=license_id,
+        is_public=is_public,
+        repo_size=repo_size,
+        has_no_ai_notice=has_no_ai_notice,
+        has_no_benchmark_notice=has_no_benchmark_notice,
+        has_security_sensitive_content=has_security_sensitive_content,
+        has_malware_or_exploit_content=has_malware_or_exploit_content,
+        owned_by_us=owned_by_us,
+    )
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def render_public_repo_eligibility_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "public_repo_eligibility_status=evaluated",
+        f"repo_url={payload['repo_url']}",
+        f"license_detected={payload['license_detected']}",
+        f"allowed_for_read_only_trial={str(payload['allowed_for_read_only_trial']).lower()}",
+        "reasons:",
+        *[f"- {item}" for item in payload["reasons"]],
+        "blocked_reasons:",
+        *([f"- {item}" for item in payload["blocked_reasons"]] or ["- none"]),
+        "rules:",
+    ]
+    rules = payload["rules"]
+    lines.extend(f"- {name}={str(value).lower()}" for name, value in rules.items())
+    lines.append("authority_boundary:")
+    boundary = payload["authority_boundary"]
+    lines.extend(f"- {field}={str(boundary[field]).lower()}" for field in AUTHORITY_FIELDS)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit public-repo-eligibility",
+        description="Screen a public repository before any read-only adoption trial.",
+    )
+    parser.add_argument("--repo-url", required=True)
+    parser.add_argument("--license", dest="license_id", required=True)
+    parser.add_argument("--out", default="build/sdetkit/public-repo-eligibility.json")
+    parser.add_argument(
+        "--repo-size", choices=["small", "medium", "large", "huge"], default="small"
+    )
+    parser.add_argument("--private", action="store_true")
+    parser.add_argument("--owned-by-us", action="store_true")
+    parser.add_argument("--has-no-ai-notice", action="store_true")
+    parser.add_argument("--has-no-benchmark-notice", action="store_true")
+    parser.add_argument("--has-security-sensitive-content", action="store_true")
+    parser.add_argument("--has-malware-or-exploit-content", action="store_true")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    payload = write_public_repo_eligibility_artifact(
+        repo_url=ns.repo_url,
+        license_id=ns.license_id,
+        out=ns.out,
+        is_public=not ns.private,
+        repo_size=ns.repo_size,
+        has_no_ai_notice=ns.has_no_ai_notice,
+        has_no_benchmark_notice=ns.has_no_benchmark_notice,
+        has_security_sensitive_content=ns.has_security_sensitive_content,
+        has_malware_or_exploit_content=ns.has_malware_or_exploit_content,
+        owned_by_us=ns.owned_by_us,
+    )
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_public_repo_eligibility_text(payload) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adoption_learning.py
+++ b/tests/test_adoption_learning.py
@@ -64,7 +64,7 @@ def test_adoption_learning_records_current_repo_self_baseline() -> None:
     assert "make proof-after-format" in payload["observed_surfaces"]["recommended_proof_commands"]
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
+    assert payload["recommended_next_upgrade"] == "first permissive public repo read-only trial"
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
 
@@ -127,6 +127,6 @@ def test_adoption_learning_text_renderer_keeps_next_upgrade_visible() -> None:
 
     text = render_adoption_learning_text(payload)
 
-    assert "recommended_next_upgrade=public repo eligibility screen" in text
+    assert "recommended_next_upgrade=first permissive public repo read-only trial" in text
     assert "learning_gaps:" in text
     assert "- semantic_equivalence_proven=false" in text

--- a/tests/test_adoption_local_external_root.py
+++ b/tests/test_adoption_local_external_root.py
@@ -119,11 +119,12 @@ def test_local_external_root_cli_dispatch_writes_artifact_outside_target(
 def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
+    assert payload["recommended_next_upgrade"] == "first permissive public repo read-only trial"
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
     assert (
         "add public repo eligibility screen before using third-party repos"
-        in payload["learning_gaps"]
+        not in payload["learning_gaps"]
     )
+    assert "run first permissive public repo read-only trial" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_eligibility.py
+++ b/tests/test_adoption_public_repo_eligibility.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_learning import build_adoption_learning_payload
+from sdetkit.adoption_public_repo_eligibility import (
+    SCHEMA_VERSION,
+    evaluate_public_repo_eligibility,
+    render_public_repo_eligibility_text,
+    write_public_repo_eligibility_artifact,
+)
+
+
+def test_public_repo_eligibility_allows_small_mit_public_repo() -> None:
+    payload = evaluate_public_repo_eligibility(
+        repo_url="https://github.com/example/demo",
+        license_id="MIT",
+        repo_size="small",
+    )
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["allowed_for_read_only_trial"] is True
+    assert payload["blocked_reasons"] == []
+    assert "license is permissive: MIT" in payload["reasons"]
+    assert payload["rules"] == {
+        "read_only_trial_only": True,
+        "no_dependency_install": True,
+        "no_test_execution": True,
+        "no_target_repo_mutation": True,
+        "no_pr_or_issue_opened_on_target": True,
+        "no_endorsement_claim": True,
+    }
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_public_repo_eligibility_blocks_missing_license() -> None:
+    payload = evaluate_public_repo_eligibility(
+        repo_url="https://github.com/example/no-license",
+        license_id="",
+        repo_size="small",
+    )
+
+    assert payload["allowed_for_read_only_trial"] is False
+    assert "license is missing" in payload["blocked_reasons"]
+
+
+def test_public_repo_eligibility_blocks_restrictive_and_sensitive_repo() -> None:
+    payload = evaluate_public_repo_eligibility(
+        repo_url="https://github.com/example/restricted",
+        license_id="Proprietary",
+        repo_size="huge",
+        has_no_ai_notice=True,
+        has_security_sensitive_content=True,
+    )
+
+    assert payload["allowed_for_read_only_trial"] is False
+    assert "license is not in permissive allowlist: Proprietary" in payload["blocked_reasons"]
+    assert "repo size is not suitable for first trial: huge" in payload["blocked_reasons"]
+    assert "repo contains no-AI usage notice" in payload["blocked_reasons"]
+    assert "repo appears security-sensitive" in payload["blocked_reasons"]
+
+
+def test_public_repo_eligibility_owned_repo_can_pass_with_operator_control() -> None:
+    payload = evaluate_public_repo_eligibility(
+        repo_url="https://github.com/example/owned-demo",
+        license_id="",
+        repo_size="small",
+        owned_by_us=True,
+    )
+
+    assert payload["allowed_for_read_only_trial"] is True
+    assert "repo is owned or controlled by the operator" in payload["reasons"]
+
+
+def test_public_repo_eligibility_cli_dispatch_writes_artifact(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out = tmp_path / "public-repo-eligibility.json"
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "public-repo-eligibility",
+            "--repo-url",
+            "https://github.com/example/demo",
+            "--license",
+            "Apache-2.0",
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["allowed_for_read_only_trial"] is True
+    assert "public_repo_eligibility_status=evaluated" in stdout
+    assert "allowed_for_read_only_trial=true" in stdout
+    assert "- no_dependency_install=true" in stdout
+    assert "- patch_application_allowed=false" in stdout
+
+
+def test_public_repo_eligibility_text_reports_blockers() -> None:
+    payload = evaluate_public_repo_eligibility(
+        repo_url="https://github.com/example/blocked",
+        license_id="",
+        has_no_benchmark_notice=True,
+    )
+
+    text = render_public_repo_eligibility_text(payload)
+
+    assert "allowed_for_read_only_trial=false" in text
+    assert "- license is missing" in text
+    assert "- repo contains no-benchmark usage notice" in text
+    assert "- patch_application_allowed=false" in text
+
+
+def test_public_repo_eligibility_writer_records_json(tmp_path: Path) -> None:
+    out = tmp_path / "eligibility.json"
+
+    payload = write_public_repo_eligibility_artifact(
+        repo_url="https://github.com/example/demo",
+        license_id="ISC",
+        out=out,
+    )
+
+    assert payload["allowed_for_read_only_trial"] is True
+    assert json.loads(out.read_text(encoding="utf-8"))["schema_version"] == SCHEMA_VERSION
+
+
+def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() -> None:
+    payload = build_adoption_learning_payload(Path("."))
+
+    assert payload["recommended_next_upgrade"] == "first permissive public repo read-only trial"
+    assert (
+        "add public repo eligibility screen before using third-party repos"
+        not in payload["learning_gaps"]
+    )
+    assert "run first permissive public repo read-only trial" in payload["learning_gaps"]
+    assert payload["authority_boundary"]["automation_allowed"] is False
+    assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -194,17 +194,18 @@ def test_adoption_surface_fixture_reports_remain_operator_readable(fixture: str)
 def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
+    assert payload["recommended_next_upgrade"] == "first permissive public repo read-only trial"
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "public repo eligibility screen"
+    assert payload["recommended_next_upgrade"] == "first permissive public repo read-only trial"
     assert "add fixture coverage for non-GitHub CI providers" not in payload["learning_gaps"]
     assert "add fixtures that prove review-first unknown handling" not in payload["learning_gaps"]
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
     assert (
         "add public repo eligibility screen before using third-party repos"
-        in payload["learning_gaps"]
+        not in payload["learning_gaps"]
     )
+    assert "run first permissive public repo read-only trial" in payload["learning_gaps"]
 
 
 def test_fixture_matrix_proves_review_first_unknown_handling() -> None:


### PR DESCRIPTION
## Summary
- Add `public-repo-eligibility` to screen public repo candidates before any read-only adoption trial.
- Allow only public, small/medium, supported-forge repos with a permissive license or operator ownership/control.
- Block missing/restrictive licenses, oversized repos, no-AI/no-benchmark notices, security-sensitive content, and malware/exploit content.
- Add CLI dispatch for `python -m sdetkit public-repo-eligibility`.
- Advance adoption-learning after the eligibility screen exists: the next recommended upgrade becomes first permissive public repo read-only trial.

## Verification
- `python -m pytest -q tests/test_adoption_public_repo_eligibility.py tests/test_adoption_local_external_root.py tests/test_adoption_surface_fixture_matrix.py tests/test_adoption_surface.py tests/test_adoption_learning.py -o addopts=`
- `python -m sdetkit public-repo-eligibility --repo-url https://github.com/example/demo --license MIT --out build/sdetkit/public-repo-eligibility.json --format text`
- `python -m sdetkit public-repo-eligibility --repo-url https://github.com/example/no-license --license '' --has-no-ai-notice --repo-size huge --out build/sdetkit/public-repo-eligibility.json --format text`
- `python -m sdetkit adoption-learning --root . --surface-json build/sdetkit/adoption-surface.json --out build/sdetkit/adoption-learning.json --format text`
- `make proof-after-format`
- `git diff --check`

## Learning Result
- Public repo eligibility screening is now proven.
- Unsafe/non-free/restrictive candidates are blocked before use.
- Safe/permissive candidates may proceed only to a future read-only trial.
- Self-adoption learning advances to: first permissive public repo read-only trial.

## Risk
- Medium-low.
- Adds a new advisory CLI/reporting surface.
- Does not clone, install, execute, mutate, or contact target repos.
- Rollback: revert this PR.

## Boundary
- eligibility_screen_only=true
- no_public_repo_trial_in_this_pr=true
- reporting_only=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false