### PR TITLE
feat(learning): connect repo memory to adoption reports

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -782,6 +782,7 @@ Then use stability-aware command discovery:
         help=argparse.SUPPRESS,
     )
     adoption_learning_report.add_argument("--matrix-json", required=True)
+    adoption_learning_report.add_argument("--repo-memory-profile", default="")
     adoption_learning_report.add_argument(
         "--out", default="build/sdetkit/adoption-learning-report.json"
     )
@@ -1652,6 +1653,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             "--format",
             str(ns.format),
         ]
+        if str(ns.repo_memory_profile):
+            forwarded.extend(["--repo-memory-profile", str(ns.repo_memory_profile)])
         if str(ns.markdown_out):
             forwarded.extend(["--markdown-out", str(ns.markdown_out)])
         return _run_module_main("sdetkit.adoption_learning_report", forwarded)

--- a/src/sdetkit/adoption_learning_report.py
+++ b/src/sdetkit/adoption_learning_report.py
@@ -61,6 +61,34 @@ def _int_value(value: object, *, default: int = 0) -> int:
         return default
 
 
+def _repo_memory_profile_summary(profile_path: str | Path | None) -> dict[str, Any]:
+    if not profile_path:
+        return {
+            "connected": False,
+            "path": "",
+            "schema_version": "",
+            "profile_status": "not_provided",
+            "memory_mode": "",
+            "review_first": True,
+            "authoritative_for_adoption_report": False,
+            "authority_boundary": _authority_boundary(),
+        }
+
+    resolved = Path(profile_path).resolve()
+    profile = _load_json_object(resolved)
+
+    return {
+        "connected": True,
+        "path": resolved.as_posix(),
+        "schema_version": str(profile.get("schema_version", "")).strip(),
+        "profile_status": str(profile.get("profile_status", "unknown")).strip(),
+        "memory_mode": str(profile.get("memory_mode", "")).strip(),
+        "review_first": True,
+        "authoritative_for_adoption_report": False,
+        "authority_boundary": _authority_boundary(),
+    }
+
+
 def _candidate_score(candidate: dict[str, Any]) -> int:
     classification = str(candidate.get("classification", "")).strip()
     frequency = _int_value(candidate.get("frequency_across_matrix"))
@@ -111,9 +139,14 @@ def _candidate_summary(candidate: dict[str, Any], *, rank: int) -> dict[str, Any
     }
 
 
-def build_adoption_learning_report(matrix_json: str | Path) -> dict[str, Any]:
+def build_adoption_learning_report(
+    matrix_json: str | Path,
+    *,
+    repo_memory_profile: str | Path | None = None,
+) -> dict[str, Any]:
     matrix_path = Path(matrix_json).resolve()
     matrix = _load_json_object(matrix_path)
+    repo_memory_summary = _repo_memory_profile_summary(repo_memory_profile)
 
     raw_candidates = matrix.get("upgrade_candidates")
     if not isinstance(raw_candidates, list):
@@ -142,6 +175,7 @@ def build_adoption_learning_report(matrix_json: str | Path) -> dict[str, Any]:
         "candidate_count": len(prioritized),
         "top_candidate": top_candidate,
         "prioritized_upgrade_candidates": prioritized,
