### PR TITLE
feat(benchmark): add replay manifest to benchmark reports

### DIFF
--- a/src/sdetkit/replayable_benchmark_harness.py
+++ b/src/sdetkit/replayable_benchmark_harness.py
@@ -638,6 +638,23 @@ def _type_rate(results: list[JsonObject], scenario_type: str) -> float:
     return round(passing / len(matching), 4)
 
 
+def _replay_manifest(results: list[JsonObject]) -> JsonObject:
+    scenario_types = [_string(item.get("scenario_type")) for item in results]
+    return {
+        "scenario_count": len(results),
+        "scenario_ids": [_string(item.get("scenario_id")) for item in results],
+        "scenario_types": scenario_types,
+        "scenario_type_counts": dict(sorted(Counter(scenario_types).items())),
+        "input_order_preserved": True,
+        "duplicate_scenario_ids_rejected": True,
+        "unsupported_scenario_types_rejected": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
 def build_benchmark_report(scenarios: list[Mapping[str, Any]]) -> JsonObject:
     results = [evaluate_scenario(scenario) for scenario in scenarios]
     safety_gate_evidence = _aggregate_safety_gate_evidence(results)
@@ -703,6 +720,7 @@ def build_benchmark_report(scenarios: list[Mapping[str, Any]]) -> JsonObject:
         "passed_count": passed_count,
         "failed_count": len(results) - passed_count,
         "scenario_type_counts": dict(sorted(type_counts.items())),
+        "replay_manifest": _replay_manifest(results),
         "safety_gate_evidence": safety_gate_evidence,
         "required_contract": {
             "required_scenario_types": list(REQUIRED_SCENARIO_TYPES),
@@ -793,6 +811,7 @@ def build_isolated_evidence_report(
         "passed_count": passed_count,
         "failed_count": len(results) - passed_count,
         "scenario_type_counts": dict(sorted(type_counts.items())),
+        "replay_manifest": _replay_manifest(results),
         "required_contract": {
             "required_scenario_types": list(ISOLATED_EVIDENCE_REQUIRED_TYPES),
             "all_required_present": required_present,
@@ -1097,6 +1116,7 @@ def build_diagnostic_worker_benchmark_report(scenarios: list[Mapping[str, Any]])
         "passed_count": passed_count,
         "failed_count": len(results) - passed_count,
         "scenario_type_counts": dict(sorted(type_counts.items())),
+        "replay_manifest": _replay_manifest(results),
         "required_contract": {
             "required_scenario_types": list(DIAGNOSTIC_WORKER_REQUIRED_SCENARIO_TYPES),
             "all_required_present": required_present,
@@ -1385,6 +1405,7 @@ def build_security_freshness_benchmark_report(scenarios: list[Mapping[str, Any]]
         "passed_count": passed_count,
         "failed_count": len(results) - passed_count,
         "scenario_type_counts": dict(sorted(type_counts.items())),
+        "replay_manifest": _replay_manifest(results),
         "required_contract": {
             "required_scenario_types": list(SECURITY_FRESHNESS_REQUIRED_SCENARIO_TYPES),
             "all_required_present": required_present,
@@ -1411,6 +1432,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     required = _as_dict(report.get("required_contract"))
     boundary = _as_dict(report.get("safety_boundary"))
     live_evidence = _as_dict(report.get("live_evidence"))
+    replay_manifest = _as_dict(report.get("replay_manifest"))
     safety_gate = _as_dict(report.get("safety_gate_evidence"))
     safety_boundary = _as_dict(safety_gate.get("decision_boundary"))
     scenarios = [_as_dict(item) for item in _as_list(report.get("scenarios"))]
@@ -1430,6 +1452,49 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         f"- Attempts scored: `{_int(report.get('attempt_scored_count'))}`",
         "",
     ]
+
+    if replay_manifest:
+        scenario_ids = ", ".join(
+            _string(item) for item in _as_list(replay_manifest.get("scenario_ids"))
+        )
+        scenario_types = ", ".join(
+            _string(item) for item in _as_list(replay_manifest.get("scenario_types"))
+        )
+        lines.extend(
+            [
+                "## Replay manifest",
+                "",
+                f"- Scenario count: `{_int(replay_manifest.get('scenario_count'))}`",
+                f"- Scenario ids: `{scenario_ids or 'none'}`",
+                f"- Scenario types: `{scenario_types or 'none'}`",
+                (
+                    "- Input order preserved: "
+                    f"`{str(_bool(replay_manifest.get('input_order_preserved'))).lower()}`"
+                ),
+                (
+                    "- Duplicate scenario IDs rejected: "
+                    f"`{str(_bool(replay_manifest.get('duplicate_scenario_ids_rejected'))).lower()}`"
+                ),
+                (
+                    "- Unsupported scenario types rejected: "
+                    f"`{str(_bool(replay_manifest.get('unsupported_scenario_types_rejected'))).lower()}`"
+                ),
+                f"- Reporting only: `{str(_bool(replay_manifest.get('reporting_only'))).lower()}`",
+                (
+                    "- Automation allowed by replay manifest: "
+                    f"`{str(_bool(replay_manifest.get('automation_allowed'))).lower()}`"
+                ),
+                (
+                    "- Merge authorized by replay manifest: "
+                    f"`{str(_bool(replay_manifest.get('merge_authorized'))).lower()}`"
+                ),
+                (
+                    "- Semantic equivalence proven by replay manifest: "
+                    f"`{str(_bool(replay_manifest.get('semantic_equivalence_proven'))).lower()}`"
+                ),
+                "",
+            ]
+        )
 
     if is_security_freshness:
         lines.extend(

--- a/tests/test_replayable_benchmark_harness.py
+++ b/tests/test_replayable_benchmark_harness.py
@@ -66,6 +66,22 @@ def test_replayable_benchmark_harness_proves_required_fixture_contracts() -> Non
     assert boundary["preserved"] is True
     assert report["attempt_scored_count"] == 3
 
+    replay = report["replay_manifest"]
+    assert replay["scenario_count"] == 3
+    assert replay["scenario_ids"] == [
+        "nop-formatting-patch",
+        "oracle-formatting-patch",
+        "unsafe-protected-path-patch",
+    ]
+    assert replay["scenario_types"] == ["nop_fail", "oracle_pass", "unsafe_patch_fail"]
+    assert replay["input_order_preserved"] is True
+    assert replay["duplicate_scenario_ids_rejected"] is True
+    assert replay["unsupported_scenario_types_rejected"] is True
+    assert replay["reporting_only"] is True
+    assert replay["automation_allowed"] is False
+    assert replay["merge_authorized"] is False
+    assert replay["semantic_equivalence_proven"] is False
+
 
 def test_replayable_benchmark_oracle_passes_structural_verification_only() -> None:
     result = evaluate_scenario(_scenario("oracle_pass"))
@@ -122,6 +138,15 @@ def test_replayable_benchmark_markdown_renders_contract_and_boundaries() -> None
     assert "NOP fail rate: `1.0000`" in markdown
     assert "Oracle pass rate: `1.0000`" in markdown
     assert "Unsafe patch rejection rate: `1.0000`" in markdown
+    assert "## Replay manifest" in markdown
+    assert (
+        "Scenario ids: `nop-formatting-patch, oracle-formatting-patch, unsafe-protected-path-patch`"
+        in markdown
+    )
+    assert "Input order preserved: `true`" in markdown
+    assert "Automation allowed by replay manifest: `false`" in markdown
+    assert "Merge authorized by replay manifest: `false`" in markdown
+    assert "Semantic equivalence proven by replay manifest: `false`" in markdown
     assert "Automation allowed count: `0`" in markdown
     assert "It does not apply patches or execute proof commands." in markdown
 
@@ -146,6 +171,12 @@ def test_replayable_benchmark_cli_writes_report_artifacts(
     assert printed["status"] == "passed"
     assert printed["scenario_count"] == 3
     assert saved["required_contract"]["all_required_passed"] is True
+    assert saved["replay_manifest"]["scenario_ids"] == [
+        "nop-formatting-patch",
+        "oracle-formatting-patch",
+        "unsafe-protected-path-patch",
+    ]
+    assert saved["replay_manifest"]["automation_allowed"] is False
     assert "Replayable Benchmark Harness report" in markdown
 
 


### PR DESCRIPTION
## Summary

- Add a first-class replay manifest to Replayable Benchmark Harness reports.
- Surface scenario IDs, scenario types, scenario type counts, and input-order preservation.
- Preserve no-authority boundaries: reporting only, no automation, no merge authority, no semantic-equivalence claim.
- Render replay manifest details in the benchmark Markdown report.

## Proof

Local proof before PR:

- Focused D.1 proof: 44 passed
- Pre-commit: passed
- make proof-after-format: passed

## Boundary

This PR is benchmark report contract hardening.

It does not authorize automation, patch application, merging, or semantic-equivalence claims.
