### PR TITLE
ci: document workflow local equivalents and cache key

### DIFF
--- a/.github/workflows/adapter-smoke-bot.yml
+++ b/.github/workflows/adapter-smoke-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#adapter-smoke-bot for workflow-specific operator notes.
 name: Adapter Smoke Bot
 
 on:

--- a/.github/workflows/adaptive-ops-weekly.yml
+++ b/.github/workflows/adaptive-ops-weekly.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#adaptive-ops-weekly for workflow-specific operator notes.
 name: adaptive-ops-weekly
 
 on:

--- a/.github/workflows/adaptive-sentinel-monitor.yml
+++ b/.github/workflows/adaptive-sentinel-monitor.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#adaptive-sentinel-monitor for workflow-specific operator notes.
 name: Adaptive Sentinel Monitor
 
 on:

--- a/.github/workflows/adoption-real-repo-canonical.yml
+++ b/.github/workflows/adoption-real-repo-canonical.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#adoption-real-repo-canonical for workflow-specific operator notes.
 name: Adoption real-repo canonical replay
 
 on:

--- a/.github/workflows/contributor-onboarding-bot.yml
+++ b/.github/workflows/contributor-onboarding-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#contributor-onboarding-bot for workflow-specific operator notes.
 name: Contributor Onboarding Bot
 
 on:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#dependency-audit for workflow-specific operator notes.
 name: Dependency Audit
 
 on:

--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#dependency-auto-merge for workflow-specific operator notes.
 name: Dependency Auto Merge
 
 on:

--- a/.github/workflows/dependency-radar-bot.yml
+++ b/.github/workflows/dependency-radar-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#dependency-radar-bot for workflow-specific operator notes.
 name: Dependency Radar Bot
 
 on:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#dependency-review for workflow-specific operator notes.
 name: Dependency Review
 
 on:

--- a/.github/workflows/docs-experience-bot.yml
+++ b/.github/workflows/docs-experience-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#docs-experience-bot for workflow-specific operator notes.
 name: Docs Experience Bot
 
 on:

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#docs-link-check for workflow-specific operator notes.
 name: Docs Link Check
 
 on:

--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#enforce-branch-protection for workflow-specific operator notes.
 name: enforce-branch-protection
 
 on:

--- a/.github/workflows/enterprise-gate.yml
+++ b/.github/workflows/enterprise-gate.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#enterprise-gate for workflow-specific operator notes.
 name: Enterprise Gate
 
 on:

--- a/.github/workflows/first-proof-artifact-publish.yml
+++ b/.github/workflows/first-proof-artifact-publish.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#first-proof-artifact-publish for workflow-specific operator notes.
 name: first-proof-artifact-publish
 
 on:

--- a/.github/workflows/first-proof.yml
+++ b/.github/workflows/first-proof.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#first-proof for workflow-specific operator notes.
 name: First proof
 
 on:

--- a/.github/workflows/ghas-alert-sla-bot.yml
+++ b/.github/workflows/ghas-alert-sla-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#ghas-alert-sla-bot for workflow-specific operator notes.
 name: GHAS Alert SLA Bot
 
 on:

--- a/.github/workflows/ghas-campaign-bot.yml
+++ b/.github/workflows/ghas-campaign-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#ghas-campaign-bot for workflow-specific operator notes.
 name: GHAS Campaign Bot
 
 on:

--- a/.github/workflows/ghas-codeql-hotspots-bot.yml
+++ b/.github/workflows/ghas-codeql-hotspots-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#ghas-codeql-hotspots-bot for workflow-specific operator notes.
 name: GHAS CodeQL Hotspots Bot
 
 on:

--- a/.github/workflows/ghas-metrics-export-bot.yml
+++ b/.github/workflows/ghas-metrics-export-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#ghas-metrics-export-bot for workflow-specific operator notes.
 name: GHAS Metrics Export Bot
 
 on:

--- a/.github/workflows/ghas-review-bot.yml
+++ b/.github/workflows/ghas-review-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#ghas-review-bot for workflow-specific operator notes.
 name: GHAS Review Bot
 
 on:

