### PR TITLE
ci: make docs workflow guidance strict

### DIFF
--- a/.github/workflows/contributor-onboarding-bot.yml
+++ b/.github/workflows/contributor-onboarding-bot.yml
@@ -25,7 +25,7 @@ jobs:
               '- `python -m pre_commit run -a`',
               '- `bash quality.sh cov`',
               '- `python -m build && python -m twine check dist/*`',
-              '- `mkdocs build` (when docs are touched)',
+              '- `mkdocs build --strict` (when docs are touched)',
               '',
               'Need bot help?',
               '- comment `/doctor` for diagnostics',

--- a/.github/workflows/pr-helper-bot.yml
+++ b/.github/workflows/pr-helper-bot.yml
@@ -125,7 +125,7 @@ jobs:
                 `- Run: \`python -m pre_commit run -a\`\n` +
                 `- Run: \`bash quality.sh cov\`\n` +
                 `- Run: \`python -m build && python -m twine check dist/*\`\n` +
-                `- Run docs gate for docs changes: \`mkdocs build\`\n` +
+                `- Run docs gate for docs changes: \`mkdocs build --strict\`\n` +
                 `- Ensure PR summary includes: What, Why, Risks, Tests.\n` +
                 `- Bot shortcuts: \`/doctor\`, \`/check\`, \`/quality\`, \`/hint\`\n` +
                 `- Reference guide: \`docs/premium-quality-gate.md\`\n\n` +


### PR DESCRIPTION
## Summary
- Updates docs-change guidance strings in workflow bot comments from `mkdocs build` to `mkdocs build --strict`.
- Keeps the PR scoped to `docs_build_strict` only.

## Why
- Fresh workflow-governance-report flagged `docs_build_strict`.
- The affected workflows contain bot/operator guidance text, not executable docs build steps.
- This makes docs guidance match strict docs expectations.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format text`
- `make proof-after-format`

## Risk
- Low.
- Rollback: revert this guidance-only workflow change.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no permission reduction in this PR
- no broad workflow-governance cleanup in this PR