### PR TITLE
security(report): preserve release anti-hijack evidence details

### DIFF
--- a/build/sdetkit/release-anti-hijack-threat-model.json
+++ b/build/sdetkit/release-anti-hijack-threat-model.json
@@ -1,0 +1,80 @@
+{
+  "authority_boundary": {
+    "automation_allowed": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "semantic_equivalence_proven": false
+  },
+  "automation_allowed": false,
+  "finding_count": 3,
+  "findings": [
+    {
+      "id": "pypi_publish_credential_surface",
+      "recommendation": "Prefer PyPI Trusted Publishing/OIDC when configured; until then, keep the publish credential narrowly scoped, rotated, and protected by maintainer review.",
+      "severity": "medium",
+      "summary": "Release publish path references a PyPI publish credential environment.",
+      "surface": "publish_credentials"
+    },
+    {
+      "id": "release_contents_write_scope",
+      "recommendation": "Keep write scope isolated to release workflows and protect release workflow changes with CODEOWNERS/rulesets.",
+      "severity": "review",
+      "summary": "Release workflow requests contents: write.",
+      "surface": "workflow_permissions"
+    },
+    {
+      "id": "manual_release_dispatch_review_surface",
+      "recommendation": "Require operator verification of the requested tag, release preflight output, and package version before manual dispatch.",
+      "severity": "review",
+      "summary": "Release workflow supports workflow_dispatch.",
+      "surface": "release_entrypoint"
+    }
+  ],
+  "merge_authorized": false,
+  "patch_application_allowed": false,
+  "positive_controls": [
+    "build_provenance_attestation_configured",
+    "release_workflow_present",
+    "tag_push_release_entrypoint_detected",
+    "third_party_actions_pinned_to_full_sha"
+  ],
+  "recommended_next_actions": [
+    "Do not claim release automation is authorized by this report.",
+    "Keep provenance/attestation evidence attached to release runs.",
+    "Prefer PyPI Trusted Publishing/OIDC when the PyPI project is configured for it.",
+    "Review release workflow changes through CODEOWNERS/rulesets.",
+    "Treat credential-based publishing as review-required until Trusted Publishing is configured."
+  ],
+  "release_controls": {
+    "attestations_write": true,
+    "build_provenance_attestation": true,
+    "contents_write": true,
+    "id_token_write": true,
+    "pypi_publish_credential_reference": true,
+    "tag_push_release": true,
+    "trusted_publishing_action_detected": false,
+    "unpinned_action_count": 0,
+    "uses_action_count": 5,
+    "workflow_dispatch": true
+  },
+  "rules": {
+    "publish_attempted": false,
+    "pypi_trusted_publisher_verified": false,
+    "release_workflow_mutated": false,
+    "repo_settings_verified": false,
+    "review_first": true,
+    "workflow_read_only": true
+  },
+  "schema_version": "sdetkit.release_anti_hijack_threat_model.v1",
+  "semantic_equivalence_proven": false,
+  "status": "review_required",
+  "unverified_settings": [
+    "CODEOWNERS enforcement for .github/workflows/release.yml",
+    "GitHub environment protection and required reviewers for publish jobs",
+    "PyPI Trusted Publisher configuration",
+    "branch protection / rulesets for release workflow changes",
+    "repository secret inventory and rotation status"
+  ],
+  "workflow_path": ".github/workflows/release.yml",
+  "workflow_present": true
+}

--- a/src/sdetkit/release_anti_hijack_threat_model.py
+++ b/src/sdetkit/release_anti_hijack_threat_model.py
@@ -374,13 +374,18 @@ def _public_report_payload(payload: dict[str, Any]) -> dict[str, Any]:
 def _public_output_summary(payload: dict[str, Any]) -> dict[str, Any]:
     controls = _public_release_controls(payload.get("release_controls"))
     rules = _public_rules(payload.get("rules"))
