### PR TITLE
feat(adoption): summarize repo topology for operator planning

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -726,6 +726,18 @@ Then use stability-aware command discovery:
         "--format", choices=["json", "text"], default="json"
     )
 
+    adoption_repo_topology = sub.add_parser(
+        "adoption-repo-topology",
+        help=argparse.SUPPRESS,
+    )
+    adoption_repo_topology.add_argument("--root", default=".")
+    adoption_repo_topology.add_argument("--surface-json", default="")
+    adoption_repo_topology.add_argument("--proof-json", default="")
+    adoption_repo_topology.add_argument(
+        "--out", default="build/sdetkit/adoption-repo-topology.json"
+    )
+    adoption_repo_topology.add_argument("--format", choices=["json", "text"], default="json")
+
     issue_queue_classifier = sub.add_parser(
         "issue-queue-classifier",
         help="[Advanced but supported] Classify issue queue snapshots without mutation",
@@ -1494,6 +1506,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         if str(ns.surface_json):
             forwarded.extend(["--surface-json", str(ns.surface_json)])
         return _run_module_main("sdetkit.adoption_proof_recommendations", forwarded)
+
+    if ns.cmd == "adoption-repo-topology":
+        forwarded = [
+            "--root",
+            str(ns.root),
+            "--out",
+            str(ns.out),
+            "--format",
+            str(ns.format),
+        ]
+        if str(ns.surface_json):
+            forwarded.extend(["--surface-json", str(ns.surface_json)])
+        if str(ns.proof_json):
+            forwarded.extend(["--proof-json", str(ns.proof_json)])
+        return _run_module_main("sdetkit.adoption_repo_topology", forwarded)
 
     if ns.cmd == "issue-queue-classifier":
         forwarded = [

--- a/src/sdetkit/adoption_learning.py
+++ b/src/sdetkit/adoption_learning.py
@@ -89,6 +89,10 @@ def _proof_command_recommendation_levels_present(repo_root: Path) -> bool:
     return (repo_root / "tests" / "test_adoption_proof_recommendations.py").is_file()
 
 
+def _repo_topology_summary_present(repo_root: Path) -> bool:
+    return (repo_root / "tests" / "test_adoption_repo_topology.py").is_file()
+
+
 def _detected_strengths(surface: dict[str, Any]) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     package_managers = set(_names(surface.get("package_managers")))
@@ -121,13 +125,13 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     ci_systems = set(_names(surface.get("ci_systems")))
     review_unknowns = surface.get("review_first_unknowns")
+
     fixture_matrix_present = _fixture_repo_matrix_present(repo_root)
     local_external_root_smoke_present = _local_external_root_smoke_present(repo_root)
     public_repo_eligibility_screen_present = _public_repo_eligibility_screen_present(repo_root)
-
     first_public_repo_trial_present = _first_public_repo_trial_present(repo_root)
-
     proof_recommendations_present = _proof_command_recommendation_levels_present(repo_root)
+    repo_topology_summary_present = _repo_topology_summary_present(repo_root)
 
     gaps: list[str] = []
     if languages <= {"python"} and not fixture_matrix_present:
@@ -144,8 +148,10 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
         gaps.append("run first permissive public repo read-only trial")
     elif not proof_recommendations_present:
         gaps.append("add proof command recommendation levels")
-    else:
+    elif not repo_topology_summary_present:
         gaps.append("add repo topology summary")
+    else:
+        gaps.append("add adoption evidence bundle")
     return gaps
 
 
@@ -162,6 +168,8 @@ def _recommended_next_upgrade(gaps: list[str]) -> str:
         return "proof command recommendation levels"
     if any("repo topology summary" in gap for gap in gaps):
         return "repo topology summary"
+    if any("adoption evidence bundle" in gap for gap in gaps):
+        return "adoption evidence bundle"
     return "review learning gaps"
 
 

--- a/src/sdetkit/adoption_repo_topology.py
+++ b/src/sdetkit/adoption_repo_topology.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .adoption_proof_recommendations import build_proof_recommendations_payload
+from .adoption_surface import discover_adoption_surface, validate_adoption_surface_payload
+
+SCHEMA_VERSION = "sdetkit.adoption_repo_topology.v1"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _names(items: object) -> list[str]:
+    if not isinstance(items, list):
+        return []
+    names: list[str] = []
+    for item in items:
+        if isinstance(item, dict):
+            names.append(str(item.get("name", "unknown")))
+    return names
+
+
+def _commands(proof_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    items = proof_payload.get("proof_recommendations", [])
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _section_lines(items: list[str]) -> list[str]:
+    if not items:
+        return ["- none"]
+    return [f"- {item}" for item in items]
+
+
+def _manual_sequence(proof_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    order = {"review_first": 0, "required": 1, "recommended": 2}
+    commands = sorted(
+        _commands(proof_payload),
+        key=lambda item: (
+            order.get(str(item.get("operator_level", "review_first")), 9),
+            int(item.get("index", 999)),
+        ),
+    )
+    return [
+        {
+            "step": index,
+            "operator_level": str(item.get("operator_level", "review_first")),
+            "surface": str(item.get("surface", "unknown")),
+            "purpose": str(item.get("purpose", "unknown")),
+            "command": str(item.get("command", "")),
+            "manual_only": True,
+            "auto_run_allowed": False,
+        }
+        for index, item in enumerate(commands, start=1)
+    ]
+
+
+def build_repo_topology_payload(
+    repo_root: str | Path = ".",
+    *,
+    surface_payload: dict[str, Any] | None = None,
+    proof_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    surface = (
+        surface_payload if surface_payload is not None else discover_adoption_surface(repo_root)
+    )
+    errors = validate_adoption_surface_payload(surface)
+    if errors:
+        raise ValueError("invalid adoption surface payload: " + "; ".join(errors))
+
+    proof = (
+        proof_payload
+        if proof_payload is not None
+        else build_proof_recommendations_payload(repo_root, surface_payload=surface)
+    )
+
+    unknowns = surface.get("review_first_unknowns", [])
+    if not isinstance(unknowns, list):
+        unknowns = []
+
+    topology = {
+        "languages": _names(surface.get("detected_languages")),
+        "package_managers": _names(surface.get("package_managers")),
+        "test_runners": _names(surface.get("test_runners")),
+        "ci_systems": _names(surface.get("ci_systems")),
+        "security_tools": _names(surface.get("security_tools")),
+        "artifact_surfaces": _names(surface.get("artifact_surfaces")),
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repo_identity": surface.get("repo_identity", {}),
+        "topology": topology,
+        "review_first_unknowns": [str(item) for item in unknowns],
+        "manual_proof_sequence": _manual_sequence(proof),
+        "operator_summary": {
+            "status": "repo_topology_summarized",
+            "primary_language": topology["languages"][0] if topology["languages"] else "unknown",
+            "has_ci": bool(topology["ci_systems"]),
+            "has_review_first_unknowns": bool(unknowns),
+            "next_action": "Review topology, resolve review-first unknowns, then run manual proof sequence.",
+        },
+        "rules": {
+            "summary_only": True,
+            "manual_only": True,
+            "no_auto_execution": True,
+            "no_dependency_install": True,
+            "no_target_repo_mutation": True,
+        },
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "authority_boundary": _authority_boundary(),
+    }
+
+
+def write_repo_topology_artifact(
+    *,
+    repo_root: str | Path = ".",
+    surface_json: str | Path | None = None,
+    proof_json: str | Path | None = None,
+    out: str | Path = "build/sdetkit/adoption-repo-topology.json",
+) -> dict[str, Any]:
+    surface_payload: dict[str, Any] | None = None
+    proof_payload: dict[str, Any] | None = None
+
+    if surface_json:
+        loaded = json.loads(Path(surface_json).read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise ValueError("surface_json must contain a JSON object")
+        surface_payload = loaded
+
+    if proof_json:
+        loaded = json.loads(Path(proof_json).read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise ValueError("proof_json must contain a JSON object")
+        proof_payload = loaded
+
+    payload = build_repo_topology_payload(
+        repo_root,
+        surface_payload=surface_payload,
+        proof_payload=proof_payload,
+    )
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def render_repo_topology_text(payload: dict[str, Any]) -> str:
+    topology = payload["topology"]
+    summary = payload["operator_summary"]
+
+    lines = [
+        "adoption_repo_topology_status=summarized",
+        f"primary_language={summary['primary_language']}",
+        f"has_ci={str(summary['has_ci']).lower()}",
+        f"has_review_first_unknowns={str(summary['has_review_first_unknowns']).lower()}",
+        "languages:",
+        *_section_lines(topology["languages"]),
+        "package_managers:",
+        *_section_lines(topology["package_managers"]),
+        "test_runners:",
+        *_section_lines(topology["test_runners"]),
+        "ci_systems:",
+        *_section_lines(topology["ci_systems"]),
+        "security_tools:",
+        *_section_lines(topology["security_tools"]),
+        "review_first_unknowns:",
+    ]
+
+    unknowns = payload["review_first_unknowns"]
+    if unknowns:
+        lines.extend(f"- {item}" for item in unknowns)
+    else:
+        lines.append("- none")
+
+    lines.append("manual_proof_sequence:")
+    sequence = payload["manual_proof_sequence"]
+    if sequence:
+        for item in sequence:
+            lines.append(
+                "- "
+                f"step={item['step']}; "
+                f"level={item['operator_level']}; "
+                f"surface={item['surface']}; "
+                f"manual_only={str(item['manual_only']).lower()}; "
+                f"auto_run_allowed={str(item['auto_run_allowed']).lower()}; "
+                f"command={item['command']}"
+            )
+    else:
+        lines.append("- none")
+
+    lines.append("authority_boundary:")
+    boundary = payload["authority_boundary"]
+    lines.extend(f"- {field}={str(boundary[field]).lower()}" for field in AUTHORITY_FIELDS)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit adoption-repo-topology",
+        description="Summarize adoption repo topology for operator planning.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--surface-json", default="")
+    parser.add_argument("--proof-json", default="")
+    parser.add_argument("--out", default="build/sdetkit/adoption-repo-topology.json")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    payload = write_repo_topology_artifact(
+        repo_root=ns.root,
+        surface_json=ns.surface_json or None,
+        proof_json=ns.proof_json or None,
+        out=ns.out,
+    )
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_repo_topology_text(payload) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adoption_learning.py
+++ b/tests/test_adoption_learning.py
@@ -64,7 +64,7 @@ def test_adoption_learning_records_current_repo_self_baseline() -> None:
     assert "make proof-after-format" in payload["observed_surfaces"]["recommended_proof_commands"]
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
 
@@ -127,6 +127,6 @@ def test_adoption_learning_text_renderer_keeps_next_upgrade_visible() -> None:
 
     text = render_adoption_learning_text(payload)
 
-    assert "recommended_next_upgrade=repo topology summary" in text
+    assert "recommended_next_upgrade=adoption evidence bundle" in text
     assert "learning_gaps:" in text
     assert "- semantic_equivalence_proven=false" in text

--- a/tests/test_adoption_local_external_root.py
+++ b/tests/test_adoption_local_external_root.py
@@ -119,7 +119,7 @@ def test_local_external_root_cli_dispatch_writes_artifact_outside_target(
 def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
     assert (
         "add public repo eligibility screen before using third-party repos"
@@ -127,6 +127,7 @@ def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -
     )
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
-    assert "add repo topology summary" in payload["learning_gaps"]
+    assert "add repo topology summary" not in payload["learning_gaps"]
+    assert "add adoption evidence bundle" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -112,8 +112,9 @@ def test_proof_recommendations_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_proof_recommendations_exist() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
-    assert "add repo topology summary" in payload["learning_gaps"]
+    assert "add repo topology summary" not in payload["learning_gaps"]
+    assert "add adoption evidence bundle" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_eligibility.py
+++ b/tests/test_adoption_public_repo_eligibility.py
@@ -139,13 +139,14 @@ def test_public_repo_eligibility_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
     assert (
         "add public repo eligibility screen before using third-party repos"
         not in payload["learning_gaps"]
     )
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
-    assert "add repo topology summary" in payload["learning_gaps"]
+    assert "add repo topology summary" not in payload["learning_gaps"]
+    assert "add adoption evidence bundle" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_readonly_trial.py
+++ b/tests/test_adoption_public_repo_readonly_trial.py
@@ -43,9 +43,10 @@ def test_first_public_readonly_trial_fixture_contains_no_source_tree() -> None:
 def test_self_learning_advances_after_first_public_readonly_trial() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
-    assert "add repo topology summary" in payload["learning_gaps"]
+    assert "add repo topology summary" not in payload["learning_gaps"]
+    assert "add adoption evidence bundle" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_repo_topology.py
+++ b/tests/test_adoption_repo_topology.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_learning import build_adoption_learning_payload
+from sdetkit.adoption_proof_recommendations import write_proof_recommendations_artifact
+from sdetkit.adoption_repo_topology import (
+    SCHEMA_VERSION,
+    build_repo_topology_payload,
+    render_repo_topology_text,
+    write_repo_topology_artifact,
+)
+from sdetkit.adoption_surface import write_adoption_surface_artifact
+
+
+def test_repo_topology_summarizes_current_repo_surfaces() -> None:
+    payload = build_repo_topology_payload(Path("."))
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert "python" in payload["topology"]["languages"]
+    assert "pytest" in payload["topology"]["test_runners"]
+    assert "github_actions" in payload["topology"]["ci_systems"]
+    assert payload["operator_summary"]["status"] == "repo_topology_summarized"
+    assert payload["operator_summary"]["has_ci"] is True
+    assert payload["manual_proof_sequence"]
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_repo_topology_preserves_review_first_unknowns_for_mixed_fixture() -> None:
+    payload = build_repo_topology_payload(Path("tests/fixtures/adoption_repos/mixed_python_node"))
+
+    assert "python" in payload["topology"]["languages"]
+    assert "javascript_typescript" in payload["topology"]["languages"]
+    assert payload["review_first_unknowns"] == [
+        "JavaScript/TypeScript package manifest detected but test command is not proven"
+    ]
+    assert payload["operator_summary"]["has_review_first_unknowns"] is True
+
+
+def test_repo_topology_cli_dispatch_writes_text_summary(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    surface = tmp_path / "adoption-surface.json"
+    proof = tmp_path / "proof-recommendations.json"
+    out = tmp_path / "repo-topology.json"
+
+    write_adoption_surface_artifact(
+        repo_root=Path("tests/fixtures/adoption_repos/mixed_python_node"),
+        out=surface,
+    )
+    write_proof_recommendations_artifact(
+        repo_root=Path("tests/fixtures/adoption_repos/mixed_python_node"),
+        surface_json=surface,
+        out=proof,
+    )
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-repo-topology",
+            "--root",
+            "tests/fixtures/adoption_repos/mixed_python_node",
+            "--surface-json",
+            str(surface),
+            "--proof-json",
+            str(proof),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert "adoption_repo_topology_status=summarized" in stdout
+    assert "has_review_first_unknowns=true" in stdout
+    assert "manual_proof_sequence:" in stdout
+    assert "- patch_application_allowed=false" in stdout
+
+
+def test_repo_topology_text_keeps_manual_sequence_visible() -> None:
+    payload = build_repo_topology_payload(Path("."))
+    text = render_repo_topology_text(payload)
+
+    assert "manual_proof_sequence:" in text
+    assert "manual_only=true" in text
+    assert "auto_run_allowed=false" in text
+    assert "authority_boundary:" in text
+
+
+def test_repo_topology_writer_records_json(tmp_path: Path) -> None:
+    out = tmp_path / "repo-topology.json"
+
+    payload = write_repo_topology_artifact(
+        repo_root=Path("tests/fixtures/adoption_repos/python_pytest_github"),
+        out=out,
+    )
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert json.loads(out.read_text(encoding="utf-8"))["schema_version"] == SCHEMA_VERSION
+
+
+def test_self_learning_advances_after_repo_topology_exists() -> None:
+    payload = build_adoption_learning_payload(Path("."))
+
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert "add repo topology summary" not in payload["learning_gaps"]
+    assert "add adoption evidence bundle" in payload["learning_gaps"]
+    assert payload["authority_boundary"]["automation_allowed"] is False
+    assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -194,10 +194,10 @@ def test_adoption_surface_fixture_reports_remain_operator_readable(fixture: str)
 def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "repo topology summary"
+    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
     assert "add fixture coverage for non-GitHub CI providers" not in payload["learning_gaps"]
     assert "add fixtures that prove review-first unknown handling" not in payload["learning_gaps"]
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
@@ -207,7 +207,8 @@ def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     )
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
-    assert "add repo topology summary" in payload["learning_gaps"]
+    assert "add repo topology summary" not in payload["learning_gaps"]
+    assert "add adoption evidence bundle" in payload["learning_gaps"]
 
 
 def test_fixture_matrix_proves_review_first_unknown_handling() -> None:


### PR DESCRIPTION
## Summary
- Add `adoption-repo-topology` to summarize detected repo surfaces for operator planning.
- Include languages, package managers, test runners, CI systems, security tools, review-first unknowns, and manual proof sequence.
- Keep the command hidden from root help while still callable directly.
- Preserve manual-only/no-auto-execution authority boundaries.
- Advance adoption-learning after topology exists: the next recommended upgrade becomes adoption evidence bundle.

## Verification
- `python -m pytest -q tests/test_adoption_repo_topology.py tests/test_adoption_proof_recommendations.py tests/test_adoption_public_repo_readonly_trial.py tests/test_adoption_public_repo_eligibility.py tests/test_adoption_local_external_root.py tests/test_adoption_surface_fixture_matrix.py tests/test_adoption_surface.py tests/test_adoption_learning.py -o addopts=`
- `python -m sdetkit adoption-repo-topology --root . --surface-json build/sdetkit/adoption-surface.json --proof-json build/sdetkit/adoption-proof-recommendations.json --out build/sdetkit/adoption-repo-topology.json --format text`
- `python -m sdetkit adoption-repo-topology --root tests/fixtures/adoption_repos/mixed_python_node --surface-json build/sdetkit/adoption-surface.json --proof-json build/sdetkit/adoption-proof-recommendations.json --out build/sdetkit/adoption-repo-topology.json --format text`
- `python -m sdetkit --help` confirms hidden advanced topology command does not leak into root help.
- `make proof-after-format`
- `git diff --check`

## Learning Result
- Repo topology summary is now proven.
- Operators get a compact repo map before manual proof execution.
- Review-first unknowns remain visible.
- Self-adoption learning advances to: adoption evidence bundle.

## Boundary
- summary_only=true
- manual_only=true
- no_auto_execution=true
- no_dependency_install=true
- no_target_repo_mutation=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false