### PR TITLE
feat(pr-quality): publish compact review comment

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1117,8 +1117,30 @@ jobs:
 
           mkdir -p "$publish_dir"
 
-          printf '### SDET Quality Gate\n' > "$body_path"
-          cat build/pr-quality/pr-comment-body.md >> "$body_path"
+          printf '### SDET Quality Gate\n\n' > "$body_path"
+
+          if [ -s build/pr-quality/pr-review-summary.md ]; then
+            cat build/pr-quality/pr-review-summary.md >> "$body_path"
+          else
+            cat build/pr-quality/pr-comment-body.md >> "$body_path"
+          fi
+
+          cat >> "$body_path" <<'MARKDOWN'
+
+          ---
+
+          <details>
+          <summary><strong>PR Quality product artifacts</strong></summary>
+
+          - `pr-review-summary.md`: concise human review panel.
+          - `pr-review-model.json`: machine-readable review model.
+          - `pr-review-dashboard.html`: browser-ready review dashboard.
+          - `pr-comment-body.md`: full raw evidence body retained in the artifact bundle.
+          - `pr-quality-comment`: uploaded artifact bundle for full diagnostic evidence.
+
+          </details>
+
+          MARKDOWN
 
           BODY_PATH="$body_path" REQUEST_PATH="$request_path" python - <<'PYCODE'
           import json

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1095,3 +1095,25 @@ def test_pr_quality_prefers_final_trusted_diagnostic_snapshot_history_output_fil
     assert text.count("diagnostic-signal-snapshots/output/") >= 4
     assert text.count("-name diagnostic-signal-snapshot-history-summary.json") >= 2
     assert text.count("-name diagnostic-signal-snapshot-history.jsonl") >= 2
+
+
+def test_pr_quality_published_comment_prefers_compact_review_summary() -> None:
+    text = _workflow_text()
+    start = text.index('publish_dir="build/pr-quality/comment-publish"')
+    end = text.index('BODY_PATH="$body_path" REQUEST_PATH="$request_path"', start)
+    publisher = text[start:end]
+
+    assert 'cat build/pr-quality/pr-review-summary.md >> "$body_path"' in publisher
+    assert 'cat build/pr-quality/pr-comment-body.md >> "$body_path"' in publisher
+    assert publisher.index("cat build/pr-quality/pr-review-summary.md") < publisher.index(
+        "cat build/pr-quality/pr-comment-body.md"
+    )
+    assert "PR Quality product artifacts" in publisher
+    assert "`pr-review-model.json`: machine-readable review model." in publisher
+    assert "`pr-review-dashboard.html`: browser-ready review dashboard." in publisher
+    assert (
+        "`pr-comment-body.md`: full raw evidence body retained in the artifact bundle." in publisher
+    )
+    assert (
+        "`pr-quality-comment`: uploaded artifact bundle for full diagnostic evidence." in publisher
+    )


### PR DESCRIPTION
## Summary

- publish the concise PR Quality review summary as the primary PR comment body
- list the product artifact bundle from the PR comment
- keep full raw evidence in uploaded artifacts, with fallback to the raw body if the summary is unavailable
- cover compact published-comment behavior with workflow observability tests

## Proof

- python -m pytest -q tests/test_pr_quality_comment_observability_workflow.py -o addopts=
- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py -o addopts=
- python -m pre_commit run -a

## Boundary

- published-comment UX only
- no gate decision logic changed
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added