### PR TITLE
chore(security): scope OSV policy for adoption fixtures

### DIFF
--- a/docs/security/adoption-fixture-osv-policy.md
+++ b/docs/security/adoption-fixture-osv-policy.md
@@ -1,0 +1,19 @@
+# Adoption fixture OSV policy
+
+Linked issue: #1678.
+
+The `tests/fixtures/adoption_repos/` directories are detector fixtures used by
+the adoption-surface and project-discovery test suite. They are not shipped
+runtime dependencies, release artifacts, or executable production projects.
+
+The repository-level OSV workflow scans recursively from the repository root and
+uploads SARIF to GitHub Code Scanning. Without fixture-local policy files, OSV
+reports vulnerabilities from these demo manifests as repository security alerts.
+
+Each affected fixture directory carries its own `osv-scanner.toml` so the
+exception stays local to the fixture directory. This keeps root/package
+dependency scanning active while preventing fixture-only manifests from
+dominating the GHAS backlog.
+
+This policy does not dismiss production alerts, does not weaken root
+dependency scanning, and does not change workflow permissions.

--- a/tests/fixtures/adoption_repos/gitlab_python/osv-scanner.toml
+++ b/tests/fixtures/adoption_repos/gitlab_python/osv-scanner.toml
@@ -1,0 +1,12 @@
+# Fixture-local OSV policy.
+#
+# This directory is an adoption-surface detector fixture, not a shipped or
+# executable project dependency. The repo-level OSV workflow scans recursively
+# from the repository root, so this fixture-local config prevents demo Python
+# fixture metadata from flooding GHAS Code Scanning.
+#
+# Scope: applies only to lock/manifests in this directory.
+
+[[PackageOverrides]]
+vulnerability.ignore = true
+reason = "Fixture-only Python adoption repo used by tests; not a production or release dependency."

--- a/tests/fixtures/adoption_repos/go_module/osv-scanner.toml
+++ b/tests/fixtures/adoption_repos/go_module/osv-scanner.toml
@@ -1,0 +1,12 @@
+# Fixture-local OSV policy.
+#
+# This directory is an adoption-surface detector fixture, not a shipped or
+# executable project dependency. The repo-level OSV workflow scans recursively
+# from the repository root, so this fixture-local config prevents demo Go module
+# metadata from flooding GHAS Code Scanning with stdlib alerts.
+#
+# Scope: applies only to lock/manifests in this directory.
+
+[[PackageOverrides]]
+vulnerability.ignore = true
+reason = "Fixture-only Go module used by adoption-surface tests; not a production or release dependency."

--- a/tests/fixtures/adoption_repos/mixed_python_node/osv-scanner.toml
+++ b/tests/fixtures/adoption_repos/mixed_python_node/osv-scanner.toml
@@ -1,0 +1,12 @@
+# Fixture-local OSV policy.
+#
+# This directory is an adoption-surface detector fixture, not a shipped or
+# executable project dependency. The repo-level OSV workflow scans recursively
+# from the repository root, so this fixture-local config prevents demo Python
+# fixture metadata from flooding GHAS Code Scanning.
+#
+# Scope: applies only to lock/manifests in this directory.
+
+[[PackageOverrides]]
+vulnerability.ignore = true
+reason = "Fixture-only Python adoption repo used by tests; not a production or release dependency."

--- a/tests/fixtures/adoption_repos/python_pytest_github/osv-scanner.toml
+++ b/tests/fixtures/adoption_repos/python_pytest_github/osv-scanner.toml
@@ -1,0 +1,12 @@
+# Fixture-local OSV policy.
+#
+# This directory is an adoption-surface detector fixture, not a shipped or
+# executable project dependency. The repo-level OSV workflow scans recursively
+# from the repository root, so this fixture-local config prevents demo Python
+# fixture metadata from flooding GHAS Code Scanning.
+#
+# Scope: applies only to lock/manifests in this directory.
+
+[[PackageOverrides]]
+vulnerability.ignore = true
+reason = "Fixture-only Python adoption repo used by tests; not a production or release dependency."


### PR DESCRIPTION
Refs #1678.

## Summary
- Adds fixture-local OSV policy files for adoption/demo fixture repos.
- Documents why these fixtures are not production dependency surfaces.
- Leaves root dependency scanning and workflow permissions unchanged.

## Evidence
- Latest OSV SARIF from run 27386767552 reported 52 fixture-only results.
- 43 results pointed to tests/fixtures/adoption_repos/go_module/go.mod.
- 9 results pointed to adoption fixture requirements-test.txt files.
- Root pip-audit was clean before this change.

## Verification
- Focused adoption fixture tests
- pre-commit
- make proof-after-format