### PR TITLE
feat(pr-quality): add review model schema v2 metadata

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1612,6 +1612,65 @@ def _markdown_table_value(value: object) -> str:
     return _review_model_scalar(value).replace("|", "\\|")
 
 
+def _review_model_artifact_index() -> list[JsonObject]:
+    return [
+        {
+            "path": "index.html",
+            "kind": "html",
+            "surface": "artifact_center",
+            "title": "Artifact landing page",
+            "description": "Browser-ready entry point for the PR Quality artifact bundle.",
+            "primary": True,
+            "format": "html",
+        },
+        {
+            "path": "pr-review-dashboard.html",
+            "kind": "html",
+            "surface": "review_dashboard",
+            "title": "Visual dashboard",
+            "description": "Browser-ready visual dashboard with state, blocker, proof, and artifact cards.",
+            "primary": False,
+            "format": "html",
+        },
+        {
+            "path": "pr-review-summary.md",
+            "kind": "markdown",
+            "surface": "review_summary",
+            "title": "Compact summary",
+            "description": "Concise human review panel used by the PR comment and step summary.",
+            "primary": False,
+            "format": "markdown",
+        },
+        {
+            "path": "pr-review-model.json",
+            "kind": "json",
+            "surface": "review_model",
+            "title": "Review model",
+            "description": "Machine-readable source-of-truth model for all rendered review surfaces.",
+            "primary": False,
+            "format": "json",
+        },
+        {
+            "path": "pr-comment-body.md",
+            "kind": "markdown",
+            "surface": "raw_evidence",
+            "title": "Raw evidence body",
+            "description": "Full diagnostic evidence retained for audit and debugging.",
+            "primary": False,
+            "format": "markdown",
+        },
+        {
+            "path": "pr-quality-comment",
+            "kind": "github_artifact",
+            "surface": "artifact_bundle",
+            "title": "Uploaded artifact bundle",
+            "description": "GitHub Actions artifact bundle containing full diagnostic evidence.",
+            "primary": False,
+            "format": "github_artifact",
+        },
+    ]
+
+
 def build_pr_quality_review_model(
     *,
     status: str,
@@ -1717,7 +1776,17 @@ def build_pr_quality_review_model(
     ]
 
     return {
-        "schema_version": "sdetkit.pr_quality.review_model.v1",
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "schema": {
+            "name": "sdetkit.pr_quality.review_model",
+            "version": 2,
+            "previous_version": "sdetkit.pr_quality.review_model.v1",
+            "compatibility": "additive",
+            "decision_logic": "unchanged",
+            "authority_boundary": "reporting_only",
+        },
+        "generated_by": "sdetkit.pr_quality_action_report",
+        "artifact_index": _review_model_artifact_index(),
         "primary_blocker": {
             "title": _string(primary_blocker.get("title") or title),
             "surface": _string(primary_blocker.get("surface") or surface),
@@ -2004,27 +2073,22 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
     else:
         status_class = "status-failed"
 
+    artifact_index = [
+        item
+        for item in (_as_dict(candidate) for candidate in _as_list(model.get("artifact_index")))
+        if _string(item.get("path"))
+    ]
+    if not artifact_index:
+        artifact_index = _review_model_artifact_index()
+
     artifact_rows = [
         (
-            "pr-review-dashboard.html",
-            "Open visual dashboard",
-            "Browser-ready visual dashboard with state, blocker, proof, and artifact cards.",
-        ),
-        (
-            "pr-review-summary.md",
-            "Open compact summary",
-            "Concise Markdown review summary used by the PR comment and step summary.",
-        ),
-        (
-            "pr-review-model.json",
-            "Open review model",
-            "Machine-readable source-of-truth model for all rendered review surfaces.",
-        ),
-        (
-            "pr-comment-body.md",
-            "Open raw evidence",
-            "Full diagnostic evidence retained for audit and debugging.",
-        ),
+            _string(item.get("path")),
+            "Open " + _string(item.get("title") or item.get("path")),
+            _string(item.get("description") or item.get("surface") or "PR Quality artifact."),
+        )
+        for item in artifact_index
+        if _string(item.get("path")) != "pr-quality-comment"
     ]
 
     def artifact_cards(rows: list[tuple[str, str, str]]) -> str:
@@ -2243,13 +2307,21 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
         ("Review-first", review_first),
     ]
     artifact_rows = [
-        ("index.html", "Artifact landing page for the full PR Quality product bundle"),
-        ("pr-review-summary.md", "Concise human review panel"),
-        ("pr-review-model.json", "Machine-readable review model"),
-        ("pr-review-dashboard.html", "Browser-ready review dashboard"),
-        ("pr-comment-body.md", "Full raw evidence body retained in the artifact bundle"),
-        ("pr-quality-comment", "Uploaded artifact bundle for full diagnostic evidence"),
+        (
+            _string(item.get("path")),
+            _string(item.get("description") or item.get("title") or "PR Quality artifact"),
+        )
+        for item in (_as_dict(candidate) for candidate in _as_list(model.get("artifact_index")))
+        if _string(item.get("path"))
     ]
+    if not artifact_rows:
+        artifact_rows = [
+            (
+                _string(item.get("path")),
+                _string(item.get("description") or item.get("title") or "PR Quality artifact"),
+            )
+            for item in _review_model_artifact_index()
+        ]
 
     def table(rows: list[tuple[str, object]]) -> str:
         body = "\n".join(

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3065,7 +3065,7 @@ def test_pr_quality_review_model_is_structured_product_surface() -> None:
         evidence_narrative=evidence_narrative,
     )
 
-    assert model["schema_version"] == "sdetkit.pr_quality.review_model.v1"
+    assert model["schema_version"] == "sdetkit.pr_quality.review_model.v2"
     assert model["decision"] == {
         "status": "green",
         "merge_assessment": "verify_listed_proof_before_routine_merge",
@@ -3162,10 +3162,10 @@ def test_write_comment_body_writes_review_model_artifact(tmp_path: Path) -> None
 
     assert result["review_model_written"] is True
     assert result["review_model_out"] == review_model_out.as_posix()
-    assert result["review_model_schema_version"] == "sdetkit.pr_quality.review_model.v1"
+    assert result["review_model_schema_version"] == "sdetkit.pr_quality.review_model.v2"
 
     model = json.loads(review_model_out.read_text(encoding="utf-8"))
-    assert model["schema_version"] == "sdetkit.pr_quality.review_model.v1"
+    assert model["schema_version"] == "sdetkit.pr_quality.review_model.v2"
     assert model["decision"]["merge_assessment"] == "verify_listed_proof_before_routine_merge"
     assert model["decision"]["next_action"] == "rerun_proof"
     assert model["decision"]["risk_surface"] == "diagnostic_engine"
@@ -3589,3 +3589,65 @@ def test_write_comment_body_writes_artifact_landing_page(tmp_path: Path) -> None
     assert 'href="pr-comment-body.md"' in index_html
     assert "Reporting-only" in index_html
     assert "does not authorize merge" in index_html
+
+
+def test_review_model_schema_v2_includes_artifact_index_metadata() -> None:
+    model = report.build_pr_quality_review_model(
+        status="green",
+        evidence_signal_heading="Evidence proof signal",
+        evidence_signal_lines=[],
+        evidence_review_required=False,
+        action_report={
+            "status": "green",
+            "primary_blocker": {},
+            "recommended_actions": [],
+            "proof_commands": ["python -m pytest -q"],
+        },
+        check_intelligence={
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+        evidence_narrative={
+            "primary_signal": {"kind": "none", "surface": "none", "title": "none"},
+            "graph": {"top_blocker": {}},
+            "next_proof": ["python -m pytest -q"],
+        },
+    )
+
+    assert model["schema_version"] == "sdetkit.pr_quality.review_model.v2"
+    assert model["schema"] == {
+        "name": "sdetkit.pr_quality.review_model",
+        "version": 2,
+        "previous_version": "sdetkit.pr_quality.review_model.v1",
+        "compatibility": "additive",
+        "decision_logic": "unchanged",
+        "authority_boundary": "reporting_only",
+    }
+    assert model["generated_by"] == "sdetkit.pr_quality_action_report"
+
+    artifact_index = model["artifact_index"]
+    paths = [artifact["path"] for artifact in artifact_index]
+
+    assert paths == [
+        "index.html",
+        "pr-review-dashboard.html",
+        "pr-review-summary.md",
+        "pr-review-model.json",
+        "pr-comment-body.md",
+        "pr-quality-comment",
+    ]
+    assert artifact_index[0]["primary"] is True
+    assert artifact_index[0]["surface"] == "artifact_center"
+    assert artifact_index[3]["kind"] == "json"
+    assert artifact_index[5]["format"] == "github_artifact"
+
+    index_html = report.render_pr_quality_artifact_index_html(model)
+    dashboard_html = report.render_pr_quality_review_html(model)
+
+    assert 'href="index.html"' in index_html
+    assert 'href="pr-review-dashboard.html"' in index_html
+    assert "Browser-ready entry point for the PR Quality artifact bundle." in index_html
+    assert "index.html" in dashboard_html
+    assert "artifact_center" not in dashboard_html


### PR DESCRIPTION
## Summary

- upgrade the PR Quality review model schema marker to v2
- add explicit additive schema metadata and reporting-only authority metadata
- add machine-readable artifact index metadata for dashboard, summary, model, raw evidence, and artifact bundle
- render artifact surfaces from the shared model artifact index metadata

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py -o addopts=
- python -m sdetkit.pr_quality_action_report --action-report <fixture> --check-intelligence <fixture> --evidence-narrative <fixture> --out <pr-comment-body.md> --review-model-out <pr-review-model.json> --review-summary-out <pr-review-summary.md> --review-html-out <pr-review-dashboard.html> --review-index-out <index.html>
- python -m pre_commit run -a

## Boundary

- schema/reporting metadata only
- no gate decision logic changed
- no workflow authority changed
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added