+    findings = _public_findings(payload.get("findings"))
     return {
         "schema_version": SCHEMA_VERSION,
         "status": "review_required",
         "workflow_path": DEFAULT_WORKFLOW,
         "workflow_present": bool(controls.get("uses_action_count", 0)),
-        "finding_count": _public_int(payload.get("finding_count")),
+        "positive_controls": _public_string_list(payload.get("positive_controls")),
+        "findings": findings,
+        "finding_count": len(findings),
+        "unverified_settings": _public_string_list(payload.get("unverified_settings")),
         "release_controls": controls,
+        "recommended_next_actions": _public_string_list(payload.get("recommended_next_actions")),
         "rules": rules,
         "automation_allowed": False,
         "patch_application_allowed": False,
@@ -393,13 +398,18 @@ def _public_output_summary(payload: dict[str, Any]) -> dict[str, Any]:
 def _render_public_json_document(summary: dict[str, Any]) -> str:
     controls = _public_release_controls(summary.get("release_controls"))
     rules = _public_rules(summary.get("rules"))
+    findings = _public_findings(summary.get("findings"))
     document = {
         "schema_version": SCHEMA_VERSION,
         "status": "review_required",
         "workflow_path": DEFAULT_WORKFLOW,
         "workflow_present": bool(summary.get("workflow_present")),
-        "finding_count": _public_int(summary.get("finding_count")),
+        "positive_controls": _public_string_list(summary.get("positive_controls")),
+        "findings": findings,
+        "finding_count": len(findings),
+        "unverified_settings": _public_string_list(summary.get("unverified_settings")),
         "release_controls": controls,
+        "recommended_next_actions": _public_string_list(summary.get("recommended_next_actions")),
         "rules": rules,
         "automation_allowed": False,
         "patch_application_allowed": False,

--- a/tests/test_release_anti_hijack_threat_model.py
+++ b/tests/test_release_anti_hijack_threat_model.py
@@ -95,7 +95,21 @@ def test_release_anti_hijack_threat_model_writes_json_and_markdown(
     markdown = out.with_suffix(".md")
     assert out.is_file()
     assert markdown.is_file()
-    assert json.loads(out.read_text(encoding="utf-8"))["schema_version"] == SCHEMA_VERSION
+    document = json.loads(out.read_text(encoding="utf-8"))
+    assert document["schema_version"] == SCHEMA_VERSION
+    assert document["finding_count"] == payload["finding_count"]
+
+    finding_ids = {finding["id"] for finding in document["findings"]}
+    assert "pypi_publish_credential_surface" in finding_ids
+    assert "release_contents_write_scope" in finding_ids
+    assert "manual_release_dispatch_review_surface" in finding_ids
+    assert document["unverified_settings"]
+    assert document["rules"]["release_workflow_mutated"] is False
+    assert document["automation_allowed"] is False
+    assert document["patch_application_allowed"] is False
+    assert document["merge_authorized"] is False
+    assert document["semantic_equivalence_proven"] is False
+
     assert "# SDETKit release anti-hijack threat model" in markdown.read_text(encoding="utf-8")
     assert payload["finding_count"] >= 1
 


### PR DESCRIPTION
## Summary

This PR hardens the release anti-hijack threat-model evidence contract.

It preserves detailed release/security evidence in the public JSON artifact instead of only exposing the aggregate `finding_count` and release controls.

This is intentionally report-only and review-first. It does not mutate `.github/workflows/release.yml`, release permissions, triggers, jobs, publishing behavior, secrets, environments, or repository security settings.

## What changed

- Updated `src/sdetkit/release_anti_hijack_threat_model.py` so the public JSON document preserves:
  - `positive_controls`
  - detailed `findings`
  - `unverified_settings`
  - `recommended_next_actions`
- Added regression coverage in `tests/test_release_anti_hijack_threat_model.py`
- Added refreshed evidence artifact:
  - `build/sdetkit/release-anti-hijack-threat-model.json`

## Key persisted evidence

The refreshed JSON now persists the three release anti-hijack findings:

- `pypi_publish_credential_surface`
- `release_contents_write_scope`
- `manual_release_dispatch_review_surface`

It also persists the unverified review settings, including CODEOWNERS enforcement, environment protection, PyPI Trusted Publisher configuration, branch protection/rulesets, and repository secret inventory/rotation status.

## Proof

Focused proof:

```text
python -m pytest -q \
  tests/test_release_anti_hijack_threat_model.py \
  tests/test_workflow_release_guardrails.py \
  -o addopts=

10 passed
```

Formatting and full proof:

```text
python -m ruff format \
  src/sdetkit/release_anti_hijack_threat_model.py \
  tests/test_release_anti_hijack_threat_model.py

python -m ruff check \
  src/sdetkit/release_anti_hijack_threat_model.py \
  tests/test_release_anti_hijack_threat_model.py

make proof-after-format
```

Result:

```text
All checks passed!
ruff_check_fix=passed
ruff_format=passed
doctor --ascii=passed
mypy=passed
```

## Authority boundary

This PR preserves the authority boundary:

- `automation_allowed`: false
- `patch_application_allowed`: false
- `merge_authorized`: false
- `semantic_equivalence_proven`: false
- no workflow YAML mutation
- no release permission change
- no security auto-fix
- no security dismissal

## Review notes

This PR should be reviewed as evidence-contract hardening only.

It must not be interpreted as approval to mutate release permissions, configure publishing, dismiss security findings, or merge without human review.