### PR TITLE
docs(ci): add deployment oidc workflow review card

### DIFF
--- a/docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md
+++ b/docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md
@@ -20,7 +20,7 @@ proposed_change=none
 human_reviewer=pending
 proof=python -m pytest -q tests/test_workflow_governance_report.py tests/test_product_maturity_radar.py tests/test_workflow_permission_review_cards.py -o addopts= && python -m pre_commit run -a
 rollback=single review-card revert
-decision=defer_until_human_reviewer_confirms_scope_usage
+decision=defer_pending_human_review
 ```
 
 ## Evidence observed

--- a/docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md
+++ b/docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md
@@ -1,0 +1,39 @@
+# Workflow permission review card: deployment_or_oidc / Pages
+
+This card records human-review evidence for the `deployment_or_oidc` workflow permission group.
+
+It is evidence-only. It does not approve a permission reduction, mutate workflow YAML, authorize automation, authorize merge, or claim semantic equivalence.
+
+## Review card
+
+```text
+workflow=.github/workflows/pages.yml
+current_write_scopes=["id-token: write", "pages: write"]
+review_group=deployment_or_oidc
+inferred_reasons=[
+  "The workflow grants pages: write and uses actions/deploy-pages.",
+  "The workflow grants id-token: write and deploys to the github-pages environment.",
+  "The workflow also uses actions/configure-pages and actions/upload-pages-artifact before deploy-pages.",
+  "Exact scope removal is not authorized from report output alone."
+]
+proposed_change=none
+human_reviewer=pending
+proof=python -m pytest -q tests/test_workflow_governance_report.py tests/test_product_maturity_radar.py tests/test_workflow_permission_review_cards.py -o addopts= && python -m pre_commit run -a
+rollback=single review-card revert
+decision=defer_until_human_reviewer_confirms_scope_usage
+```
+
+## Evidence observed
+
+- `.github/workflows/pages.yml` grants `contents: read`, `pages: write`, and `id-token: write`.
+- The build job uses pinned `actions/configure-pages`.
+- The build job uploads the built site with pinned `actions/upload-pages-artifact`.
+- The deploy job targets the `github-pages` environment.
+- The deploy job uses pinned `actions/deploy-pages`.
+- Existing generated evidence for `deployment_or_oidc` says `requires_human_review=true`, `safe_to_patch=false`, and `next_allowed_action=collect_human_review_evidence`.
+
+## Reviewer decision
+
+Pending.
+
+A future permission-only PR may only be considered after a human reviewer records a concrete decision for each write scope.

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CARD = REPO_ROOT / "docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md"
+
+
+def test_deployment_oidc_pages_review_card_is_evidence_only() -> None:
+    text = CARD.read_text(encoding="utf-8")
+
+    assert "workflow=.github/workflows/pages.yml" in text
+    assert 'current_write_scopes=["id-token: write", "pages: write"]' in text
+    assert "review_group=deployment_or_oidc" in text
+    assert "proposed_change=none" in text
+    assert "human_reviewer=pending" in text
+    assert "decision=defer_until_human_reviewer_confirms_scope_usage" in text
+
+    assert "It is evidence-only." in text
+    assert "does not approve a permission reduction" in text
+    assert "does not approve a permission reduction, mutate workflow YAML" in text
+    assert "safe_to_patch=false" in text
+    assert "next_allowed_action=collect_human_review_evidence" in text
+
+
+def test_deployment_oidc_pages_review_card_mentions_observed_pages_actions() -> None:
+    text = CARD.read_text(encoding="utf-8")
+
+    assert "actions/configure-pages" in text
+    assert "actions/upload-pages-artifact" in text
+    assert "actions/deploy-pages" in text
+    assert "github-pages" in text
+    assert "pages: write" in text
+    assert "id-token: write" in text

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CARD = REPO_ROOT / "docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md"
 
@@ -15,7 +14,7 @@ def test_deployment_oidc_pages_review_card_is_evidence_only() -> None:
     assert "review_group=deployment_or_oidc" in text
     assert "proposed_change=none" in text
     assert "human_reviewer=pending" in text
-    assert "decision=defer_until_human_reviewer_confirms_scope_usage" in text
+    assert "decision=defer_pending_human_review" in text
 
     assert "It is evidence-only." in text
     assert "does not approve a permission reduction" in text


### PR DESCRIPTION
## Summary

- add an evidence-only human-review card for the deployment_or_oidc workflow group
- document Pages workflow write scopes and observed Pages deployment actions
- keep proposed_change=none until a human reviewer confirms scope usage

## Proof

- python -m pytest -q tests/test_workflow_permission_review_cards.py tests/test_workflow_governance_report.py tests/test_product_maturity_radar.py -o addopts=
- python -m pre_commit run -a

## Boundary

- evidence-only documentation and contract test
- no workflow YAML changed
- no permission reduction
- no automatic permission reduction
- no security dismissal
- patch_application_allowed=false
- automation_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false