### PR TITLE
docs(failure-vector): add support matrix contract

### DIFF
--- a/docs/contracts/failure-vector-support-matrix.v1.json
+++ b/docs/contracts/failure-vector-support-matrix.v1.json
@@ -1,0 +1,100 @@
+{
+  "blocked_until_future_wave": [
+    {
+      "item": "SafetyGate policy expansion",
+      "reason": "Wave B starts only after FailureVector support matrix is committed and green."
+    },
+    {
+      "item": "TrajectoryStore / RepoMemory expansion",
+      "reason": "Wave C starts only after SafetyGate policy contracts are stable."
+    },
+    {
+      "item": "cloud, service, dashboard, or worker orchestration",
+      "reason": "Not allowed until local contracts prove value."
+    }
+  ],
+  "next_lane_after_completion": "Wave B / SafetyGate policy expansion",
+  "purpose": "Documents the currently supported FailureVector failure classes so future roadmap work does not repeat completed extraction contracts.",
+  "roadmap_lane": "Wave A / FailureVectorEngine",
+  "schema_version": "sdetkit.failure_vector.support_matrix.v1",
+  "supported_failure_classes": [
+    {
+      "artifact_coverage": [
+        "failure-vector-json",
+        "failure-vector-markdown",
+        "diagnostic-vector"
+      ],
+      "default_risk": "medium",
+      "failure_class": "test",
+      "first_signal_contract": "pytest FAILED node id or assertion failure line",
+      "review_policy": "review_or_focused_proof",
+      "safe_fix_candidate": false
+    },
+    {
+      "artifact_coverage": [
+        "failure-vector-json",
+        "failure-vector-markdown",
+        "safety-gate"
+      ],
+      "default_risk": "low",
+      "failure_class": "formatter_only",
+      "first_signal_contract": "ruff format failed or would be reformatted",
+      "review_policy": "mechanical_safe_fix_allowed_when_pr_owned",
+      "safe_fix_candidate": true
+    },
+    {
+      "artifact_coverage": [
+        "failure-vector-json",
+        "safety-gate"
+      ],
+      "default_risk": "medium",
+      "failure_class": "lint",
+      "first_signal_contract": "ruff rule line or ruff check signal",
+      "review_policy": "safe_fix_only_for_low_risk_mechanical_lint",
+      "safe_fix_candidate": "only mechanically fixable lint such as I001 import sorting"
+    },
+    {
+      "artifact_coverage": [
+        "failure-vector-json",
+        "diagnostic-vector"
+      ],
+      "default_risk": "medium",
+      "failure_class": "type",
+      "first_signal_contract": "mypy file:line error",
+      "review_policy": "review_first",
+      "safe_fix_candidate": false
+    },
+    {
+      "artifact_coverage": [
+        "failure-vector-json",
+        "failure-vector-markdown"
+      ],
+      "default_risk": "high",
+      "failure_class": "dependency",
+      "first_signal_contract": "pip resolver failure such as ResolutionImpossible",
+      "review_policy": "review_first",
+      "safe_fix_candidate": false
+    },
+    {
+      "artifact_coverage": [
+        "failure-vector-json"
+      ],
+      "default_risk": "high",
+      "failure_class": "merge_conflict",
+      "first_signal_contract": "CONFLICT line or merge conflict signal",
+      "review_policy": "review_first",
+      "safe_fix_candidate": false
+    },
+    {
+      "artifact_coverage": [
+        "failure-vector-json",
+        "failure-vector-markdown"
+      ],
+      "default_risk": "high",
+      "failure_class": "unknown",
+      "first_signal_contract": "first meaningful wrapper line, not generic exit-code fallback",
+      "review_policy": "review_first",
+      "safe_fix_candidate": false
+    }
+  ]
+}

