### PR TITLE
ci(report): add security upload permission review evidence

### DIFF
--- a/build/sdetkit/workflow-permission-security-upload-evidence.json
+++ b/build/sdetkit/workflow-permission-security-upload-evidence.json
@@ -1,0 +1,40 @@
+{
+  "authority_boundary": {
+    "automation_allowed": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "semantic_equivalence_proven": false
+  },
+  "automatic_permission_reduction_allowed": false,
+  "automation_allowed": false,
+  "evidence_type": "permission_group_evidence",
+  "granted_write_scopes": [
+    "issues: write",
+    "security-events: write"
+  ],
+  "merge_authorized": false,
+  "next_allowed_action": "collect_human_review_evidence",
+  "patch_application_allowed": false,
+  "permission_group": "security_upload",
+  "report_status": "review_required",
+  "requires_human_review": true,
+  "review_first": true,
+  "review_notes": [
+    "This evidence is scoped only to security upload workflows.",
+    "Repository mutation and release/provenance workflows stay in separate groups.",
+    "Use this as human-review evidence before any future permission reduction.",
+    "Do not mutate workflow YAML automatically from this evidence."
+  ],
+  "safe_to_patch": false,
+  "schema_version": 1,
+  "semantic_equivalence_proven": false,
+  "workflow_count": 5,
+  "workflow_mutation": false,
+  "workflows": [
+    ".github/workflows/osv-scanner.yml",
+    ".github/workflows/premium-gate.yml",
+    ".github/workflows/repo-audit.yml",
+    ".github/workflows/security-maintenance-bot.yml",
+    ".github/workflows/security.yml"
+  ]
+}

--- a/tests/test_workflow_security_upload_evidence_contract.py
+++ b/tests/test_workflow_security_upload_evidence_contract.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_security_upload_permission_evidence_matches_governance_summary() -> None:
+    report = json.loads(
+        Path("build/sdetkit/workflow-governance-report.json").read_text(encoding="utf-8")
+    )
+    evidence = json.loads(
+        Path("build/sdetkit/workflow-permission-security-upload-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    groups = {group["kind"]: group for group in report["permission_review_summary"]["groups"]}
+    security_group = groups["security_upload"]
+
+    assert evidence["schema_version"] == 1
+    assert evidence["report_status"] == "review_required"
+    assert evidence["evidence_type"] == "permission_group_evidence"
+    assert evidence["permission_group"] == "security_upload"
+    assert evidence["workflow_count"] == security_group["workflow_count"] == 5
+    assert evidence["workflows"] == security_group["workflows"]
+    assert evidence["granted_write_scopes"] == security_group["granted_write_scopes"]
+    assert evidence["requires_human_review"] is True
+    assert evidence["safe_to_patch"] is False
+    assert evidence["review_first"] is True
+    assert evidence["workflow_mutation"] is False
+    assert evidence["automatic_permission_reduction_allowed"] is False
+    assert evidence["next_allowed_action"] == "collect_human_review_evidence"
+
+
+def test_security_upload_permission_evidence_keeps_other_groups_separate() -> None:
+    evidence = json.loads(
+        Path("build/sdetkit/workflow-permission-security-upload-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert ".github/workflows/release.yml" not in evidence["workflows"]
+    assert ".github/workflows/dependency-auto-merge.yml" not in evidence["workflows"]
+    assert evidence["workflows"] == [
+        ".github/workflows/osv-scanner.yml",
+        ".github/workflows/premium-gate.yml",
+        ".github/workflows/repo-audit.yml",
+        ".github/workflows/security-maintenance-bot.yml",
+        ".github/workflows/security.yml",
+    ]
+
+    assert evidence["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    assert evidence["automation_allowed"] is False
+    assert evidence["patch_application_allowed"] is False
+    assert evidence["merge_authorized"] is False
+    assert evidence["semantic_equivalence_proven"] is False


### PR DESCRIPTION
## Summary

Adds evidence-only security upload permission review coverage from the workflow governance report.

## What changed

- Adds `build/sdetkit/workflow-permission-security-upload-evidence.json`.
- Adds regression coverage for the `security_upload` permission group.
- Confirms release and repository-mutation workflows remain in separate evidence groups.

## Proof

Focused proof:

```text
python -m pytest -q tests/test_workflow_security_upload_evidence_contract.py tests/test_workflow_governance_report.py tests/test_workflow_release_guardrails.py -o addopts=
22 passed
```

Full proof:

```text
make proof-after-format
passed
```

## Boundary

Evidence-only. No workflow YAML mutation, no permission reduction, no security auto-fix or dismissal, no automation authorization, no merge authorization, and no semantic-equivalence claim.