### PR TITLE
ci(report): add repository mutation permission review evidence

### DIFF
--- a/build/sdetkit/workflow-permission-repository-mutation-evidence.json
+++ b/build/sdetkit/workflow-permission-repository-mutation-evidence.json
@@ -1,0 +1,41 @@
+{
+  "authority_boundary": {
+    "automation_allowed": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "semantic_equivalence_proven": false
+  },
+  "automatic_permission_reduction_allowed": false,
+  "automation_allowed": false,
+  "evidence_type": "workflow_permission_repository_mutation_evidence",
+  "granted_write_scopes": [
+    "contents: write",
+    "issues: write",
+    "pull-requests: write"
+  ],
+  "merge_authorized": false,
+  "next_allowed_action": "collect_human_review_evidence",
+  "patch_application_allowed": false,
+  "permission_group": "repository_mutation",
+  "report_status": "review_required",
+  "requires_human_review": true,
+  "review_first": true,
+  "review_notes": [
+    "This evidence is scoped only to repository mutation workflows.",
+    "Release and provenance workflows stay in the release_or_provenance group.",
+    "Use this as human-review evidence before any future permission reduction.",
+    "Do not mutate workflow YAML automatically from this evidence."
+  ],
+  "safe_to_patch": false,
+  "schema_version": 1,
+  "semantic_equivalence_proven": false,
+  "workflow_count": 5,
+  "workflow_mutation": false,
+  "workflows": [
+    ".github/workflows/dependency-auto-merge.yml",
+    ".github/workflows/maintenance-issue-command-center.yml",
+    ".github/workflows/maintenance-on-demand.yml",
+    ".github/workflows/pre-commit-autoupdate.yml",
+    ".github/workflows/weekly-maintenance.yml"
+  ]
+}

--- a/tests/test_workflow_repository_mutation_evidence_contract.py
+++ b/tests/test_workflow_repository_mutation_evidence_contract.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_repository_mutation_permission_evidence_matches_governance_summary() -> None:
+    report = json.loads(
+        Path("build/sdetkit/workflow-governance-report.json").read_text(encoding="utf-8")
+    )
+    evidence = json.loads(
+        Path("build/sdetkit/workflow-permission-repository-mutation-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    groups = {group["kind"]: group for group in report["permission_review_summary"]["groups"]}
+    repo_group = groups["repository_mutation"]
+
+    assert evidence["schema_version"] == 1
+    assert evidence["report_status"] == "review_required"
+    assert evidence["evidence_type"] == ("workflow_permission_repository_mutation_evidence")
+    assert evidence["permission_group"] == "repository_mutation"
+    assert evidence["workflow_count"] == repo_group["workflow_count"] == 5
+    assert evidence["workflows"] == repo_group["workflows"]
+    assert evidence["granted_write_scopes"] == repo_group["granted_write_scopes"]
+    assert evidence["requires_human_review"] is True
+    assert evidence["safe_to_patch"] is False
+    assert evidence["review_first"] is True
+    assert evidence["workflow_mutation"] is False
+    assert evidence["automatic_permission_reduction_allowed"] is False
+    assert evidence["next_allowed_action"] == "collect_human_review_evidence"
+
+
+def test_repository_mutation_permission_evidence_keeps_release_separate() -> None:
+    evidence = json.loads(
+        Path("build/sdetkit/workflow-permission-repository-mutation-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert ".github/workflows/release.yml" not in evidence["workflows"]
+    assert evidence["workflows"] == [
+        ".github/workflows/dependency-auto-merge.yml",
+        ".github/workflows/maintenance-issue-command-center.yml",
+        ".github/workflows/maintenance-on-demand.yml",
+        ".github/workflows/pre-commit-autoupdate.yml",
+        ".github/workflows/weekly-maintenance.yml",
+    ]
+
+    assert evidence["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    assert evidence["automation_allowed"] is False
+    assert evidence["patch_application_allowed"] is False
+    assert evidence["merge_authorized"] is False
+    assert evidence["semantic_equivalence_proven"] is False

--- a/tests/test_workflow_repository_mutation_evidence_contract.py
+++ b/tests/test_workflow_repository_mutation_evidence_contract.py
@@ -19,7 +19,10 @@ def test_repository_mutation_permission_evidence_matches_governance_summary() ->
 
     assert evidence["schema_version"] == 1
     assert evidence["report_status"] == "review_required"
-    assert evidence["evidence_type"] == ("workflow_permission_repository_mutation_evidence")
+    expected_evidence_type = "_".join(
+        ("workflow", "permission", "repository", "mutation", "evidence")
+    )
+    assert evidence["evidence_type"] == expected_evidence_type
     assert evidence["permission_group"] == "repository_mutation"
     assert evidence["workflow_count"] == repo_group["workflow_count"] == 5
     assert evidence["workflows"] == repo_group["workflows"]


### PR DESCRIPTION
## Summary

Adds a focused repository-mutation permission review evidence contract for the workflow governance lane.

## What changed

- Adds `build/sdetkit/workflow-permission-repository-mutation-evidence.json`.
- Adds regression coverage for the repository mutation permission group.
- Keeps release/provenance workflow evidence separate from repository mutation evidence.

## Proof

Focused proof: `22 passed`.
Full proof: `make proof-after-format` passed.

## Boundary

Evidence only. No workflow YAML mutation. No permission reduction. No automation, patch application, merge authorization, or semantic equivalence claim.