### PR TITLE
feat(adoption): classify proof commands for operator guidance

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -715,7 +715,7 @@ Then use stability-aware command discovery:
 
     adoption_proof_recommendations = sub.add_parser(
         "adoption-proof-recommendations",
-        help="[Advanced but supported] Classify adoption proof commands for operators",
+        help=argparse.SUPPRESS,
     )
     adoption_proof_recommendations.add_argument("--root", default=".")
     adoption_proof_recommendations.add_argument("--surface-json", default="")

--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -713,6 +713,19 @@ Then use stability-aware command discovery:
     public_repo_eligibility.add_argument("--has-malware-or-exploit-content", action="store_true")
     public_repo_eligibility.add_argument("--format", choices=["json", "text"], default="json")
 
+    adoption_proof_recommendations = sub.add_parser(
+        "adoption-proof-recommendations",
+        help="[Advanced but supported] Classify adoption proof commands for operators",
+    )
+    adoption_proof_recommendations.add_argument("--root", default=".")
+    adoption_proof_recommendations.add_argument("--surface-json", default="")
+    adoption_proof_recommendations.add_argument(
+        "--out", default="build/sdetkit/adoption-proof-recommendations.json"
+    )
+    adoption_proof_recommendations.add_argument(
+        "--format", choices=["json", "text"], default="json"
+    )
+
     issue_queue_classifier = sub.add_parser(
         "issue-queue-classifier",
         help="[Advanced but supported] Classify issue queue snapshots without mutation",
@@ -1468,6 +1481,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         if ns.has_malware_or_exploit_content:
             forwarded.append("--has-malware-or-exploit-content")
         return _run_module_main("sdetkit.adoption_public_repo_eligibility", forwarded)
+
+    if ns.cmd == "adoption-proof-recommendations":
+        forwarded = [
+            "--root",
+            str(ns.root),
+            "--out",
+            str(ns.out),
+            "--format",
+            str(ns.format),
+        ]
+        if str(ns.surface_json):
+            forwarded.extend(["--surface-json", str(ns.surface_json)])
+        return _run_module_main("sdetkit.adoption_proof_recommendations", forwarded)
 
     if ns.cmd == "issue-queue-classifier":
         forwarded = [

--- a/src/sdetkit/adoption_learning.py
+++ b/src/sdetkit/adoption_learning.py
@@ -85,6 +85,10 @@ def _first_public_repo_trial_present(repo_root: Path) -> bool:
     ).is_file()
 
 
+def _proof_command_recommendation_levels_present(repo_root: Path) -> bool:
+    return (repo_root / "tests" / "test_adoption_proof_recommendations.py").is_file()
+
+
 def _detected_strengths(surface: dict[str, Any]) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     package_managers = set(_names(surface.get("package_managers")))
@@ -123,6 +127,8 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
 
     first_public_repo_trial_present = _first_public_repo_trial_present(repo_root)
 
+    proof_recommendations_present = _proof_command_recommendation_levels_present(repo_root)
+
     gaps: list[str] = []
     if languages <= {"python"} and not fixture_matrix_present:
         gaps.append("add fixture repo matrix for non-Python repo shapes")
@@ -136,8 +142,10 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
         gaps.append("add public repo eligibility screen before using third-party repos")
     elif not first_public_repo_trial_present:
         gaps.append("run first permissive public repo read-only trial")
-    else:
+    elif not proof_recommendations_present:
         gaps.append("add proof command recommendation levels")
+    else:
+        gaps.append("add repo topology summary")
     return gaps
 
 
@@ -152,6 +160,8 @@ def _recommended_next_upgrade(gaps: list[str]) -> str:
         return "first permissive public repo read-only trial"
     if any("proof command recommendation levels" in gap for gap in gaps):
         return "proof command recommendation levels"
+    if any("repo topology summary" in gap for gap in gaps):
+        return "repo topology summary"
     return "review learning gaps"
 
 

--- a/src/sdetkit/adoption_proof_recommendations.py
+++ b/src/sdetkit/adoption_proof_recommendations.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .adoption_surface import discover_adoption_surface, validate_adoption_surface_payload
+
+SCHEMA_VERSION = "sdetkit.adoption_proof_recommendations.v1"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _command_text(item: dict[str, Any]) -> str:
+    return str(item.get("command", "")).strip()
+
+
+def _surface(item: dict[str, Any]) -> str:
+    return str(item.get("surface", "unknown")).strip() or "unknown"
+
+
+def _purpose(item: dict[str, Any]) -> str:
+    return str(item.get("purpose", "unknown")).strip() or "unknown"
+
+
+def _operator_level(item: dict[str, Any]) -> str:
+    purpose = _purpose(item)
+    surface = _surface(item)
+    command = _command_text(item)
+
+    if not command:
+        return "review_first"
+    if command == "make proof-after-format":
+        return "required"
+    if purpose == "test":
+        return "required"
+    if purpose in {"docs", "quality"}:
+        return "recommended"
+    if surface in {"security", "ci"}:
+        return "recommended"
+    return "review_first"
+
+
+def _reason(item: dict[str, Any]) -> str:
+    purpose = _purpose(item)
+    command = _command_text(item)
+
+    if command == "make proof-after-format":
+        return "full repository quality proof; run manually before merge confidence"
+    if purpose == "test":
+        return "test proof for detected target repo surface"
+    if purpose == "docs":
+        return "documentation proof for detected docs surface"
+    if purpose == "quality":
+        return "quality proof for detected formatter/lint/pre-commit surface"
+    return "operator review required before trusting this proof command"
+
+
+def _recommendation_from_command(item: dict[str, Any], index: int) -> dict[str, Any]:
+    command = _command_text(item)
+    level = _operator_level(item)
+    return {
+        "index": index,
+        "command": command,
+        "surface": _surface(item),
+        "purpose": _purpose(item),
+        "operator_level": level,
+        "execution_policy": "manual_only",
+        "executes_target_code": bool(command),
+        "manual_execution_required": True,
+        "auto_run_allowed": False,
+        "reason": _reason(item),
+    }
+
+
+def _review_first_items(surface_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    unknowns = surface_payload.get("review_first_unknowns", [])
+    if not isinstance(unknowns, list):
+        return []
+
+    return [
+        {
+            "description": str(item),
+            "operator_level": "review_first",
+            "manual_resolution_required": True,
+            "auto_run_allowed": False,
+            "reason": "unknown repo surface must be reviewed before proof execution",
+        }
+        for item in unknowns
+    ]
+
+
+def _first_manual_command(recommendations: list[dict[str, Any]]) -> str:
+    for level in ("required", "recommended", "review_first"):
+        for item in recommendations:
+            if item["operator_level"] == level and item["command"]:
+                return str(item["command"])
+    return ""
+
+
+def build_proof_recommendations_payload(
+    repo_root: str | Path = ".",
+    *,
+    surface_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    surface = (
+        surface_payload if surface_payload is not None else discover_adoption_surface(repo_root)
+    )
+    errors = validate_adoption_surface_payload(surface)
+    if errors:
+        raise ValueError("invalid adoption surface payload: " + "; ".join(errors))
+
+    raw_commands = surface.get("recommended_proof_commands", [])
+    if not isinstance(raw_commands, list):
+        raw_commands = []
+
+    recommendations = [
+        _recommendation_from_command(item, index)
+        for index, item in enumerate(raw_commands, start=1)
+        if isinstance(item, dict)
+    ]
+
+    review_first = _review_first_items(surface)
+    required_count = sum(1 for item in recommendations if item["operator_level"] == "required")
+    recommended_count = sum(
+        1 for item in recommendations if item["operator_level"] == "recommended"
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repo_identity": surface.get("repo_identity", {}),
+        "summary": {
+            "recommended_next_action": "review_and_run_manual_proof",
+            "first_manual_command": _first_manual_command(recommendations),
+            "required_count": required_count,
+            "recommended_count": recommended_count,
+            "review_first_count": len(review_first),
+        },
+        "proof_recommendations": recommendations,
+        "review_first_items": review_first,
+        "rules": {
+            "manual_only": True,
+            "no_auto_execution": True,
+            "no_dependency_install": True,
+            "no_target_repo_mutation": True,
+        },
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "authority_boundary": _authority_boundary(),
+    }
+
+
+def write_proof_recommendations_artifact(
+    *,
+    repo_root: str | Path = ".",
+    surface_json: str | Path | None = None,
+    out: str | Path = "build/sdetkit/adoption-proof-recommendations.json",
+) -> dict[str, Any]:
+    surface_payload: dict[str, Any] | None = None
+    if surface_json:
+        loaded = json.loads(Path(surface_json).read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise ValueError("surface_json must contain a JSON object")
+        surface_payload = loaded
+
+    payload = build_proof_recommendations_payload(
+        repo_root,
+        surface_payload=surface_payload,
+    )
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def render_proof_recommendations_text(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "adoption_proof_recommendations_status=generated",
+        f"recommended_next_action={summary['recommended_next_action']}",
+        f"first_manual_command={summary['first_manual_command']}",
+        f"required_count={summary['required_count']}",
+        f"recommended_count={summary['recommended_count']}",
+        f"review_first_count={summary['review_first_count']}",
+        "proof_recommendations:",
+    ]
+
+    for item in payload["proof_recommendations"]:
+        lines.append(
+            "- "
+            f"level={item['operator_level']}; "
+            f"surface={item['surface']}; "
+            f"purpose={item['purpose']}; "
+            f"manual_only={str(item['manual_execution_required']).lower()}; "
+            f"auto_run_allowed={str(item['auto_run_allowed']).lower()}; "
+            f"command={item['command']}"
+        )
+
+    lines.append("review_first_items:")
+    review_first_items = payload["review_first_items"]
+    if review_first_items:
+        for item in review_first_items:
+            lines.append(f"- {item['description']}")
+    else:
+        lines.append("- none")
+
+    lines.append("authority_boundary:")
+    boundary = payload["authority_boundary"]
+    lines.extend(f"- {field}={str(boundary[field]).lower()}" for field in AUTHORITY_FIELDS)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit adoption-proof-recommendations",
+        description="Classify adoption-surface proof commands for operator review.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--surface-json", default="")
+    parser.add_argument("--out", default="build/sdetkit/adoption-proof-recommendations.json")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    payload = write_proof_recommendations_artifact(
+        repo_root=ns.root,
+        surface_json=ns.surface_json or None,
+        out=ns.out,
+    )
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_proof_recommendations_text(payload) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adoption_learning.py
+++ b/tests/test_adoption_learning.py
@@ -64,7 +64,7 @@ def test_adoption_learning_records_current_repo_self_baseline() -> None:
     assert "make proof-after-format" in payload["observed_surfaces"]["recommended_proof_commands"]
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "proof command recommendation levels"
+    assert payload["recommended_next_upgrade"] == "repo topology summary"
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
 
@@ -127,6 +127,6 @@ def test_adoption_learning_text_renderer_keeps_next_upgrade_visible() -> None:
 
     text = render_adoption_learning_text(payload)
 
-    assert "recommended_next_upgrade=proof command recommendation levels" in text
+    assert "recommended_next_upgrade=repo topology summary" in text
     assert "learning_gaps:" in text
     assert "- semantic_equivalence_proven=false" in text

--- a/tests/test_adoption_local_external_root.py
+++ b/tests/test_adoption_local_external_root.py
@@ -119,13 +119,14 @@ def test_local_external_root_cli_dispatch_writes_artifact_outside_target(
 def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "proof command recommendation levels"
+    assert payload["recommended_next_upgrade"] == "repo topology summary"
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
     assert (
         "add public repo eligibility screen before using third-party repos"
         not in payload["learning_gaps"]
     )
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
-    assert "add proof command recommendation levels" in payload["learning_gaps"]
+    assert "add proof command recommendation levels" not in payload["learning_gaps"]
+    assert "add repo topology summary" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_learning import build_adoption_learning_payload
+from sdetkit.adoption_proof_recommendations import (
+    SCHEMA_VERSION,
+    build_proof_recommendations_payload,
+    render_proof_recommendations_text,
+    write_proof_recommendations_artifact,
+)
+from sdetkit.adoption_surface import write_adoption_surface_artifact
+
+
+def test_proof_recommendations_classify_current_repo_commands() -> None:
+    payload = build_proof_recommendations_payload(Path("."))
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["summary"]["recommended_next_action"] == "review_and_run_manual_proof"
+    assert payload["summary"]["first_manual_command"]
+    assert payload["summary"]["required_count"] >= 1
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+    commands = {item["command"]: item for item in payload["proof_recommendations"]}
+    assert "python -m pytest -q -o addopts=" in commands
+    assert commands["python -m pytest -q -o addopts="]["operator_level"] == "required"
+    assert commands["python -m pytest -q -o addopts="]["execution_policy"] == "manual_only"
+    assert commands["python -m pytest -q -o addopts="]["auto_run_allowed"] is False
+    assert all(item["manual_execution_required"] is True for item in commands.values())
+
+
+def test_proof_recommendations_turn_unknowns_into_review_first_items() -> None:
+    payload = build_proof_recommendations_payload(
+        Path("tests/fixtures/adoption_repos/mixed_python_node")
+    )
+
+    assert payload["review_first_items"] == [
+        {
+            "description": "JavaScript/TypeScript package manifest detected but test command is not proven",
+            "operator_level": "review_first",
+            "manual_resolution_required": True,
+            "auto_run_allowed": False,
+            "reason": "unknown repo surface must be reviewed before proof execution",
+        }
+    ]
+    assert payload["summary"]["review_first_count"] == 1
+
+
+def test_proof_recommendations_cli_dispatch_writes_text_summary(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    surface = tmp_path / "adoption-surface.json"
+    out = tmp_path / "proof-recommendations.json"
+    write_adoption_surface_artifact(
+        repo_root=Path("tests/fixtures/adoption_repos/mixed_python_node"),
+        out=surface,
+    )
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-proof-recommendations",
+            "--root",
+            ".",
+            "--surface-json",
+            str(surface),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert "adoption_proof_recommendations_status=generated" in stdout
+    assert "manual_only=true" in stdout
+    assert "auto_run_allowed=false" in stdout
+    assert "review_first_count=1" in stdout
+
+
+def test_proof_recommendations_text_keeps_authority_boundary_visible() -> None:
+    payload = build_proof_recommendations_payload(Path("."))
+    text = render_proof_recommendations_text(payload)
+
+    assert "authority_boundary:" in text
+    assert "- automation_allowed=false" in text
+    assert "- patch_application_allowed=false" in text
+    assert "first_manual_command=" in text
+
+
+def test_proof_recommendations_writer_records_json(tmp_path: Path) -> None:
+    out = tmp_path / "proof-recommendations.json"
+
+    payload = write_proof_recommendations_artifact(
+        repo_root=Path("tests/fixtures/adoption_repos/python_pytest_github"),
+        out=out,
+    )
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert json.loads(out.read_text(encoding="utf-8"))["schema_version"] == SCHEMA_VERSION
+
+
+def test_self_learning_advances_after_proof_recommendations_exist() -> None:
+    payload = build_adoption_learning_payload(Path("."))
+
+    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert "add proof command recommendation levels" not in payload["learning_gaps"]
+    assert "add repo topology summary" in payload["learning_gaps"]
+    assert payload["authority_boundary"]["automation_allowed"] is False
+    assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_eligibility.py
+++ b/tests/test_adoption_public_repo_eligibility.py
@@ -139,12 +139,13 @@ def test_public_repo_eligibility_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "proof command recommendation levels"
+    assert payload["recommended_next_upgrade"] == "repo topology summary"
     assert (
         "add public repo eligibility screen before using third-party repos"
         not in payload["learning_gaps"]
     )
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
-    assert "add proof command recommendation levels" in payload["learning_gaps"]
+    assert "add proof command recommendation levels" not in payload["learning_gaps"]
+    assert "add repo topology summary" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_readonly_trial.py
+++ b/tests/test_adoption_public_repo_readonly_trial.py
@@ -43,8 +43,9 @@ def test_first_public_readonly_trial_fixture_contains_no_source_tree() -> None:
 def test_self_learning_advances_after_first_public_readonly_trial() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "proof command recommendation levels"
+    assert payload["recommended_next_upgrade"] == "repo topology summary"
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
-    assert "add proof command recommendation levels" in payload["learning_gaps"]
+    assert "add proof command recommendation levels" not in payload["learning_gaps"]
+    assert "add repo topology summary" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -194,10 +194,10 @@ def test_adoption_surface_fixture_reports_remain_operator_readable(fixture: str)
 def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "proof command recommendation levels"
+    assert payload["recommended_next_upgrade"] == "repo topology summary"
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "proof command recommendation levels"
+    assert payload["recommended_next_upgrade"] == "repo topology summary"
     assert "add fixture coverage for non-GitHub CI providers" not in payload["learning_gaps"]
     assert "add fixtures that prove review-first unknown handling" not in payload["learning_gaps"]
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
@@ -206,7 +206,8 @@ def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
         not in payload["learning_gaps"]
     )
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
-    assert "add proof command recommendation levels" in payload["learning_gaps"]
+    assert "add proof command recommendation levels" not in payload["learning_gaps"]
+    assert "add repo topology summary" in payload["learning_gaps"]
 
 
 def test_fixture_matrix_proves_review_first_unknown_handling() -> None:


### PR DESCRIPTION
## Summary
- Add `adoption-proof-recommendations` CLI and module.
- Classify adoption-surface proof commands into operator levels: required, recommended, review_first.
- Preserve authority boundaries and manual-only execution.
- Learning surface advances after proof recommendations to `repo topology summary`.

## Verification
- Focused pytest proof passes.
- CLI shows correct required/recommended/manual-only classification.
- Mixed fixture surface shows review_first unknowns.
- Self-adoption learning advances correctly.
- `make proof-after-format` passes.

## Boundary & Safety
- manual_only=true, no target repo mutation.
- auto_run_allowed=false
- Patch/merge/automation authority boundaries remain false.

## Next Upgrade
- `repo topology summary` next upgrade to guide operator manual proof execution.