### PR TITLE
ci(pr-quality): wire trusted diagnostic history into runtime proof

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -569,6 +569,41 @@ jobs:
           printf '%s\n' "$trusted_history_head_sha" \
             > build/pr-quality/trusted-history/selected-head-sha.txt
 
+          mkdir -p build/pr-quality/trusted-diagnostic-signal-snapshot-history
+          trusted_diagnostic_signal_snapshot_history_for_runtime_rc=2
+          runtime_trusted_snapshot_history_summary="$(
+            find build/pr-quality/trusted-history/download \
+              -name diagnostic-signal-snapshot-history-summary.json \
+              -print \
+              -quit
+          )"
+          runtime_trusted_snapshot_history_jsonl="$(
+            find build/pr-quality/trusted-history/download \
+              -name diagnostic-signal-snapshot-history.jsonl \
+              -print \
+              -quit
+          )"
+          if [ "$trusted_history_rc" -eq 0 ] \
+            && [ -n "$runtime_trusted_snapshot_history_summary" ] \
+            && [ -n "$runtime_trusted_snapshot_history_jsonl" ] \
+            && [ -f "$runtime_trusted_snapshot_history_summary" ] \
+            && [ -f "$runtime_trusted_snapshot_history_jsonl" ]; then
+            trusted_diagnostic_signal_snapshot_history_for_runtime_rc=0
+            PYTHONPATH=src python -m sdetkit.trusted_diagnostic_signal_snapshot_history \
+              --history-summary "$runtime_trusted_snapshot_history_summary" \
+              --history-jsonl "$runtime_trusted_snapshot_history_jsonl" \
+              --repo-root . \
+              --selected-retention-run-id "$trusted_history_run_id" \
+              --selected-head-sha "$trusted_history_head_sha" \
+              --base-sha "$PR_BASE_SHA" \
+              --out-dir build/pr-quality/trusted-diagnostic-signal-snapshot-history \
+              --format json \
+              > build/pr-quality/trusted-diagnostic-signal-snapshot-history/runtime-evidence-cli.json \
+              || trusted_diagnostic_signal_snapshot_history_for_runtime_rc=3
+          fi
+          printf '%s\n' "$trusted_diagnostic_signal_snapshot_history_for_runtime_rc" \
+            > build/pr-quality/trusted-diagnostic-signal-snapshot-history/runtime-exit-code.txt
+
           reviewed_disposition_history="$(
             find build/pr-quality/trusted-history/download \
               -name security-reviewed-disposition-history.jsonl \
@@ -600,6 +635,7 @@ jobs:
             --live-benchmark-report build/pr-quality/live-benchmark/live-report/benchmark-report.json \
             --repo-memory-profile build/pr-quality/repo-memory/repo-memory-profile.json \
             --trusted-history-evidence build/pr-quality/trusted-history/evidence/trusted-history-evidence.json \
+            --trusted-diagnostic-signal-snapshot-history build/pr-quality/trusted-diagnostic-signal-snapshot-history/trusted-diagnostic-signal-snapshot-history.json \
             --out-dir build/pr-quality/runtime-proof/summary \
             --format json \
             > build/pr-quality/runtime-proof/summary-metadata.json

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1009,7 +1009,7 @@ def test_pr_quality_snapshot_history_falls_back_to_latest_ancestor_artifact_with
     assert '--selected-head-sha "$trusted_snapshot_history_head_sha"' in trusted_visibility
 
 
-def test_pr_quality_builds_trusted_snapshot_history_in_bounded_follow_on_step() -> None:
+def test_pr_quality_builds_trusted_snapshot_history_for_runtime_and_visibility() -> None:
     text = _workflow_text()
     comment_builder = text[
         text.index("- name: Build PR comment body") : text.index(
@@ -1026,7 +1026,23 @@ def test_pr_quality_builds_trusted_snapshot_history_in_bounded_follow_on_step() 
     assert "python -m sdetkit.pr_quality_candidate_validation" in comment_builder
     assert "runtime_guard_worker_oracle.json" in comment_builder
     assert "security_freshness_stale_runtime_oracle.json" in comment_builder
-    assert "python -m sdetkit.trusted_diagnostic_signal_snapshot_history" not in comment_builder
+
+    runtime_summary = comment_builder.index("python -m sdetkit.pr_quality_runtime_proof_artifacts")
+    early_trusted_history = comment_builder.index(
+        "python -m sdetkit.trusted_diagnostic_signal_snapshot_history"
+    )
+    runtime_command = comment_builder[
+        runtime_summary : comment_builder.index(
+            "> build/pr-quality/runtime-proof/summary-metadata.json", runtime_summary
+        )
+    ]
+
+    assert early_trusted_history < runtime_summary
+    assert "--trusted-diagnostic-signal-snapshot-history" in runtime_command
+    assert (
+        "build/pr-quality/trusted-diagnostic-signal-snapshot-history/"
+        "trusted-diagnostic-signal-snapshot-history.json"
+    ) in runtime_command
     assert "python -m sdetkit.trusted_diagnostic_signal_snapshot_history" in trusted_visibility
     assert "trusted-diagnostic-signal-snapshot-history.md" in trusted_visibility
     assert 'body = body.replace(snapshot, f"{snapshot}\\n\\n{history}", 1)' in trusted_visibility


### PR DESCRIPTION
## Summary

- Wire trusted diagnostic signal snapshot history into PR Quality runtime-proof artifacts.
- Build reporting-only trusted diagnostic history before runtime-proof summary generation.
- Pass `--trusted-diagnostic-signal-snapshot-history` into `sdetkit.pr_quality_runtime_proof_artifacts`.
- Keep the existing follow-on visibility/comment section for diagnostic snapshot history.

## Proof

Local proof before PR:

- Focused C.4 proof: 65 passed
- Full focused workflow/contract proof: 69 passed
- Pre-commit: passed
- make proof-after-format: passed

## Boundary

This is workflow/reporting wiring only.

It does not authorize automation, patch application, merging, or semantic-equivalence claims.
