### PR TITLE
ci(report): add PR issue interaction permission review evidence

### DIFF
--- a/build/sdetkit/workflow-permission-pr-issue-interaction-evidence.json
+++ b/build/sdetkit/workflow-permission-pr-issue-interaction-evidence.json
@@ -1,0 +1,39 @@
+{
+  "authority_boundary": {
+    "automation_allowed": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "semantic_equivalence_proven": false
+  },
+  "automatic_permission_reduction_allowed": false,
+  "automation_allowed": false,
+  "evidence_type": "permission_group_evidence",
+  "granted_write_scopes": [
+    "issues: write",
+    "pull-requests: write"
+  ],
+  "merge_authorized": false,
+  "next_allowed_action": "collect_human_review_evidence",
+  "patch_application_allowed": false,
+  "permission_group": "pr_issue_interaction",
+  "report_status": "review_required",
+  "requires_human_review": true,
+  "review_first": true,
+  "review_notes": [
+    "This evidence is scoped only to PR and issue interaction workflows.",
+    "Repository mutation, security upload, deployment, and release workflows stay in separate groups.",
+    "Use this as human-review evidence before any future permission reduction.",
+    "Do not mutate workflow YAML automatically from this evidence."
+  ],
+  "safe_to_patch": false,
+  "schema_version": 1,
+  "semantic_equivalence_proven": false,
+  "workflow_count": 4,
+  "workflow_mutation": false,
+  "workflows": [
+    ".github/workflows/contributor-onboarding-bot.yml",
+    ".github/workflows/maintenance-autopilot.yml",
+    ".github/workflows/pr-helper-bot.yml",
+    ".github/workflows/pr-quality-comment.yml"
+  ]
+}

--- a/tests/test_workflow_pr_issue_interaction_evidence_contract.py
+++ b/tests/test_workflow_pr_issue_interaction_evidence_contract.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_pr_issue_interaction_permission_evidence_matches_governance_summary() -> None:
+    report = json.loads(
+        Path("build/sdetkit/workflow-governance-report.json").read_text(encoding="utf-8")
+    )
+    evidence = json.loads(
+        Path("build/sdetkit/workflow-permission-pr-issue-interaction-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    groups = {group["kind"]: group for group in report["permission_review_summary"]["groups"]}
+    target_group = groups["pr_issue_interaction"]
+
+    assert evidence["schema_version"] == 1
+    assert evidence["report_status"] == "review_required"
+    assert evidence["evidence_type"] == "permission_group_evidence"
+    assert evidence["permission_group"] == "pr_issue_interaction"
+    assert evidence["workflow_count"] == target_group["workflow_count"] == 4
+    assert evidence["workflows"] == target_group["workflows"]
+    assert evidence["granted_write_scopes"] == target_group["granted_write_scopes"]
+    assert evidence["requires_human_review"] is True
+    assert evidence["safe_to_patch"] is False
+    assert evidence["review_first"] is True
+    assert evidence["workflow_mutation"] is False
+    assert evidence["automatic_permission_reduction_allowed"] is False
+    assert evidence["next_allowed_action"] == "collect_human_review_evidence"
+
+
+def test_pr_issue_interaction_permission_evidence_keeps_other_groups_separate() -> None:
+    evidence = json.loads(
+        Path("build/sdetkit/workflow-permission-pr-issue-interaction-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert ".github/workflows/release.yml" not in evidence["workflows"]
+    assert ".github/workflows/security.yml" not in evidence["workflows"]
+    assert ".github/workflows/dependency-auto-merge.yml" not in evidence["workflows"]
+    assert evidence["workflows"] == [
+        ".github/workflows/contributor-onboarding-bot.yml",
+        ".github/workflows/maintenance-autopilot.yml",
+        ".github/workflows/pr-helper-bot.yml",
+        ".github/workflows/pr-quality-comment.yml",
+    ]
+
+    assert evidence["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    assert evidence["automation_allowed"] is False
+    assert evidence["patch_application_allowed"] is False
+    assert evidence["merge_authorized"] is False
+    assert evidence["semantic_equivalence_proven"] is False


### PR DESCRIPTION
## Summary

Adds an evidence-only permission review contract for the pr_issue_interaction workflow group.

## Proof

- Focused proof: 22 passed
- Full proof: make proof-after-format passed

## Boundary

No workflow YAML mutation, no permission reduction, no automation authorization, no merge authorization.