### PR TITLE
feat(roadmap): mark accepted radar candidates from history

### DIFF
--- a/src/sdetkit/product_maturity_radar.py
+++ b/src/sdetkit/product_maturity_radar.py
@@ -2,12 +2,69 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from collections import Counter
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
+
+
+def _accepted_candidate_history(root: Path) -> set[str]:
+    """Return normalized commit subjects already accepted on the local history."""
+
+    try:
+        completed = subprocess.run(
+            ["git", "log", "--format=%s", "--max-count=300"],
+            cwd=root,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return set()
+
+    if completed.returncode != 0:
+        return set()
+
+    subjects: set[str] = set()
+    for line in completed.stdout.splitlines():
+        subject = line.strip()
+        if not subject:
+            continue
+        if " (#" in subject and subject.endswith(")"):
+            subject = subject.rsplit(" (#", 1)[0].strip()
+        subjects.add(subject.lower())
+
+    return subjects
+
+
+def _normalized_history_subject(value: str) -> str:
+    return " ".join(value.strip().lower().replace("-", " ").split())
+
+
+def _candidate_accepted_on_main(candidate_title: str, accepted_subjects: set[str]) -> bool:
+    normalized_candidate = _normalized_history_subject(candidate_title)
+    if not normalized_candidate:
+        return False
+
+    if normalized_candidate in accepted_subjects:
+        return True
+
+    for subject in accepted_subjects:
+        normalized_subject = _normalized_history_subject(subject)
+        if not normalized_subject:
+            continue
+        if normalized_candidate == normalized_subject:
+            return True
+        if SequenceMatcher(None, normalized_candidate, normalized_subject).ratio() >= 0.82:
+            return True
+
+    return False
+
 
 SCHEMA_VERSION = "sdetkit.product_maturity_radar.v1"
 
@@ -569,8 +626,9 @@ def _remediation_surface(root: Path, text_index: dict[str, str]) -> dict[str, An
     )
 
 
-def _rank_candidates(surfaces: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+def _rank_candidates(surfaces: Sequence[dict[str, Any]], root: Path) -> list[dict[str, Any]]:
     priority_weight = {"P0": 400, "P1": 300, "P2": 200, "P3": 100}
+    accepted_subjects = _accepted_candidate_history(root)
     ranked: list[dict[str, Any]] = []
     for surface in surfaces:
         surface_score = int(surface["score"])
@@ -578,12 +636,26 @@ def _rank_candidates(surfaces: Sequence[dict[str, Any]]) -> list[dict[str, Any]]
         maturity_gap = surface_max - surface_score
         for candidate in surface["upgrade_candidates"]:
             priority = str(candidate.get("priority", "P3"))
+            candidate_title = str(
+                candidate.get("upgrade_candidate_title") or candidate.get("title") or ""
+            )
+            accepted_on_main = _candidate_accepted_on_main(
+                candidate_title,
+                accepted_subjects,
+            )
+            ranking_status = "accepted_on_main" if accepted_on_main else "fresh_candidate"
+            accepted_penalty = 1000 if accepted_on_main else 0
+
             ranked.append(
                 {
                     **candidate,
                     "surface_score": surface_score,
                     "surface_max_score": surface_max,
-                    "ranking_score": priority_weight.get(priority, 0) + maturity_gap * 10,
+                    "ranking_score": priority_weight.get(priority, 0)
+                    + maturity_gap * 10
+                    - accepted_penalty,
+                    "accepted_on_main": accepted_on_main,
+                    "ranking_status": ranking_status,
                 }
             )
 
@@ -612,7 +684,7 @@ def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
         _learning_surface(root),
         _remediation_surface(root, text_index),
     ]
-    ranked = _rank_candidates(surfaces)
+    ranked = _rank_candidates(surfaces, root)
     status_counts = Counter(str(surface["status"]) for surface in surfaces)
     total_score = sum(int(surface["score"]) for surface in surfaces)
     total_max_score = sum(int(surface["max_score"]) for surface in surfaces)
@@ -689,6 +761,11 @@ def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"   - classification: `{candidate['classification']}`")
             lines.append(f"   - priority: `{candidate['priority']}`")
             lines.append(f"   - ranking_score: `{candidate['ranking_score']}`")
