### PR TITLE
feat(radar): expose roadmap actionability summary

### DIFF
--- a/src/sdetkit/product_maturity_radar.py
+++ b/src/sdetkit/product_maturity_radar.py
@@ -723,6 +723,52 @@ def _rank_candidates(surfaces: Sequence[dict[str, Any]], root: Path) -> list[dic
     )
 
 
+def _actionability_summary(ranked: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    status_counts = Counter(str(item.get("ranking_status") or "unknown") for item in ranked)
+    patch_ready = [
+        item
+        for item in ranked
+        if item.get("accepted_on_main") is not True
+        and item.get("safe_to_patch") is True
+        and item.get("ranking_status") != "blocked_review_first_candidate"
+    ]
+    blocked = [
+        item for item in ranked if item.get("ranking_status") == "blocked_review_first_candidate"
+    ]
+
+    if patch_ready:
+        next_allowed_action = "review_patch_ready_candidate"
+        status = "patch_ready_candidate_available"
+    elif blocked:
+        next_allowed_action = str(
+            blocked[0].get("next_allowed_action") or "collect_human_review_evidence"
+        )
+        status = "blocked_review_first_candidate"
+    elif ranked:
+        next_allowed_action = "review_accepted_candidate_history"
+        status = "no_unaccepted_patch_ready_candidates"
+    else:
+        next_allowed_action = "none"
+        status = "no_candidates"
+
+    return {
+        "status": status,
+        "candidate_count": len(ranked),
+        "patch_ready_candidate_count": len(patch_ready),
+        "blocked_review_first_candidate_count": len(blocked),
+        "accepted_on_main_candidate_count": status_counts.get("accepted_on_main", 0),
+        "ranking_status_counts": dict(sorted(status_counts.items())),
+        "has_patch_ready_candidate": bool(patch_ready),
+        "next_allowed_action": next_allowed_action,
+        "review_first": True,
+        "safe_to_patch": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
 def _operator_summary(ranked: Sequence[dict[str, Any]]) -> dict[str, Any]:
     if not ranked:
         return {
@@ -786,6 +832,7 @@ def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
         "status_counts": dict(sorted(status_counts.items())),
         "surfaces": surfaces,
         "ranked_upgrade_candidates": ranked,
+        "actionability_summary": _actionability_summary(ranked),
         "operator_summary": _operator_summary(ranked),
         "rules": {
             "advisory_only": True,
@@ -813,6 +860,15 @@ def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
         "- advisory_only: true",
         "- repo_mutation: false",
         "- review_first: true",
+        "",
+        "## Actionability summary",
+        "",
+        f"- status: `{payload['actionability_summary']['status']}`",
+        f"- patch_ready_candidate_count: `{payload['actionability_summary']['patch_ready_candidate_count']}`",
+        f"- blocked_review_first_candidate_count: `{payload['actionability_summary']['blocked_review_first_candidate_count']}`",
+        f"- accepted_on_main_candidate_count: `{payload['actionability_summary']['accepted_on_main_candidate_count']}`",
+        f"- next_allowed_action: `{payload['actionability_summary']['next_allowed_action']}`",
+        "- safe_to_patch: false",
         "",
         "## Surfaces",
         "",

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -210,7 +210,35 @@ def test_product_maturity_radar_marks_review_first_unsafe_candidates_as_blocked(
     assert "automatic_permission_reduction" in workflow["blocked_actions"]
     assert "semantic_equivalence_claim" in workflow["blocked_actions"]
 
-    markdown = radar_module.render_product_maturity_radar_markdown(payload)
+    payload_actionability = payload["actionability_summary"]
+    assert payload_actionability["patch_ready_candidate_count"] == 0
+    assert payload_actionability["blocked_review_first_candidate_count"] >= 1
+    assert payload_actionability["has_patch_ready_candidate"] is False
+
+    actionability = radar_module._actionability_summary([workflow])
+    assert actionability["status"] == "blocked_review_first_candidate"
+    assert actionability["patch_ready_candidate_count"] == 0
+    assert actionability["blocked_review_first_candidate_count"] == 1
+    assert actionability["accepted_on_main_candidate_count"] == 0
+    assert actionability["has_patch_ready_candidate"] is False
+    assert actionability["next_allowed_action"] == "collect_human_review_evidence"
+    assert actionability["automation_allowed"] is False
+    assert actionability["patch_application_allowed"] is False
+    assert actionability["merge_authorized"] is False
+    assert actionability["semantic_equivalence_proven"] is False
+
+    single_candidate_payload = {
+        **payload,
+        "ranked_upgrade_candidates": [workflow],
+        "candidate_count": 1,
+        "actionability_summary": actionability,
+        "operator_summary": radar_module._operator_summary([workflow]),
+    }
+    markdown = radar_module.render_product_maturity_radar_markdown(single_candidate_payload)
+    assert "## Actionability summary" in markdown
+    assert "patch_ready_candidate_count: `0`" in markdown
+    assert "blocked_review_first_candidate_count: `1`" in markdown
+    assert "next_allowed_action: `collect_human_review_evidence`" in markdown
     assert "ranking_status: `blocked_review_first_candidate`" in markdown
     assert "blocked_by: `human_review_evidence_required`" in markdown
     assert "next_allowed_action: `collect_human_review_evidence`" in markdown


### PR DESCRIPTION
## Summary

- add a top-level product maturity radar actionability summary
- expose patch-ready, blocked review-first, and accepted-on-main candidate counts
- make roadmap selection explicitly report that there are zero patch-ready candidates and that the next allowed action is collect_human_review_evidence

## Proof

- python -m pytest -q tests/test_product_maturity_radar.py tests/test_workflow_governance_report.py -o addopts=
- python -m pre_commit run -a

## Boundary

- reporting-only radar/actionability change
- no workflow permissions changed
- no automatic permission reduction
- no remediation automation
- no security dismissal
- patch_application_allowed=false
- automation_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false