### PR TITLE
docs(safety-gate): add policy matrix contract

### DIFF
--- a/docs/contracts/safety-gate-policy-matrix.v1.json
+++ b/docs/contracts/safety-gate-policy-matrix.v1.json
@@ -1,0 +1,105 @@
+{
+  "blocked_until_future_wave": [
+    {
+      "item": "automatic patch application",
+      "reason": "SafetyGate can declare eligibility, but patch application remains outside this policy matrix."
+    },
+    {
+      "item": "merge authorization",
+      "reason": "SafetyGate decisions never authorize merging."
+    },
+    {
+      "item": "TrajectoryStore / RepoMemory expansion",
+      "reason": "Wave C starts only after SafetyGate policy contracts are stable."
+    },
+    {
+      "item": "cloud, service, dashboard, or worker orchestration",
+      "reason": "Not allowed until local contracts prove value."
+    }
+  ],
+  "depends_on": "docs/contracts/failure-vector-support-matrix.v1.json",
+  "global_blocked_actions": [
+    "delete or weaken tests",
+    "skip CI or verifier checks",
+    "edit workflow gates to hide the failure",
+    "modify files outside allowed_files"
+  ],
+  "policy_by_failure_class": [
+    {
+      "allowed_files_policy": "affected_files_only",
+      "default_decision": "safe_fix_allowed_if_all_global_conditions_pass",
+      "failure_class": "formatter_only",
+      "review_first_when": [
+        "affected_files is empty",
+        "scope is not pr_owned_only",
+        "risk is not low",
+        "safe_fix_candidate is false"
+      ]
+    },
+    {
+      "allowed_files_policy": "affected_files_only",
+      "default_decision": "safe_fix_allowed_if_all_global_conditions_pass",
+      "failure_class": "lint",
+      "review_first_when": [
+        "lint is not mechanically fixable",
+        "affected_files is empty",
+        "scope is not pr_owned_only",
+        "risk is not low",
+        "safe_fix_candidate is false"
+      ]
+    },
+    {
+      "allowed_files_policy": "none",
+      "default_decision": "review_first",
+      "failure_class": "test",
+      "review_first_when": [
+        "always in current policy"
+      ]
+    },
+    {
+      "allowed_files_policy": "none",
+      "default_decision": "review_first",
+      "failure_class": "type",
+      "review_first_when": [
+        "always in current policy"
+      ]
+    },
+    {
+      "allowed_files_policy": "none",
+      "default_decision": "review_first",
+      "failure_class": "dependency",
+      "review_first_when": [
+        "always in current policy"
+      ]
+    },
+    {
+      "allowed_files_policy": "none",
+      "default_decision": "review_first",
+      "failure_class": "merge_conflict",
+      "review_first_when": [
+        "always in current policy"
+      ]
+    },
+    {
+      "allowed_files_policy": "none",
+      "default_decision": "review_first",
+      "failure_class": "unknown",
+      "review_first_when": [
+        "always in current policy"
+      ]
+    }
+  ],
+  "purpose": "Documents the SafetyGate policy that maps FailureVector classes to safe-fix or review-first outcomes.",
+  "roadmap_lane": "Wave B / SafetyGate policy expansion",
+  "safe_fix_allowed_only_when": {
+    "affected_files": "non_empty",
+    "failure_class_in": [
+      "formatter_only",
+      "lint"
+    ],
+    "risk": "low",
+    "safe_fix_candidate": true,
+    "scope": "pr_owned_only"
+  },
+  "schema_version": "sdetkit.safety_gate.policy_matrix.v1"
+}

--- a/docs/safety-gate-policy-matrix.md
+++ b/docs/safety-gate-policy-matrix.md
@@ -1,0 +1,50 @@
+# SafetyGate policy matrix
+
+This page is the Wave B checkpoint for SafetyGate policy.
+
+It records when a FailureVector can become a safe-fix candidate and when it must stay review-first.
+
+Contract file:
+
+- `docs/contracts/safety-gate-policy-matrix.v1.json`
+
+## Global safe-fix requirements
+
+SafetyGate may allow a safe fix only when all of these are true:
+
+- failure class is `formatter_only` or `lint`
+- `safe_fix_candidate` is `true`
+- risk is `low`
+- scope is `pr_owned_only`
+- affected files are non-empty
+
+## Policy by failure class
+
+| Failure class | Default decision | Allowed files policy | Review-first when |
+| --- | --- | --- | --- |
+| `formatter_only` | `safe_fix_allowed_if_all_global_conditions_pass` | `affected_files_only` | affected_files is empty, scope is not pr_owned_only, risk is not low, safe_fix_candidate is false |
+| `lint` | `safe_fix_allowed_if_all_global_conditions_pass` | `affected_files_only` | lint is not mechanically fixable, affected_files is empty, scope is not pr_owned_only, risk is not low, safe_fix_candidate is false |
+| `test` | `review_first` | `none` | always in current policy |
+| `type` | `review_first` | `none` | always in current policy |
+| `dependency` | `review_first` | `none` | always in current policy |
+| `merge_conflict` | `review_first` | `none` | always in current policy |
+| `unknown` | `review_first` | `none` | always in current policy |
+
+## Global blocked actions
+
+SafetyGate must never authorize:
+
+- deleting or weakening tests
+- skipping CI or verifier checks
+- editing workflow gates to hide a failure
+- modifying files outside `allowed_files`
+- automatic patch application
+- merge authorization
+
+## Roadmap boundary
+
+Wave B is about safe-fix versus review-first policy.
+
+This matrix does not add workers, cloud services, dashboards, automatic patch application, or merge authorization.
+
+After this matrix is green, the next Wave B PR may expand SafetyGate behavior only if it remains review-first by default and keeps automation blocked.

