### PR TITLE
feat(pr-quality): write review model artifact

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2022,6 +2022,7 @@ def write_comment_body(
     action_report_path: Path,
     check_intelligence_path: Path,
     out: Path,
+    review_model_out: Path | None = None,
     evidence_narrative_path: Path | None = None,
     trajectory_jsonl_path: Path | None = None,
     runtime_proof_artifacts_path: Path | None = None,
@@ -2113,9 +2114,30 @@ def write_comment_body(
     else:
         evidence_signal_kind = "none"
 
+    review_model = build_pr_quality_review_model(
+        status=status,
+        evidence_signal_heading=_heading,
+        evidence_signal_lines=evidence_signal_lines,
+        evidence_review_required=evidence_review_required,
+        action_report=action_report,
+        check_intelligence=check_intelligence,
+        evidence_narrative=evidence_narrative,
+    )
+    review_model_written = False
+    if review_model_out is not None:
+        review_model_out.parent.mkdir(parents=True, exist_ok=True)
+        review_model_out.write_text(
+            json.dumps(review_model, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        review_model_written = True
+
     trajectory_summary = _trajectory_summary(trajectory_records)
     result: JsonObject = {
         "out": out.as_posix(),
+        "review_model_out": review_model_out.as_posix() if review_model_out is not None else "",
+        "review_model_written": review_model_written,
+        "review_model_schema_version": _string(review_model.get("schema_version")),
         "status": status,
         "result_title": _result_title(
             status,
@@ -2238,6 +2260,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--runtime-proof-artifacts", type=Path)
     parser.add_argument("--security-finding-diagnosis", type=Path)
     parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--review-model-out", type=Path)
     parser.add_argument("--failure-bundle-out-dir", type=Path)
     parser.add_argument("--pr-number", type=int, default=0)
     parser.add_argument("--head-sha", default="")
@@ -2255,6 +2278,7 @@ def main(argv: list[str] | None = None) -> int:
         runtime_proof_artifacts_path=args.runtime_proof_artifacts,
         security_finding_diagnosis_path=args.security_finding_diagnosis,
         out=args.out,
+        review_model_out=args.review_model_out,
         failure_bundle_out_dir=args.failure_bundle_out_dir,
         pr_number=args.pr_number,
         head_sha=args.head_sha,

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3091,3 +3091,96 @@ def test_pr_quality_review_model_is_structured_product_surface() -> None:
         "merge_authorization": False,
         "semantic_equivalence_claim": False,
     }
+
+
+def test_write_comment_body_writes_review_model_artifact(tmp_path: Path) -> None:
+    action_report_path = tmp_path / "action-report.json"
+    check_intelligence_path = tmp_path / "check-intelligence.json"
+    evidence_narrative_path = tmp_path / "evidence-narrative.json"
+    comment_out = tmp_path / "comment.md"
+    review_model_out = tmp_path / "review-model.json"
+
+    action_report = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    check_intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "diagnostic_engine",
+            "title": "Diagnostic intelligence evidence changed",
+        },
+        "graph": {
+            "node_count": 1,
+            "review_first_count": 0,
+            "critical_count": 0,
+            "top_blocker": {
+                "title": "Diagnostic intelligence evidence changed",
+                "surface": "diagnostic_engine",
+                "action": "rerun_proof",
+                "review_first": False,
+            },
+        },
+        "next_proof": [
+            "python -m pytest -q tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py -o addopts=",
+            "python -m pre_commit run -a",
+        ],
+    }
+
+    action_report_path.write_text(
+        json.dumps(action_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    check_intelligence_path.write_text(
+        json.dumps(check_intelligence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    evidence_narrative_path.write_text(
+        json.dumps(evidence_narrative, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = report.write_comment_body(
+        action_report_path=action_report_path,
+        check_intelligence_path=check_intelligence_path,
+        evidence_narrative_path=evidence_narrative_path,
+        out=comment_out,
+        review_model_out=review_model_out,
+    )
+
+    assert result["review_model_written"] is True
+    assert result["review_model_out"] == review_model_out.as_posix()
+    assert result["review_model_schema_version"] == "sdetkit.pr_quality.review_model.v1"
+
+    model = json.loads(review_model_out.read_text(encoding="utf-8"))
+    assert model["schema_version"] == "sdetkit.pr_quality.review_model.v1"
+    assert model["decision"]["merge_assessment"] == "verify_listed_proof_before_routine_merge"
+    assert model["decision"]["next_action"] == "rerun_proof"
+    assert model["decision"]["risk_surface"] == "diagnostic_engine"
+    assert model["proof_to_rerun"] == [
+        "python -m pytest -q tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py -o addopts=",
+        "python -m pre_commit run -a",
+    ]
+    assert model["authority_boundary"] == {
+        "boundary_mode": "reporting_only",
+        "merge_authorization": False,
+        "patch_automation": False,
+        "security_dismissal": False,
+        "semantic_equivalence_claim": False,
+    }
+
+    body = comment_out.read_text(encoding="utf-8")
+    assert "## Reviewer dashboard" in body
+    assert "### Proof to rerun" in body


### PR DESCRIPTION
## Summary

- add optional PR Quality review-model JSON artifact output beside the Markdown comment
- expose review model metadata in write_comment_body results
- add CLI support for --review-model-out
- cover the artifact contract with renderer and CLI smoke tests

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_operator_evidence_loop.py::test_operator_evidence_loop_builds_review_first_handoff tests/test_trajectory_store.py::test_pr_quality_comment_can_show_green_evidence_review_trajectory_summary tests/test_full_spine_real_blocker_integration.py::test_patch_plan_handoff_flows_through_full_evidence_spine -o addopts=
- python -m sdetkit.pr_quality_action_report --action-report <fixture> --check-intelligence <fixture> --evidence-narrative <fixture> --out <comment.md> --review-model-out <review-model.json>
- python -m pre_commit run -a

## Boundary

- reporting artifact only
- no workflow YAML changed
- no decision logic changed
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added