### PR TITLE
ci(report): add workflow permission evidence index

### DIFF
--- a/build/sdetkit/workflow-permission-evidence-index.json
+++ b/build/sdetkit/workflow-permission-evidence-index.json
@@ -1,0 +1,85 @@
+{
+  "authority_boundary": {
+    "automation_allowed": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "semantic_equivalence_proven": false
+  },
+  "automatic_permission_reduction_allowed": false,
+  "evidence_type": "workflow_permission_evidence_index",
+  "group_count": 5,
+  "groups": [
+    {
+      "permission_group": "repository_mutation",
+      "requires_human_review": true,
+      "safe_to_patch": false,
+      "source_path": "build/sdetkit/workflow-permission-repository-mutation-evidence.json",
+      "workflow_count": 5,
+      "workflow_mutation": false,
+      "workflows": [
+        ".github/workflows/dependency-auto-merge.yml",
+        ".github/workflows/maintenance-issue-command-center.yml",
+        ".github/workflows/maintenance-on-demand.yml",
+        ".github/workflows/pre-commit-autoupdate.yml",
+        ".github/workflows/weekly-maintenance.yml"
+      ]
+    },
+    {
+      "permission_group": "security_upload",
+      "requires_human_review": true,
+      "safe_to_patch": false,
+      "source_path": "build/sdetkit/workflow-permission-security-upload-evidence.json",
+      "workflow_count": 5,
+      "workflow_mutation": false,
+      "workflows": [
+        ".github/workflows/osv-scanner.yml",
+        ".github/workflows/premium-gate.yml",
+        ".github/workflows/repo-audit.yml",
+        ".github/workflows/security-maintenance-bot.yml",
+        ".github/workflows/security.yml"
+      ]
+    },
+    {
+      "permission_group": "pr_issue_interaction",
+      "requires_human_review": true,
+      "safe_to_patch": false,
+      "source_path": "build/sdetkit/workflow-permission-pr-issue-interaction-evidence.json",
+      "workflow_count": 4,
+      "workflow_mutation": false,
+      "workflows": [
+        ".github/workflows/contributor-onboarding-bot.yml",
+        ".github/workflows/maintenance-autopilot.yml",
+        ".github/workflows/pr-helper-bot.yml",
+        ".github/workflows/pr-quality-comment.yml"
+      ]
+    },
+    {
+      "permission_group": "deployment_or_oidc",
+      "requires_human_review": true,
+      "safe_to_patch": false,
+      "source_path": "build/sdetkit/workflow-permission-deployment-oidc-evidence.json",
+      "workflow_count": 1,
+      "workflow_mutation": false,
+      "workflows": [
+        ".github/workflows/pages.yml"
+      ]
+    },
+    {
+      "permission_group": "release_or_provenance",
+      "requires_human_review": true,
+      "safe_to_patch": false,
+      "source_path": "build/sdetkit/workflow-permission-release-provenance-evidence.json",
+      "workflow_count": 1,
+      "workflow_mutation": false,
+      "workflows": [
+        ".github/workflows/release.yml"
+      ]
+    }
+  ],
+  "next_allowed_action": "human_review_permission_evidence",
+  "report_status": "review_required",
+  "review_first": true,
+  "schema_version": 1,
+  "workflow_count": 16,
+  "workflow_mutation": false
+}

--- a/tests/test_workflow_permission_evidence_index.py
+++ b/tests/test_workflow_permission_evidence_index.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_workflow_permission_evidence_index_covers_all_groups() -> None:
+    index = json.loads(
+        Path("build/sdetkit/workflow-permission-evidence-index.json").read_text(encoding="utf-8")
+    )
+
+    groups = {group["permission_group"]: group for group in index["groups"]}
+
+    assert index["schema_version"] == 1
+    assert index["report_status"] == "review_required"
+    assert index["evidence_type"] == "workflow_permission_evidence_index"
+    assert index["group_count"] == 5
+    assert index["workflow_count"] == 16
+    assert set(groups) == {
+        "repository_mutation",
+        "security_upload",
+        "pr_issue_interaction",
+        "deployment_or_oidc",
+        "release_or_provenance",
+    }
+
+
+def test_workflow_permission_evidence_index_preserves_no_mutation_boundary() -> None:
+    index = json.loads(
+        Path("build/sdetkit/workflow-permission-evidence-index.json").read_text(encoding="utf-8")
+    )
+
+    assert index["review_first"] is True
+    assert index["workflow_mutation"] is False
+    assert index["automatic_permission_reduction_allowed"] is False
+    assert index["next_allowed_action"] == "human_review_permission_evidence"
+    assert index["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    for group in index["groups"]:
+        assert group["requires_human_review"] is True
+        assert group["safe_to_patch"] is False
+        assert group["workflow_mutation"] is False
+        assert Path(group["source_path"]).exists()


### PR DESCRIPTION
## Summary

Adds a consolidated evidence-only index for all five workflow permission review groups.

## Proof

- Focused proof: 22 passed
- Full proof: make proof-after-format passed

## Boundary

No workflow YAML mutation, no permission reduction, no automation authorization, no merge authorization.