### PR TITLE
feat(pr-quality): show failure vector in HTML dashboard

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2439,6 +2439,7 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
     decision = _as_dict(model.get("decision"))
     authority = _as_dict(model.get("authority_boundary"))
     primary_blocker = _as_dict(model.get("primary_blocker"))
+    failure_vector_signal = _as_dict(model.get("failure_vector_signal"))
     proof_commands = [
         str(command)
         for command in _as_list(model.get("proof_to_rerun"))
@@ -2549,6 +2550,19 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
         ("Path", primary_blocker.get("path")),
         ("Details", primary_blocker.get("details")),
     ]
+    failure_vector_rows = [
+        ("Source", failure_vector_signal.get("source") or "none"),
+        ("Headline signal", failure_vector_signal.get("headline_signal") or "none"),
+        ("Actual failure", failure_vector_signal.get("actual_failure") or "none"),
+        ("Failure type", failure_vector_signal.get("failure_type") or "none"),
+        ("Failing command", failure_vector_signal.get("failing_command") or "none"),
+        ("Failing test/check", failure_vector_signal.get("failing_test_or_check") or "none"),
+        ("Exit code", failure_vector_signal.get("exit_code")),
+        ("Owner hint", failure_vector_signal.get("owner_hint") or "none"),
+        ("Safe-fix candidate", failure_vector_signal.get("safe_fix_candidate")),
+        ("Safe-fix allowed", failure_vector_signal.get("safe_fix_allowed")),
+        ("Reporting only", failure_vector_signal.get("reporting_only")),
+    ]
     authority_rows = [
         ("Boundary mode", authority.get("boundary_mode")),
         ("Patch automation", authority.get("patch_automation")),
@@ -2638,6 +2652,8 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
             f"<article><span>Recommended action</span><strong>{_html_escape(first_recommended_action)}</strong></article>"
             f"<article><span>Failed checks</span><strong>{_html_escape(failed_total)}</strong></article>"
             f"<article><span>Missing contexts</span><strong>{_html_escape(missing_total)}</strong></article>"
+            f"<article><span>Actual failure</span><strong>{_html_escape(failure_vector_signal.get('actual_failure') or 'none')}</strong></article>"
+            f"<article><span>Owner hint</span><strong>{_html_escape(failure_vector_signal.get('owner_hint') or 'none')}</strong></article>"
             "</div>"
             "</section>"
         )
@@ -2723,6 +2739,12 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
         '        <span class="section-kicker">Triage</span>\n'
         "        <h2>First blocker</h2>\n"
         f"        {table(blocker_rows)}\n"
+        "      </article>\n"
+        '      <article class="card">\n'
+        '        <span class="section-kicker">FailureVector</span>\n'
+        "        <h2>Failure vector signal</h2>\n"
+        f"        {table(failure_vector_rows)}\n"
+        '        <p class="boundary">Reporting-only FailureVector projection. This signal does not authorize safe-fix execution, patch automation, or merge.</p>\n'
         "      </article>\n"
         "    </section>\n"
         '    <section class="card">\n'

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4004,3 +4004,55 @@ def test_review_summary_renders_failure_vector_signal() -> None:
     assert "| Owner hint | `tests/test_pr_quality_action_report.py` |" in summary
     assert "| Failure-vector safe-fix allowed | `false` |" in summary
     assert "does not authorize merge" in summary
+
+
+def test_review_html_renders_failure_vector_signal() -> None:
+    model = report.build_pr_quality_review_model(
+        status="failed",
+        evidence_signal_heading="Evidence review signal",
+        evidence_signal_lines=[],
+        evidence_review_required=False,
+        action_report={
+            "status": "failed",
+            "primary_blocker": {},
+            "recommended_actions": ["Fix the ruff finding."],
+            "proof_commands": ["python -m pre_commit run -a"],
+        },
+        check_intelligence={
+            "failed_checks": [
+                {
+                    "name": "pre-commit / ruff",
+                    "command": "python -m pre_commit run -a",
+                    "headline_signal": "pre-commit / ruff: lint",
+                    "actual_failure": "F821 Undefined name `JsonObject`",
+                    "failure_type": "lint",
+                    "failing_test_or_check": "F821",
+                    "owner_hint": "tests/test_pr_quality_action_report.py",
+                    "affected_files": ["tests/test_pr_quality_action_report.py"],
+                    "safe_fix_candidate": False,
+                    "safe_fix_allowed": False,
+                    "reporting_only": True,
+                }
+            ],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+        evidence_narrative={
+            "primary_signal": {"kind": "actual_failure", "surface": "diagnostic_engine"},
+            "graph": {"top_blocker": {}},
+            "next_proof": ["python -m pre_commit run -a"],
+        },
+    )
+
+    html = report.render_pr_quality_review_html(model)
+
+    assert "Failure vector signal" in html
+    assert "pre-commit / ruff: lint" in html
+    assert "F821 Undefined name `JsonObject`" in html
+    assert "python -m pre_commit run -a" in html
+    assert "tests/test_pr_quality_action_report.py" in html
+    assert "Safe-fix allowed" in html
+    assert "Reporting-only FailureVector projection" in html
+    assert "does not authorize safe-fix execution" in html
+    assert "does not authorize merge" in html


### PR DESCRIPTION
## Summary

- render the normalized failure_vector_signal in the static PR Quality HTML dashboard
- show actual failure, failure type, failing command, failing test/check, owner hint, and safe-fix boundary
- keep the HTML dashboard aligned with the Markdown review summary and review model

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_failure_vector_extraction.py -o addopts=
- direct V21 smoke for HTML failure-vector signal rendering
- python -m pre_commit run -a

## Boundary

- diagnostic/reporting UI only
- no SafetyGate behavior changed
- no safe-fix permission change
- no proof execution authority added
- no patch automation authority added
- no security dismissal authority added
- no merge authorization added