### PR TITLE
feat(pr-quality): write review summary artifact

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1794,6 +1794,61 @@ def _reviewer_dashboard_lines(
     return lines
 
 
+def render_pr_quality_review_summary(model: JsonObject) -> str:
+    decision = _as_dict(model.get("decision"))
+    authority = _as_dict(model.get("authority_boundary"))
+    proof_commands = [
+        str(command)
+        for command in _as_list(model.get("proof_to_rerun"))
+        if isinstance(command, str) and command.strip()
+    ]
+
+    lines = [
+        "# PR Quality Review Summary",
+        "",
+        "## Decision",
+        "",
+        "| Item | Value |",
+        "|---|---|",
+        f"| Status | `{_review_model_scalar(decision.get('status'))}` |",
+        f"| Merge assessment | `{_review_model_scalar(decision.get('merge_assessment'))}` |",
+        f"| Next action | `{_review_model_scalar(decision.get('next_action'))}` |",
+        f"| Risk surface | `{_markdown_table_value(decision.get('risk_surface'))}` |",
+        f"| Signal | `{_markdown_table_value(decision.get('comment_signal'))}` |",
+        f"| Review-first evidence | `{_review_model_scalar(decision.get('review_first_evidence'))}` |",
+        f"| Failed checks | `{_review_model_scalar(decision.get('failed_checks'))}` |",
+        "",
+        "## Proof to rerun",
+        "",
+    ]
+
+    if proof_commands:
+        lines.append("```bash")
+        lines.extend(proof_commands)
+        lines.append("```")
+    else:
+        lines.append("`none`")
+
+    lines.extend(
+        [
+            "",
+            "## Authority boundary",
+            "",
+            "| Authority | Value |",
+            "|---|---|",
+            f"| Boundary mode | `{_review_model_scalar(authority.get('boundary_mode'))}` |",
+            f"| Patch automation | `{_review_model_scalar(authority.get('patch_automation'))}` |",
+            f"| Security dismissal | `{_review_model_scalar(authority.get('security_dismissal'))}` |",
+            f"| Merge authorization | `{_review_model_scalar(authority.get('merge_authorization'))}` |",
+            f"| Semantic equivalence claim | `{_review_model_scalar(authority.get('semantic_equivalence_claim'))}` |",
+            "",
+            "> This summary is generated from the structured PR Quality review model. It is reporting-only and does not authorize merge, patch automation, security dismissal, or semantic-equivalence claims.",
+        ]
+    )
+
+    return "\n".join(lines) + "\n"
+
+
 def render_comment_body(
     *,
     action_report: JsonObject,
@@ -2023,6 +2078,7 @@ def write_comment_body(
     check_intelligence_path: Path,
     out: Path,
     review_model_out: Path | None = None,
+    review_summary_out: Path | None = None,
     evidence_narrative_path: Path | None = None,
     trajectory_jsonl_path: Path | None = None,
     runtime_proof_artifacts_path: Path | None = None,
@@ -2132,12 +2188,25 @@ def write_comment_body(
         )
         review_model_written = True
 
+    review_summary_written = False
+    if review_summary_out is not None:
+        review_summary_out.parent.mkdir(parents=True, exist_ok=True)
+        review_summary_out.write_text(
+            render_pr_quality_review_summary(review_model),
+            encoding="utf-8",
+        )
+        review_summary_written = True
+
     trajectory_summary = _trajectory_summary(trajectory_records)
     result: JsonObject = {
         "out": out.as_posix(),
         "review_model_out": review_model_out.as_posix() if review_model_out is not None else "",
         "review_model_written": review_model_written,
         "review_model_schema_version": _string(review_model.get("schema_version")),
+        "review_summary_out": review_summary_out.as_posix()
+        if review_summary_out is not None
+        else "",
+        "review_summary_written": review_summary_written,
         "status": status,
         "result_title": _result_title(
             status,
@@ -2261,6 +2330,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--security-finding-diagnosis", type=Path)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--review-model-out", type=Path)
+    parser.add_argument("--review-summary-out", type=Path)
     parser.add_argument("--failure-bundle-out-dir", type=Path)
     parser.add_argument("--pr-number", type=int, default=0)
     parser.add_argument("--head-sha", default="")
@@ -2279,6 +2349,7 @@ def main(argv: list[str] | None = None) -> int:
         security_finding_diagnosis_path=args.security_finding_diagnosis,
         out=args.out,
         review_model_out=args.review_model_out,
+        review_summary_out=args.review_summary_out,
         failure_bundle_out_dir=args.failure_bundle_out_dir,
         pr_number=args.pr_number,
         head_sha=args.head_sha,

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3184,3 +3184,88 @@ def test_write_comment_body_writes_review_model_artifact(tmp_path: Path) -> None
     body = comment_out.read_text(encoding="utf-8")
     assert "## Reviewer dashboard" in body
     assert "### Proof to rerun" in body
+
+
+def test_write_comment_body_writes_review_summary_artifact(tmp_path: Path) -> None:
+    action_report_path = tmp_path / "action-report.json"
+    check_intelligence_path = tmp_path / "check-intelligence.json"
+    evidence_narrative_path = tmp_path / "evidence-narrative.json"
+    comment_out = tmp_path / "comment.md"
+    review_model_out = tmp_path / "review-model.json"
+    review_summary_out = tmp_path / "review-summary.md"
+
+    action_report = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    check_intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "diagnostic_engine",
+            "title": "Diagnostic intelligence evidence changed",
+        },
+        "graph": {
+            "node_count": 1,
+            "review_first_count": 0,
+            "critical_count": 0,
+            "top_blocker": {
+                "title": "Diagnostic intelligence evidence changed",
+                "surface": "diagnostic_engine",
+                "action": "rerun_proof",
+                "review_first": False,
+            },
+        },
+        "next_proof": [
+            "python -m pytest -q tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py -o addopts=",
+            "python -m pre_commit run -a",
+        ],
+    }
+
+    action_report_path.write_text(
+        json.dumps(action_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    check_intelligence_path.write_text(
+        json.dumps(check_intelligence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    evidence_narrative_path.write_text(
+        json.dumps(evidence_narrative, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = report.write_comment_body(
+        action_report_path=action_report_path,
+        check_intelligence_path=check_intelligence_path,
+        evidence_narrative_path=evidence_narrative_path,
+        out=comment_out,
+        review_model_out=review_model_out,
+        review_summary_out=review_summary_out,
+    )
+
+    assert result["review_model_written"] is True
+    assert result["review_summary_written"] is True
+    assert result["review_summary_out"] == review_summary_out.as_posix()
+
+    summary = review_summary_out.read_text(encoding="utf-8")
+    assert "# PR Quality Review Summary" in summary
+    assert "| Merge assessment | `verify_listed_proof_before_routine_merge` |" in summary
+    assert "| Next action | `rerun_proof` |" in summary
+    assert "| Risk surface | `diagnostic_engine` |" in summary
+    assert "```bash" in summary
+    assert "python -m pre_commit run -a" in summary
+    assert "| Boundary mode | `reporting_only` |" in summary
+    assert "| Merge authorization | `false` |" in summary
+    assert "does not authorize merge" in summary


### PR DESCRIPTION
## Summary

- add optional PR Quality review-summary Markdown artifact output beside the comment and JSON model
- render the human summary from the structured review model
- expose review summary metadata in write_comment_body results
- add CLI support for --review-summary-out
- cover the summary artifact with renderer and CLI smoke tests

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_operator_evidence_loop.py::test_operator_evidence_loop_builds_review_first_handoff tests/test_trajectory_store.py::test_pr_quality_comment_can_show_green_evidence_review_trajectory_summary tests/test_full_spine_real_blocker_integration.py::test_patch_plan_handoff_flows_through_full_evidence_spine -o addopts=
- python -m sdetkit.pr_quality_action_report --action-report <fixture> --check-intelligence <fixture> --evidence-narrative <fixture> --out <comment.md> --review-model-out <review-model.json> --review-summary-out <review-summary.md>
- python -m pre_commit run -a

## Boundary

- reporting artifact only
- no workflow YAML changed
- no decision logic changed
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added