### PR TITLE
feat(safety-gate): require proof command for safe fix

### DIFF
--- a/docs/contracts/safety-gate-policy-matrix.v1.json
+++ b/docs/contracts/safety-gate-policy-matrix.v1.json
@@ -33,7 +33,8 @@
         "affected_files is empty",
         "scope is not pr_owned_only",
         "risk is not low",
-        "safe_fix_candidate is false"
+        "safe_fix_candidate is false",
+        "local_repro_command is empty"
       ]
     },
     {
@@ -45,7 +46,8 @@
         "affected_files is empty",
         "scope is not pr_owned_only",
         "risk is not low",
-        "safe_fix_candidate is false"
+        "safe_fix_candidate is false",
+        "local_repro_command is empty"
       ]
     },
     {
@@ -97,6 +99,7 @@
       "formatter_only",
       "lint"
     ],
+    "local_repro_command": "non_empty",
     "risk": "low",
     "safe_fix_candidate": true,
     "scope": "pr_owned_only"

--- a/docs/safety-gate-policy-matrix.md
+++ b/docs/safety-gate-policy-matrix.md
@@ -17,13 +17,14 @@ SafetyGate may allow a safe fix only when all of these are true:
 - risk is `low`
 - scope is `pr_owned_only`
 - affected files are non-empty
+- local repro command is present
 
 ## Policy by failure class
 
 | Failure class | Default decision | Allowed files policy | Review-first when |
 | --- | --- | --- | --- |
-| `formatter_only` | `safe_fix_allowed_if_all_global_conditions_pass` | `affected_files_only` | affected_files is empty, scope is not pr_owned_only, risk is not low, safe_fix_candidate is false |
-| `lint` | `safe_fix_allowed_if_all_global_conditions_pass` | `affected_files_only` | lint is not mechanically fixable, affected_files is empty, scope is not pr_owned_only, risk is not low, safe_fix_candidate is false |
+| `formatter_only` | `safe_fix_allowed_if_all_global_conditions_pass` | `affected_files_only` | affected_files is empty, scope is not pr_owned_only, risk is not low, safe_fix_candidate is false, local_repro_command is empty |
+| `lint` | `safe_fix_allowed_if_all_global_conditions_pass` | `affected_files_only` | lint is not mechanically fixable, affected_files is empty, scope is not pr_owned_only, risk is not low, safe_fix_candidate is false, local_repro_command is empty |
 | `test` | `review_first` | `none` | always in current policy |
 | `type` | `review_first` | `none` | always in current policy |
 | `dependency` | `review_first` | `none` | always in current policy |

--- a/src/sdetkit/safety_gate.py
+++ b/src/sdetkit/safety_gate.py
@@ -103,18 +103,21 @@ def _safe_fix_allowed(vector: FailureVectorLike) -> bool:
         and vector.risk == "low"
         and vector.scope == "pr_owned_only"
         and bool(vector.affected_files)
+        and bool(vector.local_repro_command)
     )
 
 
 def _decision_reason(vector: FailureVectorLike, safe_fix_allowed: bool) -> str:
     if safe_fix_allowed:
-        return "failure vector is low-risk, PR-owned, and mechanically eligible"
+        return "failure vector is low-risk, PR-owned, mechanically eligible, and has required proof"
     if not vector.safe_fix_candidate:
         return (
             f"failure_class {vector.failure_class!r} is review-first or not mechanically eligible"
         )
     if not vector.affected_files:
         return "safe candidate lacks affected files, so patch scope cannot be verified"
+    if not vector.local_repro_command:
+        return "safe candidate lacks local repro command, so required proof cannot be selected"
     if vector.scope != "pr_owned_only":
         return f"scope {vector.scope!r} is not eligible for mechanical remediation"
     if vector.risk != "low":

--- a/tests/test_safety_gate.py
+++ b/tests/test_safety_gate.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 from sdetkit.failure_vector import extract_failure_vector
 from sdetkit.safety_gate import (
@@ -47,6 +48,24 @@ def test_safety_gate_allows_import_sort_lint_only_when_vector_is_safe_candidate(
     assert vector.safe_fix_candidate is True
     assert decision.safe_fix_allowed is True
     assert decision.allowed_files == ("tests/test_widget.py",)
+
+
+def test_safety_gate_blocks_safe_candidate_without_required_proof_command() -> None:
+    vector = SimpleNamespace(
+        failure_class="formatter_only",
+        risk="low",
+        scope="pr_owned_only",
+        safe_fix_candidate=True,
+        affected_files=("tests/test_widget.py",),
+        local_repro_command=None,
+    )
+
+    decision = evaluate_failure_vector(vector)
+
+    assert decision.safe_fix_allowed is False
+    assert decision.review_first is True
+    assert decision.allowed_files == ()
+    assert "local repro command" in decision.reason
 
 
 def test_safety_gate_blocks_unknown_failure_review_first() -> None:

--- a/tests/test_safety_gate_policy_matrix.py
+++ b/tests/test_safety_gate_policy_matrix.py
@@ -22,7 +22,7 @@ class MinimalFailureVector:
     scope: str = "pr_owned_only"
     safe_fix_candidate: bool = True
     affected_files: tuple[str, ...] = ("tests/test_widget.py",)
-    local_repro_command: str | None = None
+    local_repro_command: str | None = "python -m ruff format --check tests/test_widget.py"
 
 
 def _load_policy() -> dict[str, object]:
@@ -48,6 +48,7 @@ def test_safety_gate_policy_matrix_matches_current_safe_fix_classes() -> None:
 
     safe_fix_classes = set(policy["safe_fix_allowed_only_when"]["failure_class_in"])
     assert safe_fix_classes == set(SAFE_FIX_CLASSES)
+    assert policy["safe_fix_allowed_only_when"]["local_repro_command"] == "non_empty"
 
     allowed_rows = {
         row["failure_class"]
@@ -102,6 +103,7 @@ def test_safety_gate_policy_matrix_markdown_matches_contract() -> None:
     assert "SafetyGate policy matrix" in markdown
     assert "docs/contracts/safety-gate-policy-matrix.v1.json" in markdown
     assert "automatic patch application" in markdown
+    assert "local repro command" in markdown
     assert "merge authorization" in markdown
 
     for row in policy["policy_by_failure_class"]:


### PR DESCRIPTION
## Summary

- Require a non-empty local_repro_command before SafetyGate can return safe_fix_allowed=true.
- Keep formatter_only and lint as the only safe-fix eligible classes.
- Keep affected_files, low risk, pr_owned_only scope, and safe_fix_candidate=true as required conditions.
- Update the SafetyGate policy matrix JSON and Markdown to document the stricter proof requirement.
- Add runtime and policy tests for the required proof command guard.

## Scope

Changed only:

- docs/contracts/safety-gate-policy-matrix.v1.json
- docs/safety-gate-policy-matrix.md
- src/sdetkit/safety_gate.py
- tests/test_safety_gate.py
- tests/test_safety_gate_policy_matrix.py

## Proof

Commands run locally:

- python -m pytest -q tests/test_safety_gate.py tests/test_safety_gate_policy_matrix.py tests/test_pr_quality_action_report.py tests/test_patch_scorer.py tests/test_protected_verifier.py -o addopts=
- python -m pre_commit run -a
- make proof-after-format

Observed before PR:

- Focused proof: 77 passed
- Pre-commit: passed
- make proof-after-format: passed

## Boundary

This PR tightens the proof contract only.

It does not authorize:

- automation
- patch application
- merging
- semantic-equivalence claims
