### PR TITLE
fix(ci): recognize setup-python cache dependency paths

### DIFF
--- a/src/sdetkit/workflow_governance_report.py
+++ b/src/sdetkit/workflow_governance_report.py
@@ -142,12 +142,22 @@ def analyze_workflow(repo_root: str | Path, workflow_path: str | Path) -> dict[s
     upload_artifact_used = "actions/upload-artifact" in lower
     artifact_retention = None if not upload_artifact_used else "retention-days:" in lower
 
-    cache_used = "actions/cache" in lower or "setup-python" in lower and "cache:" in lower
-    cache_key_appropriate = (
-        None
-        if not cache_used
-        else "key:" in lower and ("hashfiles(" in lower or "github.sha" in lower)
+    actions_cache_used = "actions/cache" in lower
+    setup_python_cache_used = "setup-python" in lower and "cache:" in lower
+    setup_python_cache_has_dependency_path = (
+        setup_python_cache_used and "cache-dependency-path:" in lower
     )
+    explicit_cache_key_appropriate = "key:" in lower and (
+        "hashfiles(" in lower or "github.sha" in lower
+    )
+    if not actions_cache_used and not setup_python_cache_used:
+        cache_key_appropriate = None
+    elif actions_cache_used and not explicit_cache_key_appropriate:
+        cache_key_appropriate = False
+    elif setup_python_cache_used and not setup_python_cache_has_dependency_path:
+        cache_key_appropriate = False
+    else:
+        cache_key_appropriate = True
 
     mkdocs_used = "mkdocs build" in lower
     docs_build_strict = None if not mkdocs_used else "--strict" in lower

--- a/tests/test_workflow_governance_report.py
+++ b/tests/test_workflow_governance_report.py
@@ -163,3 +163,65 @@ jobs:
     assert "workflow_mutation: false" in stdout
     assert out.is_file()
     assert out.with_suffix(".md").is_file()
+
+
+def test_workflow_governance_accepts_setup_python_cache_dependency_path(tmp_path: Path) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "setup-python-cache.yml",
+        """
+name: setup-python-cache
+on: [push]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+      - uses: actions/setup-python@abcdef0123456789abcdef0123456789abcdef01
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-test.txt
+            constraints-ci.txt
+      - run: python -m pip install -c constraints-ci.txt -e '.[test]'
+      - run: python -m pytest -q tests/test_workflow_governance_report.py -o addopts=
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+
+    assert payload["checklist"]["cache_key_appropriate"] == "yes"
+    assert "cache_key_appropriate" not in payload["findings"]
+
+
+def test_workflow_governance_flags_setup_python_cache_without_dependency_path(
+    tmp_path: Path,
+) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "setup-python-cache.yml",
+        """
+name: setup-python-cache
+on: [push]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+      - uses: actions/setup-python@abcdef0123456789abcdef0123456789abcdef01
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - run: python -m pip install -c constraints-ci.txt -e '.[test]'
+      - run: python -m pytest -q tests/test_workflow_governance_report.py -o addopts=
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+
+    assert payload["checklist"]["cache_key_appropriate"] == "no"
+    assert "cache_key_appropriate" in payload["findings"]


### PR DESCRIPTION
## Summary
- Fixes workflow-governance cache hygiene detection for `actions/setup-python`.
- Treats `cache-dependency-path` as the correct cache hygiene signal for setup-python managed pip cache.
- Keeps `actions/cache` workflows on the explicit `key:` / `hashFiles()` style check.
- Adds focused tests for setup-python cache with and without dependency paths.

## Why
- PR #1635 introduced the workflow governance report.
- PR #1636 used that report for the first artifact-retention hardening slice.
- The accepted-main report then showed cache findings on workflows that already use setup-python cache dependency paths.
- This PR improves the report accuracy before more workflow mutations.

## Governance delta
- `cache_key_appropriate` finding count drops from `23` to `1`.
- `.github/workflows/adapter-smoke-bot.yml` now reports `cache_key_appropriate=yes`.
- `.github/workflows/adaptive-sentinel-monitor.yml` now reports `cache_key_appropriate=yes`.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_external_tool_pin_contract.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format json`
- Verified `cache_key_appropriate_count=1`.
- `make proof-after-format`

## Risk
- Low: report logic and tests only.
- No workflow YAML changes.
- No permission changes.
- No dependency changes.
- Rollback: revert this PR.

## Authority boundary
- workflow_mutation=false
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
