### PR TITLE
feat(adoption): turn learning gaps into detector upgrades

### DIFF
--- a/src/sdetkit/adoption_real_world_learning_matrix.py
+++ b/src/sdetkit/adoption_real_world_learning_matrix.py
@@ -89,15 +89,24 @@ def _classification_for_surface(
     test_runners = _names(surface.get("test_runners"))
     ci_systems = _names(surface.get("ci_systems"))
     security_tools = _names(surface.get("security_tools"))
+    docs_tools = _names(surface.get("docs_tools"))
+    release_surfaces = _names(surface.get("release_surfaces"))
     artifact_surfaces = _names(surface.get("artifact_surfaces"))
     proof_commands = surface.get("recommended_proof_commands")
     review_first_unknowns = _list_strings(surface.get("review_first_unknowns"))
 
     if integration.get("integration_status") != "passed":
         observations.add("integration_runner_bug")
-    if languages or package_managers or ci_systems or proof_commands:
+    if (
+        languages
+        or package_managers
+        or ci_systems
+        or docs_tools
+        or release_surfaces
+        or proof_commands
+    ):
         observations.add("supported_surface")
-    if not languages:
+    if not languages and not docs_tools:
         observations.add("unsupported_language")
     if languages and not package_managers:
         observations.add("unsupported_package_manager")
@@ -111,6 +120,8 @@ def _classification_for_surface(
         observations.add("review_first_unknown")
     if ci_systems and not security_tools:
         observations.add("missed_security_surface")
+    if package_managers and not release_surfaces:
+        observations.add("missed_release_surface")
     if not artifact_surfaces:
         observations.add("artifact_path_gap")
     if len(languages) > 1 or len(package_managers) > 1:
@@ -306,6 +317,8 @@ def run_real_world_learning_matrix(
                 "test_runners": _names(surface.get("test_runners")),
                 "ci_systems": _names(surface.get("ci_systems")),
                 "security_tools": _names(surface.get("security_tools")),
+                "docs_tools": _names(surface.get("docs_tools")),
+                "release_surfaces": _names(surface.get("release_surfaces")),
                 "review_first_unknowns": _list_strings(surface.get("review_first_unknowns")),
                 "learning_observations": learning_observations,
                 "artifact_paths": {

--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -15,6 +15,8 @@ REQUIRED_LIST_FIELDS = (
     "test_runners",
     "ci_systems",
     "security_tools",
+    "docs_tools",
+    "release_surfaces",
     "artifact_surfaces",
     "recommended_proof_commands",
     "review_first_unknowns",
@@ -211,6 +213,8 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     test_runners: list[dict[str, Any]] = []
     ci_systems: list[dict[str, Any]] = []
     security_tools: list[dict[str, Any]] = []
+    docs_tools: list[dict[str, Any]] = []
+    release_surfaces: list[dict[str, Any]] = []
     artifact_surfaces: list[dict[str, Any]] = []
     recommended_proof_commands: list[dict[str, Any]] = []
     review_first_unknowns: list[str] = []
@@ -268,12 +272,25 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
         )
 
     if _file(root, "mkdocs.yml"):
+        _add_named(
+            docs_tools,
+            "mkdocs",
+            confidence="high",
+            evidence=["mkdocs.yml", *(["docs/"] if _dir(root, "docs") else [])],
+        )
         _add_proof_command(
             recommended_proof_commands,
             surface="docs",
             command="NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict",
             confidence="high",
             purpose="docs",
+        )
+    elif _dir(root, "docs"):
+        _add_named(
+            docs_tools,
+            "docs_directory",
+            confidence="medium",
+            evidence=["docs/"],
         )
 
     js_evidence = [
@@ -399,6 +416,29 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     if "pip-audit" in workflow_text or "pip-audit" in python_tool_text:
         _add_named(security_tools, "pip_audit", confidence="detected", evidence=workflows)
 
+    release_workflows = [
+        path
+        for path in workflows
+        if "release" in Path(path).name.lower()
+        or "publish" in Path(path).name.lower()
+        or "release" in _read_text(root, path).lower()
+        or "publish" in _read_text(root, path).lower()
+    ]
+    if release_workflows:
+        _add_named(
+            release_surfaces,
+            "release_workflow",
+            confidence="detected",
+            evidence=release_workflows,
+        )
+    if _file(root, "CHANGELOG.md"):
+        _add_named(
+            release_surfaces,
+            "changelog",
+            confidence="detected",
+            evidence=["CHANGELOG.md"],
+        )
+
     if _file(root, "coverage.xml"):
         _add_named(artifact_surfaces, "coverage", paths=["coverage.xml"])
     if _dir(root, "dist"):
@@ -415,6 +455,8 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
         "test_runners": sorted(test_runners, key=lambda item: item["name"]),
         "ci_systems": sorted(ci_systems, key=lambda item: item["name"]),
         "security_tools": sorted(security_tools, key=lambda item: item["name"]),
+        "docs_tools": sorted(docs_tools, key=lambda item: item["name"]),
+        "release_surfaces": sorted(release_surfaces, key=lambda item: item["name"]),
         "artifact_surfaces": sorted(artifact_surfaces, key=lambda item: item["name"]),
         "recommended_proof_commands": sorted(
             recommended_proof_commands,
@@ -493,6 +535,12 @@ def render_adoption_surface_report(payload: dict[str, Any]) -> str:
         "",
         "## Security tools",
         *_format_named_items(payload.get("security_tools")),
+        "",
+        "## Docs tools",
+        *_format_named_items(payload.get("docs_tools")),
+        "",
+        "## Release surfaces",
+        *_format_named_items(payload.get("release_surfaces")),
         "",
         "## Recommended proof commands",
         *_format_proof_commands(payload.get("recommended_proof_commands")),

--- a/tests/test_adoption_real_world_learning_matrix.py
+++ b/tests/test_adoption_real_world_learning_matrix.py
@@ -186,3 +186,31 @@ def test_real_world_learning_matrix_cli_dispatch(tmp_path: Path, capsys) -> None
     assert "install_dependencies: false" in stdout
     assert (artifact_root / "adoption-real-world-matrix.json").is_file()
     assert (artifact_root / "adoption-real-world-matrix.md").is_file()
+
+
+def test_real_world_learning_matrix_uses_docs_and_release_detector_fields(
+    tmp_path: Path,
+) -> None:
+    matrix_json, _snapshots = _matrix(tmp_path)
+    artifact_root = tmp_path / "artifacts"
+
+    payload = run_real_world_learning_matrix(
+        matrix_json=matrix_json,
+        artifact_root=artifact_root,
+    )
+
+    docs_repo = next(repo for repo in payload["repos"] if repo["shape"] == "minimal_docs_project")
+    assert docs_repo["docs_tools"] == ["mkdocs"]
+    assert "unsupported_language" not in docs_repo["learning_observations"]
+
+    package_repos = [
+        repo
+        for repo in payload["repos"]
+        if repo["package_managers"] and not repo["release_surfaces"]
+    ]
+    assert package_repos
+    assert "missed_release_surface" in payload["observation_counts"]
+    assert any(
+        candidate["classification"] == "missed_release_surface"
+        for candidate in payload["upgrade_candidates"]
+    )

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -271,6 +271,8 @@ def test_adoption_surface_payload_validator_rejects_authority_escalation() -> No
         "test_runners": [],
         "ci_systems": [],
         "security_tools": [],
+        "docs_tools": [],
+        "release_surfaces": [],
         "artifact_surfaces": [],
         "recommended_proof_commands": [],
         "review_first_unknowns": [],
@@ -348,3 +350,53 @@ def test_adoption_surface_cli_dispatch_renders_operator_report(
     assert "## Recommended proof commands" in report
     assert "auto_run_allowed=false" in report
     assert "- patch_application_allowed: false" in report
+
+
+def test_adoption_surface_detects_docs_and_release_surfaces_without_running_commands(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "mkdocs.yml", "site_name: Example\n")
+    _write(tmp_path / "docs" / "index.md", "# Example\n")
+    _write(tmp_path / "CHANGELOG.md", "# Changelog\n")
+    _write(
+        tmp_path / ".github" / "workflows" / "release.yml",
+        "name: release\non: workflow_dispatch\njobs:\n  publish:\n    runs-on: ubuntu-latest\n    steps: []\n",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert payload["docs_tools"] == [
+        {
+            "name": "mkdocs",
+            "confidence": "high",
+            "evidence": ["mkdocs.yml", "docs/"],
+        }
+    ]
+    assert _names(payload["release_surfaces"]) == {"changelog", "release_workflow"}
+    assert "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict" in _commands(payload)
+
+
+def test_adoption_surface_payload_validator_accepts_docs_and_release_surface_lists() -> None:
+    from sdetkit.adoption_surface import validate_adoption_surface_payload
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "detected_languages": [],
+        "package_managers": [],
+        "test_runners": [],
+        "ci_systems": [],
+        "security_tools": [],
+        "docs_tools": [],
+        "release_surfaces": [],
+        "artifact_surfaces": [],
+        "recommended_proof_commands": [],
+        "review_first_unknowns": [],
+        "repo_identity": {},
+        "operator_summary": {},
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    assert validate_adoption_surface_payload(payload) == []


### PR DESCRIPTION
## Summary
- Add read-only docs-site and release-surface detector fields to adoption surface output.
- Feed those detector fields into the real-world learning matrix.
- Keep docs-only repositories from being misclassified as unsupported-language gaps.
- Emit missed release-surface learning observations when package-manager evidence exists without release evidence.

## Why
- Product maturity radar ranked adoption detector upgrades as the next P1 candidate after the real-world learning matrix and product maturity radar were accepted.
- This turns repeated real-world learning gaps into concrete detector evidence instead of leaving them as generic review-first unknowns.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py tests/test_adoption_real_world_learning_matrix.py tests/test_adoption_learning_report.py -o addopts=`
- Matrix smoke confirmed `matrix_status=passed`, `repo_count=10`, docs detector evidence for the minimal docs project, and no unsupported-language observation for that docs-only repo.
- `make proof-after-format`

## Risk
- Medium: additive artifact fields and learning classifications.
- Rollback: revert this PR.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no target repo mutation
- no dependency install
- no target tests executed