### PR TITLE
feat(pr-quality): add artifact bundle manifest

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -668,6 +668,7 @@ jobs:
             --review-summary-out build/pr-quality/pr-review-summary.md \
             --review-html-out build/pr-quality/pr-review-dashboard.html \
             --review-index-out build/pr-quality/index.html \
+            --review-artifacts-manifest-out build/pr-quality/pr-review-artifacts-manifest.json \
             > build/pr-quality/pr-comment-metadata.json
 
           if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -s build/pr-quality/pr-review-summary.md ]; then
@@ -1073,6 +1074,7 @@ jobs:
           name: pr-quality-comment
           path: |
             build/pr-quality/index.html
+            build/pr-quality/pr-review-artifacts-manifest.json
             build/pr-quality/pr-comment-body.md
             build/pr-quality/pr-comment-metadata.json
             build/pr-quality/pr-review-model.json
@@ -1135,6 +1137,7 @@ jobs:
           <summary><strong>PR Quality product artifacts</strong></summary>
 
           - `index.html`: artifact landing page.
+          - `pr-review-artifacts-manifest.json`: machine-readable artifact bundle manifest.
           - `pr-review-summary.md`: concise human review panel.
           - `pr-review-model.json`: machine-readable review model.
           - `pr-review-dashboard.html`: browser-ready review dashboard.

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1624,6 +1624,15 @@ def _review_model_artifact_index() -> list[JsonObject]:
             "format": "html",
         },
         {
+            "path": "pr-review-artifacts-manifest.json",
+            "kind": "json",
+            "surface": "artifact_manifest",
+            "title": "Artifact manifest",
+            "description": "Machine-readable manifest for expected PR Quality artifact bundle entries.",
+            "primary": False,
+            "format": "json",
+        },
+        {
             "path": "pr-review-dashboard.html",
             "kind": "html",
             "surface": "review_dashboard",
@@ -2093,6 +2102,53 @@ def _html_escape(value: object) -> str:
         .replace(">", "&gt;")
         .replace('"', "&quot;")
     )
+
+
+def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
+    artifacts = [
+        item
+        for item in (_as_dict(candidate) for candidate in _as_list(model.get("artifact_index")))
+        if _string(item.get("path"))
+    ]
+    if not artifacts:
+        artifacts = _review_model_artifact_index()
+
+    expected_paths = [_string(item.get("path")) for item in artifacts if _string(item.get("path"))]
+    primary_entrypoint = next(
+        (
+            _string(item.get("path"))
+            for item in artifacts
+            if bool(item.get("primary")) and _string(item.get("path"))
+        ),
+        expected_paths[0] if expected_paths else "index.html",
+    )
+
+    decision = _as_dict(model.get("decision"))
+    authority = _as_dict(model.get("authority_boundary"))
+
+    return {
+        "schema_version": "sdetkit.pr_quality.artifacts_manifest.v1",
+        "review_model_schema_version": _string(model.get("schema_version")),
+        "review_model_schema": _as_dict(model.get("schema")),
+        "generated_by": "sdetkit.pr_quality_action_report",
+        "primary_entrypoint": primary_entrypoint,
+        "expected_artifact_paths": expected_paths,
+        "artifacts": artifacts,
+        "reporting_only": True,
+        "authority_boundary": {
+            "boundary_mode": _string(authority.get("boundary_mode") or "reporting_only"),
+            "patch_automation": bool(authority.get("patch_automation", False)),
+            "security_dismissal": bool(authority.get("security_dismissal", False)),
+            "merge_authorization": bool(authority.get("merge_authorization", False)),
+            "semantic_equivalence_claim": bool(authority.get("semantic_equivalence_claim", False)),
+        },
+        "decision": {
+            "status": _review_model_scalar(decision.get("status") or "unknown"),
+            "review_state": _review_model_state(model),
+            "merge_assessment": _review_model_scalar(decision.get("merge_assessment") or "unknown"),
+            "next_action": _review_model_scalar(decision.get("next_action") or "unknown"),
+        },
+    }
 
 
 def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
