### PR TITLE
feat(maintenance): detect stale command center queue snapshots

### DIFF
--- a/tests/test_maintenance_command_center_live_scan.py
+++ b/tests/test_maintenance_command_center_live_scan.py
@@ -95,3 +95,65 @@ def test_alert_scan_falls_back_when_endpoint_rejects_page_parameter() -> None:
     assert scan == {"available": True, "count": 2, "error": ""}
     assert client.requested_path == "/repos/example/repo/dependabot/alerts"
     assert client.requested_params == {"state": "open"}
+
+
+def test_command_center_live_scan_lines_include_queue_snapshot_status() -> None:
+    module = _load_module()
+
+    live_scan = {
+        "generated_at": "2026-06-09T00:00:00Z",
+        "source": "GitHub API live scan",
+        "open_pull_requests": {"available": True, "count": 0, "items": []},
+        "open_issues_excluding_command_center": {"available": True, "count": 2, "items": []},
+        "recent_workflow_runs": {
+            "available": True,
+            "total": 0,
+            "counts": {"success": 0, "failure": 0, "pending": 0, "other": 0},
+            "latest_failures": [],
+        },
+        "security_alerts": {
+            "dependabot": {"available": True, "count": 0},
+            "code_scanning": {"available": True, "count": 0},
+            "secret_scanning": {"available": True, "count": 0},
+        },
+    }
+
+    rendered = "\n".join(module._live_scan_lines(live_scan))
+
+    assert "## Live repository scan" in rendered
+    assert "Queue snapshot status: **fresh_no_open_prs**" in rendered
+    assert "open PRs **0**, open issues **2**" in rendered
+    assert "Next allowed action: `continue_roadmap_selection`" in rendered
+
+
+def test_command_center_queue_snapshot_detects_stale_pr_samples() -> None:
+    module = _load_module()
+
+    live_scan = {
+        "open_pull_requests": {
+            "available": True,
+            "count": 1,
+            "items": [
+                {
+                    "number": 1657,
+                    "title": "ci: add workflow permission review intelligence",
+                    "state": "closed",
+                }
+            ],
+        },
+        "open_issues_excluding_command_center": {
+            "available": True,
+            "count": 6,
+            "items": [],
+        },
+    }
+
+    summary = module._queue_snapshot_summary(live_scan)
+
+    assert summary["status"] == "stale"
+    assert summary["stale_open_pr_sample_count"] == 1
+    assert summary["next_allowed_action"] == "refresh_command_center_snapshot"
+
+    rendered = "\n".join(module._queue_snapshot_lines(live_scan))
+    assert "Queue snapshot status: **stale**" in rendered
+    assert "Stale open PR samples detected: **1**" in rendered

--- a/tools/maintenance_command_center.py
+++ b/tools/maintenance_command_center.py
@@ -415,6 +415,67 @@ def _collect_live_scan(
     }
 
 
+def _queue_snapshot_summary(live_scan: dict[str, Any]) -> dict[str, Any]:
+    prs = live_scan.get("open_pull_requests") or live_scan.get("pull_requests", {})
+    issues = live_scan.get("open_issues_excluding_command_center") or live_scan.get("issues", {})
+
+    if prs.get("error") or issues.get("error"):
+        return {
+            "status": "unknown",
+            "open_pr_count": prs.get("count"),
+            "open_issue_count": issues.get("count"),
+            "stale_open_pr_sample_count": 0,
+            "next_allowed_action": "retry_live_queue_scan",
+        }
+
+    open_pr_count = int(prs.get("count", 0) or 0)
+    open_issue_count = int(issues.get("count", 0) or 0)
+    samples = prs.get("items", [])
+    if not isinstance(samples, list):
+        samples = []
+
+    stale_samples = [
+        sample for sample in samples if str(sample.get("state", "open")).lower() != "open"
+    ]
+
+    if stale_samples:
+        status = "stale"
+        next_action = "refresh_command_center_snapshot"
+    elif open_pr_count == 0:
+        status = "fresh_no_open_prs"
+        next_action = "continue_roadmap_selection"
+    else:
+        status = "fresh_open_prs"
+        next_action = "review_open_pr_queue"
+
+    return {
+        "status": status,
+        "open_pr_count": open_pr_count,
+        "open_issue_count": open_issue_count,
+        "stale_open_pr_sample_count": len(stale_samples),
+        "next_allowed_action": next_action,
+    }
+
+
+def _queue_snapshot_lines(live_scan: dict[str, Any]) -> list[str]:
+    summary = _queue_snapshot_summary(live_scan)
+
+    lines = [
+        "- Queue snapshot status: "
+        f"**{summary['status']}**; "
+        f"open PRs **{summary.get('open_pr_count')}**, "
+        f"open issues **{summary.get('open_issue_count')}**",
+        f"  - Next allowed action: `{summary['next_allowed_action']}`",
+    ]
+
+    if int(summary.get("stale_open_pr_sample_count", 0) or 0):
+        lines.append(
+            f"  - Stale open PR samples detected: **{summary['stale_open_pr_sample_count']}**"
+        )
+
+    return lines
+
+
 def _scan_count_line(label: str, scan: dict[str, Any]) -> str:
     if scan.get("available") is False:
         return f"- {label}: **unavailable** — {scan.get('error', 'unknown error')}"
@@ -431,9 +492,14 @@ def _live_scan_lines(live_scan: dict[str, Any]) -> list[str]:
         "## Live repository scan",
         f"- Generated at: **{live_scan.get('generated_at', 'unknown')}**",
         f"- Source: **{live_scan.get('source', 'GitHub API live scan')}**",
-        _scan_count_line("Open pull requests", prs),
-        _scan_count_line("Open issues excluding command center", issues),
     ]
+    lines.extend(_queue_snapshot_lines(live_scan))
+    lines.extend(
+        [
+            _scan_count_line("Open pull requests", prs),
+            _scan_count_line("Open issues excluding command center", issues),
+        ]
+    )
 
     if prs.get("items"):
         lines.append("  - Open PR sample:")


### PR DESCRIPTION
## Summary
- Adds queue snapshot freshness status to the maintenance command center live scan.
- Adds next allowed action metadata for open PR queue state.
- Detects stale open PR samples so the command center can guide refresh instead of stale queue decisions.
- Adds focused command-center tests for fresh and stale queue snapshots.

## Why
- Accepted main is green and live queue has no open PRs.
- The rolling command-center issue can lag behind merges and continue showing stale open PR samples.
- This improves operator control-plane freshness without touching workflow permissions or automation authority.

## Verification
- `python -m pytest -q tests/test_maintenance_command_center_live_scan.py -o addopts=`
- command-center live scan rendering smoke
- `make proof-after-format`

## Risk
- Low-medium.
- Rendering/reporting change only.
- No workflow YAML changes.
- No permission changes.
- Rollback: revert this command-center reporting commit.

## Authority boundary
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no automatic permission reduction