### PR TITLE
feat(pr-quality): render reviewer command center

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1682,28 +1682,52 @@ def _reviewer_dashboard_lines(
     required_startup = _required_count(_as_list(check_intelligence.get("startup_failures")))
     missing_required = len(_as_list(check_intelligence.get("missing_required_contexts")))
 
+    safe_surface = surface.replace("|", "\\|")
+    safe_title = title.replace("|", "\\|")
+    safe_signal = _string(evidence_signal_heading or "none").replace("|", "\\|")
+
     lines = [
-        f"- Merge assessment: `{merge_assessment}`",
-        f"- Next action: `{next_action}`",
-        f"- Risk surface: `{surface}`",
-        f"- Signal title: {title}",
-        f"- Comment signal: `{_string(evidence_signal_heading or 'none')}`",
-        f"- Review-first evidence: `{str(evidence_review_required).lower()}`",
-        f"- Failed checks: `{failed_count}`",
-        f"- Required queued checks: `{required_queued}`",
-        f"- Required startup failures: `{required_startup}`",
-        f"- Missing required contexts: `{missing_required}`",
-        "- Authority boundary: `reporting_only`",
-        "- Patch automation authority: `false`",
-        "- Security dismissal authority: `false`",
-        "- Merge authorization claimed: `false`",
+        "### Decision",
+        "",
+        "| Item | Value |",
+        "|---|---|",
+        f"| SDETKit status | `{status}` |",
+        f"| Merge assessment | `{merge_assessment}` |",
+        f"| Next reviewer action | `{next_action}` |",
+        f"| Changed risk surface | `{safe_surface}` |",
+        f"| Signal title | {safe_title} |",
+        f"| Comment signal | `{safe_signal}` |",
+        f"| Review-first evidence | `{str(evidence_review_required).lower()}` |",
+        f"| Failed checks | `{failed_count}` |",
+        f"| Required queued checks | `{required_queued}` |",
+        f"| Required startup failures | `{required_startup}` |",
+        f"| Missing required contexts | `{missing_required}` |",
+        "",
+        "### Proof to rerun",
+        "",
     ]
 
     if proof_commands:
-        lines.append("- Proof commands:")
-        lines.extend(f"  - `{command}`" for command in proof_commands[:5])
+        lines.append("```bash")
+        lines.extend(proof_commands[:5])
+        lines.append("```")
     else:
-        lines.append("- Proof commands: `none`")
+        lines.append("`none`")
+
+    lines.extend(
+        [
+            "",
+            "### Authority boundary",
+            "",
+            "| Authority | Value |",
+            "|---|---|",
+            "| Boundary mode | `reporting_only` |",
+            "| Patch automation | `false` |",
+            "| Security dismissal | `false` |",
+            "| Merge authorization | `false` |",
+            "| Semantic equivalence claim | `false` |",
+        ]
+    )
 
     return lines
 

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -806,7 +806,8 @@ def test_action_report_reconciles_cleared_security_review_signal() -> None:
     assert "Evidence review signal present; quality gate passed" not in body
     assert "human review required before merge" not in body
     assert "Fix the flagged surface or dismiss the false positive" not in body
-    assert "- Proof commands: `none`" in body
+    assert "### Proof to rerun" in body
+    assert "`none`" in body
 
 
 def test_action_report_comment_renders_failed_check_first_failure() -> None:
@@ -2991,14 +2992,19 @@ def test_pr_quality_comment_v3_renders_reviewer_dashboard_top_card() -> None:
 
     assert "## Reviewer dashboard" in body
     assert "## Reviewer dashboard" in body.split("## Quality summary", maxsplit=1)[0]
-    assert "- Merge assessment: `verify_listed_proof_before_routine_merge`" in body
-    assert "- Next action: `rerun_proof`" in body
-    assert "- Risk surface: `workflow`" in body
-    assert "- Signal title: Workflow evidence changed" in body
-    assert "- Review-first evidence: `false`" in body
-    assert "- Authority boundary: `reporting_only`" in body
-    assert "- Patch automation authority: `false`" in body
-    assert "- Security dismissal authority: `false`" in body
-    assert "- Merge authorization claimed: `false`" in body
-    assert "- Proof commands:" in body
-    assert "  - `python -m pre_commit run -a`" in body
+    assert "### Decision" in body
+    assert "| SDETKit status | `green` |" in body
+    assert "| Merge assessment | `verify_listed_proof_before_routine_merge` |" in body
+    assert "| Next reviewer action | `rerun_proof` |" in body
+    assert "| Changed risk surface | `workflow` |" in body
+    assert "| Signal title | Workflow evidence changed |" in body
+    assert "| Review-first evidence | `false` |" in body
+    assert "### Proof to rerun" in body
+    assert "```bash" in body
+    assert "python -m pre_commit run -a" in body
+    assert "### Authority boundary" in body
+    assert "| Boundary mode | `reporting_only` |" in body
+    assert "| Patch automation | `false` |" in body
+    assert "| Security dismissal | `false` |" in body
+    assert "| Merge authorization | `false` |" in body
+    assert "| Semantic equivalence claim | `false` |" in body


### PR DESCRIPTION
## Summary

- upgrade the PR Quality reviewer dashboard from a bullet list into a command-center layout
- render the decision, proof-to-rerun, and authority boundary as clear reviewer sections
- keep proof commands in a copy-ready bash block
- preserve reporting-only boundaries and existing collapsible evidence sections

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_operator_evidence_loop.py::test_operator_evidence_loop_builds_review_first_handoff tests/test_trajectory_store.py::test_pr_quality_comment_can_show_green_evidence_review_trajectory_summary tests/test_full_spine_real_blocker_integration.py::test_patch_plan_handoff_flows_through_full_evidence_spine -o addopts=
- python -m pre_commit run -a

## Boundary

- renderer/test only
- no workflow YAML changed
- no decision logic changed
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added