### PR TITLE
test(failure-vector): cover dependency and wrapper CLI artifacts

### DIFF
--- a/src/sdetkit/failure_vector.py
+++ b/src/sdetkit/failure_vector.py
@@ -262,9 +262,37 @@ def render_failure_vector_bundle_report(payload: dict[str, object]) -> str:
         "- patch_application_allowed: `false`",
         "- merge_authorized: `false`",
         "",
-        "## By failure class",
+        "## Failure vectors",
         "",
     ]
+
+    if vector_payloads:
+        for vector_payload in sorted(
+            vector_payloads,
+            key=lambda item: str(item.get("check") or "unknown"),
+        ):
+            affected_files = _affected_files(vector_payload.get("affected_files"))
+            affected = ", ".join(f"`{path}`" for path in affected_files) or "`none`"
+            safe = "yes" if bool(vector_payload.get("safe_fix_candidate", False)) else "no"
+            local_repro = _optional_string(vector_payload.get("local_repro_command")) or "none"
+            lines.extend(
+                [
+                    f"### {str(vector_payload.get('check') or 'unknown')}",
+                    "",
+                    f"- class: `{str(vector_payload.get('failure_class') or 'unknown')}`",
+                    f"- risk: `{str(vector_payload.get('risk') or 'unknown')}`",
+                    f"- safe_fix_candidate: `{safe}`",
+                    f"- first_failing_line: `{str(vector_payload.get('first_failing_line') or 'unknown')}`",
+                    f"- affected_files: {affected}",
+                    f"- local_repro_command: `{local_repro}`",
+                    "",
+                ]
+            )
+    else:
+        lines.append("- none")
+        lines.append("")
+
+    lines.extend(["## By failure class", ""])
 
     if by_class:
         lines.extend(f"- `{name}`: `{count}`" for name, count in sorted(by_class.items()))

--- a/tests/fixtures/ci_failures/dependency_resolver/ci_log.txt
+++ b/tests/fixtures/ci_failures/dependency_resolver/ci_log.txt
@@ -1,0 +1,3 @@
+Run python -m pip install -c constraints-ci.txt -e .[dev,test]
+ERROR: ResolutionImpossible: for help visit https://pip.pypa.io
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/unknown_wrapper/ci_log.txt
+++ b/tests/fixtures/ci_failures/unknown_wrapper/ci_log.txt
@@ -1,0 +1,2 @@
+custom quality wrapper returned an unexpected integrity result
+Process completed with exit code 42

--- a/tests/test_ci_failure_extractor.py
+++ b/tests/test_ci_failure_extractor.py
@@ -161,3 +161,67 @@ def test_ci_failure_extractor_cli_can_emit_failure_vector_bundle(
     assert vector_payload["environment"] == "github_actions"
     assert vector_payload["failure_vectors"][0]["command"] == "python -m mypy src"
     assert vector_payload["failure_vectors"][0]["failure_class"] == "type"
+
+
+def test_ci_failure_extractor_cli_artifacts_cover_dependency_and_unknown_wrapper(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    dependency_log = Path("tests/fixtures/ci_failures/dependency_resolver/ci_log.txt")
+    unknown_log = Path("tests/fixtures/ci_failures/unknown_wrapper/ci_log.txt")
+    failed_logs = tmp_path / "failed-check-logs.json"
+    vectors_out = tmp_path / "failure-vectors.json"
+    vectors_md = tmp_path / "failure-vectors.md"
+
+    rc = main(
+        [
+            "--log",
+            str(dependency_log),
+            "--log",
+            str(unknown_log),
+            "--out",
+            str(failed_logs),
+            "--failure-vectors-out",
+            str(vectors_out),
+            "--failure-vectors-md",
+            str(vectors_md),
+            "--environment",
+            "github_actions",
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert f"failure_vectors_json={vectors_out}" in stdout
+    assert f"failure_vectors_md={vectors_md}" in stdout
+    assert "failure_vector_count=2" in stdout
+
+    payload = json.loads(vectors_out.read_text(encoding="utf-8"))
+    vectors = {item["check"]: item for item in payload["failure_vectors"]}
+
+    dependency = vectors["dependency_resolver"]
+    assert dependency["failure_class"] == "dependency"
+    assert dependency["risk"] == "high"
+    assert dependency["safe_fix_candidate"] is False
+    assert dependency["first_failing_line"] == (
+        "ERROR: ResolutionImpossible: for help visit https://pip.pypa.io"
+    )
+    assert dependency["local_repro_command"] is None
+
+    unknown = vectors["unknown_wrapper"]
+    assert unknown["failure_class"] == "unknown"
+    assert unknown["risk"] == "high"
+    assert unknown["safe_fix_candidate"] is False
+    assert unknown["exit_code"] == 42
+    assert unknown["first_failing_line"] == (
+        "custom quality wrapper returned an unexpected integrity result"
+    )
+    assert unknown["local_repro_command"] is None
+
+    markdown = vectors_md.read_text(encoding="utf-8")
+    assert "# Failure Vector Bundle" in markdown
+    assert "- `dependency`: `1`" in markdown
+    assert "- `unknown`: `1`" in markdown
+    assert "custom quality wrapper returned an unexpected integrity result" in markdown


### PR DESCRIPTION
## Summary
- Adds fixture-backed CLI artifact coverage for dependency resolver failures.
- Adds fixture-backed CLI artifact coverage for unknown wrapper failures.
- Extends FailureVector bundle Markdown output with per-vector details, including first failing lines.

## Why
- Wave A.1 improved direct FailureVector extraction.
- Wave A.2 proves the same behavior through the CLI artifact path.
- Dependency and unknown wrapper logs must preserve review-first evidence in both JSON and Markdown artifacts.

## Verification
- `python -m pytest -q tests/test_ci_failure_extractor.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Scope is limited to FailureVector artifact rendering, fixtures, and focused tests.
- Dependency and unknown failures remain review-first.
