### PR TITLE
ci: add artifact retention to second workflow slice

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -41,4 +41,5 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: pip-audit-report
+          retention-days: 7
           path: pip-audit-report.json

--- a/.github/workflows/dependency-radar-bot.yml
+++ b/.github/workflows/dependency-radar-bot.yml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: dependency-radar
+          retention-days: 7
           path: |
             build/dependency-radar.json
             build/dependency-radar.md

--- a/.github/workflows/docs-experience-bot.yml
+++ b/.github/workflows/docs-experience-bot.yml
@@ -161,6 +161,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: docs-experience-radar
+          retention-days: 7
           path: |
             build/docs-experience-radar.json
             build/docs-experience-radar.md

--- a/.github/workflows/enterprise-gate.yml
+++ b/.github/workflows/enterprise-gate.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: sdet_check
+          retention-days: 7
           path: |
             sdet_check.json
             build/doctor-enterprise.json


### PR DESCRIPTION
## Summary
- Adds `retention-days: 7` to the second workflow artifact-retention slice.
- Covers four simple existing `actions/upload-artifact` workflows:
  - `.github/workflows/dependency-audit.yml`
  - `.github/workflows/dependency-radar-bot.yml`
  - `.github/workflows/docs-experience-bot.yml`
  - `.github/workflows/enterprise-gate.yml`

## Why
- Follows the workflow governance report from PR #1635.
- Continues workflow professionalization in a small mechanical slice.
- Keeps artifact retention debt reduction reviewable and safe.

## Governance delta
- `artifacts_have_retention` finding count dropped from `23` to `19`.
- No permissions changes.
- No dependency changes.
- No workflow trigger changes.
- No check bypassing.

## Verification
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format json`
- Verified selected workflows now report `artifacts_have_retention=yes`.
- Verified `artifacts_have_retention_count=19`.
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_external_tool_pin_contract.py -o addopts=`
- `python -m pre_commit run check-yaml --files .github/workflows/dependency-audit.yml .github/workflows/dependency-radar-bot.yml .github/workflows/docs-experience-bot.yml .github/workflows/enterprise-gate.yml`
- `make proof-after-format`

## Risk
- Low: adds only artifact retention metadata to existing upload steps.
- Rollback: revert this PR.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
