### PR TITLE
test(adoption): prove external repo integration runner

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -752,6 +752,15 @@ Then use stability-aware command discovery:
     )
     adoption_evidence_bundle.add_argument("--format", choices=["json", "text"], default="json")
 
+    adoption_external_integration = sub.add_parser(
+        "adoption-external-integration",
+        help=argparse.SUPPRESS,
+    )
+    adoption_external_integration.add_argument("--target-root", required=True)
+    adoption_external_integration.add_argument("--artifact-dir", required=True)
+    adoption_external_integration.add_argument("--out", default="")
+    adoption_external_integration.add_argument("--format", choices=["json", "text"], default="json")
+
     issue_queue_classifier = sub.add_parser(
         "issue-queue-classifier",
         help="[Advanced but supported] Classify issue queue snapshots without mutation",
@@ -1554,6 +1563,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         if str(ns.learning_json):
             forwarded.extend(["--learning-json", str(ns.learning_json)])
         return _run_module_main("sdetkit.adoption_evidence_bundle", forwarded)
+
+    if ns.cmd == "adoption-external-integration":
+        forwarded = [
+            "--target-root",
+            str(ns.target_root),
+            "--artifact-dir",
+            str(ns.artifact_dir),
+            "--format",
+            str(ns.format),
+        ]
+        if str(ns.out):
+            forwarded.extend(["--out", str(ns.out)])
+        return _run_module_main("sdetkit.adoption_external_integration", forwarded)
 
     if ns.cmd == "issue-queue-classifier":
         forwarded = [

--- a/src/sdetkit/adoption_external_integration.py
+++ b/src/sdetkit/adoption_external_integration.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .adoption_evidence_bundle import write_adoption_evidence_bundle_artifact
+from .adoption_proof_recommendations import write_proof_recommendations_artifact
+from .adoption_repo_topology import write_repo_topology_artifact
+from .adoption_surface import write_adoption_surface_artifact
+
+SCHEMA_VERSION = "sdetkit.adoption_external_integration.v1"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _ensure_artifact_dir_outside_target(target_root: Path, artifact_dir: Path) -> None:
+    target = target_root.resolve()
+    artifact = artifact_dir.resolve()
+
+    if artifact == target or artifact.is_relative_to(target):
+        raise ValueError("artifact_dir must be outside target_root")
+
+
+def run_external_integration(
+    *,
+    target_root: str | Path,
+    artifact_dir: str | Path,
+) -> dict[str, Any]:
+    target = Path(target_root).resolve()
+    artifact_root = Path(artifact_dir).resolve()
+
+    if not target.is_dir():
+        raise ValueError(f"target_root does not exist or is not a directory: {target}")
+
+    _ensure_artifact_dir_outside_target(target, artifact_root)
+    artifact_root.mkdir(parents=True, exist_ok=True)
+
+    before_digest = _tree_digest(target)
+
+    surface_json = artifact_root / "adoption-surface.json"
+    proof_json = artifact_root / "adoption-proof-recommendations.json"
+    topology_json = artifact_root / "adoption-repo-topology.json"
+    bundle_json = artifact_root / "adoption-evidence-bundle.json"
+
+    write_adoption_surface_artifact(repo_root=target, out=surface_json)
+    write_proof_recommendations_artifact(
+        repo_root=target,
+        surface_json=surface_json,
+        out=proof_json,
+    )
+    write_repo_topology_artifact(
+        repo_root=target,
+        surface_json=surface_json,
+        proof_json=proof_json,
+        out=topology_json,
+    )
+    write_adoption_evidence_bundle_artifact(
+        repo_root=target,
+        surface_json=surface_json,
+        proof_json=proof_json,
+        topology_json=topology_json,
+        out=bundle_json,
+    )
+
+    after_digest = _tree_digest(target)
+    target_tree_unchanged = before_digest == after_digest
+
+    bundle = json.loads(bundle_json.read_text(encoding="utf-8"))
+    surface = json.loads(surface_json.read_text(encoding="utf-8"))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "integration_status": "passed" if target_tree_unchanged else "failed",
+        "target_root": target.as_posix(),
+        "artifact_dir": artifact_root.as_posix(),
+        "repo_identity": surface.get("repo_identity", {}),
+        "artifact_paths": {
+            "surface_json": surface_json.as_posix(),
+            "proof_recommendations_json": proof_json.as_posix(),
+            "repo_topology_json": topology_json.as_posix(),
+            "evidence_bundle_json": bundle_json.as_posix(),
+        },
+        "target_tree_unchanged": target_tree_unchanged,
+        "bundle_status": bundle.get("bundle_status", ""),
+        "rules": {
+            "external_target_root_required": True,
+            "artifacts_outside_target_root": True,
+            "read_only": True,
+            "manual_only": True,
+            "no_dependency_install": True,
+            "no_target_tests_executed": True,
+            "no_target_repo_mutation": True,
+            "no_target_pr_or_issue_opened": True,
+            "no_endorsement_claim": True,
+        },
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "authority_boundary": _authority_boundary(),
+    }
+
+
+def write_external_integration_artifact(
+    *,
+    target_root: str | Path,
+    artifact_dir: str | Path,
+    out: str | Path | None = None,
+) -> dict[str, Any]:
+    payload = run_external_integration(target_root=target_root, artifact_dir=artifact_dir)
+    out_path = Path(out) if out else Path(artifact_dir) / "adoption-external-integration.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def render_external_integration_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"adoption_external_integration_status={payload['integration_status']}",
+        f"target_root={payload['target_root']}",
+        f"artifact_dir={payload['artifact_dir']}",
+        f"target_tree_unchanged={str(payload['target_tree_unchanged']).lower()}",
+        f"bundle_status={payload['bundle_status']}",
+        "rules:",
+    ]
+
+    rules = payload["rules"]
+    lines.extend(f"- {name}={str(value).lower()}" for name, value in rules.items())
+
+    lines.append("authority_boundary:")
+    boundary = payload["authority_boundary"]
+    lines.extend(f"- {field}={str(boundary[field]).lower()}" for field in AUTHORITY_FIELDS)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit adoption-external-integration",
+        description="Run the read-only adoption artifact stack against an external target root.",
+    )
+    parser.add_argument("--target-root", required=True)
+    parser.add_argument("--artifact-dir", required=True)
+    parser.add_argument("--out", default="")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    payload = write_external_integration_artifact(
+        target_root=ns.target_root,
+        artifact_dir=ns.artifact_dir,
+        out=ns.out or None,
+    )
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_external_integration_text(payload) + "\n")
+
+    if not payload["target_tree_unchanged"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adoption_learning.py
+++ b/src/sdetkit/adoption_learning.py
@@ -97,6 +97,16 @@ def _adoption_evidence_bundle_present(repo_root: Path) -> bool:
     return (repo_root / "tests" / "test_adoption_evidence_bundle.py").is_file()
 
 
+def _public_repo_trial_matrix_present(repo_root: Path) -> bool:
+    return (
+        repo_root
+        / "tests"
+        / "fixtures"
+        / "adoption_public_trials"
+        / "public_repo_trial_matrix.json"
+    ).is_file()
+
+
 def _detected_strengths(surface: dict[str, Any]) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     package_managers = set(_names(surface.get("package_managers")))
@@ -137,6 +147,7 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
     proof_recommendations_present = _proof_command_recommendation_levels_present(repo_root)
     repo_topology_summary_present = _repo_topology_summary_present(repo_root)
     adoption_evidence_bundle_present = _adoption_evidence_bundle_present(repo_root)
+    public_repo_trial_matrix_present = _public_repo_trial_matrix_present(repo_root)
 
     gaps: list[str] = []
     if languages <= {"python"} and not fixture_matrix_present:
@@ -157,8 +168,10 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
         gaps.append("add repo topology summary")
     elif not adoption_evidence_bundle_present:
         gaps.append("add adoption evidence bundle")
-    else:
+    elif not public_repo_trial_matrix_present:
         gaps.append("add public repo trial matrix")
+    else:
+        gaps.append("add public repo trial matrix report")
     return gaps
 
 
@@ -177,6 +190,8 @@ def _recommended_next_upgrade(gaps: list[str]) -> str:
         return "repo topology summary"
     if any("adoption evidence bundle" in gap for gap in gaps):
         return "adoption evidence bundle"
+    if any("public repo trial matrix report" in gap for gap in gaps):
+        return "public repo trial matrix report"
     if any("public repo trial matrix" in gap for gap in gaps):
         return "public repo trial matrix"
     return "review learning gaps"

--- a/tests/fixtures/adoption_public_trials/public_repo_trial_matrix.json
+++ b/tests/fixtures/adoption_public_trials/public_repo_trial_matrix.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "sdetkit.public_repo_trial_matrix.v1",
+  "matrix_name": "pallets_public_readonly_trial_matrix",
+  "trial_mode": "manual_read_only_public_repo_matrix",
+  "source_code_vendored": false,
+  "dependency_install_performed": false,
+  "target_tests_executed": false,
+  "target_repo_mutated": false,
+  "target_pr_or_issue_opened": false,
+  "endorsement_claimed": false,
+  "trials": [
+    {
+      "repo_full_name": "pallets/markupsafe",
+      "repo_url": "https://github.com/pallets/markupsafe",
+      "license_id": "BSD-3-Clause",
+      "expected_primary_language": "python",
+      "eligibility_allowed_for_read_only_trial": true,
+      "prior_single_repo_trial": true
+    },
+    {
+      "repo_full_name": "pallets/click",
+      "repo_url": "https://github.com/pallets/click",
+      "license_id": "BSD-3-Clause",
+      "expected_primary_language": "python",
+      "eligibility_allowed_for_read_only_trial": true,
+      "prior_single_repo_trial": false
+    },
+    {
+      "repo_full_name": "pallets/itsdangerous",
+      "repo_url": "https://github.com/pallets/itsdangerous",
+      "license_id": "BSD-3-Clause",
+      "expected_primary_language": "python",
+      "eligibility_allowed_for_read_only_trial": true,
+      "prior_single_repo_trial": false
+    }
+  ],
+  "authority_boundary": {
+    "automation_allowed": false,
+    "patch_application_allowed": false,
+    "merge_authorized": false,
+    "semantic_equivalence_proven": false
+  },
+  "recommended_next_upgrade_after_matrix": "public repo trial matrix report"
+}

