### PR TITLE
ci: add workflow permission review intelligence

### DIFF
--- a/docs/ci/workflow-permission-review-playbook.md
+++ b/docs/ci/workflow-permission-review-playbook.md
@@ -1,0 +1,74 @@
+# Workflow permission review playbook
+
+This playbook supports `sdetkit workflow-governance-report` permission findings.
+
+The report is advisory-only. It does not authorize automatic permission reduction, workflow mutation, security dismissal, merge, or semantic-equivalence claims.
+
+## Review rule
+
+When a workflow is flagged with `permissions_least_privilege` and `safe_to_patch=false`, treat it as a human review task.
+
+Do not reduce permissions unless a reviewer proves all of the following:
+
+1. The workflow job does not use the write scope directly.
+2. The workflow job does not call a script, action, `gh`, GitHub API, SARIF upload, Pages deploy, release, attestation, OIDC provider, or repository mutation path that needs the write scope.
+3. The workflow still passes focused proof after a tiny permission-only change.
+4. The PR changes only the reviewed permission slice.
+5. The rollback is a single workflow revert.
+
+## Permission review groups
+
+The workflow governance report groups permission findings into these review buckets:
+
+- `pr_issue_interaction`: issue or pull request comments/reviews/updates.
+- `repository_mutation`: branch, content, release, or repository write paths.
+- `security_upload`: SARIF or code-scanning upload surfaces.
+- `deployment_or_oidc`: Pages or OIDC deployment/provider surfaces.
+- `release_or_provenance`: release, provenance, attestation, or OIDC release surfaces.
+- `other_write_scope`: write scopes that need manual classification.
+
+These groups are not approvals. They are triage queues for human review.
+
+## Required evidence for a permission PR
+
+For every reviewed workflow, include:
+
+- workflow path
+- current granted write scopes
+- inferred permission reasons from the report
+- exact scope proposed for removal, if any
+- exact proof command
+- rollback plan
+- reviewer decision
+
+## Allowed next action
+
+The only allowed next action from this report is:
+
+```text
+collect_human_review_evidence
+```
+
+## Blocked actions
+
+The report blocks:
+
+- automatic permission reduction
+- broad workflow permission sweeps
+- security alert dismissal
+- merge authorization
+- semantic-equivalence claims
+
+## Example review card
+
+```text
+workflow=<path>
+current_write_scopes=<list>
+review_group=<group>
+inferred_reasons=<list>
+proposed_change=<none|scope removal>
+human_reviewer=<name>
+proof=<command>
+rollback=<single workflow revert>
+decision=<keep|reduce|split|defer>
+```

--- a/src/sdetkit/workflow_governance_report.py
+++ b/src/sdetkit/workflow_governance_report.py
@@ -380,6 +380,76 @@ def _permission_review_entry(repo_root: Path, workflow: dict[str, Any]) -> dict[
     }
 
 