+        "repo_memory_profile": repo_memory_summary,
         "operator_summary": {
             "status": "review_first_learning_report_generated",
             "next_action": (
@@ -151,7 +185,9 @@ def build_adoption_learning_report(matrix_json: str | Path) -> dict[str, Any]:
             ),
         },
         "rules": {
-            "source_matrix_only": True,
+            "source_matrix_only": not repo_memory_summary["connected"],
+            "repo_memory_profile_read": repo_memory_summary["connected"],
+            "repo_memory_profile_authoritative": False,
             "target_repos_read": False,
             "install_dependencies": False,
             "target_tests_executed": False,
@@ -200,6 +236,20 @@ def render_adoption_learning_report_markdown(payload: dict[str, Any]) -> str:
             lines.append("   - review_first: true")
             lines.append("   - safe_to_patch: false")
 
+    repo_memory = payload.get("repo_memory_profile")
+    if not isinstance(repo_memory, dict):
+        repo_memory = {}
+    lines.extend(
+        [
+            "",
+            "## RepoMemory profile",
+            "",
+            f"- connected: {str(repo_memory.get('connected', False)).lower()}",
+            f"- profile_status: {repo_memory.get('profile_status', 'unknown')}",
+            "- authoritative_for_adoption_report: false",
+        ]
+    )
+
     lines.extend(
         [
             "",
@@ -220,8 +270,12 @@ def write_adoption_learning_report_artifacts(
     matrix_json: str | Path,
     out: str | Path,
     markdown_out: str | Path | None = None,
+    repo_memory_profile: str | Path | None = None,
 ) -> dict[str, Any]:
-    payload = build_adoption_learning_report(matrix_json)
+    payload = build_adoption_learning_report(
+        matrix_json,
+        repo_memory_profile=repo_memory_profile,
+    )
     out_path = Path(out)
     markdown_path = Path(markdown_out) if markdown_out else out_path.with_suffix(".md")
 
@@ -242,6 +296,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         description="Prioritize review-first upgrade candidates from an adoption matrix artifact.",
     )
     parser.add_argument("--matrix-json", required=True)
+    parser.add_argument("--repo-memory-profile", default="")
     parser.add_argument("--out", default="build/sdetkit/adoption-learning-report.json")
     parser.add_argument("--markdown-out", default="")
     parser.add_argument("--format", choices=["json", "text"], default="json")
@@ -251,6 +306,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         matrix_json=ns.matrix_json,
         out=ns.out,
         markdown_out=ns.markdown_out or None,
+        repo_memory_profile=ns.repo_memory_profile or None,
     )
 
     if ns.format == "json":

--- a/tests/test_adoption_learning_report.py
+++ b/tests/test_adoption_learning_report.py
@@ -135,3 +135,97 @@ def test_adoption_learning_report_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert "safe_to_patch: false" in stdout
     assert out.is_file()
     assert out.with_suffix(".md").is_file()
+
+
+def test_adoption_learning_report_attaches_non_authorizing_repo_memory_profile(
+    tmp_path: Path,
+) -> None:
+    matrix_json = _matrix(tmp_path / "matrix.json")
+    repo_memory_profile = tmp_path / "repo-memory-profile.json"
+    repo_memory_profile.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.repo_memory.v6",
+                "profile_status": "live_proof_supported_memory",
+                "memory_mode": "trusted_main_profile",
+                "decision_boundary": {
+                    "automation_allowed": True,
+                    "patch_application_allowed": True,
+                    "merge_authorized": True,
+                    "semantic_equivalence_proven": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = build_adoption_learning_report(
+        matrix_json,
+        repo_memory_profile=repo_memory_profile,
+    )
+
+    assert payload["rules"]["source_matrix_only"] is False
+    assert payload["rules"]["repo_memory_profile_read"] is True
+    assert payload["rules"]["repo_memory_profile_authoritative"] is False
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+    memory = payload["repo_memory_profile"]
+    assert memory["connected"] is True
+    assert memory["schema_version"] == "sdetkit.repo_memory.v6"
+    assert memory["profile_status"] == "live_proof_supported_memory"
+    assert memory["memory_mode"] == "trusted_main_profile"
+    assert memory["authoritative_for_adoption_report"] is False
+    assert memory["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_adoption_learning_report_cli_accepts_repo_memory_profile_context(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    matrix_json = _matrix(tmp_path / "matrix.json")
+    repo_memory_profile = tmp_path / "repo-memory-profile.json"
+    repo_memory_profile.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.repo_memory.v6",
+                "profile_status": "live_proof_supported_memory",
+                "memory_mode": "trusted_main_profile",
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "reports" / "adoption-learning-report.json"
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "adoption-learning-report",
+            "--matrix-json",
+            str(matrix_json),
+            "--repo-memory-profile",
+            str(repo_memory_profile),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "## RepoMemory profile" in stdout
+    assert "connected: true" in stdout
+    assert "authoritative_for_adoption_report: false" in stdout
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["repo_memory_profile"]["connected"] is True
+    assert payload["rules"]["repo_memory_profile_authoritative"] is False


### PR DESCRIPTION
## Summary
- Add optional RepoMemory profile context to the adoption learning report.
- Expose the context through the public `sdetkit adoption-learning-report` CLI wrapper.
- Preserve the adoption report as review-first and non-authorizing.
- Render RepoMemory profile connection status in JSON and Markdown output.
- Add CLI and safety tests proving RepoMemory cannot expand adoption-report authority.

## Why
- Product maturity radar ranks learning-loop integration as the next P1 candidate after adoption detector upgrades and docs/product refresh.
- This connects RepoMemory evidence to real-world adoption learning without making memory authoritative or mutating target repositories.

## Verification
- `python -m pytest -q tests/test_adoption_learning_report.py tests/test_adoption_real_world_learning_matrix.py tests/test_repo_memory.py -o addopts=`
- Public CLI smoke with synthetic matrix and RepoMemory profile
- `make proof-after-format`

## Risk
- Medium-low: additive optional report input and schema fields.
- Rollback: revert this PR.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- RepoMemory profile is context only, not authorization
- no target repo mutation
- no dependency install
- no target tests executed