--- a/.github/workflows/impact-release-control.yml
+++ b/.github/workflows/impact-release-control.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#impact-release-control for workflow-specific operator notes.
 name: impact-release-control
 
 on:

--- a/.github/workflows/integration-topology-radar-bot.yml
+++ b/.github/workflows/integration-topology-radar-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#integration-topology-radar-bot for workflow-specific operator notes.
 name: Integration Topology Radar Bot
 
 on:

--- a/.github/workflows/kpi-weekly.yml
+++ b/.github/workflows/kpi-weekly.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#kpi-weekly for workflow-specific operator notes.
 name: Weekly Release Confidence KPI Pack
 
 on:

--- a/.github/workflows/legacy-required-status-bridge.yml
+++ b/.github/workflows/legacy-required-status-bridge.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#legacy-required-status-bridge for workflow-specific operator notes.
 name: legacy-required-status-bridge
 
 on:

--- a/.github/workflows/maintenance-autopilot.yml
+++ b/.github/workflows/maintenance-autopilot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#maintenance-autopilot for workflow-specific operator notes.
 name: maintenance-autopilot
 
 on:

--- a/.github/workflows/maintenance-issue-command-center.yml
+++ b/.github/workflows/maintenance-issue-command-center.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#maintenance-issue-command-center for workflow-specific operator notes.
 name: maintenance-issue-command-center
 
 on:

--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#maintenance-on-demand for workflow-specific operator notes.
 name: Maintenance On Demand
 
 on:

--- a/.github/workflows/operational-readiness-governance-contract.yml
+++ b/.github/workflows/operational-readiness-governance-contract.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#operational-readiness-governance-contract for workflow-specific operator notes.
 name: operational-readiness-governance-contract
 
 on:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#osv-scanner for workflow-specific operator notes.
 name: OSV Vulnerability Scan
 
 on:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#pages for workflow-specific operator notes.
 name: Pages
 
 on:

--- a/.github/workflows/platform-readiness-quality-contract.yml
+++ b/.github/workflows/platform-readiness-quality-contract.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#platform-readiness-quality-contract for workflow-specific operator notes.
 name: platform-readiness-quality-contract
 
 on:

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#pr-quality-comment for workflow-specific operator notes.
 name: PR Quality Comment
 
 on:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#pre-commit-autoupdate for workflow-specific operator notes.
 name: Pre-commit Autoupdate
 
 on:

--- a/.github/workflows/premium-gate.yml
+++ b/.github/workflows/premium-gate.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#premium-gate for workflow-specific operator notes.
 name: Premium Gate
 
 on:
@@ -21,6 +24,10 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            constraints-ci.txt
+            pyproject.toml
+            requirements*.txt
 
       - name: Install
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#quality for workflow-specific operator notes.
 name: Quality
 
 on:

--- a/.github/workflows/release-readiness-radar-bot.yml
+++ b/.github/workflows/release-readiness-radar-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#release-readiness-radar-bot for workflow-specific operator notes.
 name: Release Readiness Radar Bot
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#release for workflow-specific operator notes.
 name: Release
 
 on:

--- a/.github/workflows/repo-audit.yml
+++ b/.github/workflows/repo-audit.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#repo-audit for workflow-specific operator notes.
 name: Repo Audit
 
 on:

--- a/.github/workflows/repo-memory-history.yml
+++ b/.github/workflows/repo-memory-history.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#repo-memory-history for workflow-specific operator notes.
 name: RepoMemory Profile History
 
 on:

--- a/.github/workflows/repo-optimization-bot.yml
+++ b/.github/workflows/repo-optimization-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#repo-optimization-bot for workflow-specific operator notes.
 name: Repo Optimization Bot
 
 on:

--- a/.github/workflows/runtime-watchlist-bot.yml
+++ b/.github/workflows/runtime-watchlist-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#runtime-watchlist-bot for workflow-specific operator notes.
 name: Runtime Watchlist Bot
 
 on:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#sbom for workflow-specific operator notes.
 name: SBOM
 
 on:

