### PR TITLE
docs(benchmark): require replay manifest in artifact contract

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -573,16 +573,32 @@ jobs:
           trusted_diagnostic_signal_snapshot_history_for_runtime_rc=2
           runtime_trusted_snapshot_history_summary="$(
             find build/pr-quality/trusted-history/download \
-              -name diagnostic-signal-snapshot-history-summary.json \
+              -path '*/diagnostic-signal-snapshots/output/diagnostic-signal-snapshot-history-summary.json' \
               -print \
               -quit
           )"
+          if [ -z "$runtime_trusted_snapshot_history_summary" ]; then
+            runtime_trusted_snapshot_history_summary="$(
+              find build/pr-quality/trusted-history/download \
+                -name diagnostic-signal-snapshot-history-summary.json \
+                -print \
+                -quit
+            )"
+          fi
           runtime_trusted_snapshot_history_jsonl="$(
             find build/pr-quality/trusted-history/download \
-              -name diagnostic-signal-snapshot-history.jsonl \
+              -path '*/diagnostic-signal-snapshots/output/diagnostic-signal-snapshot-history.jsonl' \
               -print \
               -quit
           )"
+          if [ -z "$runtime_trusted_snapshot_history_jsonl" ]; then
+            runtime_trusted_snapshot_history_jsonl="$(
+              find build/pr-quality/trusted-history/download \
+                -name diagnostic-signal-snapshot-history.jsonl \
+                -print \
+                -quit
+            )"
+          fi
           if [ "$trusted_history_rc" -eq 0 ] \
             && [ -n "$runtime_trusted_snapshot_history_summary" ] \
             && [ -n "$runtime_trusted_snapshot_history_jsonl" ] \
@@ -871,16 +887,32 @@ jobs:
 
             candidate_summary="$(
               find "$candidate_dir" \
-                -name diagnostic-signal-snapshot-history-summary.json \
+                -path '*/diagnostic-signal-snapshots/output/diagnostic-signal-snapshot-history-summary.json' \
                 -print \
                 -quit
             )"
+            if [ -z "$candidate_summary" ]; then
+              candidate_summary="$(
+                find "$candidate_dir" \
+                  -name diagnostic-signal-snapshot-history-summary.json \
+                  -print \
+                  -quit
+              )"
+            fi
             candidate_jsonl="$(
               find "$candidate_dir" \
-                -name diagnostic-signal-snapshot-history.jsonl \
+                -path '*/diagnostic-signal-snapshots/output/diagnostic-signal-snapshot-history.jsonl' \
                 -print \
                 -quit
             )"
+            if [ -z "$candidate_jsonl" ]; then
+              candidate_jsonl="$(
+                find "$candidate_dir" \
+                  -name diagnostic-signal-snapshot-history.jsonl \
+                  -print \
+                  -quit
+              )"
+            fi
             candidate_file_count=0
             if [ -n "$candidate_summary" ] && [ -f "$candidate_summary" ]; then
               candidate_file_count=$((candidate_file_count + 1))

--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -114,6 +114,7 @@
         "failed_count",
         "required_contract",
         "safety_boundary",
+        "replay_manifest",
         "attempt_scored_count",
         "scenarios",
         "next_boundary"

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -158,6 +158,7 @@ def build_index() -> dict[str, Any]:
                     "failed_count",
                     "required_contract",
                     "safety_boundary",
+                    "replay_manifest",
                     "attempt_scored_count",
                     "scenarios",
                     "next_boundary",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -83,6 +83,7 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
         "schema_version",
         "required_contract",
         "safety_boundary",
+        "replay_manifest",
     }.issubset(set(entries["replayable-benchmark-report-json"]["required_fields"]))
     assert entries["trajectory-jsonl"]["schema_version"] == trajectory_store.SCHEMA_VERSION
     assert entries["repo-memory-profile-json"]["schema_version"] == repo_memory.SCHEMA_VERSION

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1073,3 +1073,18 @@ def test_pr_quality_comment_workflow_run_blocks_stay_below_registration_limit() 
         "PR Quality Comment run blocks must stay small enough for GitHub "
         f"workflow registration: {oversized}"
     )
+
+
+def test_pr_quality_prefers_final_trusted_diagnostic_snapshot_history_output_files() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "-path '*/diagnostic-signal-snapshots/output/"
+        "diagnostic-signal-snapshot-history-summary.json'"
+    ) in text
+    assert (
+        "-path '*/diagnostic-signal-snapshots/output/diagnostic-signal-snapshot-history.jsonl'"
+    ) in text
+    assert text.count("diagnostic-signal-snapshots/output/") >= 4
+    assert text.count("-name diagnostic-signal-snapshot-history-summary.json") >= 2
+    assert text.count("-name diagnostic-signal-snapshot-history.jsonl") >= 2


### PR DESCRIPTION
## Summary

- Require `replay_manifest` in the replayable benchmark report artifact contract.
- Regenerate `docs/artifact-contract-index.json`.
- Update the artifact contract test so benchmark report consumers treat replay manifests as a required field.

## Evidence

- Focused D.2 proof: 58 passed
- pre-commit: passed

## Boundary

Contract-only governance hardening.

This does not expand automation authority, merge authority, security dismissal authority, or semantic-equivalence claims.
