### PR TITLE
ci: add retention to impact release artifacts

### DIFF
--- a/.github/workflows/impact-release-control.yml
+++ b/.github/workflows/impact-release-control.yml
@@ -102,6 +102,7 @@ jobs:
       - name: Upload impact artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: impact-release-artifacts
           path: |
             build/impact-workflow-run.json


### PR DESCRIPTION
## Summary
- Adds explicit artifact retention to the impact-release-control workflow upload-artifact step.

## Why
- Fresh workflow-governance-report still flags `artifacts_have_retention`.
- This is a narrow P1 evidence-retention slice.
- This avoids permission changes and avoids broad workflow cleanup.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format text`
- `make proof-after-format`

## Risk
- Low.
- Rollback: revert this workflow-only commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no permission reduction in this PR