--- a/tests/test_safety_gate_policy_matrix.py
+++ b/tests/test_safety_gate_policy_matrix.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from sdetkit.safety_gate import (
+    GENERAL_BLOCKED_ACTIONS,
+    SAFE_FIX_CLASSES,
+    evaluate_failure_vector,
+)
+
+POLICY_PATH = Path("docs/contracts/safety-gate-policy-matrix.v1.json")
+FAILURE_VECTOR_MATRIX_PATH = Path("docs/contracts/failure-vector-support-matrix.v1.json")
+DOC_PATH = Path("docs/safety-gate-policy-matrix.md")
+
+
+@dataclass(frozen=True)
+class MinimalFailureVector:
+    failure_class: str
+    risk: str = "low"
+    scope: str = "pr_owned_only"
+    safe_fix_candidate: bool = True
+    affected_files: tuple[str, ...] = ("tests/test_widget.py",)
+    local_repro_command: str | None = None
+
+
+def _load_policy() -> dict[str, object]:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def test_safety_gate_policy_matrix_matches_failure_vector_support_matrix() -> None:
+    policy = _load_policy()
+    failure_vector_matrix = json.loads(FAILURE_VECTOR_MATRIX_PATH.read_text(encoding="utf-8"))
+
+    policy_classes = {row["failure_class"] for row in policy["policy_by_failure_class"]}
+    supported_classes = {
+        row["failure_class"] for row in failure_vector_matrix["supported_failure_classes"]
+    }
+
+    assert policy["schema_version"] == "sdetkit.safety_gate.policy_matrix.v1"
+    assert policy["roadmap_lane"] == "Wave B / SafetyGate policy expansion"
+    assert policy_classes == supported_classes
+
+
+def test_safety_gate_policy_matrix_matches_current_safe_fix_classes() -> None:
+    policy = _load_policy()
+
+    safe_fix_classes = set(policy["safe_fix_allowed_only_when"]["failure_class_in"])
+    assert safe_fix_classes == set(SAFE_FIX_CLASSES)
+
+    allowed_rows = {
+        row["failure_class"]
+        for row in policy["policy_by_failure_class"]
+        if row["default_decision"] == "safe_fix_allowed_if_all_global_conditions_pass"
+    }
+    assert allowed_rows == set(SAFE_FIX_CLASSES)
+
+    review_first_rows = {
+        row["failure_class"]
+        for row in policy["policy_by_failure_class"]
+        if row["default_decision"] == "review_first"
+    }
+    assert review_first_rows.isdisjoint(allowed_rows)
+
+
+def test_safety_gate_policy_matrix_matches_runtime_decisions() -> None:
+    policy = _load_policy()
+    rows = {
+        row["failure_class"]: row["default_decision"] for row in policy["policy_by_failure_class"]
+    }
+
+    for failure_class, default_decision in rows.items():
+        decision = evaluate_failure_vector(MinimalFailureVector(failure_class))
+
+        if default_decision == "safe_fix_allowed_if_all_global_conditions_pass":
+            assert decision.safe_fix_allowed is True
+            assert decision.review_first is False
+            assert decision.allowed_files == ("tests/test_widget.py",)
+        else:
+            assert decision.safe_fix_allowed is False
+            assert decision.review_first is True
+            assert decision.allowed_files == ()
+
+
+def test_safety_gate_policy_matrix_keeps_global_blocked_actions_aligned() -> None:
+    policy = _load_policy()
+
+    assert tuple(policy["global_blocked_actions"]) == GENERAL_BLOCKED_ACTIONS
+
+    blocked_items = {item["item"] for item in policy["blocked_until_future_wave"]}
+    assert "automatic patch application" in blocked_items
+    assert "merge authorization" in blocked_items
+    assert "TrajectoryStore / RepoMemory expansion" in blocked_items
+    assert "cloud, service, dashboard, or worker orchestration" in blocked_items
+
+
+def test_safety_gate_policy_matrix_markdown_matches_contract() -> None:
+    policy = _load_policy()
+    markdown = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "SafetyGate policy matrix" in markdown
+    assert "docs/contracts/safety-gate-policy-matrix.v1.json" in markdown
+    assert "automatic patch application" in markdown
+    assert "merge authorization" in markdown
+
+    for row in policy["policy_by_failure_class"]:
+        assert f"`{row['failure_class']}`" in markdown


### PR DESCRIPTION
## Summary
- Adds a SafetyGate policy matrix contract.
- Documents safe-fix eligibility versus review-first outcomes by FailureVector class.
- Adds regression coverage that keeps the policy aligned with current runtime behavior.

## Why
- Wave A completed FailureVector extraction, CLI artifact coverage, and support matrix documentation.
- Wave B starts by locking SafetyGate policy before expanding behavior.
- This prevents premature automation, patch application, merge authorization, or worker/cloud work.

## Policy boundary
Safe-fix is allowed only when all global requirements pass:
- failure class is `formatter_only` or `lint`
- `safe_fix_candidate` is true
- risk is `low`
- scope is `pr_owned_only`
- affected files are non-empty

Everything else remains review-first.

## Verification
- `python -m pytest -q tests/test_safety_gate_policy_matrix.py tests/test_safety_gate.py tests/test_failure_vector_support_matrix.py -o addopts=`
- `python -m pre_commit run -a`

## Risk
- Low.
- Documentation + contract + test only.
- No runtime behavior change.
- No automation or merge authorization added.
