### PR TITLE
feat(radar): mark review-first unsafe candidates as blocked

### DIFF
--- a/src/sdetkit/product_maturity_radar.py
+++ b/src/sdetkit/product_maturity_radar.py
@@ -668,7 +668,12 @@ def _rank_candidates(surfaces: Sequence[dict[str, Any]], root: Path) -> list[dic
                 candidate_title,
                 accepted_subjects,
             )
-            ranking_status = "accepted_on_main" if accepted_on_main else "fresh_candidate"
+            if accepted_on_main:
+                ranking_status = "accepted_on_main"
+            elif candidate.get("review_first") is True and candidate.get("safe_to_patch") is False:
+                ranking_status = "blocked_review_first_candidate"
+            else:
+                ranking_status = "fresh_candidate"
             accepted_penalty = 1000 if accepted_on_main else 0
 
             ranked.append(
@@ -788,9 +793,11 @@ def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"   - ranking_score: `{candidate['ranking_score']}`")
             if candidate.get("accepted_on_main"):
                 lines.append("   - accepted_on_main: true")
-                lines.append(
-                    f"   - ranking_status: `{candidate.get('ranking_status', 'accepted_on_main')}`"
-                )
+            lines.append(
+                f"   - ranking_status: `{candidate.get('ranking_status', 'fresh_candidate')}`"
+            )
+            if candidate.get("ranking_status") == "blocked_review_first_candidate":
+                lines.append("   - blocked_by: `human_review_evidence_required`")
             lines.append("   - review_first: true")
             lines.append("   - safe_to_patch: false")
 

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -177,6 +177,28 @@ def test_product_maturity_radar_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert out.with_suffix(".md").is_file()
 
 
+def test_product_maturity_radar_marks_review_first_unsafe_candidates_as_blocked(
+    tmp_path: Path,
+) -> None:
+    _fixture_repo(tmp_path)
+
+    payload = build_product_maturity_radar(tmp_path)
+    workflow = next(
+        candidate
+        for candidate in _ranked_radar_candidates(payload)
+        if candidate["classification"] == "workflow_governance_followup"
+    )
+
+    assert workflow["accepted_on_main"] is False
+    assert workflow["review_first"] is True
+    assert workflow["safe_to_patch"] is False
+    assert workflow["ranking_status"] == "blocked_review_first_candidate"
+
+    markdown = radar_module.render_product_maturity_radar_markdown(payload)
+    assert "ranking_status: `blocked_review_first_candidate`" in markdown
+    assert "blocked_by: `human_review_evidence_required`" in markdown
+
+
 def test_product_maturity_radar_marks_accepted_candidates_from_git_history(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- mark review-first unsafe radar candidates as blocked instead of ordinary fresh candidates
- render the human-review-evidence blocker in the product maturity radar
- align radar selection with adaptive reviewer behavior so non-patch-ready workflow governance work is not re-selected as patch-ready

## Proof

Focused proof passed:

19 passed in 0.62s

Quality proof passed:

- check for merge conflicts: Passed
- check yaml: Passed
- fix end of files: Passed
- trim trailing whitespace: Passed
- ruff: Passed
- ruff format: Passed
- doctor --ascii: Passed
- mypy: Passed

## Boundary

- reporting-only radar/actionability change
- workflow permissions were not changed
- patch_application_allowed=false
- automation_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- blocked candidates still require human review evidence