--- a/docs/failure-vector-support-matrix.md
+++ b/docs/failure-vector-support-matrix.md
@@ -1,0 +1,40 @@
+# FailureVector support matrix
+
+This page is the Wave A checkpoint for the FailureVectorEngine.
+
+It records which failure classes are currently supported, how they should be treated, and what must not be repeated in later PRs.
+
+Contract file:
+
+- `docs/contracts/failure-vector-support-matrix.v1.json`
+
+## Supported failure classes
+
+| Failure class | Default risk | Safe-fix candidate | Review policy | First signal contract |
+| --- | --- | --- | --- | --- |
+| `test` | `medium` | `False` | `review_or_focused_proof` | pytest FAILED node id or assertion failure line |
+| `formatter_only` | `low` | `True` | `mechanical_safe_fix_allowed_when_pr_owned` | ruff format failed or would be reformatted |
+| `lint` | `medium` | `only mechanically fixable lint such as I001 import sorting` | `safe_fix_only_for_low_risk_mechanical_lint` | ruff rule line or ruff check signal |
+| `type` | `medium` | `False` | `review_first` | mypy file:line error |
+| `dependency` | `high` | `False` | `review_first` | pip resolver failure such as ResolutionImpossible |
+| `merge_conflict` | `high` | `False` | `review_first` | CONFLICT line or merge conflict signal |
+| `unknown` | `high` | `False` | `review_first` | first meaningful wrapper line, not generic exit-code fallback |
+
+## Roadmap boundary
+
+Wave A is about extraction and artifact evidence.
+
+After this matrix is green:
+
+1. Finish any missing FailureVector documentation/indexing only if it is directly related to this support matrix.
+2. Move to Wave B: SafetyGate policy expansion.
+3. Do not start TrajectoryStore, ReplayableBenchmarkHarness, ProtectedVerifier, PRReporter, JobQueue, cloud, service, or dashboard work until their roadmap waves are reached.
+
+## Non-loop rule
+
+Do not repeat completed work:
+
+- dependency resolver classification is already covered.
+- unknown wrapper first meaningful line extraction is already covered.
+- CLI JSON/Markdown artifact coverage is already covered.
+- workflow permission evidence lane is already complete.

--- a/tests/test_failure_vector_support_matrix.py
+++ b/tests/test_failure_vector_support_matrix.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+MATRIX_PATH = Path("docs/contracts/failure-vector-support-matrix.v1.json")
+DOC_PATH = Path("docs/failure-vector-support-matrix.md")
+
+EXPECTED_CLASSES = {
+    "test",
+    "formatter_only",
+    "lint",
+    "type",
+    "dependency",
+    "merge_conflict",
+    "unknown",
+}
+
+
+def test_failure_vector_support_matrix_contract_is_complete() -> None:
+    payload = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "sdetkit.failure_vector.support_matrix.v1"
+    assert payload["roadmap_lane"] == "Wave A / FailureVectorEngine"
+    assert payload["next_lane_after_completion"] == "Wave B / SafetyGate policy expansion"
+
+    rows = payload["supported_failure_classes"]
+    classes = {row["failure_class"] for row in rows}
+
+    assert classes == EXPECTED_CLASSES
+
+    for row in rows:
+        assert row["default_risk"] in {"low", "medium", "high"}
+        assert row["review_policy"]
+        assert row["first_signal_contract"]
+        assert row["artifact_coverage"]
+
+
+def test_failure_vector_support_matrix_blocks_roadmap_loops() -> None:
+    payload = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+    blocked_items = {item["item"] for item in payload["blocked_until_future_wave"]}
+
+    assert "SafetyGate policy expansion" in blocked_items
+    assert "TrajectoryStore / RepoMemory expansion" in blocked_items
+    assert "cloud, service, dashboard, or worker orchestration" in blocked_items
+
+
+def test_failure_vector_support_matrix_markdown_matches_contract() -> None:
+    payload = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+    markdown = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "FailureVector support matrix" in markdown
+    assert "docs/contracts/failure-vector-support-matrix.v1.json" in markdown
+    assert "Do not repeat completed work" in markdown
+
+    for row in payload["supported_failure_classes"]:
+        assert f"`{row['failure_class']}`" in markdown


### PR DESCRIPTION
## Summary
- Adds a FailureVector support matrix contract.
- Documents supported failure classes and their review/safe-fix policy.
- Adds a regression test that prevents roadmap loops and premature wave jumps.

## Why
- Wave A now has direct extraction coverage and CLI artifact coverage.
- This PR records what FailureVector supports so future work does not repeat completed contracts.
- This creates the checkpoint before moving to Wave B / SafetyGate policy expansion.

## Supported classes
- `test`
- `formatter_only`
- `lint`
- `type`
- `dependency`
- `merge_conflict`
- `unknown`

## Verification
- `python -m pytest -q tests/test_failure_vector_support_matrix.py tests/test_failure_vector_extraction.py tests/test_ci_failure_extractor.py tests/test_safety_gate.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Documentation + contract + test only.
- No engine behavior change.
