### PR TITLE
test(pr-quality): cover dashboard state matrix

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1906,6 +1906,44 @@ def _reviewer_dashboard_lines(
     return lines
 
 
+def _review_model_state(model: JsonObject) -> str:
+    decision = _as_dict(model.get("decision"))
+    status = _review_model_scalar(decision.get("status") or "unknown")
+    failed_total = _int(decision.get("failed_checks"))
+    queued_total = _int(decision.get("required_queued_checks"))
+    startup_total = _int(decision.get("required_startup_failures"))
+    missing_total = _int(decision.get("missing_required_contexts"))
+    review_first = bool(decision.get("review_first_evidence"))
+
+    needs_attention = (
+        status != "green"
+        or failed_total > 0
+        or queued_total > 0
+        or startup_total > 0
+        or missing_total > 0
+        or review_first
+    )
+    is_blocked = status != "green" or failed_total > 0 or startup_total > 0 or missing_total > 0
+
+    if is_blocked:
+        return "needs_attention"
+    if needs_attention:
+        return "review_required"
+    return "green"
+
+
+def _review_model_state_class(review_state: str) -> str:
+    if review_state == "green":
+        return "status-green"
+    if review_state == "review_required":
+        return "status-review"
+    return "status-failed"
+
+
+def _review_model_state_label(review_state: str) -> str:
+    return review_state.replace("_", " ")
+
+
 def render_pr_quality_review_summary(model: JsonObject) -> str:
     decision = _as_dict(model.get("decision"))
     authority = _as_dict(model.get("authority_boundary"))
@@ -2061,17 +2099,12 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
     decision = _as_dict(model.get("decision"))
     authority = _as_dict(model.get("authority_boundary"))
 
-    status = _review_model_scalar(decision.get("status") or "unknown")
+    review_state = _review_model_state(model)
+    status_label = _review_model_state_label(review_state)
+    status_class = _review_model_state_class(review_state)
     merge_assessment = _review_model_scalar(decision.get("merge_assessment") or "unknown")
     next_action = _review_model_scalar(decision.get("next_action") or "unknown")
     risk_surface = _review_model_scalar(decision.get("risk_surface") or "unknown")
-
-    if status == "green":
-        status_class = "status-green"
-    elif status in {"review", "review_required"}:
-        status_class = "status-review"
-    else:
-        status_class = "status-failed"
 
     artifact_index = [
         item
@@ -2154,7 +2187,7 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         '    <section class="hero">\n'
         '      <div class="eyebrow">SDET Quality Gate</div>\n'
         "      <h1>PR Quality Artifact Center</h1>\n"
-        f'      <span class="status-badge {status_class}">{_html_escape(status)}</span>\n'
+        f'      <span class="status-badge {status_class}">{_html_escape(status_label)}</span>\n'
         '      <div class="summary-grid">\n'
         f'        <article class="summary-card"><span>Merge assessment</span><strong>{_html_escape(merge_assessment)}</strong></article>\n'
         f'        <article class="summary-card"><span>Next action</span><strong>{_html_escape(next_action)}</strong></article>\n'

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3651,3 +3651,112 @@ def test_review_model_schema_v2_includes_artifact_index_metadata() -> None:
     assert "Browser-ready entry point for the PR Quality artifact bundle." in index_html
     assert "index.html" in dashboard_html
     assert "artifact_center" not in dashboard_html
+
+
+def _build_review_state_matrix_model(
+    *,
+    status: str,
+    evidence_review_required: bool,
+    failed_check: bool = False,
+) -> dict[str, object]:
+    primary_blocker = (
+        {
+            "title": "Ruff check failed",
+            "surface": "workflow",
+            "action": "fix_lint",
+            "code": "ruff",
+            "path": "src/example.py",
+            "details": "unused import",
+        }
+        if status != "green" or failed_check
+        else {}
+    )
+
+    return report.build_pr_quality_review_model(
+        status=status,
+        evidence_signal_heading="Evidence review signal"
+        if evidence_review_required
+        else "Evidence proof signal",
+        evidence_signal_lines=[],
+        evidence_review_required=evidence_review_required,
+        action_report={
+            "status": status,
+            "primary_blocker": primary_blocker,
+            "recommended_actions": ["Fix the lint finding."] if primary_blocker else [],
+            "proof_commands": [
+                "python -m pytest -q tests/test_pr_quality_action_report.py -o addopts="
+            ],
+        },
+        check_intelligence={
+            "failed_checks": [{"name": "quality"}] if failed_check else [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+        evidence_narrative={
+            "primary_signal": {
+                "kind": "review_signal" if evidence_review_required else "none",
+                "surface": "workflow" if evidence_review_required else "none",
+                "title": "Workflow review evidence changed" if evidence_review_required else "none",
+            },
+            "graph": {"top_blocker": primary_blocker},
+            "next_proof": [
+                "python -m pytest -q tests/test_pr_quality_action_report.py -o addopts="
+            ],
+        },
+    )
+
+
+def test_review_surfaces_cover_green_review_required_and_needs_attention_states() -> None:
+    cases = [
+        {
+            "name": "green",
+            "model": _build_review_state_matrix_model(
+                status="green",
+                evidence_review_required=False,
+            ),
+            "review_state": "green",
+            "class_name": "status-green",
+            "label": "green",
+            "caption": "No PR Quality blocker is currently reported.",
+        },
+        {
+            "name": "review_required",
+            "model": _build_review_state_matrix_model(
+                status="green",
+                evidence_review_required=True,
+            ),
+            "review_state": "review_required",
+            "class_name": "status-review",
+            "label": "review required",
+            "caption": "Review-first evidence is present.",
+        },
+        {
+            "name": "needs_attention",
+            "model": _build_review_state_matrix_model(
+                status="failed",
+                evidence_review_required=False,
+                failed_check=True,
+            ),
+            "review_state": "needs_attention",
+            "class_name": "status-failed",
+            "label": "needs attention",
+            "caption": "Failure signals are present.",
+        },
+    ]
+
+    for case in cases:
+        model = case["model"]
+        summary = report.render_pr_quality_review_summary(model)
+        dashboard_html = report.render_pr_quality_review_html(model)
+        artifact_index_html = report.render_pr_quality_artifact_index_html(model)
+
+        assert f"| Review state | `{case['review_state']}` |" in summary, case["name"]
+        assert f'class="hero {case["class_name"]}"' in dashboard_html, case["name"]
+        assert f'class="status-badge {case["class_name"]}"' in dashboard_html, case["name"]
+        assert f'class="status-badge {case["class_name"]}"' in artifact_index_html, case["name"]
+        assert case["label"] in dashboard_html, case["name"]
+        assert case["label"] in artifact_index_html, case["name"]
+        assert case["caption"] in dashboard_html, case["name"]
+        assert "Reporting-only" in artifact_index_html, case["name"]
+        assert "does not authorize merge" in artifact_index_html, case["name"]


### PR DESCRIPTION
## Summary

- add a shared review-state helper for rendered artifact surfaces
- make the artifact center use the same green/review-required/needs-attention state classification as the dashboard summary
- add regression coverage for green, review-required, and needs-attention states across summary, dashboard, and artifact center

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py -o addopts=
- direct state-matrix smoke for green/review-required/needs-attention rendered surfaces
- python -m pre_commit run -a

## Boundary

- state-label/reporting UX only
- no gate decision logic changed
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added