+            if candidate.get("accepted_on_main"):
+                lines.append("   - accepted_on_main: true")
+                lines.append(
+                    f"   - ranking_status: `{candidate.get('ranking_status', 'accepted_on_main')}`"
+                )
             lines.append("   - review_first: true")
             lines.append("   - safe_to_patch: false")
 

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from sdetkit.product_maturity_radar import (
@@ -85,6 +87,19 @@ sdetkit = ["data/*.json"]
         _write(root / "tests" / filename, "def test_demo():\n    assert True\n")
 
 
+def _ranked_radar_candidates(payload: dict) -> list[dict]:
+    for key in (
+        "ranked_upgrade_candidates",
+        "ranked_candidates",
+        "upgrade_candidates",
+        "candidates",
+    ):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+    raise AssertionError(f"No ranked candidate list found in payload keys: {sorted(payload)}")
+
+
 def test_product_maturity_radar_builds_repo_wide_surface_report(tmp_path: Path) -> None:
     _fixture_repo(tmp_path)
 
@@ -161,3 +176,39 @@ def test_product_maturity_radar_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert "repo_mutation: false" in stdout
     assert out.is_file()
     assert out.with_suffix(".md").is_file()
+
+
+def test_product_maturity_radar_marks_accepted_candidates_from_git_history(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    out = tmp_path / "radar.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "product-maturity-radar",
+            "--root",
+            str(root),
+            "--out",
+            str(out),
+            "--format",
+            "text",
+        ],
+        check=True,
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    accepted = [
+        candidate
+        for candidate in _ranked_radar_candidates(payload)
+        if candidate.get("accepted_on_main") is True
+    ]
+
+    assert accepted
+    assert "accepted_on_main: true" in completed.stdout
+    assert all(candidate["ranking_status"] == "accepted_on_main" for candidate in accepted)
+    assert all(candidate["safe_to_patch"] is False for candidate in accepted)

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
-import sys
 from pathlib import Path
 
 from sdetkit.product_maturity_radar import (
@@ -178,30 +176,25 @@ def test_product_maturity_radar_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert out.with_suffix(".md").is_file()
 
 
-def test_product_maturity_radar_marks_accepted_candidates_from_git_history(tmp_path: Path) -> None:
-    root = Path(__file__).resolve().parents[1]
-    out = tmp_path / "radar.json"
+def test_product_maturity_radar_marks_accepted_candidates_from_git_history(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _fixture_repo(tmp_path)
 
-    completed = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "sdetkit",
-            "product-maturity-radar",
-            "--root",
-            str(root),
-            "--out",
-            str(out),
-            "--format",
-            "text",
-        ],
-        check=True,
-        cwd=root,
-        text=True,
-        stdout=subprocess.PIPE,
+    before = build_product_maturity_radar(tmp_path)
+    candidate_title = before["ranked_upgrade_candidates"][0]["upgrade_candidate_title"]
+
+    def fake_accepted_candidate_history(root: Path) -> set[str]:
+        assert root == tmp_path.resolve()
+        return {candidate_title.lower()}
+
+    monkeypatch.setattr(
+        "sdetkit.product_maturity_radar._accepted_candidate_history",
+        fake_accepted_candidate_history,
     )
 
-    payload = json.loads(out.read_text(encoding="utf-8"))
+    payload = build_product_maturity_radar(tmp_path)
     accepted = [
         candidate
         for candidate in _ranked_radar_candidates(payload)
@@ -209,6 +202,7 @@ def test_product_maturity_radar_marks_accepted_candidates_from_git_history(tmp_p
     ]
 
     assert accepted
-    assert "accepted_on_main: true" in completed.stdout
-    assert all(candidate["ranking_status"] == "accepted_on_main" for candidate in accepted)
+    assert accepted[0]["upgrade_candidate_title"] == candidate_title
+    assert accepted[0]["ranking_status"] == "accepted_on_main"
+    assert accepted[0]["ranking_score"] < before["ranked_upgrade_candidates"][0]["ranking_score"]
     assert all(candidate["safe_to_patch"] is False for candidate in accepted)


### PR DESCRIPTION
## Summary
- Marks product maturity radar candidates that already appear in accepted local git history.
- Adds `accepted_on_main` and `ranking_status` fields to ranked upgrade candidates.
- Uses conservative fuzzy matching so accepted roadmap work with minor title wording drift is recognized.
- Lowers accepted candidates in ranking so stale accepted roadmap items do not look like equally fresh next work.

## Why
- The radar was still surfacing already-merged roadmap candidate titles as if they were fresh.
- This keeps the radar useful as a control panel after roadmap work has been accepted.
- This is advisory-only and does not mutate the repo.

## Verification
- `python -m pytest -q tests/test_product_maturity_radar.py -o addopts=`
- `python -m sdetkit product-maturity-radar --root . --out build/sdetkit/product-maturity-radar.json --format text`
- `make proof-after-format`

## Risk
- Low-medium.
- Schema-additive radar output fields.
- Matching is advisory-only and only affects ranking/status metadata.
- Rollback: revert this radar-only commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false