--- a/tests/test_adoption_evidence_bundle.py
+++ b/tests/test_adoption_evidence_bundle.py
@@ -125,8 +125,9 @@ def test_evidence_bundle_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_evidence_bundle_exists() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
-    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_external_integration.py
+++ b/tests/test_adoption_external_integration.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_external_integration import (
+    SCHEMA_VERSION,
+    run_external_integration,
+    write_external_integration_artifact,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_external_python_repo(root: Path) -> None:
+    _write(
+        root / ".git" / "config",
+        '[remote "origin"]\n\turl = https://github.com/pallets/click.git\n',
+    )
+    _write(root / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(root / "requirements-test.txt", "pytest==9.0.3\n")
+    _write(root / "tests" / "test_demo.py", "def test_demo():\n    assert True\n")
+    _write(root / ".github" / "workflows" / "tests.yml", "name: tests\non: [push]\n")
+
+
+def _snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_external_integration_runner_writes_artifacts_outside_target(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "external_repo"
+    artifacts = tmp_path / "artifacts"
+    _make_external_python_repo(target)
+    before = _snapshot(target)
+
+    payload = write_external_integration_artifact(
+        target_root=target,
+        artifact_dir=artifacts,
+    )
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["integration_status"] == "passed"
+    assert payload["target_tree_unchanged"] is True
+    assert _snapshot(target) == before
+
+    for artifact_path in payload["artifact_paths"].values():
+        path = Path(artifact_path)
+        assert path.is_file()
+        assert not path.is_relative_to(target)
+
+    assert payload["bundle_status"] == "adoption_evidence_bundle_generated"
+    assert payload["rules"]["artifacts_outside_target_root"] is True
+    assert payload["rules"]["no_dependency_install"] is True
+    assert payload["rules"]["no_target_tests_executed"] is True
+    assert payload["rules"]["no_target_repo_mutation"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_external_integration_rejects_artifacts_inside_target(tmp_path: Path) -> None:
+    target = tmp_path / "external_repo"
+    _make_external_python_repo(target)
+
+    with pytest.raises(ValueError, match="artifact_dir must be outside target_root"):
+        run_external_integration(
+            target_root=target,
+            artifact_dir=target / "build" / "sdetkit",
+        )
+
+
+def test_external_integration_cli_dispatch_remains_hidden_but_callable(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    target = tmp_path / "external_repo"
+    artifacts = tmp_path / "artifacts"
+    out = artifacts / "external-integration.json"
+    _make_external_python_repo(target)
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-external-integration",
+            "--target-root",
+            str(target),
+            "--artifact-dir",
+            str(artifacts),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert "adoption_external_integration_status=passed" in stdout
+    assert "target_tree_unchanged=true" in stdout
+    assert "- no_target_repo_mutation=true" in stdout
+    assert "- patch_application_allowed=false" in stdout

--- a/tests/test_adoption_learning.py
+++ b/tests/test_adoption_learning.py
@@ -64,7 +64,7 @@ def test_adoption_learning_records_current_repo_self_baseline() -> None:
     assert "make proof-after-format" in payload["observed_surfaces"]["recommended_proof_commands"]
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
 
@@ -127,6 +127,6 @@ def test_adoption_learning_text_renderer_keeps_next_upgrade_visible() -> None:
 
     text = render_adoption_learning_text(payload)
 
-    assert "recommended_next_upgrade=public repo trial matrix" in text
+    assert "recommended_next_upgrade=public repo trial matrix report" in text
     assert "learning_gaps:" in text
     assert "- semantic_equivalence_proven=false" in text

--- a/tests/test_adoption_local_external_root.py
+++ b/tests/test_adoption_local_external_root.py
@@ -119,7 +119,7 @@ def test_local_external_root_cli_dispatch_writes_artifact_outside_target(
 def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
     assert (
         "add public repo eligibility screen before using third-party repos"
@@ -129,6 +129,7 @@ def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
-    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -112,10 +112,11 @@ def test_proof_recommendations_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_proof_recommendations_exist() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
-    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_eligibility.py
+++ b/tests/test_adoption_public_repo_eligibility.py
@@ -139,7 +139,7 @@ def test_public_repo_eligibility_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert (
         "add public repo eligibility screen before using third-party repos"
         not in payload["learning_gaps"]
@@ -148,6 +148,7 @@ def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() 
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
-    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_external_stack.py
+++ b/tests/test_adoption_public_repo_external_stack.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_evidence_bundle import build_adoption_evidence_bundle_payload
+from sdetkit.adoption_proof_recommendations import build_proof_recommendations_payload
+from sdetkit.adoption_repo_topology import build_repo_topology_payload
+from sdetkit.adoption_surface import write_adoption_surface_artifact
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _snapshot_tree(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): path.read_text(encoding="utf-8")
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _make_external_python_repo(root: Path) -> None:
+    _write(
+        root / ".git" / "config",
+        '[remote "origin"]\n\turl = https://github.com/pallets/click.git\n',
+    )
+    _write(root / "pyproject.toml", '[project]\ndependencies = ["pytest"]\n')
+    _write(root / "requirements-test.txt", "pytest==9.0.3\n")
+    _write(root / "tests" / "test_demo.py", "def test_demo():\n    assert True\n")
+    _write(root / ".github" / "workflows" / "tests.yml", "name: tests\non: [push]\n")
+
+
+def test_external_repo_stack_runs_against_target_without_mutating_it(tmp_path: Path) -> None:
+    target = tmp_path / "external_public_repo_clone"
+    artifact_root = tmp_path / "artifacts"
+    _make_external_python_repo(target)
+
+    before = _snapshot_tree(target)
+
+    surface_path = artifact_root / "adoption-surface.json"
+    write_adoption_surface_artifact(repo_root=target, out=surface_path)
+    surface = json.loads(surface_path.read_text(encoding="utf-8"))
+    proof = build_proof_recommendations_payload(target, surface_payload=surface)
+    topology = build_repo_topology_payload(target, surface_payload=surface, proof_payload=proof)
+    bundle = build_adoption_evidence_bundle_payload(
+        target,
+        surface_payload=surface,
+        proof_payload=proof,
+        topology_payload=topology,
+    )
+
+    assert _snapshot_tree(target) == before
+    assert surface_path.is_file()
+    assert not surface_path.is_relative_to(target)
+
+    assert surface["repo_identity"]["is_current_sdetkit_repo"] is False
+    assert surface["repo_identity"]["git_detected"] is True
+    assert any(item["name"] == "python" for item in surface["detected_languages"])
+    assert all(
+        command["auto_run_allowed"] is False for command in surface["recommended_proof_commands"]
+    )
+
+    assert proof["rules"]["no_target_repo_mutation"] is True
+    assert proof["rules"]["no_dependency_install"] is True
+    assert topology["rules"]["no_target_repo_mutation"] is True
+    assert bundle["rules"]["no_target_repo_mutation"] is True
+    assert bundle["rules"]["no_auto_execution"] is True
+    assert bundle["operator_summary"]["manual_proof_step_count"] >= 1
+
+    for payload in [surface, proof, topology, bundle]:
+        assert payload["automation_allowed"] is False
+        assert payload["patch_application_allowed"] is False
+        assert payload["merge_authorized"] is False
+        assert payload["semantic_equivalence_proven"] is False
+
+
+def test_public_trial_matrix_declares_real_external_stack_intent() -> None:
+    payload = json.loads(
+        Path("tests/fixtures/adoption_public_trials/public_repo_trial_matrix.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert payload["trial_mode"] == "manual_read_only_public_repo_matrix"
+    assert payload["source_code_vendored"] is False
+    assert payload["dependency_install_performed"] is False
+    assert payload["target_tests_executed"] is False
+    assert payload["target_repo_mutated"] is False
+    assert payload["target_pr_or_issue_opened"] is False
+    assert payload["endorsement_claimed"] is False
+    assert len(payload["trials"]) >= 3

--- a/tests/test_adoption_public_repo_readonly_trial.py
+++ b/tests/test_adoption_public_repo_readonly_trial.py
@@ -37,17 +37,20 @@ def test_first_public_readonly_trial_fixture_contains_no_source_tree() -> None:
         if path.is_file()
     )
 
-    assert files == ["pallets_markupsafe_readonly_trial.json"]
+    assert "pallets_markupsafe_readonly_trial.json" in files
+    assert all(file_name.endswith(".json") for file_name in files)
+    assert all(not file_name.endswith(".py") for file_name in files)
 
 
 def test_self_learning_advances_after_first_public_readonly_trial() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
-    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_trial_matrix.py
+++ b/tests/test_adoption_public_repo_trial_matrix.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_learning import build_adoption_learning_payload
+
+MATRIX_PATH = Path("tests/fixtures/adoption_public_trials/public_repo_trial_matrix.json")
+
+
+def _matrix() -> dict:
+    return json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def test_public_repo_trial_matrix_records_safe_readonly_boundaries() -> None:
+    payload = _matrix()
+
+    assert payload["schema_version"] == "sdetkit.public_repo_trial_matrix.v1"
+    assert payload["trial_mode"] == "manual_read_only_public_repo_matrix"
+    assert payload["source_code_vendored"] is False
+    assert payload["dependency_install_performed"] is False
+    assert payload["target_tests_executed"] is False
+    assert payload["target_repo_mutated"] is False
+    assert payload["target_pr_or_issue_opened"] is False
+    assert payload["endorsement_claimed"] is False
+    assert payload["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_public_repo_trial_matrix_contains_expected_permissive_candidates() -> None:
+    payload = _matrix()
+    trials = {trial["repo_full_name"]: trial for trial in payload["trials"]}
+
+    assert set(trials) == {
+        "pallets/markupsafe",
+        "pallets/click",
+        "pallets/itsdangerous",
+    }
+
+    for trial in trials.values():
+        assert trial["repo_url"].startswith("https://github.com/pallets/")
+        assert trial["license_id"] == "BSD-3-Clause"
+        assert trial["expected_primary_language"] == "python"
+        assert trial["eligibility_allowed_for_read_only_trial"] is True
+
+    assert trials["pallets/markupsafe"]["prior_single_repo_trial"] is True
+    assert trials["pallets/click"]["prior_single_repo_trial"] is False
+    assert trials["pallets/itsdangerous"]["prior_single_repo_trial"] is False
+
+
+def test_public_repo_trial_matrix_fixture_contains_no_source_tree() -> None:
+    fixture_root = MATRIX_PATH.parent
+    files = sorted(
+        path.relative_to(fixture_root).as_posix()
+        for path in fixture_root.rglob("*")
+        if path.is_file()
+    )
+
+    assert "public_repo_trial_matrix.json" in files
+    assert "pallets_markupsafe_readonly_trial.json" in files
+    assert all(not file_name.endswith(".py") for file_name in files)
+
+
+def test_self_learning_advances_after_public_repo_trial_matrix_exists() -> None:
+    payload = build_adoption_learning_payload(Path("."))
+
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert payload["authority_boundary"]["automation_allowed"] is False
+    assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_repo_topology.py
+++ b/tests/test_adoption_repo_topology.py
@@ -112,9 +112,10 @@ def test_repo_topology_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_repo_topology_exists() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
-    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -194,10 +194,10 @@ def test_adoption_surface_fixture_reports_remain_operator_readable(fixture: str)
 def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix"
+    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
     assert "add fixture coverage for non-GitHub CI providers" not in payload["learning_gaps"]
     assert "add fixtures that prove review-first unknown handling" not in payload["learning_gaps"]
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
@@ -209,7 +209,8 @@ def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
-    assert "add public repo trial matrix" in payload["learning_gaps"]
+    assert "add public repo trial matrix" not in payload["learning_gaps"]
+    assert "add public repo trial matrix report" in payload["learning_gaps"]
 
 
 def test_fixture_matrix_proves_review_first_unknown_handling() -> None:


### PR DESCRIPTION
## Summary
- Add `adoption-external-integration`, a hidden advanced CLI that runs the full adoption artifact stack against an external target repo root.
- Prove SDETKit can run from this repo against cloned external repos as targets.
- Generate adoption surface, proof recommendations, topology, and evidence bundle outside the target repo.
- Add public repo trial matrix metadata for permissive Pallets repos.
- Add regression tests proving target repos are not mutated and artifacts stay outside target roots.
- Advance adoption-learning after the public repo trial matrix exists: next recommended upgrade becomes public repo trial matrix report.

## Verification
- Focused proof: external integration, public repo matrix, evidence bundle, topology, proof recommendations, eligibility, local external root, fixture matrix, adoption surface, and adoption learning.
- Hidden root help proof for `adoption-external-integration`.
- Live public repo integration runner smoke:
  - `pallets/click`
  - `pallets/itsdangerous`
- For each live repo:
  - cloned to `/tmp`
  - used as `--target-root`
  - artifacts written outside target repo
  - target tree digest unchanged
  - no dependency install
  - no target tests executed
  - no target repo mutation
  - no PR/issue/comment
  - no endorsement claim
- `make proof-after-format`
- `git diff --check`

## Learning Result
- SDETKit is now proven against external cloned repos as target roots.
- The public repo trial matrix is now proven.
- Self-adoption learning advances to: public repo trial matrix report.

## Boundary
- external_target_root_required=true
- artifacts_outside_target_root=true
- read_only=true
- manual_only=true
- no_dependency_install=true
- no_target_tests_executed=true
- no_target_repo_mutation=true
- no_target_pr_or_issue_opened=true
- no_endorsement_claim=true
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false