### PR TITLE
ci: add artifact retention to first workflow slice

### DIFF
--- a/.github/workflows/adapter-smoke-bot.yml
+++ b/.github/workflows/adapter-smoke-bot.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: adapter-smoke-pack
+          retention-days: 7
           path: |
             build/adapter-smoke-worker-run.json
             build/adapter-smoke.md

--- a/.github/workflows/adaptive-ops-weekly.yml
+++ b/.github/workflows/adaptive-ops-weekly.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: adaptive-ops-${{ github.run_id }}
+          retention-days: 7
           path: |
             docs/artifacts/adaptive-postcheck-*.json
             docs/artifacts/adaptive-scenario-database-*.json

--- a/.github/workflows/adaptive-sentinel-monitor.yml
+++ b/.github/workflows/adaptive-sentinel-monitor.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: adaptive-sentinel-monitor
+          retention-days: 7
           path: |
             build/sdetkit/sentinel/
             .sdetkit/adaptive-sentinel/

--- a/.github/workflows/adoption-real-repo-canonical.yml
+++ b/.github/workflows/adoption-real-repo-canonical.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: adoption-real-repo-canonical
+          retention-days: 7
           path: |
             examples/adoption/real-repo/build/gate-fast.json
             examples/adoption/real-repo/build/release-preflight.json


### PR DESCRIPTION
## Summary
- Adds `retention-days: 7` to the first workflow artifact-retention slice.
- Covers four existing `actions/upload-artifact` workflows:
  - `.github/workflows/adapter-smoke-bot.yml`
  - `.github/workflows/adaptive-ops-weekly.yml`
  - `.github/workflows/adaptive-sentinel-monitor.yml`
  - `.github/workflows/adoption-real-repo-canonical.yml`

## Why
- Follows the workflow governance report from PR #1635.
- Reduces artifact retention debt in a small, mechanical, reviewable slice.
- Keeps CI workflow professionalization evidence-driven and incremental.

## Governance delta
- `artifacts_have_retention` finding count dropped from `27` to `23`.
- No permissions changes.
- No dependency changes.
- No workflow trigger changes.
- No check bypassing.

## Verification
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format json`
- Verified selected workflows now report `artifacts_have_retention=yes`.
- Verified `artifacts_have_retention_count=23`.
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_external_tool_pin_contract.py -o addopts=`
- `python -m pre_commit run check-yaml --files .github/workflows/adapter-smoke-bot.yml .github/workflows/adaptive-ops-weekly.yml .github/workflows/adaptive-sentinel-monitor.yml .github/workflows/adoption-real-repo-canonical.yml`
- `make proof-after-format`

## Risk
- Low: adds only artifact retention metadata to existing upload steps.
- Rollback: revert this PR.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
