### PR TITLE
ci: add retention to product evidence artifacts

### DIFF
--- a/.github/workflows/first-proof-artifact-publish.yml
+++ b/.github/workflows/first-proof-artifact-publish.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Upload first-proof execution report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
+          retention-days: 14
           name: first-proof-execution-report
           path: |
             build/first-proof/execution-report.json
@@ -47,6 +48,7 @@ jobs:
       - name: Upload first-proof ops pack
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
+          retention-days: 14
           name: first-proof-ops-pack
           path: |
             build/first-proof/health-score.json

--- a/.github/workflows/ghas-codeql-hotspots-bot.yml
+++ b/.github/workflows/ghas-codeql-hotspots-bot.yml
@@ -178,6 +178,7 @@ jobs:
       - name: Upload hotspot artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: ghas-codeql-hotspots
           path: |
             build/ghas-codeql-hotspots.json

--- a/.github/workflows/ghas-metrics-export-bot.yml
+++ b/.github/workflows/ghas-metrics-export-bot.yml
@@ -232,6 +232,7 @@ jobs:
       - name: Upload GHAS metrics artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: ghas-metrics-snapshot
           path: |
             build/ghas-metrics.json

--- a/.github/workflows/workflow-governance-bot.yml
+++ b/.github/workflows/workflow-governance-bot.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Upload governance artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: workflow-governance-audit
           path: |
             build/workflow-governance-audit.json


### PR DESCRIPTION
## Summary
- Add explicit `retention-days: 14` to a narrow product-evidence artifact slice.
- Covered workflows:
  - `first-proof-artifact-publish.yml`
  - `ghas-codeql-hotspots-bot.yml`
  - `ghas-metrics-export-bot.yml`
  - `workflow-governance-bot.yml`
- Preserve triggers, permissions, jobs, commands, and artifact paths.

## Why
- The workflow governance report ranks `artifacts_have_retention` as the top P1 follow-up.
- Artifact retention protects operator evidence inspectability after CI completes.
- This intentionally patches only a small product-evidence slice, not all 19 affected workflows.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py tests/test_pr_quality_comment_observability_workflow.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format text`
- machine-output assertion that selected workflows no longer carry `artifacts_have_retention`
- `python -m pre_commit run -a`
- `make proof-after-format`

## Risk
- Low: workflow artifact-retention metadata only.
- Rollback: remove the four `retention-days` entries.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no workflow trigger changes
- no permission changes
- no job behavior changes
- no checks skipped