### PR TITLE
feat(pr-quality): collapse operator report sections

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -682,6 +682,37 @@ def _command_lines(values: list[Any]) -> list[str]:
     return [f"- `{item}`" for item in items] or ["- none"]
 
 
+def _has_operator_content(lines: list[str]) -> bool:
+    return any(line.strip() and line.strip() != "- none" for line in lines)
+
+
+def _details_block(title: str, lines: list[str], *, open_by_default: bool = False) -> list[str]:
+    marker = " open" if open_by_default else ""
+    return [
+        f"## {title}",
+        "",
+        f"<details{marker}>",
+        f"<summary>{title}</summary>",
+        "",
+        *lines,
+        "",
+        "</details>",
+    ]
+
+
+def _operator_section(
+    title: str,
+    lines: list[str],
+    *,
+    open_when: bool = False,
+) -> list[str]:
+    return _details_block(
+        title,
+        lines,
+        open_by_default=open_when and _has_operator_content(lines),
+    )
+
+
 def _runtime_proof_artifact_lines(runtime_proof_artifacts: JsonObject | None) -> list[str]:
     summary = _as_dict(runtime_proof_artifacts)
     if not summary:
@@ -1507,37 +1538,68 @@ def render_comment_body(
     if operator_summary:
         lines.extend(["## Operator SafetyGate summary", "", *operator_summary, ""])
 
+    primary_blocker_lines = _primary_blocker_lines(_as_dict(action_report.get("primary_blocker")))
+    automation_decision_lines = _automation_lines(action_report)
+    safe_fix_lines = [
+        *_safe_fix_outcome_lines(_as_dict(safe_fix_outcome)),
+        "",
+        "Remediation refresh",
+        *_remediation_refresh_lines(_as_dict(remediation_refresh)),
+    ]
+    evidence_collected_lines = _evidence_lines(check_intelligence, action_report)
+    failed_check_lines = _failed_check_lines(check_intelligence)
+    recommended_action_lines = _bullet_lines(_as_list(action_report.get("recommended_actions")))
+    required_proof_lines = _command_lines(_as_list(action_report.get("proof_commands")))
+
+    has_primary_blocker = _as_dict(action_report.get("primary_blocker")) != {}
+    has_failed_checks = bool(_as_list(check_intelligence.get("failed_checks")))
+    has_recommended_actions = _has_operator_content(recommended_action_lines)
+    has_required_proof = _has_operator_content(required_proof_lines)
+    status_needs_operator = status != "green"
+
     lines.extend(
         [
-            "## Primary blocker",
+            *_operator_section(
+                "Primary blocker",
+                primary_blocker_lines,
+                open_when=status_needs_operator or has_primary_blocker,
+            ),
             "",
-            *_primary_blocker_lines(_as_dict(action_report.get("primary_blocker"))),
+            *_operator_section(
+                "Automation decision",
+                automation_decision_lines,
+                open_when=status_needs_operator,
+            ),
             "",
-            "## Automation decision",
+            *_operator_section(
+                "Safe fix outcome",
+                safe_fix_lines,
+                open_when=status in {"safe_fix_available", "review_required"},
+            ),
             "",
-            *_automation_lines(action_report),
+            *_operator_section(
+                "Evidence collected",
+                evidence_collected_lines,
+                open_when=status_needs_operator,
+            ),
             "",
-            "## Safe fix outcome",
+            *_operator_section(
+                "Failed check diagnoses",
+                failed_check_lines,
+                open_when=has_failed_checks,
+            ),
             "",
-            *_safe_fix_outcome_lines(_as_dict(safe_fix_outcome)),
-            "Remediation refresh",
-            *_remediation_refresh_lines(_as_dict(remediation_refresh)),
+            *_operator_section(
+                "Recommended actions",
+                recommended_action_lines,
+                open_when=status_needs_operator or has_recommended_actions,
+            ),
             "",
-            "## Evidence collected",
-            "",
-            *_evidence_lines(check_intelligence, action_report),
-            "",
-            "## Failed check diagnoses",
-            "",
-            *_failed_check_lines(check_intelligence),
-            "",
-            "## Recommended actions",
-            "",
-            *_bullet_lines(_as_list(action_report.get("recommended_actions"))),
-            "",
-            "## Required proof",
-            "",
-            *_command_lines(_as_list(action_report.get("proof_commands"))),
+            *_operator_section(
+                "Required proof",
+                required_proof_lines,
+                open_when=status_needs_operator or has_required_proof,
+            ),
             "",
         ]
     )

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2617,3 +2617,79 @@ def test_action_report_operator_safetygate_summary_surfaces_authority_expansion(
     )
     assert "- Operator summary automation allowed: `true`" in body
     assert "- Operator summary merge authorized: `false`" in body
+
+
+def test_action_report_green_comment_collapses_operator_sections_by_default() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 12,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative={"quality": {"ok": True}},
+    )
+
+    assert "<summary>Primary blocker</summary>" in body
+    assert "<summary>Failed check diagnoses</summary>" in body
+    assert "<details open>" not in body
+    assert "No action required from SDETKit." in body
+
+
+def test_action_report_failure_comment_expands_operator_action_sections() -> None:
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "ruff",
+            "title": "Ruff lint contract failed",
+            "surface": "quality",
+            "code": "RUFF_LINT_FAILURE",
+            "impact": "CI is blocked by a lint finding.",
+            "path": "src/sdetkit/check_intelligence.py",
+        },
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "diagnosis is review-first",
+        },
+        "recommended_actions": ["Fix the lint finding."],
+        "proof_commands": ["python -m ruff check src tests"],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [
+            {
+                "name": "ruff",
+                "safe_to_auto_fix": False,
+                "diagnosis": {
+                    "code": "RUFF_LINT_FAILURE",
+                    "title": "Ruff lint contract failed",
+                },
+            }
+        ],
+        "queued_checks": [],
+        "startup_failures": [],
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "<details open>" in body
+    assert "<summary>Primary blocker</summary>" in body
+    assert "<summary>Failed check diagnoses</summary>" in body
+    assert "<summary>Recommended actions</summary>" in body
+    assert "Ruff lint contract failed" in body
+    assert "Fix the lint finding." in body
+    assert "python -m ruff check src tests" in body


### PR DESCRIPTION
## Summary
- Makes PR Quality operator comment sections collapsible with GitHub `<details>` blocks.
- Preserves existing markdown section anchors such as `## Safe fix outcome`.
- Keeps green/no-action sections collapsed by default.
- Expands operator-action sections when there are blockers, failures, recommended actions, or required proof.
- Adds focused tests for green collapsed comments and failure expanded comments.

## Why
- Reduces noise in green PR comments.
- Keeps real blockers and required operator actions visible when something fails.
- Improves reviewer/operator readability without changing SafetyGate authority.

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py -o addopts=`
- `python -m pytest -q tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `make proof-after-format`

## Risk
- Low/medium: markdown rendering change for PR comments.
- Existing headings are preserved for compatibility.
- Rollback: revert this PR.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
