### PR TITLE
docs(product): refresh README and docs map for real-world learning lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Secondary lanes cover review, investigation, quality, maintenance, and CI automa
 
 ## Core operator lanes
 
+## Real-world learning and governance lanes
+
+SDETKit now includes read-only adoption and learning lanes for understanding real repositories before recommending proof or remediation. These lanes are advisory by default: they collect evidence, classify repo shape, surface review-first unknowns, and produce upgrade candidates for SDETKit itself without installing target dependencies, running target tests, mutating target repositories, or opening target PRs/issues.
+
+Use these lanes when you need to evaluate repository readiness beyond the local release gate:
+
+| Lane | Start here | What it proves |
+| --- | --- | --- |
+| External repo adoption | [`docs/adoption.md`](docs/adoption.md) | Detects language, package, CI, docs, release, security, artifact, and proof-command surfaces. |
+| Evidence bundles | [`docs/artifact-reference.md`](docs/artifact-reference.md) | Keeps operator evidence reviewable and machine-readable. |
+| Learning loop | [`docs/investigation-operator-guide.md`](docs/investigation-operator-guide.md) | Turns repeated gaps into detector, report, memory, or roadmap upgrades. |
+| Product maturity radar | [`docs/docs-map.md`](docs/docs-map.md) | Treats radar/report tools as control panels, not replacements for the roadmap. |
+
+Authority boundary remains unchanged: `automation_allowed=false`, `patch_application_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false`.
+
+
 | Lane | Command | Start here when... |
 | --- | --- | --- |
 | Release gate | `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor` | You need a ship/no-ship decision. |
@@ -68,7 +84,6 @@ For a guided command router, run:
 ```bash
 make upgrade-next
 ```
-
 ## Product proof
 
 <!-- product-proof-start -->

--- a/docs/docs-map.md
+++ b/docs/docs-map.md
@@ -20,6 +20,7 @@ Use this map when the `docs/` tree feels large. It separates the primary operato
 | Getting started | [Install](install.md), [Quickstart](quickstart-copy-paste.md), [Blank repo to value](blank-repo-to-value-60-seconds.md), [Ready to use](ready-to-use.md) | Keep these copy-pasteable and starter-oriented. |
 | Operator guide | [Operator essentials](operator-essentials.md), [Operator onboarding](operator-onboarding-7-day.md), [Recommended CI flow](recommended-ci-flow.md) | Daily operator work belongs here, not in the README. |
 | Investigation / diagnosis | [Investigation operator guide](investigation-operator-guide.md), [Adaptive Diagnosis Intelligence](adaptive-diagnosis.md), [First failure triage](first-failure-triage.md) | Diagnostic/report-only unless a guarded lane explicitly authorizes mutation. |
+| Real-world adoption and learning | [Adopt in your repository](adoption.md), [Artifact reference](artifact-reference.md), [Investigation operator guide](investigation-operator-guide.md) | Read-only external-repo evidence, learning observations, detector upgrades, and roadmap/radar control panels. |
 | Maintenance / autopilot | [Artifact reference](artifact-reference.md#maintenance-autopilot-upload-set), [Operations handbook](operations-handbook.md), [Automation bots](automation-bots.md) | Treat plans, candidates, and safe-fix outputs as evidence until reviewed policy approves the next step. |
 | Quality gates | [Premium quality gate](premium-quality-gate.md), [Security gate](security-gate.md), [Determinism checklist](determinism-checklist.md), [Determinism contract](determinism-contract.md) | Gate docs explain proof and policy, not broad default auto-fix. |
 | Artifact reference | [Artifact reference](artifact-reference.md), [CI artifact walkthrough](ci-artifact-walkthrough.md), [Evidence showcase](evidence-showcase.md) | Runtime artifacts live under `build/` and `.sdetkit/`; committed examples live under `docs/artifacts/`. |
@@ -42,6 +43,19 @@ Use this map when the `docs/` tree feels large. It separates the primary operato
 | `docs/roadmap/` | Roadmap artifacts and reports. | Keep roadmap/reporting secondary to current operator guidance. |
 
 ## Navigation rules for future cleanup
+
+## Real-world learning lanes
+
+Use these pages when SDETKit is being evaluated as a repository doctor rather than only a local release gate:
+
+| Lane | Primary pages | Operator rule |
+| --- | --- | --- |
+| Adoption surface | [Adopt in your repository](adoption.md), [Artifact reference](artifact-reference.md) | Detect repo shape and proof surfaces before recommending commands. |
+| Evidence and learning loop | [Investigation operator guide](investigation-operator-guide.md), [Adaptive Diagnosis Intelligence](adaptive-diagnosis.md) | Convert repeated gaps into detector/report/memory upgrades. |
+| Roadmap control panels | [Docs map and organization](docs-map.md), [Artifact reference](artifact-reference.md) | Use radar/report outputs to choose focused PRs; do not replace the roadmap. |
+
+External repositories remain learning targets, not patch targets. Default posture is no install, no target tests, no mutation, no target PRs/issues, and no endorsement claim.
+
 
 1. Keep the README as a concise front door; move command matrices to focused docs.
 2. Keep [Operator essentials](operator-essentials.md) as the day-to-day runbook.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,10 @@ This page is the product homepage/router for first-time adoption.
 
 ### Top journeys
 
+
+- Run a read-only external-repo adoption check and inspect evidence before prescribing work
+- Convert repeated real-world repo gaps into detector, report, memory, or roadmap upgrades
+- Use the product maturity radar as a roadmap control panel without replacing review-first governance
 - Run first command in under 60 seconds
 - Validate docs links and anchors before publishing
 - Ship a first contribution with deterministic quality gates
@@ -97,6 +101,18 @@ Use this index as the primary human navigation map. The docs are organized aroun
 For a compact tree-level map, use [Docs map and organization](docs-map.md).
 
 ## Team rollout / CI
+
+## Real-world learning and governance
+
+SDETKit can now run read-only adoption and learning lanes against cloned external repositories while keeping artifacts outside the target repo. These lanes are designed for product learning and operator evidence, not automatic target patching.
+
+- Start with [Adopt in your repository](adoption.md) for external-repo readiness and adoption-surface evidence.
+- Use [Artifact reference and generated sample map](artifact-reference.md) to understand machine-readable outputs and evidence bundles.
+- Use [Investigation operator guide](investigation-operator-guide.md) when a CI log, repo shape, or proof command needs review-first diagnosis.
+- Use this docs homepage and [Docs map and organization](docs-map.md) to keep radar, report, and governance tools connected to the broader roadmap.
+
+Safety boundary: adoption and learning outputs are advisory unless an explicit guarded policy says otherwise.
+
 
 - [Adopt in your repository](adoption.md)
 - [Team adoption checklist](team-adoption-checklist.md)


### PR DESCRIPTION
## Summary
- Refresh README with real-world learning and governance lanes.
- Add real-world learning guidance to the docs homepage.
- Add real-world adoption and learning to the docs map information architecture.
- Preserve the authority boundary: advisory/read-only by default.

## Why
- Product maturity radar ranks the docs/product refresh as the next P1 roadmap candidate after the adoption detector upgrade.
- The project now has external repo adoption, real-world learning matrix, adoption detector upgrades, and product maturity radar capabilities that should be visible in the product front doors.

## Verification
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_mkdocs_exclude_docs_scope.py tests/test_docs_qa.py::test_repository_front_doors_are_polished_and_consistent -o addopts=`
- `make proof-after-format`

## Risk
- Low: docs-only front-door and navigation update.
- Rollback: revert this PR.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no target repo mutation
- no dependency install
- no target tests executed