### PR TITLE
feat(report): add integration topology worker evidence contract

### DIFF
--- a/build/sdetkit/integration-topology-worker-evidence.json
+++ b/build/sdetkit/integration-topology-worker-evidence.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "report_status": "review_required",
+  "evidence_type": "integration_topology_worker_evidence",
+  "review_first": true,
+  "safe_to_patch": false,
+  "repo_mutation": false,
+  "workflow_mutation": false,
+  "automation_allowed": false,
+  "patch_application_allowed": false,
+  "merge_authorized": false,
+  "semantic_equivalence_proven": false,
+  "authority_boundary": {
+    "automation_allowed": false,
+    "patch_application_allowed": false,
+    "merge_authorized": false,
+    "semantic_equivalence_proven": false
+  },
+  "workers": [
+    {
+      "id": "integration-topology-worker",
+      "template_path": "templates/automations/integration-topology-worker.yaml",
+      "purpose": "Validate heterogeneous topology proof, capture optimize guidance, and bundle architecture-ready artifacts.",
+      "expected_step_ids": [
+        "topology-check",
+        "topology-optimize",
+        "topology-summary",
+        "bundle"
+      ],
+      "expected_outputs": [
+        "topology-check.json",
+        "optimize.json",
+        "summary.md",
+        "bundle.tar"
+      ],
+      "command_surfaces": [
+        "python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json",
+        "python -m sdetkit kits optimize --goal \"integration topology premium gate alignment\" --format json"
+      ],
+      "review_notes": [
+        "Use topology-check.json before topology/platform refactors.",
+        "Use optimize.json as guidance only.",
+        "Do not infer automation, patch application, merge authorization, or semantic equivalence from this evidence."
+      ]
+    },
+    {
+      "id": "worker-alignment-radar",
+      "template_path": "templates/automations/worker-alignment-radar.yaml",
+      "purpose": "Keep worker templates aligned with the repo's expansion plan, automation coverage, and template inventory.",
+      "expected_step_ids": [
+        "expand",
+        "automation-check",
+        "templates-list",
+        "summary",
+        "bundle"
+      ],
+      "expected_outputs": [
+        "expand.json",
+        "automation-check.json",
+        "templates.json",
+        "summary.md",
+        "bundle.tar"
+      ],
+      "command_surfaces": [
+        "python -m sdetkit kits expand --goal \"${{inputs.goal}}\" --format json",
+        "python -m sdetkit maintenance --include-check github_automation_check --format json",
+        "python -m sdetkit agent templates list"
+      ],
+      "review_notes": [
+        "Use expand.json to compare expansion guidance against the worker inventory.",
+        "Use automation-check.json to keep automation health visible.",
+        "Use templates.json to detect worker inventory drift."
+      ]
+    }
+  ],
+  "recommended_next_actions": [
+    "Keep this contract as evidence only.",
+    "Run the worker templates before topology/platform/premium-gate refactors.",
+    "Review generated artifacts before any human-authored patch.",
+    "Do not auto-apply workflow, platform, or topology changes from this report."
+  ]
+}

--- a/tests/test_worker_alignment_evidence_contract.py
+++ b/tests/test_worker_alignment_evidence_contract.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from sdetkit.agent.templates import template_by_id
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_integration_topology_worker_evidence_contract_matches_templates() -> None:
+    repo_root = Path.cwd()
+    evidence_path = repo_root / "build/sdetkit/integration-topology-worker-evidence.json"
+
+    payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == 1
+    assert payload["report_status"] == "review_required"
+    assert payload["evidence_type"] == "integration_topology_worker_evidence"
+    assert payload["review_first"] is True
+    assert payload["safe_to_patch"] is False
+    assert payload["repo_mutation"] is False
+    assert payload["workflow_mutation"] is False
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+    assert payload["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    workers = {worker["id"]: worker for worker in payload["workers"]}
+    assert set(workers) == {"integration-topology-worker", "worker-alignment-radar"}
+
+    for worker_id, worker in workers.items():
+        template = template_by_id(repo_root, worker_id)
+        template_path = repo_root / worker["template_path"]
+        template_doc = _load_yaml(template_path)
+
+        assert template.metadata["id"] == worker_id
+        assert template_doc["metadata"]["description"] == worker["purpose"]
+
+        workflow = template_doc["workflow"]
+        assert [step["id"] for step in workflow] == worker["expected_step_ids"]
+
+        rendered_commands = [
+            step.get("with", {}).get("cmd")
+            for step in workflow
+            if step.get("action") == "shell.run"
+        ]
+        assert rendered_commands == worker["command_surfaces"]
+
+
+def test_integration_topology_worker_evidence_contract_names_expected_outputs() -> None:
+    payload = json.loads(
+        Path("build/sdetkit/integration-topology-worker-evidence.json").read_text(encoding="utf-8")
+    )
+
+    workers = {worker["id"]: worker for worker in payload["workers"]}
+
+    assert workers["integration-topology-worker"]["expected_outputs"] == [
+        "topology-check.json",
+        "optimize.json",
+        "summary.md",
+        "bundle.tar",
+    ]
+    assert workers["worker-alignment-radar"]["expected_outputs"] == [
+        "expand.json",
+        "automation-check.json",
+        "templates.json",
+        "summary.md",
+        "bundle.tar",
+    ]
+
+    next_actions = payload["recommended_next_actions"]
+    assert "Keep this contract as evidence only." in next_actions
+    assert any("before topology/platform/premium-gate refactors" in item for item in next_actions)
+    assert any("Do not auto-apply" in item for item in next_actions)


### PR DESCRIPTION
## Summary

Adds a review-first evidence contract for the integration topology worker and worker alignment radar templates.

## What changed

- Adds `build/sdetkit/integration-topology-worker-evidence.json`.
- Adds regression coverage in `tests/test_worker_alignment_evidence_contract.py`.
- Verifies worker IDs, template paths, expected step IDs, command surfaces, expected outputs, and authority boundary.

## Proof

Focused proof:

```text
python -m pytest -q \
  tests/test_worker_alignment_evidence_contract.py \
  tests/test_agent_templates_engine.py::test_template_run_supports_new_alignment_workers \
  tests/test_integration_topology_check.py \
  -o addopts=
6 passed
```

Full proof:

```text
make proof-after-format
passed
```

## Boundary

This is evidence-only. It does not mutate workflows, change template behavior, authorize automation, apply patches, authorize merge, or claim semantic equivalence.