### PR TITLE
feat(radar): surface workflow review evidence blocker details

### DIFF
--- a/src/sdetkit/product_maturity_radar.py
+++ b/src/sdetkit/product_maturity_radar.py
@@ -418,6 +418,30 @@ def _workflow_surface(root: Path) -> dict[str, Any]:
             priority="P2",
         )
     ]
+    candidates[0].update(
+        {
+            "blocked_by": "human_review_evidence_required",
+            "blocker_source_report": "sdetkit.workflow_governance_report",
+            "blocker_playbook": "docs/ci/workflow-permission-review-playbook.md",
+            "next_allowed_action": "collect_human_review_evidence",
+            "required_evidence": [
+                "workflow path",
+                "current granted write scopes",
+                "inferred permission reasons from the report",
+                "exact scope proposed for removal, if any",
+                "exact proof command",
+                "rollback plan",
+                "reviewer decision",
+            ],
+            "blocked_actions": [
+                "automatic_permission_reduction",
+                "broad_workflow_permission_sweep",
+                "security_alert_dismissal",
+                "merge_authorization",
+                "semantic_equivalence_claim",
+            ],
+        }
+    )
 
     return _surface_payload(
         name="workflow",
@@ -797,7 +821,17 @@ def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
                 f"   - ranking_status: `{candidate.get('ranking_status', 'fresh_candidate')}`"
             )
             if candidate.get("ranking_status") == "blocked_review_first_candidate":
-                lines.append("   - blocked_by: `human_review_evidence_required`")
+                lines.append(
+                    f"   - blocked_by: `{candidate.get('blocked_by', 'human_review_evidence_required')}`"
+                )
+                if candidate.get("next_allowed_action"):
+                    lines.append(f"   - next_allowed_action: `{candidate['next_allowed_action']}`")
+                if candidate.get("blocker_source_report"):
+                    lines.append(
+                        f"   - blocker_source_report: `{candidate['blocker_source_report']}`"
+                    )
+                if candidate.get("blocker_playbook"):
+                    lines.append(f"   - blocker_playbook: `{candidate['blocker_playbook']}`")
             lines.append("   - review_first: true")
             lines.append("   - safe_to_patch: false")
 

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -193,10 +193,20 @@ def test_product_maturity_radar_marks_review_first_unsafe_candidates_as_blocked(
     assert workflow["review_first"] is True
     assert workflow["safe_to_patch"] is False
     assert workflow["ranking_status"] == "blocked_review_first_candidate"
+    assert workflow["blocked_by"] == "human_review_evidence_required"
+    assert workflow["blocker_source_report"] == "sdetkit.workflow_governance_report"
+    assert workflow["blocker_playbook"] == "docs/ci/workflow-permission-review-playbook.md"
+    assert workflow["next_allowed_action"] == "collect_human_review_evidence"
+    assert "reviewer decision" in workflow["required_evidence"]
+    assert "automatic_permission_reduction" in workflow["blocked_actions"]
+    assert "semantic_equivalence_claim" in workflow["blocked_actions"]
 
     markdown = radar_module.render_product_maturity_radar_markdown(payload)
     assert "ranking_status: `blocked_review_first_candidate`" in markdown
     assert "blocked_by: `human_review_evidence_required`" in markdown
+    assert "next_allowed_action: `collect_human_review_evidence`" in markdown
+    assert "blocker_source_report: `sdetkit.workflow_governance_report`" in markdown
+    assert "blocker_playbook: `docs/ci/workflow-permission-review-playbook.md`" in markdown
 
 
 def test_product_maturity_radar_marks_accepted_candidates_from_git_history(


### PR DESCRIPTION
## Summary

- add workflow governance blocker metadata to the product maturity radar candidate payload
- render next allowed action, blocker source report, and permission review playbook for blocked workflow candidates
- align the radar/adaptive reviewer with existing workflow permission evidence contracts without changing workflow permissions

## Proof

Focused proof:

- product maturity radar tests
- workflow governance report tests
- workflow permission evidence index tests
- workflow permission group evidence contract tests

Quality proof:

- pre-commit run -a

## Boundary

- reporting-only radar/actionability change
- no workflow permissions changed
- no automatic permission reduction
- no security dismissal
- patch_application_allowed=false
- automation_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false