@@ -2770,6 +2826,7 @@ def write_comment_body(
     review_summary_out: Path | None = None,
     review_html_out: Path | None = None,
     review_index_out: Path | None = None,
+    review_artifacts_manifest_out: Path | None = None,
     evidence_narrative_path: Path | None = None,
     trajectory_jsonl_path: Path | None = None,
     runtime_proof_artifacts_path: Path | None = None,
@@ -2906,6 +2963,20 @@ def write_comment_body(
         )
         review_index_written = True
 
+    review_artifacts_manifest_written = False
+    if review_artifacts_manifest_out is not None:
+        review_artifacts_manifest_out.parent.mkdir(parents=True, exist_ok=True)
+        review_artifacts_manifest_out.write_text(
+            json.dumps(
+                build_pr_quality_artifacts_manifest(review_model),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        review_artifacts_manifest_written = True
+
     trajectory_summary = _trajectory_summary(trajectory_records)
     result: JsonObject = {
         "out": out.as_posix(),
@@ -2920,6 +2991,10 @@ def write_comment_body(
         "review_html_written": review_html_written,
         "review_index_out": review_index_out.as_posix() if review_index_out is not None else "",
         "review_index_written": review_index_written,
+        "review_artifacts_manifest_out": review_artifacts_manifest_out.as_posix()
+        if review_artifacts_manifest_out is not None
+        else "",
+        "review_artifacts_manifest_written": review_artifacts_manifest_written,
         "status": status,
         "result_title": _result_title(
             status,
@@ -3046,6 +3121,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--review-summary-out", type=Path)
     parser.add_argument("--review-html-out", type=Path)
     parser.add_argument("--review-index-out", type=Path)
+    parser.add_argument("--review-artifacts-manifest-out", type=Path)
     parser.add_argument("--failure-bundle-out-dir", type=Path)
     parser.add_argument("--pr-number", type=int, default=0)
     parser.add_argument("--head-sha", default="")
@@ -3067,6 +3143,7 @@ def main(argv: list[str] | None = None) -> int:
         review_summary_out=args.review_summary_out,
         review_html_out=args.review_html_out,
         review_index_out=args.review_index_out,
+        review_artifacts_manifest_out=args.review_artifacts_manifest_out,
         failure_bundle_out_dir=args.failure_bundle_out_dir,
         pr_number=args.pr_number,
         head_sha=args.head_sha,

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3632,6 +3632,7 @@ def test_review_model_schema_v2_includes_artifact_index_metadata() -> None:
 
     assert paths == [
         "index.html",
+        "pr-review-artifacts-manifest.json",
         "pr-review-dashboard.html",
         "pr-review-summary.md",
         "pr-review-model.json",
@@ -3640,13 +3641,16 @@ def test_review_model_schema_v2_includes_artifact_index_metadata() -> None:
     ]
     assert artifact_index[0]["primary"] is True
     assert artifact_index[0]["surface"] == "artifact_center"
-    assert artifact_index[3]["kind"] == "json"
-    assert artifact_index[5]["format"] == "github_artifact"
+    assert artifact_index[1]["surface"] == "artifact_manifest"
+    assert artifact_index[1]["kind"] == "json"
+    assert artifact_index[4]["kind"] == "json"
+    assert artifact_index[6]["format"] == "github_artifact"
 
     index_html = report.render_pr_quality_artifact_index_html(model)
     dashboard_html = report.render_pr_quality_review_html(model)
 
     assert 'href="index.html"' in index_html
+    assert 'href="pr-review-artifacts-manifest.json"' in index_html
     assert 'href="pr-review-dashboard.html"' in index_html
     assert "Browser-ready entry point for the PR Quality artifact bundle." in index_html
     assert "index.html" in dashboard_html
@@ -3760,3 +3764,139 @@ def test_review_surfaces_cover_green_review_required_and_needs_attention_states(
         assert case["caption"] in dashboard_html, case["name"]
         assert "Reporting-only" in artifact_index_html, case["name"]
         assert "does not authorize merge" in artifact_index_html, case["name"]
+
+
+def test_review_artifacts_manifest_describes_bundle_contract() -> None:
+    model = report.build_pr_quality_review_model(
+        status="green",
+        evidence_signal_heading="Evidence proof signal",
+        evidence_signal_lines=[],
+        evidence_review_required=False,
+        action_report={
+            "status": "green",
+            "primary_blocker": {},
+            "recommended_actions": [],
+            "proof_commands": ["python -m pytest -q"],
+        },
+        check_intelligence={
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+        evidence_narrative={
+            "primary_signal": {"kind": "none", "surface": "none", "title": "none"},
+            "graph": {"top_blocker": {}},
+            "next_proof": ["python -m pytest -q"],
+        },
+    )
+
+    manifest = report.build_pr_quality_artifacts_manifest(model)
+
+    assert manifest["schema_version"] == "sdetkit.pr_quality.artifacts_manifest.v1"
+    assert manifest["review_model_schema_version"] == "sdetkit.pr_quality.review_model.v2"
+    assert manifest["primary_entrypoint"] == "index.html"
+    assert manifest["reporting_only"] is True
+    assert manifest["authority_boundary"] == {
+        "boundary_mode": "reporting_only",
+        "patch_automation": False,
+        "security_dismissal": False,
+        "merge_authorization": False,
+        "semantic_equivalence_claim": False,
+    }
+    assert manifest["decision"]["review_state"] == "green"
+    assert manifest["decision"]["merge_assessment"] == "no_sdetkit_action_required"
+
+    paths = manifest["expected_artifact_paths"]
+    assert paths[0] == "index.html"
+    assert "pr-review-artifacts-manifest.json" in paths
+    assert "pr-review-dashboard.html" in paths
+    assert "pr-review-summary.md" in paths
+    assert "pr-review-model.json" in paths
+    assert "pr-comment-body.md" in paths
+    assert "pr-quality-comment" in paths
+
+    artifact_by_path = {artifact["path"]: artifact for artifact in manifest["artifacts"]}
+    assert artifact_by_path["pr-review-artifacts-manifest.json"]["surface"] == "artifact_manifest"
+    assert artifact_by_path["pr-review-artifacts-manifest.json"]["format"] == "json"
+
+
+def test_write_comment_body_writes_review_artifacts_manifest(tmp_path: Path) -> None:
+    action_report_path = tmp_path / "action-report.json"
+    check_intelligence_path = tmp_path / "check-intelligence.json"
+    evidence_narrative_path = tmp_path / "evidence-narrative.json"
+    out = tmp_path / "pr-comment-body.md"
+    review_model_out = tmp_path / "pr-review-model.json"
+    review_summary_out = tmp_path / "pr-review-summary.md"
+    review_html_out = tmp_path / "pr-review-dashboard.html"
+    review_index_out = tmp_path / "index.html"
+    review_artifacts_manifest_out = tmp_path / "pr-review-artifacts-manifest.json"
+
+    action_report_path.write_text(
+        json.dumps(
+            {
+                "automation": {
+                    "allowed": False,
+                    "attempted": False,
+                    "reason": "reporting only",
+                },
+                "evidence": {},
+                "primary_blocker": {},
+                "proof_commands": ["python -m pytest -q"],
+                "recommended_actions": [],
+                "status": "green",
+            }
+        ),
+        encoding="utf-8",
+    )
+    check_intelligence_path.write_text(
+        json.dumps(
+            {
+                "checks_seen": 44,
+                "failed_checks": [],
+                "missing_required_contexts": [],
+                "queued_checks": [],
+                "security_review": {"collected": True, "unresolved_findings": 0},
+                "startup_failures": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_narrative_path.write_text(
+        json.dumps(
+            {
+                "graph": {
+                    "critical_count": 0,
+                    "node_count": 1,
+                    "review_first_count": 0,
+                    "top_blocker": {},
+                },
+                "next_proof": ["python -m pytest -q"],
+                "primary_signal": {"kind": "none", "surface": "none", "title": "none"},
+                "quality": {"coverage_percent": "96.69%", "ok": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = report.write_comment_body(
+        action_report_path=action_report_path,
+        check_intelligence_path=check_intelligence_path,
+        evidence_narrative_path=evidence_narrative_path,
+        out=out,
+        review_model_out=review_model_out,
+        review_summary_out=review_summary_out,
+        review_html_out=review_html_out,
+        review_index_out=review_index_out,
+        review_artifacts_manifest_out=review_artifacts_manifest_out,
+    )
+
+    assert result["review_artifacts_manifest_out"] == review_artifacts_manifest_out.as_posix()
+    assert result["review_artifacts_manifest_written"] is True
+
+    manifest = json.loads(review_artifacts_manifest_out.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "sdetkit.pr_quality.artifacts_manifest.v1"
+    assert manifest["review_model_schema_version"] == "sdetkit.pr_quality.review_model.v2"
+    assert manifest["primary_entrypoint"] == "index.html"
+    assert "pr-review-artifacts-manifest.json" in manifest["expected_artifact_paths"]
+    assert manifest["authority_boundary"]["merge_authorization"] is False

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1126,3 +1126,19 @@ def test_pr_quality_comment_workflow_builds_artifact_landing_page() -> None:
     assert "build/pr-quality/index.html" in text
     assert "`index.html`: artifact landing page." in text
     assert "Upload PR quality comment artifacts" in text
+
+
+def test_pr_quality_comment_workflow_builds_artifact_manifest() -> None:
+    text = _workflow_text()
+
+    assert (
+        "--review-artifacts-manifest-out build/pr-quality/pr-review-artifacts-manifest.json" in text
+    )
+    assert "build/pr-quality/pr-review-artifacts-manifest.json" in text
+    assert "`pr-review-artifacts-manifest.json`: machine-readable artifact bundle manifest." in text
+    assert text.index("--review-index-out build/pr-quality/index.html") < text.index(
+        "--review-artifacts-manifest-out build/pr-quality/pr-review-artifacts-manifest.json"
+    )
+    assert text.index("build/pr-quality/index.html") < text.index(
+        "build/pr-quality/pr-review-artifacts-manifest.json"
+    )


### PR DESCRIPTION
## Summary

- add `pr-review-artifacts-manifest.json` as a machine-readable artifact bundle manifest
- include expected artifact paths, primary entry point, artifact metadata, schema version, and reporting-only boundary
- wire the manifest into CLI output, workflow generation, artifact upload, and PR comment artifact inventory
- keep artifact rendering and manifest generation sourced from review model schema v2 metadata

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py -o addopts=
- python -m sdetkit.pr_quality_action_report --action-report <fixture> --check-intelligence <fixture> --evidence-narrative <fixture> --out <pr-comment-body.md> --review-model-out <pr-review-model.json> --review-summary-out <pr-review-summary.md> --review-html-out <pr-review-dashboard.html> --review-index-out <index.html> --review-artifacts-manifest-out <pr-review-artifacts-manifest.json>
- python -m pre_commit run -a

## Boundary

- artifact manifest/reporting contract only
- no gate decision logic changed
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added