### PR TITLE
feat(roadmap): match accepted radar title drift

### DIFF
--- a/src/sdetkit/product_maturity_radar.py
+++ b/src/sdetkit/product_maturity_radar.py
@@ -46,6 +46,29 @@ def _normalized_history_subject(value: str) -> str:
     return " ".join(value.strip().lower().replace("-", " ").split())
 
 
+def _history_title_tokens(value: str) -> set[str]:
+    cleaned = value.lower().replace("-", " ")
+    for char in "()[]{}:,_/.":
+        cleaned = cleaned.replace(char, " ")
+
+    return {token for token in cleaned.split() if len(token) >= 3}
+
+
+def _accepted_title_drift_match(candidate_title: str, accepted_subject: str) -> bool:
+    candidate_tokens = _history_title_tokens(candidate_title)
+    subject_tokens = _history_title_tokens(accepted_subject)
+
+    if not candidate_tokens or not subject_tokens:
+        return False
+
+    overlap = candidate_tokens & subject_tokens
+
+    # Conservative title-drift rule:
+    # - catches wording drift like "refresh README and docs map" vs "refresh docs lanes"
+    # - avoids overmatching broad workflow/ci subjects where only 1-3 generic tokens overlap
+    return len(overlap) >= 4
+
+
 def _candidate_accepted_on_main(candidate_title: str, accepted_subjects: set[str]) -> bool:
     normalized_candidate = _normalized_history_subject(candidate_title)
     if not normalized_candidate:
@@ -61,6 +84,8 @@ def _candidate_accepted_on_main(candidate_title: str, accepted_subjects: set[str
         if normalized_candidate == normalized_subject:
             return True
         if SequenceMatcher(None, normalized_candidate, normalized_subject).ratio() >= 0.82:
+            return True
+        if _accepted_title_drift_match(candidate_title, subject):
             return True
 
     return False

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from sdetkit import product_maturity_radar as radar_module
 from sdetkit.product_maturity_radar import (
     SCHEMA_VERSION,
     build_product_maturity_radar,
@@ -206,3 +207,25 @@ def test_product_maturity_radar_marks_accepted_candidates_from_git_history(
     assert accepted[0]["ranking_status"] == "accepted_on_main"
     assert accepted[0]["ranking_score"] < before["ranked_upgrade_candidates"][0]["ranking_score"]
     assert all(candidate["safe_to_patch"] is False for candidate in accepted)
+
+
+def test_product_maturity_radar_matches_accepted_candidate_title_drift() -> None:
+    assert radar_module._candidate_accepted_on_main(
+        "docs(product): refresh README and docs map for real-world learning lanes",
+        {"docs(product): refresh real-world learning lanes"},
+    )
+
+    assert radar_module._candidate_accepted_on_main(
+        "security: refresh anti-hijack and release threat model",
+        {"security: add release anti-hijack threat model"},
+    )
+
+    assert radar_module._candidate_accepted_on_main(
+        "feat(packaging): publish stable versus hidden command surface report",
+        {"feat(packaging): add public command surface report"},
+    )
+
+    assert not radar_module._candidate_accepted_on_main(
+        "ci: continue workflow hardening from governance report findings",
+        {"ci: explain workflow permission findings"},
+    )


### PR DESCRIPTION
## Summary
- Extends product maturity radar accepted-history matching for conservative title wording drift.
- Recognizes accepted docs, security, and packaging roadmap work whose commit titles differ slightly from candidate titles.
- Keeps workflow hardening fresh when only broad/partial CI wording overlaps.

## Why
- #1655 introduced accepted-history candidate status, but some already-related roadmap items still ranked as fresh due title wording drift.
- This keeps the radar useful as a roadmap control panel after accepted work accumulates.
- Matching remains advisory-only and only affects ranking/status metadata.

## Verification
- `python -m pytest -q tests/test_product_maturity_radar.py -o addopts=`
- `python -m sdetkit product-maturity-radar --root . --out build/sdetkit/product-maturity-radar.json --format text`
- `make proof-after-format`

## Risk
- Low-medium.
- Schema remains additive from #1655.
- Matching is conservative: requires at least four overlapping title tokens after exact/fuzzy checks.
- Rollback: revert this radar-only commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false