### PR TITLE
feat(adoption): build adoption evidence bundle

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -738,6 +738,20 @@ Then use stability-aware command discovery:
     )
     adoption_repo_topology.add_argument("--format", choices=["json", "text"], default="json")
 
+    adoption_evidence_bundle = sub.add_parser(
+        "adoption-evidence-bundle",
+        help=argparse.SUPPRESS,
+    )
+    adoption_evidence_bundle.add_argument("--root", default=".")
+    adoption_evidence_bundle.add_argument("--surface-json", default="")
+    adoption_evidence_bundle.add_argument("--proof-json", default="")
+    adoption_evidence_bundle.add_argument("--topology-json", default="")
+    adoption_evidence_bundle.add_argument("--learning-json", default="")
+    adoption_evidence_bundle.add_argument(
+        "--out", default="build/sdetkit/adoption-evidence-bundle.json"
+    )
+    adoption_evidence_bundle.add_argument("--format", choices=["json", "text"], default="json")
+
     issue_queue_classifier = sub.add_parser(
         "issue-queue-classifier",
         help="[Advanced but supported] Classify issue queue snapshots without mutation",
@@ -1521,6 +1535,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         if str(ns.proof_json):
             forwarded.extend(["--proof-json", str(ns.proof_json)])
         return _run_module_main("sdetkit.adoption_repo_topology", forwarded)
+
+    if ns.cmd == "adoption-evidence-bundle":
+        forwarded = [
+            "--root",
+            str(ns.root),
+            "--out",
+            str(ns.out),
+            "--format",
+            str(ns.format),
+        ]
+        if str(ns.surface_json):
+            forwarded.extend(["--surface-json", str(ns.surface_json)])
+        if str(ns.proof_json):
+            forwarded.extend(["--proof-json", str(ns.proof_json)])
+        if str(ns.topology_json):
+            forwarded.extend(["--topology-json", str(ns.topology_json)])
+        if str(ns.learning_json):
+            forwarded.extend(["--learning-json", str(ns.learning_json)])
+        return _run_module_main("sdetkit.adoption_evidence_bundle", forwarded)
 
     if ns.cmd == "issue-queue-classifier":
         forwarded = [

--- a/src/sdetkit/adoption_evidence_bundle.py
+++ b/src/sdetkit/adoption_evidence_bundle.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .adoption_learning import build_adoption_learning_payload
+from .adoption_proof_recommendations import build_proof_recommendations_payload
+from .adoption_repo_topology import build_repo_topology_payload
+from .adoption_surface import discover_adoption_surface, validate_adoption_surface_payload
+
+SCHEMA_VERSION = "sdetkit.adoption_evidence_bundle.v1"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _load_json_object(path: str | Path | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    loaded = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return loaded
+
+
+def _component_schema(payload: dict[str, Any] | None) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    return str(payload.get("schema_version", ""))
+
+
+def _review_first_count(proof_payload: dict[str, Any]) -> int:
+    summary = proof_payload.get("summary", {})
+    if not isinstance(summary, dict):
+        return 0
+    return int(summary.get("review_first_count", 0))
+
+
+def _manual_step_count(topology_payload: dict[str, Any]) -> int:
+    steps = topology_payload.get("manual_proof_sequence", [])
+    if not isinstance(steps, list):
+        return 0
+    return len(steps)
+
+
+def _learning_next_upgrade(learning_payload: dict[str, Any]) -> str:
+    return str(learning_payload.get("recommended_next_upgrade", ""))
+
+
+def _learning_gaps(learning_payload: dict[str, Any]) -> list[str]:
+    gaps = learning_payload.get("learning_gaps", [])
+    if not isinstance(gaps, list):
+        return []
+    return [str(item) for item in gaps]
+
+
+def build_adoption_evidence_bundle_payload(
+    repo_root: str | Path = ".",
+    *,
+    surface_payload: dict[str, Any] | None = None,
+    proof_payload: dict[str, Any] | None = None,
+    topology_payload: dict[str, Any] | None = None,
+    learning_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    surface = (
+        surface_payload if surface_payload is not None else discover_adoption_surface(repo_root)
+    )
+    errors = validate_adoption_surface_payload(surface)
+    if errors:
+        raise ValueError("invalid adoption surface payload: " + "; ".join(errors))
+
+    proof = (
+        proof_payload
+        if proof_payload is not None
+        else build_proof_recommendations_payload(repo_root, surface_payload=surface)
+    )
+    topology = (
+        topology_payload
+        if topology_payload is not None
+        else build_repo_topology_payload(
+            repo_root,
+            surface_payload=surface,
+            proof_payload=proof,
+        )
+    )
+    learning = (
+        learning_payload
+        if learning_payload is not None
+        else build_adoption_learning_payload(Path(repo_root))
+    )
+
+    review_first_count = _review_first_count(proof)
+    manual_step_count = _manual_step_count(topology)
+    next_upgrade = _learning_next_upgrade(learning)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "bundle_status": "adoption_evidence_bundle_generated",
+        "repo_identity": surface.get("repo_identity", {}),
+        "components": {
+            "surface_profile": {
+                "present": True,
+                "schema_version": _component_schema(surface),
+            },
+            "proof_recommendations": {
+                "present": True,
+                "schema_version": _component_schema(proof),
+            },
+            "repo_topology": {
+                "present": True,
+                "schema_version": _component_schema(topology),
+            },
+            "learning": {
+                "present": True,
+                "schema_version": _component_schema(learning),
+            },
+        },
+        "operator_summary": {
+            "status": "ready_for_human_review",
+            "review_first_count": review_first_count,
+            "manual_proof_step_count": manual_step_count,
+            "recommended_next_upgrade": next_upgrade,
+            "next_action": (
+                "Review bundled evidence, resolve review-first unknowns, then run the "
+                "manual proof sequence outside automation."
+            ),
+        },
+        "evidence": {
+            "surface": {
+                "repo_identity": surface.get("repo_identity", {}),
+                "detected_languages": surface.get("detected_languages", []),
+                "package_managers": surface.get("package_managers", []),
+                "test_runners": surface.get("test_runners", []),
+                "ci_systems": surface.get("ci_systems", []),
+                "security_tools": surface.get("security_tools", []),
+                "review_first_unknowns": surface.get("review_first_unknowns", []),
+            },
+            "proof_recommendations": {
+                "summary": proof.get("summary", {}),
+                "proof_recommendations": proof.get("proof_recommendations", []),
+                "review_first_items": proof.get("review_first_items", []),
+            },
+            "repo_topology": {
+                "topology": topology.get("topology", {}),
+                "manual_proof_sequence": topology.get("manual_proof_sequence", []),
+                "operator_summary": topology.get("operator_summary", {}),
+            },
+            "learning": {
+                "target": learning.get("target", ""),
+                "recommended_next_upgrade": next_upgrade,
+                "learning_gaps": _learning_gaps(learning),
+            },
+        },
+        "rules": {
+            "bundle_only": True,
+            "read_only": True,
+            "manual_only": True,
+            "no_auto_execution": True,
+            "no_dependency_install": True,
+            "no_target_repo_mutation": True,
+        },
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "authority_boundary": _authority_boundary(),
+    }
+
+
+def write_adoption_evidence_bundle_artifact(
+    *,
+    repo_root: str | Path = ".",
+    surface_json: str | Path | None = None,
+    proof_json: str | Path | None = None,
+    topology_json: str | Path | None = None,
+    learning_json: str | Path | None = None,
+    out: str | Path = "build/sdetkit/adoption-evidence-bundle.json",
+) -> dict[str, Any]:
+    payload = build_adoption_evidence_bundle_payload(
+        repo_root,
+        surface_payload=_load_json_object(surface_json),
+        proof_payload=_load_json_object(proof_json),
+        topology_payload=_load_json_object(topology_json),
+        learning_payload=_load_json_object(learning_json),
+    )
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def _lines(items: list[str]) -> list[str]:
+    if not items:
+        return ["- none"]
+    return [f"- {item}" for item in items]
+
+
+def render_adoption_evidence_bundle_text(payload: dict[str, Any]) -> str:
+    summary = payload["operator_summary"]
+    components = payload["components"]
+    evidence = payload["evidence"]
+    learning = evidence["learning"]
+
+    lines = [
+        "adoption_evidence_bundle_status=generated",
+        f"review_first_count={summary['review_first_count']}",
+        f"manual_proof_step_count={summary['manual_proof_step_count']}",
+        f"recommended_next_upgrade={summary['recommended_next_upgrade']}",
+        "components:",
+    ]
+
+    for name, component in components.items():
+        lines.append(
+            "- "
+            f"{name}: present={str(component['present']).lower()}; "
+            f"schema_version={component['schema_version']}"
+        )
+
+    lines.extend(
+        [
+            "learning_gaps:",
+            *_lines([str(item) for item in learning["learning_gaps"]]),
+            "rules:",
+        ]
+    )
+    rules = payload["rules"]
+    lines.extend(f"- {name}={str(value).lower()}" for name, value in rules.items())
+
+    lines.append("authority_boundary:")
+    boundary = payload["authority_boundary"]
+    lines.extend(f"- {field}={str(boundary[field]).lower()}" for field in AUTHORITY_FIELDS)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit adoption-evidence-bundle",
+        description="Build a read-only adoption evidence bundle for operator review.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--surface-json", default="")
+    parser.add_argument("--proof-json", default="")
+    parser.add_argument("--topology-json", default="")
+    parser.add_argument("--learning-json", default="")
+    parser.add_argument("--out", default="build/sdetkit/adoption-evidence-bundle.json")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    payload = write_adoption_evidence_bundle_artifact(
+        repo_root=ns.root,
+        surface_json=ns.surface_json or None,
+        proof_json=ns.proof_json or None,
+        topology_json=ns.topology_json or None,
+        learning_json=ns.learning_json or None,
+        out=ns.out,
+    )
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_adoption_evidence_bundle_text(payload) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adoption_learning.py
+++ b/src/sdetkit/adoption_learning.py
@@ -93,6 +93,10 @@ def _repo_topology_summary_present(repo_root: Path) -> bool:
     return (repo_root / "tests" / "test_adoption_repo_topology.py").is_file()
 
 
+def _adoption_evidence_bundle_present(repo_root: Path) -> bool:
+    return (repo_root / "tests" / "test_adoption_evidence_bundle.py").is_file()
+
+
 def _detected_strengths(surface: dict[str, Any]) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     package_managers = set(_names(surface.get("package_managers")))
@@ -132,6 +136,7 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
     first_public_repo_trial_present = _first_public_repo_trial_present(repo_root)
     proof_recommendations_present = _proof_command_recommendation_levels_present(repo_root)
     repo_topology_summary_present = _repo_topology_summary_present(repo_root)
+    adoption_evidence_bundle_present = _adoption_evidence_bundle_present(repo_root)
 
     gaps: list[str] = []
     if languages <= {"python"} and not fixture_matrix_present:
@@ -150,8 +155,10 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
         gaps.append("add proof command recommendation levels")
     elif not repo_topology_summary_present:
         gaps.append("add repo topology summary")
-    else:
+    elif not adoption_evidence_bundle_present:
         gaps.append("add adoption evidence bundle")
+    else:
+        gaps.append("add public repo trial matrix")
     return gaps
 
 
@@ -170,6 +177,8 @@ def _recommended_next_upgrade(gaps: list[str]) -> str:
         return "repo topology summary"
     if any("adoption evidence bundle" in gap for gap in gaps):
         return "adoption evidence bundle"
+    if any("public repo trial matrix" in gap for gap in gaps):
+        return "public repo trial matrix"
     return "review learning gaps"
 
 

--- a/tests/test_adoption_evidence_bundle.py
+++ b/tests/test_adoption_evidence_bundle.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_evidence_bundle import (
+    SCHEMA_VERSION,
+    build_adoption_evidence_bundle_payload,
+    render_adoption_evidence_bundle_text,
+    write_adoption_evidence_bundle_artifact,
+)
+from sdetkit.adoption_learning import build_adoption_learning_payload
+from sdetkit.adoption_proof_recommendations import write_proof_recommendations_artifact
+from sdetkit.adoption_repo_topology import write_repo_topology_artifact
+from sdetkit.adoption_surface import write_adoption_surface_artifact
+
+
+def test_evidence_bundle_collects_all_adoption_components() -> None:
+    payload = build_adoption_evidence_bundle_payload(Path("."))
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["bundle_status"] == "adoption_evidence_bundle_generated"
+    assert payload["components"]["surface_profile"]["present"] is True
+    assert payload["components"]["proof_recommendations"]["present"] is True
+    assert payload["components"]["repo_topology"]["present"] is True
+    assert payload["components"]["learning"]["present"] is True
+    assert payload["operator_summary"]["status"] == "ready_for_human_review"
+    assert payload["operator_summary"]["manual_proof_step_count"] >= 1
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_evidence_bundle_preserves_review_first_unknowns_for_mixed_fixture() -> None:
+    payload = build_adoption_evidence_bundle_payload(
+        Path("tests/fixtures/adoption_repos/mixed_python_node")
+    )
+
+    assert payload["operator_summary"]["review_first_count"] == 1
+    assert payload["evidence"]["surface"]["review_first_unknowns"] == [
+        "JavaScript/TypeScript package manifest detected but test command is not proven"
+    ]
+    assert payload["rules"]["bundle_only"] is True
+    assert payload["rules"]["no_auto_execution"] is True
+
+
+def test_evidence_bundle_cli_dispatch_writes_text_summary(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    surface = tmp_path / "adoption-surface.json"
+    proof = tmp_path / "proof-recommendations.json"
+    topology = tmp_path / "repo-topology.json"
+    out = tmp_path / "evidence-bundle.json"
+
+    root = Path("tests/fixtures/adoption_repos/mixed_python_node")
+    write_adoption_surface_artifact(repo_root=root, out=surface)
+    write_proof_recommendations_artifact(
+        repo_root=root,
+        surface_json=surface,
+        out=proof,
+    )
+    write_repo_topology_artifact(
+        repo_root=root,
+        surface_json=surface,
+        proof_json=proof,
+        out=topology,
+    )
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-evidence-bundle",
+            "--root",
+            str(root),
+            "--surface-json",
+            str(surface),
+            "--proof-json",
+            str(proof),
+            "--topology-json",
+            str(topology),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert "adoption_evidence_bundle_status=generated" in stdout
+    assert "review_first_count=1" in stdout
+    assert "- no_target_repo_mutation=true" in stdout
+    assert "- patch_application_allowed=false" in stdout
+
+
+def test_evidence_bundle_text_keeps_authority_boundary_visible() -> None:
+    payload = build_adoption_evidence_bundle_payload(Path("."))
+    text = render_adoption_evidence_bundle_text(payload)
+
+    assert "adoption_evidence_bundle_status=generated" in text
+    assert "components:" in text
+    assert "rules:" in text
+    assert "- manual_only=true" in text
+    assert "- automation_allowed=false" in text
+    assert "- patch_application_allowed=false" in text
+
+
+def test_evidence_bundle_writer_records_json(tmp_path: Path) -> None:
+    out = tmp_path / "evidence-bundle.json"
+
+    payload = write_adoption_evidence_bundle_artifact(
+        repo_root=Path("tests/fixtures/adoption_repos/python_pytest_github"),
+        out=out,
+    )
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert json.loads(out.read_text(encoding="utf-8"))["schema_version"] == SCHEMA_VERSION
+
+
+def test_self_learning_advances_after_evidence_bundle_exists() -> None:
+    payload = build_adoption_learning_payload(Path("."))
+
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert "add adoption evidence bundle" not in payload["learning_gaps"]
+    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert payload["authority_boundary"]["automation_allowed"] is False
+    assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_learning.py
+++ b/tests/test_adoption_learning.py
@@ -64,7 +64,7 @@ def test_adoption_learning_records_current_repo_self_baseline() -> None:
     assert "make proof-after-format" in payload["observed_surfaces"]["recommended_proof_commands"]
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
 
@@ -127,6 +127,6 @@ def test_adoption_learning_text_renderer_keeps_next_upgrade_visible() -> None:
 
     text = render_adoption_learning_text(payload)
 
-    assert "recommended_next_upgrade=adoption evidence bundle" in text
+    assert "recommended_next_upgrade=public repo trial matrix" in text
     assert "learning_gaps:" in text
     assert "- semantic_equivalence_proven=false" in text

--- a/tests/test_adoption_local_external_root.py
+++ b/tests/test_adoption_local_external_root.py
@@ -119,7 +119,7 @@ def test_local_external_root_cli_dispatch_writes_artifact_outside_target(
 def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
     assert (
         "add public repo eligibility screen before using third-party repos"
@@ -128,6 +128,7 @@ def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
-    assert "add adoption evidence bundle" in payload["learning_gaps"]
+    assert "add adoption evidence bundle" not in payload["learning_gaps"]
+    assert "add public repo trial matrix" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -112,9 +112,10 @@ def test_proof_recommendations_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_proof_recommendations_exist() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
-    assert "add adoption evidence bundle" in payload["learning_gaps"]
+    assert "add adoption evidence bundle" not in payload["learning_gaps"]
+    assert "add public repo trial matrix" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_eligibility.py
+++ b/tests/test_adoption_public_repo_eligibility.py
@@ -139,7 +139,7 @@ def test_public_repo_eligibility_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert (
         "add public repo eligibility screen before using third-party repos"
         not in payload["learning_gaps"]
@@ -147,6 +147,7 @@ def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() 
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
-    assert "add adoption evidence bundle" in payload["learning_gaps"]
+    assert "add adoption evidence bundle" not in payload["learning_gaps"]
+    assert "add public repo trial matrix" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_readonly_trial.py
+++ b/tests/test_adoption_public_repo_readonly_trial.py
@@ -43,10 +43,11 @@ def test_first_public_readonly_trial_fixture_contains_no_source_tree() -> None:
 def test_self_learning_advances_after_first_public_readonly_trial() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
-    assert "add adoption evidence bundle" in payload["learning_gaps"]
+    assert "add adoption evidence bundle" not in payload["learning_gaps"]
+    assert "add public repo trial matrix" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_repo_topology.py
+++ b/tests/test_adoption_repo_topology.py
@@ -112,8 +112,9 @@ def test_repo_topology_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_repo_topology_exists() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert "add repo topology summary" not in payload["learning_gaps"]
-    assert "add adoption evidence bundle" in payload["learning_gaps"]
+    assert "add adoption evidence bundle" not in payload["learning_gaps"]
+    assert "add public repo trial matrix" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -194,10 +194,10 @@ def test_adoption_surface_fixture_reports_remain_operator_readable(fixture: str)
 def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "adoption evidence bundle"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
     assert "add fixture coverage for non-GitHub CI providers" not in payload["learning_gaps"]
     assert "add fixtures that prove review-first unknown handling" not in payload["learning_gaps"]
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
@@ -208,7 +208,8 @@ def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
-    assert "add adoption evidence bundle" in payload["learning_gaps"]
+    assert "add adoption evidence bundle" not in payload["learning_gaps"]
+    assert "add public repo trial matrix" in payload["learning_gaps"]
 
 
 def test_fixture_matrix_proves_review_first_unknown_handling() -> None:


### PR DESCRIPTION
## Summary
- Add `adoption-evidence-bundle` to combine adoption surface, proof recommendations, repo topology, and learning into one read-only operator artifact.
- Preserve review-first counts, manual proof step count, learning gaps, and component schema versions.
- Keep the command hidden from root help while still callable directly.
- Preserve read-only/manual-only/no-auto-execution boundaries.
- Advance adoption-learning after evidence bundle exists: the next recommended upgrade becomes public repo trial matrix.

## Verification
- `python -m pytest -q tests/test_adoption_evidence_bundle.py tests/test_adoption_repo_topology.py tests/test_adoption_proof_recommendations.py tests/test_adoption_public_repo_readonly_trial.py tests/test_adoption_public_repo_eligibility.py tests/test_adoption_local_external_root.py tests/test_adoption_surface_fixture_matrix.py tests/test_adoption_surface.py tests/test_adoption_learning.py -o addopts=`
- `python -m sdetkit adoption-evidence-bundle --root . --surface-json build/sdetkit/adoption-surface.json --proof-json build/sdetkit/adoption-proof-recommendations.json --topology-json build/sdetkit/adoption-repo-topology.json --learning-json build/sdetkit/adoption-learning.json --out build/sdetkit/adoption-evidence-bundle.json --format text`
- `python -m sdetkit adoption-evidence-bundle --root tests/fixtures/adoption_repos/mixed_python_node --surface-json build/sdetkit/adoption-surface.json --proof-json build/sdetkit/adoption-proof-recommendations.json --topology-json build/sdetkit/adoption-repo-topology.json --out build/sdetkit/adoption-evidence-bundle.json --format text`
- `python -m sdetkit --help` confirms hidden advanced evidence bundle command does not leak into root help.
- `make proof-after-format`
- `git diff --check`

## Learning Result
- Adoption evidence bundle is now proven.
- Operators get one artifact containing surface profile, proof levels, topology, and learning state.
- Review-first unknowns remain visible.
- Self-adoption learning advances to: public repo trial matrix.

## Boundary
- bundle_only=true
- read_only=true
- manual_only=true
- no_auto_execution=true
- no_dependency_install=true
- no_target_repo_mutation=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false