### PR TITLE
ci: add retention to remaining workflow artifacts

### DIFF
--- a/.github/workflows/integration-topology-radar-bot.yml
+++ b/.github/workflows/integration-topology-radar-bot.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Upload integration topology artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: integration-topology-radar
           path: |
             build/integration-topology-worker-run.json

--- a/.github/workflows/maintenance-autopilot.yml
+++ b/.github/workflows/maintenance-autopilot.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Upload autopilot artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: maintenance-autopilot
           path: |
             build/maintenance/autopilot/autopilot-report.json

--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -242,6 +242,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: maintenance-on-demand
           path: |
             artifacts/maintenance.json

--- a/.github/workflows/operational-readiness-governance-contract.yml
+++ b/.github/workflows/operational-readiness-governance-contract.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Upload operational-readiness artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: operational-readiness-governance-artifacts
           path: |
             build/operational-readiness-governance/operational-readiness-governance-contract.json

--- a/.github/workflows/platform-readiness-quality-contract.yml
+++ b/.github/workflows/platform-readiness-quality-contract.yml
@@ -52,6 +52,7 @@ jobs:
       # legacy artifact compatibility: phase3-quality-artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: platform-readiness-quality-artifacts
           path: |
             build/platform-readiness-quality/*.json

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -963,6 +963,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: pr-quality-failure-intelligence
           path: build/pr-quality/failure-intelligence/
           if-no-files-found: ignore
@@ -971,6 +972,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: pr-quality-adaptive-sentinel
           path: |
             build/sdetkit/sentinel/
@@ -981,6 +983,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: pr-quality-comment
           path: |
             build/pr-quality/pr-comment-body.md

--- a/.github/workflows/premium-gate.yml
+++ b/.github/workflows/premium-gate.yml
@@ -39,5 +39,6 @@ jobs:
         if: always() && hashFiles('.sdetkit/out/evidence.zip') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: evidence-pack
           path: .sdetkit/out/evidence.zip

--- a/.github/workflows/release-readiness-radar-bot.yml
+++ b/.github/workflows/release-readiness-radar-bot.yml
@@ -193,6 +193,7 @@ jobs:
       - name: Upload release readiness artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: release-readiness-radar
           path: |
             build/release-readiness-radar.json

--- a/.github/workflows/repo-optimization-bot.yml
+++ b/.github/workflows/repo-optimization-bot.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Upload optimization artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: repo-optimization
           path: |
             build/repo-optimization.json

--- a/.github/workflows/runtime-watchlist-bot.yml
+++ b/.github/workflows/runtime-watchlist-bot.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Upload runtime watchlist artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: runtime-watchlist
           path: |
             build/runtime-watchlist-worker-run.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -30,5 +30,6 @@ jobs:
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: sbom-cyclonedx
           path: sbom.cdx.json

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Upload baseline artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: weekly-maintenance
           path: |
             artifacts/maintenance.json
@@ -62,6 +63,7 @@ jobs:
         if: steps.decide_fix.outputs.run_fix == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: weekly-maintenance-fixed
           path: |
             artifacts/maintenance_fixed.json

--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Upload worker-alignment artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
+          retention-days: 14
           name: worker-alignment-radar
           path: |
             build/adapter-smoke-worker-run.json


### PR DESCRIPTION
## Summary
- Adds explicit artifact retention to all remaining workflows flagged by `artifacts_have_retention`.
- Keeps the PR scoped to artifact retention metadata only.

## Why
- Fresh workflow-governance-report still flagged remaining artifact uploads without retention.
- Batching this single finding class avoids noisy one-file PR churn.
- This does not touch workflow permissions, triggers, jobs, install constraints, docs strictness, cache keys, or local-equivalent command docs.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format text`
- `make proof-after-format`

## Risk
- Low.
- Rollback: revert this workflow-metadata-only commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no permission reduction in this PR
- no broad workflow-governance cleanup in this PR