+def _permission_review_kind(entry: dict[str, Any]) -> str:
+    scopes = set(entry.get("granted_write_scopes", []))
+    reasons = " ".join(str(reason) for reason in entry.get("inferred_permission_reasons", []))
+
+    if (
+        "attestations: write" in scopes
+        or "id-token: write" in scopes
+        and "release" in reasons.lower()
+    ):
+        return "release_or_provenance"
+    if "pages: write" in scopes or "id-token: write" in scopes:
+        return "deployment_or_oidc"
+    if "security-events: write" in scopes:
+        return "security_upload"
+    if "contents: write" in scopes:
+        return "repository_mutation"
+    if {"issues: write", "pull-requests: write"} & scopes:
+        return "pr_issue_interaction"
+    return "other_write_scope"
+
+
+def _permission_review_summary(
+    permission_review_matrix: list[dict[str, Any]],
+) -> dict[str, Any]:
+    groups: dict[str, dict[str, Any]] = {}
+
+    for entry in permission_review_matrix:
+        kind = _permission_review_kind(entry)
+        group = groups.setdefault(
+            kind,
+            {
+                "kind": kind,
+                "workflow_count": 0,
+                "workflows": [],
+                "granted_write_scopes": [],
+                "requires_human_review": True,
+                "safe_to_patch": False,
+            },
+        )
+        group["workflow_count"] += 1
+        group["workflows"].append(
+            entry.get("path") or entry.get("workflow_path") or entry.get("file")
+        )
+        group["granted_write_scopes"] = sorted(
+            set(group["granted_write_scopes"]) | set(entry.get("granted_write_scopes", []))
+        )
+
+    grouped = sorted(
+        groups.values(),
+        key=lambda item: (-int(item["workflow_count"]), str(item["kind"])),
+    )
+
+    return {
+        "status": "human_review_required",
+        "permission_review_count": len(permission_review_matrix),
+        "group_count": len(grouped),
+        "groups": grouped,
+        "automatic_permission_reduction_allowed": False,
+        "safe_to_patch": False,
+        "review_first": True,
+        "next_allowed_action": "collect_human_review_evidence",
+        "blocked_actions": [
+            "automatic_permission_reduction",
+            "broad_workflow_permission_sweep",
+            "security_alert_dismissal",
+            "merge_authorization",
+        ],
+    }
+
+
 def _permission_review_matrix(
     *,
     repo_root: Path,
@@ -420,6 +490,8 @@ def build_workflow_governance_report(repo_root: str | Path = ".") -> dict[str, A
         repo_root=root,
         workflows=workflows,
     )
+    permission_review_summary = _permission_review_summary(permission_review_matrix)
+
     actionability_summary = _actionability_summary(
         workflow_count=len(workflows),
         review_required_count=len(review_required),
@@ -436,8 +508,15 @@ def build_workflow_governance_report(repo_root: str | Path = ".") -> dict[str, A
         "finding_count": finding_count,
         "finding_counts": sorted_finding_counts,
         "ranked_followups": ranked_followups,
+        "permission_review_playbook": "docs/ci/workflow-permission-review-playbook.md",
+        "permission_review_next_actions": [
+            "Use the workflow permission review playbook before any permission reduction.",
+            "Keep permission changes human-reviewed and one narrow workflow slice at a time.",
+            "Do not patch permissions automatically when safe_to_patch is false.",
+        ],
         "permission_review_matrix": permission_review_matrix,
         "permission_review_count": len(permission_review_matrix),
+        "permission_review_summary": permission_review_summary,
         "actionability_summary": actionability_summary,
         "workflows": workflows,
         "operator_summary": {
@@ -519,6 +598,34 @@ def render_workflow_governance_markdown(payload: dict[str, Any]) -> str:
     else:
         lines.append("- none")
 
+    lines.extend(["", "## Permission review summary", ""])
+    permission_summary = payload.get("permission_review_summary", {})
+    if isinstance(permission_summary, dict) and permission_summary:
+        lines.append(f"- status: `{permission_summary.get('status', 'unknown')}`")
+        lines.append(
+            "- automatic_permission_reduction_allowed: "
+            f"{str(bool(permission_summary.get('automatic_permission_reduction_allowed', False))).lower()}"
+        )
+        lines.append(
+            f"- next_allowed_action: `{permission_summary.get('next_allowed_action', 'human_review')}`"
+        )
+        groups = permission_summary.get("groups", [])
+        if isinstance(groups, list) and groups:
+            lines.append("- groups:")
+            for group in groups:
+                lines.append(
+                    f"  - `{group.get('kind')}`: {group.get('workflow_count', 0)} workflows"
+                )
+
+    lines.extend(["", "## Permission review playbook", ""])
+    playbook = payload.get("permission_review_playbook")
+    if playbook:
+        lines.append(f"- playbook: `{playbook}`")
+    next_actions = payload.get("permission_review_next_actions", [])
+    if next_actions:
+        lines.append("- next_actions:")
+        for action in next_actions:
+            lines.append(f"  - {action}")
     lines.extend(["", "## Permission review matrix", ""])
     permission_review = payload.get("permission_review_matrix")
     if isinstance(permission_review, list) and permission_review:

--- a/tests/test_workflow_governance_report.py
+++ b/tests/test_workflow_governance_report.py
@@ -415,3 +415,116 @@ jobs:
     assert "`pull-requests: write`" in markdown
     assert "requires_human_review: true" in markdown
     assert "safe_to_patch: false" in markdown
+
+
+def test_workflow_governance_report_exposes_permission_review_playbook(tmp_path: Path) -> None:
+    root = tmp_path
+    workflow_dir = root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "bot.yml").write_text(
+        """
+name: bot
+on:
+  workflow_dispatch:
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  bot:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue comment 1 --body hi
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    from sdetkit.workflow_governance_report import build_workflow_governance_report
+
+    payload = build_workflow_governance_report(root)
+
+    assert payload["permission_review_playbook"] == "docs/ci/workflow-permission-review-playbook.md"
+    assert payload["permission_review_next_actions"]
+    assert payload["permission_review_matrix"]
+    assert payload["safe_to_patch"] is False
+    assert payload["review_first"] is True
+
+
+def test_workflow_governance_report_groups_permission_review_intelligence(tmp_path: Path) -> None:
+    root = tmp_path
+    workflow_dir = root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+
+    (workflow_dir / "issue-bot.yml").write_text(
+        """
+name: issue bot
+on:
+  workflow_dispatch:
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  bot:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue comment 1 --body hi
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (workflow_dir / "security-upload.yml").write_text(
+        """
+name: security upload
+on:
+  workflow_dispatch:
+permissions:
+  security-events: write
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo upload sarif
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (workflow_dir / "release.yml").write_text(
+        """
+name: release
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+  attestations: write
+  id-token: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo release
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    from sdetkit.workflow_governance_report import (
+        build_workflow_governance_report,
+        render_workflow_governance_markdown,
+    )
+
+    payload = build_workflow_governance_report(root)
+    summary = payload["permission_review_summary"]
+    markdown = render_workflow_governance_markdown(payload)
+
+    assert summary["status"] == "human_review_required"
+    assert summary["permission_review_count"] == payload["permission_review_count"]
+    assert summary["automatic_permission_reduction_allowed"] is False
+    assert summary["safe_to_patch"] is False
+    assert summary["review_first"] is True
+    assert summary["next_allowed_action"] == "collect_human_review_evidence"
+    assert "automatic_permission_reduction" in summary["blocked_actions"]
+
+    groups = {group["kind"]: group for group in summary["groups"]}
+    assert "pr_issue_interaction" in groups
+    assert "security_upload" in groups
+    assert "release_or_provenance" in groups or "repository_mutation" in groups
+
+    assert "## Permission review summary" in markdown
+    assert "automatic_permission_reduction_allowed: false" in markdown
+    assert "collect_human_review_evidence" in markdown


### PR DESCRIPTION
## Summary
- Adds workflow permission review playbook documentation.
- Adds permission review summary/grouping to workflow-governance-report JSON and markdown.
- Adds human-review decision metadata: next allowed action, blocked actions, and automatic-permission-reduction=false.
- Keeps the remaining permission lane advisory-only and review-first.

## Why
- Workflow governance now has only `permissions_least_privilege` findings left.
- Those findings are not safe to patch automatically.
- This turns the remaining lane into an operator-ready human-review evidence packet instead of a tiny docs-only PR.

## Verification
- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m sdetkit workflow-governance-report --root . --out build/sdetkit/workflow-governance-report.json --format text`
- `make proof-after-format`

## Risk
- Low-medium.
- Report/docs/test additive.
- No workflow YAML permission changes.
- No automatic permission reduction.
- Rollback: revert this report/docs-only commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- automatic_security_fix_allowed=false
- automatic_dismissal_allowed=false