### PR TITLE
ci: apply constraints to remaining workflow installs

### DIFF
--- a/.github/workflows/advanced-github-actions-reference-64.yml
+++ b/.github/workflows/advanced-github-actions-reference-64.yml
@@ -48,9 +48,9 @@ jobs:
 
       - name: Install deps
         run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          python -m pip install -c constraints-ci.txt --upgrade pip
+          if [ -f requirements.txt ]; then python -m pip install -c constraints-ci.txt -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then python -m pip install -c constraints-ci.txt -r requirements-dev.txt; fi
 
       - name: Lint + tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install project
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e .
 
       - name: Run repo audit
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install project + dev/test extras
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e .[dev,test]
 
       - name: Ruff lint baseline
@@ -165,7 +165,7 @@ jobs:
 
       - name: Install project
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e .
 
       - name: Run deterministic example
@@ -193,7 +193,7 @@ jobs:
 
       - name: Install packaging tooling
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e .[dev,packaging]
 
       - name: Build distributions
@@ -259,7 +259,7 @@ jobs:
             echo "No wheel found under dist/ after artifact download" >&2
             exit 1
           fi
-          python -m pip install "$WHEEL_PATH"
+          python -m pip install -c constraints-ci.txt "$WHEEL_PATH"
           python tests/contract/check_installed_wheel.py \
             --python .venv-smoke/bin/python \
             --repo-root .
@@ -281,7 +281,7 @@ jobs:
 
       - name: Install project + all extras
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
 
       - name: Pre-commit

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install audit tooling
         run: |
-          python -m pip install pip-audit==2.10.0
+          python -m pip install -c constraints-ci.txt pip-audit==2.10.0
 
       - name: Audit dependencies (blocking, baseline aware)
         run: |

--- a/.github/workflows/enterprise-gate.yml
+++ b/.github/workflows/enterprise-gate.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install package
         run: |
-          python -m pip install -U pip
+          python -m pip install -c constraints-ci.txt -U pip
           python -m pip install -c constraints-ci.txt -e .
 
       - name: Doctor

--- a/.github/workflows/first-proof-artifact-publish.yml
+++ b/.github/workflows/first-proof-artifact-publish.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install runtime deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e .
 
       - name: Run first-proof verify (local lane)

--- a/.github/workflows/first-proof.yml
+++ b/.github/workflows/first-proof.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install project
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .
 
       - name: Run first-proof lane + contract validation

--- a/.github/workflows/platform-readiness-quality-contract.yml
+++ b/.github/workflows/platform-readiness-quality-contract.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
 
       - name: Seed baseline summary for contract lane

--- a/.github/workflows/premium-gate.yml
+++ b/.github/workflows/premium-gate.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e '.[dev,test,docs]'
       - name: Run premium gate
         run: bash premium-gate.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pip install --force-reinstall dist/*.whl
+          python -m pip install -c constraints-ci.txt --force-reinstall dist/*.whl
           sdetkit --help
 
       - name: Publish to PyPI when token is configured

--- a/.github/workflows/repo-optimization-bot.yml
+++ b/.github/workflows/repo-optimization-bot.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install SDETKit
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip
+          python -m pip install -c constraints-ci.txt --upgrade pip
           python -m pip install -c constraints-ci.txt -e .
 
       - name: Run optimize lane snapshot

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install project dependencies + CycloneDX
         run: |
           python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
-          python -m pip install cyclonedx-bom==7.3.0
+          python -m pip install -c constraints-ci.txt cyclonedx-bom==7.3.0
 
       - name: Generate SBOM
         run: |

--- a/tests/test_repo_optimization_bot_workflow.py
+++ b/tests/test_repo_optimization_bot_workflow.py
@@ -24,7 +24,7 @@ def test_repo_optimization_bot_installs_sdetkit_before_module_execution() -> Non
     install_step = next(step for step in steps if step.get("name") == "Install SDETKit")
     run = str(install_step.get("run", ""))
 
-    assert "python -m pip install --upgrade pip" in run
+    assert "python -m pip install -c constraints-ci.txt --upgrade pip" in run
     assert "python -m pip install -c constraints-ci.txt -e ." in run
 
 


### PR DESCRIPTION
## Summary
- Applies `-c constraints-ci.txt` to remaining workflow install commands flagged by `install_uses_constraints`.
- Keeps the PR scoped to dependency install reproducibility only.

## Why
- Fresh workflow-governance-report still flagged `install_uses_constraints`.
- Batching this single finding class avoids one-file PR churn.
- This improves CI dependency determinism without touching permissions, triggers, jobs, artifact retention, docs strictness, cache keys, or local-equivalent command docs.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format text`
- `make proof-after-format`

## Risk
- Medium-low.
- Rollback: revert this workflow-install-only commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no permission reduction in this PR
- no broad workflow-governance cleanup in this PR