### PR TITLE
ci(pr-quality): avoid untrusted head ref in workflow scripts

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -455,7 +455,7 @@ jobs:
             --evidence-narrative build/pr-quality/pr-evidence-narrative.json \
             --out build/pr-quality/trajectory/trajectory.jsonl \
             --repo "${{ github.repository }}" \
-            --branch "${{ github.event.pull_request.head.ref }}" \
+            --branch "$GITHUB_HEAD_REF" \
             --commit-sha "${{ github.event.pull_request.head.sha }}" \
             --pr-number "${{ github.event.pull_request.number }}" \
             --format json \
@@ -701,7 +701,7 @@ jobs:
               --diagnostic-worker-result build/pr-quality/diagnostic-job/diagnostic-worker-result.json \
               --diagnostic-vector build/pr-quality/diagnostic-job/vector/diagnostic-vector.json \
               --repo "$REPOSITORY" \
-              --branch "${{ github.event.pull_request.head.ref }}" \
+              --branch "$GITHUB_HEAD_REF" \
               --commit-sha "$HEAD_SHA" \
               --pr-number "${{ github.event.pull_request.number }}" \
               --out-dir build/pr-quality/diagnostic-job/trajectory \

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1046,3 +1046,31 @@ def test_pr_quality_builds_trusted_snapshot_history_for_runtime_and_visibility()
     assert "python -m sdetkit.trusted_diagnostic_signal_snapshot_history" in trusted_visibility
     assert "trusted-diagnostic-signal-snapshot-history.md" in trusted_visibility
     assert 'body = body.replace(snapshot, f"{snapshot}\\n\\n{history}", 1)' in trusted_visibility
+
+
+def test_pr_quality_comment_avoids_untrusted_head_ref_expression_in_run_blocks() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    direct_expression = "${{ github.event.pull_request.head.ref }}"
+    offending_run_lines: list[int] = []
+
+    for index, line in enumerate(lines):
+        if line.strip() != "run: |":
+            continue
+
+        run_indent = len(line) - len(line.lstrip())
+        block: list[str] = []
+        for block_line in lines[index + 1 :]:
+            stripped = block_line.strip()
+            block_indent = len(block_line) - len(block_line.lstrip())
+            if stripped and block_indent <= run_indent:
+                break
+            block.append(block_line)
+
+        if direct_expression in "\n".join(block):
+            offending_run_lines.append(index + 1)
+
+    assert not offending_run_lines, (
+        "PR Quality Comment must pass untrusted pull_request.head.ref through "
+        f"an environment variable before inline scripts: {offending_run_lines}"
+    )


### PR DESCRIPTION
## Summary

- Restore PR Quality Comment workflow startup by removing direct `github.event.pull_request.head.ref` usage from inline shell scripts.
- Use the runtime `GITHUB_HEAD_REF` environment variable instead.
- Add a regression test so inline `run:` blocks cannot directly use the untrusted PR head ref expression again.

## Proof

Local proof before PR:

- actionlint: passed
- Focused PR Quality workflow tests: 82 passed
- pre-commit: passed

## Boundary

This PR is workflow-governance only.

It does not change benchmark logic, authorize automation, authorize merge, or claim semantic equivalence.
