### PR TITLE
feat(radar): align operator summary with blocked action

### DIFF
--- a/src/sdetkit/product_maturity_radar.py
+++ b/src/sdetkit/product_maturity_radar.py
@@ -723,6 +723,38 @@ def _rank_candidates(surfaces: Sequence[dict[str, Any]], root: Path) -> list[dic
     )
 
 
+def _operator_summary(ranked: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    if not ranked:
+        return {
+            "status": "product_maturity_radar_generated",
+            "next_action": "No product maturity candidates found.",
+        }
+
+    top = ranked[0]
+    summary = {
+        "status": "product_maturity_radar_generated",
+        "top_candidate": str(top.get("upgrade_candidate_title") or ""),
+        "top_candidate_classification": str(top.get("classification") or ""),
+        "top_candidate_ranking_status": str(top.get("ranking_status") or "fresh_candidate"),
+    }
+
+    if top.get("ranking_status") == "blocked_review_first_candidate":
+        summary["next_action"] = str(
+            top.get("next_allowed_action") or "collect_human_review_evidence"
+        )
+        summary["blocked_by"] = str(top.get("blocked_by") or "human_review_evidence_required")
+        if top.get("blocker_source_report"):
+            summary["blocker_source_report"] = str(top["blocker_source_report"])
+        if top.get("blocker_playbook"):
+            summary["blocker_playbook"] = str(top["blocker_playbook"])
+        return summary
+
+    summary["next_action"] = str(
+        top.get("upgrade_candidate_title") or "Review ranked product maturity candidates."
+    )
+    return summary
+
+
 def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root).resolve()
     text_index = _repo_text_index(root)
@@ -754,12 +786,7 @@ def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
         "status_counts": dict(sorted(status_counts.items())),
         "surfaces": surfaces,
         "ranked_upgrade_candidates": ranked,
-        "operator_summary": {
-            "status": "product_maturity_radar_generated",
-            "next_action": ranked[0]["upgrade_candidate_title"]
-            if ranked
-            else "No product maturity candidates found.",
-        },
+        "operator_summary": _operator_summary(ranked),
         "rules": {
             "advisory_only": True,
             "repo_mutation": False,

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -197,6 +197,15 @@ def test_product_maturity_radar_marks_review_first_unsafe_candidates_as_blocked(
     assert workflow["blocker_source_report"] == "sdetkit.workflow_governance_report"
     assert workflow["blocker_playbook"] == "docs/ci/workflow-permission-review-playbook.md"
     assert workflow["next_allowed_action"] == "collect_human_review_evidence"
+
+    summary = radar_module._operator_summary([workflow])
+    assert summary["next_action"] == "collect_human_review_evidence"
+    assert summary["top_candidate"] == workflow["upgrade_candidate_title"]
+    assert summary["top_candidate_classification"] == "workflow_governance_followup"
+    assert summary["top_candidate_ranking_status"] == "blocked_review_first_candidate"
+    assert summary["blocked_by"] == "human_review_evidence_required"
+    assert summary["blocker_source_report"] == "sdetkit.workflow_governance_report"
+    assert summary["blocker_playbook"] == "docs/ci/workflow-permission-review-playbook.md"
     assert "reviewer decision" in workflow["required_evidence"]
     assert "automatic_permission_reduction" in workflow["blocked_actions"]
     assert "semantic_equivalence_claim" in workflow["blocked_actions"]


### PR DESCRIPTION
## Summary

- make product maturity radar operator summary respect blocked review-first candidates
- set next_action to collect_human_review_evidence when the top candidate is blocked
- carry top candidate blocker metadata into the operator summary for adaptive reviewer alignment

## Proof

- python -m pytest -q tests/test_product_maturity_radar.py tests/test_workflow_governance_report.py -o addopts=
- python -m pre_commit run -a

## Boundary

- reporting-only radar/actionability change
- no workflow permissions changed
- no automatic permission reduction
- no security dismissal
- patch_application_allowed=false
- automation_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false