### PR TITLE
feat(pr-quality): render no-candidate remediation visibility

### DIFF
--- a/src/sdetkit/pr_quality_candidate_visibility.py
+++ b/src/sdetkit/pr_quality_candidate_visibility.py
@@ -187,9 +187,6 @@ def build_candidate_visibility(
 
 def render_markdown(payload: Mapping[str, Any]) -> str:
     candidate_count = int(payload.get("candidate_count", 0) or 0)
-    if candidate_count == 0:
-        return ""
-
     boundary = _as_dict(payload.get("decision_boundary"))
     score = _as_dict(payload.get("patch_score"))
     score_decision = _as_dict(score.get("decision"))

--- a/tests/test_pr_quality_candidate_visibility.py
+++ b/tests/test_pr_quality_candidate_visibility.py
@@ -130,7 +130,7 @@ def test_candidate_visibility_keeps_broader_pr_diff_review_first() -> None:
     assert verification["decision"]["merge_authorized"] is False
 
 
-def test_candidate_visibility_stays_quiet_without_candidate() -> None:
+def test_candidate_visibility_renders_no_candidate_boundary() -> None:
     payload = build_candidate_visibility(
         check_intelligence={"failed_checks": []},
         evidence_graph={},
@@ -144,7 +144,19 @@ def test_candidate_visibility_stays_quiet_without_candidate() -> None:
     assert payload["candidate_count"] == 0
     assert payload["patch_score"] == {}
     assert payload["protected_verifier"] == {}
-    assert render_markdown(payload) == ""
+
+    markdown = render_markdown(payload)
+    assert "Read-only remediation candidate verification" in markdown
+    assert "Status: `no_candidate`" in markdown
+    assert "Candidates observed: `0`" in markdown
+    assert "Review-first plans observed: `0`" in markdown
+    assert "Candidate scope: none" in markdown
+    assert "Observed PR changed files: none" in markdown
+    assert "Automation allowed: `false`" in markdown
+    assert "Merge authorized: `false`" in markdown
+    assert "Semantic equivalence proven: `false`" in markdown
+    assert "PatchScorer decision" not in markdown
+    assert "ProtectedVerifier decision" not in markdown
 
 
 def test_candidate_visibility_cli_writes_read_only_artifacts(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- render read-only remediation candidate visibility even when no candidate exists
- expose the no-candidate boundary instead of returning empty Markdown
- protect the no-candidate reporting contract with focused tests

## Proof

Focused PR B proof passed:

76 passed in 0.79s

Quality proof passed:

- check for merge conflicts: Passed
- check yaml: Passed
- fix end of files: Passed
- trim trailing whitespace: Passed
- ruff: Passed
- ruff format: Passed
- doctor --ascii: Passed
- mypy: Passed

## Boundary

- reporting-only change
- patch_application_allowed=false
- automation_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- no write/remediation authority added