--- a/.github/workflows/secret-protection-review-bot.yml
+++ b/.github/workflows/secret-protection-review-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#secret-protection-review-bot for workflow-specific operator notes.
 name: Secret Protection Review Bot
 
 on:

--- a/.github/workflows/security-configuration-audit-bot.yml
+++ b/.github/workflows/security-configuration-audit-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#security-configuration-audit-bot for workflow-specific operator notes.
 name: Security Configuration Audit Bot
 
 on:

--- a/.github/workflows/security-maintenance-bot.yml
+++ b/.github/workflows/security-maintenance-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#security-maintenance-bot for workflow-specific operator notes.
 name: Security Maintenance Bot
 
 on:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#security for workflow-specific operator notes.
 name: Security
 
 on:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#versioning for workflow-specific operator notes.
 name: Versioning & Changelog
 
 on:

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#weekly-maintenance for workflow-specific operator notes.
 name: Weekly Maintenance
 
 on:

--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#worker-alignment-bot for workflow-specific operator notes.
 name: Worker Alignment Bot
 
 on:

--- a/.github/workflows/workflow-governance-bot.yml
+++ b/.github/workflows/workflow-governance-bot.yml
@@ -1,3 +1,6 @@
+# Local equivalent command:
+#   python -m sdetkit workflow-governance-report --root . --format text
+#   See docs/ci/workflow-local-equivalents.md#workflow-governance-bot for workflow-specific operator notes.
 name: Workflow Governance Bot
 
 on:

--- a/docs/ci/workflow-local-equivalents.md
+++ b/docs/ci/workflow-local-equivalents.md
@@ -1,0 +1,753 @@
+# Workflow local equivalents
+
+This file maps workflow governance findings to local operator commands.
+It is intentionally review-first and does not authorize workflow mutation or permission reduction.
+
+Baseline governance check for every workflow:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/adapter-smoke-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .[test]
+|
+python -m sdetkit agent templates run adapter-smoke-worker --output-dir .sdetkit/agent/template-runs/adapter-smoke-worker > build/adapter-smoke-worker-run.json
+python - <<'PY'
+```
+
+## `.github/workflows/adaptive-ops-weekly.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m venv .venv
+python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
+make adaptive-ops-bundle DATE_TAG="$DATE_TAG" ADAPTIVE_SCENARIO="$ADAPTIVE_SCENARIO"
+```
+
+## `.github/workflows/adaptive-sentinel-monitor.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .
+python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+```
+
+## `.github/workflows/adoption-real-repo-canonical.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .
+python scripts/regenerate_real_repo_adoption_goldens.py --check
+|
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor --format json --out build/doctor.json
+python ../../../scripts/real_repo_adoption_projection.py \
+```
+
+## `.github/workflows/contributor-onboarding-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/dependency-audit.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt pip-audit==2.10.0
+python -m pip install -c constraints-ci.txt -e .
+python .github/scripts/check_pip_audit_baseline.py
+```
+
+## `.github/workflows/dependency-auto-merge.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/dependency-radar-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .
+|
+python -m sdetkit intelligence upgrade-audit --format json --used-in-repo-only --top 10 > build/dependency-radar.json
+python -m sdetkit intelligence upgrade-audit --impact-area runtime-core --repo-usage-tier hot-path --format md > build/runtime-fast-follow.md
+python - <<'PY'
+```
+
+## `.github/workflows/dependency-review.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/docs-experience-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python - <<'PY'
+```
+
+## `.github/workflows/docs-link-check.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/enforce-branch-protection.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .
+|
+python tools/enforce_branch_protection.py \
+```
+
+## `.github/workflows/enterprise-gate.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -U pip
+python -m pip install -c constraints-ci.txt -e .
+sdetkit doctor --all --format json --out build/doctor-enterprise.json || true
+python - <<'PY'
+sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force || rc=$?
+```
+
+## `.github/workflows/first-proof-artifact-publish.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt --upgrade pip
+python -m pip install -c constraints-ci.txt -e .
+make first-proof-verify-local
+```
+
+## `.github/workflows/first-proof.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt --upgrade pip
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .
+make first-proof-verify
+python - <<'PY'
+```
+
+## `.github/workflows/ghas-alert-sla-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/ghas-campaign-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/ghas-codeql-hotspots-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/ghas-metrics-export-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/ghas-review-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/impact-release-control.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -e .
+python -m pip install -c constraints-ci.txt -r requirements-test.txt
+python scripts/impact_policy_validate.py \
+python scripts/impact_workflow_run.py \
+python scripts/impact_trend_alert.py \
+python scripts/impact_step1_scorecard.py \
+python scripts/impact_step_scorecards.py \
+```
+
+## `.github/workflows/integration-topology-radar-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .[test]
+|
+python -m sdetkit agent templates run integration-topology-worker --output-dir .sdetkit/agent/template-runs/integration-topology-worker > build/integration-topology-worker-run.json
+python - <<'PY'
+```
+
+## `.github/workflows/kpi-weekly.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .[dev,test]
+|
+python -m ruff check src tests --output-format json > build/ruff-report.json || true
+python -m mypy src/sdetkit --hide-error-context --no-color-output --no-error-summary > build/mypy-report.txt || true
+bash -lc "$CMD"
+python - <<'PY'
+python -m sdetkit kpi-report \
+```
+
+## `.github/workflows/legacy-required-status-bridge.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/maintenance-autopilot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -e .[dev,test]
+python - <<'PY'
+```
+
+## `.github/workflows/maintenance-issue-command-center.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .
+|
+```
+
+## `.github/workflows/maintenance-on-demand.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -e .[dev,test]
+bash scripts/maintenance_ci.sh "${{ inputs.mode }}" "${{ inputs.fix && 'true' || 'false' }}" artifacts/maintenance
+python -m sdetkit.github_actions_annotation_hygiene_report \
+python -m sdetkit.maintenance_priority_rollup \
+python -m sdetkit.maintenance_policy_decisions \
+python -m sdetkit.maintenance_policy_memory_context \
+python -m sdetkit.maintenance_recommendations \
+```
+
+## `.github/workflows/operational-readiness-governance-contract.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m venv .venv
+python -m pip install -c constraints-ci.txt -e .
+make governance-contract-check
+python - <<'PYCODE'
+```
+
+## `.github/workflows/osv-scanner.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+./
+```
+
+## `.github/workflows/pages.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -r requirements-docs.txt -e .
+python scripts/check_public_surface_alignment.py
+NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
+```
+
+## `.github/workflows/platform-readiness-quality-contract.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt --upgrade pip
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
+python scripts/seed_quality_baseline_summary_fixture.py --summary build/baseline-baseline/baseline-baseline-summary.json
+make quality-contract-run
+```
+
+## `.github/workflows/pr-quality-comment.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
+bash quality.sh cov 2>&1 | tee build/pr-quality/failure-intelligence/quality.log
+gh api graphql \
+gh api \
+python - <<'PY'
+bash build/pr-quality/check-logs/download-failed-check-logs.sh || true
+gh run download "$trusted_history_run_id" \
+```
+
+## `.github/workflows/pre-commit-autoupdate.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt pre-commit
+pre-commit autoupdate
+```
+
+## `.github/workflows/premium-gate.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt --upgrade pip
+python -m pip install -c constraints-ci.txt -e '.[dev,test,docs]'
+bash premium-gate.sh
+```
+
+## `.github/workflows/quality.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
+python -m sdetkit.doctor --ascii
+python -m pre_commit run -a
+bash quality.sh registry
+bash quality.sh cov
+```
+
+## `.github/workflows/release-readiness-radar-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .[test]
+|
+python -m sdetkit doctor --format json > build/release-readiness-doctor.json || true
+python -m sdetkit maintenance --include-check github_automation_check --format json > build/release-readiness-maintenance.json || true
+python - <<'PY'
+```
+
+## `.github/workflows/release.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python scripts/release_preflight.py --tag "${{ steps.resolved.outputs.tag }}" --format json --out build/release-preflight.json
+python scripts/check_release_tag_version.py "${{ steps.resolved.outputs.tag }}"
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
+bash quality.sh cov
+python -m build
+python -m twine check dist/*
+python -m check_wheel_contents --ignore W009 dist/*.whl
+```
+
+## `.github/workflows/repo-audit.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/repo-memory-history.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .
+python - <<'PY'
+gh api --paginate \
+gh run download "$prior_run_id" \
+gh api \
+```
+
+## `.github/workflows/repo-optimization-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt --upgrade pip
+python -m pip install -c constraints-ci.txt -e .
+python -m sdetkit kits optimize "repo optimization control loop" --format json --limit 3 > build/repo-optimization.json
+python - <<'PY'
+```
+
+## `.github/workflows/runtime-watchlist-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .[test]
+|
+python -m sdetkit agent templates run runtime-watchlist-worker --output-dir .sdetkit/agent/template-runs/runtime-watchlist-worker > build/runtime-watchlist-worker-run.json
+python - <<'PY'
+```
+
+## `.github/workflows/sbom.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
+python -m pip install -c constraints-ci.txt cyclonedx-bom==7.3.0
+```
+
+## `.github/workflows/secret-protection-review-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/security-configuration-audit-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/security-maintenance-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+```
+
+## `.github/workflows/security.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/versioning.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+```
+
+## `.github/workflows/weekly-maintenance.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python -m pip install -c constraints-ci.txt -e .[dev,test]
+bash scripts/maintenance_ci.sh full false artifacts/maintenance
+python - <<'PY'
+bash scripts/maintenance_ci.sh full true artifacts/maintenance
+```
+
+## `.github/workflows/worker-alignment-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
+|
+python -m sdetkit agent templates run adapter-smoke-worker --output-dir .sdetkit/agent/template-runs/adapter-smoke-worker > build/adapter-smoke-worker-run.json
+python -m sdetkit agent templates run dependency-radar-worker --output-dir .sdetkit/agent/template-runs/dependency-radar-worker > build/dependency-radar-worker-run.json
+python -m sdetkit agent templates run docs-search-radar --output-dir .sdetkit/agent/template-runs/docs-search-radar > build/docs-search-radar-run.json
+python -m sdetkit agent templates run integration-topology-worker --output-dir .sdetkit/agent/template-runs/integration-topology-worker > build/integration-topology-worker-run.json
+python -m sdetkit agent templates run release-readiness-worker --output-dir .sdetkit/agent/template-runs/release-readiness-worker > build/release-readiness-worker-run.json
+python -m sdetkit agent templates run runtime-watchlist-worker --output-dir .sdetkit/agent/template-runs/runtime-watchlist-worker > build/runtime-watchlist-worker-run.json
+```
+
+## `.github/workflows/workflow-governance-bot.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+Workflow command hints extracted from the YAML for operator review:
+
+```bash
+|
+python - <<'PY'
+```


### PR DESCRIPTION
## Summary
- Adds explicit local-equivalent operator documentation for workflows flagged by `local_equivalent_command_documented`.
- Adds the premium-gate setup-python `cache-dependency-path` fix already proven on this branch.
- Keeps the PR scoped to non-permission workflow governance followups.

## Why
- A cache-only PR would be too small/noisy.
- Fresh workflow-governance-report had:
  - `cache_key_appropriate: 1`
  - `local_equivalent_command_documented: 50`
  - `permissions_least_privilege: 16`
- This burns down the cache and local-equivalent lanes together.
- Permissions remain intentionally untouched because they require human review and are not safe to patch automatically.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format text`
- `make proof-after-format`

## Risk
- Medium-low.
- Workflow comments/docs only, plus one cache dependency-path metadata fix.
- No workflow permission changes.
- No trigger or job behavior changes.
- Rollback: revert this workflow-governance documentation/cache commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no permission reduction in this PR
- no broad mutation or auto-fix in this PR