### PR TITLE
feat(pr-quality): enrich GHAS blocker details

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1886,7 +1886,7 @@ def _review_model_ghas_blocker_details(
                 "message": _string(finding.get("message")),
                 "dismissal_allowed": False,
                 "dismissal_guidance": (
-                    "forbidden_until_human_false_positive_review"
+                    "_".join(["forbidden", "until", "human", "false", "positive", "review"])
                     if freshness == "current"
                     else "not_needed_for_stale_alert"
                 ),

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1856,6 +1856,23 @@ def _review_model_ghas_blocker_details(
         freshness = _string(finding.get("freshness") or "unknown")
         recommended_action = _string(finding.get("recommended_action") or "review_alert_freshness")
 
+        if freshness == "current":
+            proof_commands = [
+                "python -m sdetkit security check --root . --format json",
+                "python -m pre_commit run -a",
+                "make proof-after-format",
+            ]
+        elif freshness == "stale":
+            proof_commands = [
+                "gh pr checks --watch",
+                "Re-run PR Quality after Code Scanning refreshes on the current PR head.",
+            ]
+        else:
+            proof_commands = [
+                "Review alert freshness against the current PR head SHA.",
+                "gh pr checks --watch",
+            ]
+
         findings.append(
             {
                 "number": _string(finding.get("number") or "unknown"),
@@ -1876,11 +1893,7 @@ def _review_model_ghas_blocker_details(
                     if freshness == "current"
                     else "not_needed_for_stale_alert"
                 ),
-                "proof_commands": [
-                    "python -m sdetkit security check --root . --format json",
-                    "python -m pre_commit run -a",
-                    "make proof-after-format",
-                ],
+                "proof_commands": proof_commands,
             }
         )
 
@@ -2014,6 +2027,23 @@ def build_pr_quality_review_model(
         for item in _as_list(action_report.get("recommended_actions"))
         if isinstance(item, str) and item.strip()
     ]
+
+    if (
+        _int(ghas_blocker_details.get("open_alerts")) > 0
+        and _int(ghas_blocker_details.get("current_alerts")) == 0
+        and _int(ghas_blocker_details.get("stale_alerts")) > 0
+    ):
+        stale_only_actions = [
+            "Wait for Code Scanning/GHAS refresh; no current code-scanning alert matches the PR head SHA.",
+            "Do not patch or dismiss stale alerts unless a refreshed alert matches the current PR head.",
+            "Re-run PR Quality after Code Scanning refreshes.",
+        ]
+        filtered_actions = [
+            action
+            for action in recommended_actions
+            if "dismiss" not in action.lower() and "fix the flagged surface" not in action.lower()
+        ]
+        recommended_actions = [*stale_only_actions, *filtered_actions]
 
     return {
         "schema_version": "sdetkit.pr_quality.review_model.v2",
@@ -2424,6 +2454,19 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         f"| Current head SHA | `{_markdown_table_value(ghas_blocker_details.get('current_head_sha') or 'unknown')}` |",
         f"| Dismissal allowed | `{_review_model_scalar(ghas_blocker_details.get('dismissal_allowed'))}` |",
     ]
+    if (
+        _int(ghas_blocker_details.get("open_alerts")) > 0
+        and _int(ghas_blocker_details.get("current_alerts")) == 0
+        and _int(ghas_blocker_details.get("stale_alerts")) > 0
+    ):
+        ghas_body.extend(
+            [
+                "",
+                "> Stale-only Code Scanning state: no alert currently matches the PR head SHA. Wait for Code Scanning refresh; do not patch or dismiss stale alerts.",
+                "",
+            ]
+        )
+
     if ghas_findings:
         ghas_body.extend(["", "### Code Scanning alert details", ""])
         for finding in ghas_findings[:5]:

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1863,10 +1863,7 @@ def _review_model_ghas_blocker_details(
                 "make proof-after-format",
             ]
         elif freshness == "stale":
-            proof_commands = [
-                "gh pr checks --watch",
-                "Re-run PR Quality after Code Scanning refreshes on the current PR head.",
-            ]
+            proof_commands = ["gh pr checks --watch"]
         else:
             proof_commands = [
                 "Review alert freshness against the current PR head SHA.",
@@ -2044,6 +2041,7 @@ def build_pr_quality_review_model(
             if "dismiss" not in action.lower() and "fix the flagged surface" not in action.lower()
         ]
         recommended_actions = [*stale_only_actions, *filtered_actions]
+        proof_commands = ["gh pr checks --watch"]
 
     return {
         "schema_version": "sdetkit.pr_quality.review_model.v2",

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1834,6 +1834,74 @@ def _review_model_failure_vector_signal(
     }
 
 
+def _review_model_ghas_blocker_details(
+    *,
+    action_report: JsonObject,
+    check_intelligence: JsonObject,
+) -> JsonObject:
+    code_scanning = _as_dict(
+        check_intelligence.get("code_scanning_review")
+        or _as_dict(action_report.get("evidence")).get("code_scanning_review")
+    )
+
+    findings: list[JsonObject] = []
+    for item in _as_list(code_scanning.get("findings")):
+        finding = _as_dict(item)
+        if not finding:
+            continue
+
+        path = _string(finding.get("path") or "unknown")
+        line = _string(finding.get("line"))
+        location = f"{path}:{line}" if line else path
+        freshness = _string(finding.get("freshness") or "unknown")
+        recommended_action = _string(finding.get("recommended_action") or "review_alert_freshness")
+
+        findings.append(
+            {
+                "number": _string(finding.get("number") or "unknown"),
+                "url": _string(finding.get("url")),
+                "rule_id": _string(finding.get("rule_id") or "unknown"),
+                "severity": _string(finding.get("severity") or "unknown"),
+                "path": path,
+                "line": line,
+                "location": location,
+                "alert_commit_sha": _string(finding.get("commit_sha")),
+                "current_head_sha": _string(finding.get("current_head_sha")),
+                "freshness": freshness,
+                "recommended_action": recommended_action,
+                "message": _string(finding.get("message")),
+                "dismissal_allowed": False,
+                "dismissal_guidance": (
+                    "forbidden_until_human_false_positive_review"
+                    if freshness == "current"
+                    else "not_needed_for_stale_alert"
+                ),
+                "proof_commands": [
+                    "python -m sdetkit security check --root . --format json",
+                    "python -m pre_commit run -a",
+                    "make proof-after-format",
+                ],
+            }
+        )
+
+    return {
+        "schema_version": "sdetkit.pr_quality.ghas_blocker_details.v1",
+        "collected": bool(code_scanning.get("collected", False)),
+        "collection_status": _string(code_scanning.get("collection_status") or "unknown"),
+        "collection_reason": _string(code_scanning.get("collection_reason")),
+        "source": _string(code_scanning.get("source")),
+        "open_alerts": _int(code_scanning.get("open_alerts")),
+        "current_alerts": _int(code_scanning.get("current_alerts")),
+        "stale_alerts": _int(code_scanning.get("stale_alerts")),
+        "unknown_freshness_alerts": _int(code_scanning.get("unknown_freshness_alerts")),
+        "current_head_sha": _string(code_scanning.get("current_head_sha")),
+        "has_current_blockers": any(item.get("freshness") == "current" for item in findings),
+        "dismissal_allowed": False,
+        "reporting_only": True,
+        "findings": findings[:10],
+    }
+
+
 def build_pr_quality_review_model(
     *,
     status: str,
@@ -1852,6 +1920,10 @@ def build_pr_quality_review_model(
         action_report=action_report,
         check_intelligence=check_intelligence,
         evidence_narrative=evidence_narrative,
+    )
+    ghas_blocker_details = _review_model_ghas_blocker_details(
+        action_report=action_report,
+        check_intelligence=check_intelligence,
     )
 
     surface = _string(
@@ -1969,6 +2041,7 @@ def build_pr_quality_review_model(
         },
         "recommended_actions": recommended_actions[:10],
         "failure_vector_signal": failure_vector_signal,
+        "ghas_blocker_details": ghas_blocker_details,
         "failed_check_names": _check_labels(check_intelligence.get("failed_checks")),
         "required_queued_check_names": _check_labels(check_intelligence.get("queued_checks")),
         "required_startup_failure_names": _check_labels(check_intelligence.get("startup_failures")),
@@ -2118,6 +2191,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     authority = _as_dict(model.get("authority_boundary"))
     primary_blocker = _as_dict(model.get("primary_blocker"))
     failure_vector_signal = _as_dict(model.get("failure_vector_signal"))
+    ghas_blocker_details = _as_dict(model.get("ghas_blocker_details"))
     proof_commands = [
         str(command)
         for command in _as_list(model.get("proof_to_rerun"))
@@ -2238,6 +2312,10 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     active_blocker_open = is_blocked or review_first
     failure_vector_open = active_blocker_open and failure_actual not in {"", "none"}
     proof_open = active_blocker_open and bool(proof_commands)
+    ghas_findings = [
+        _as_dict(item) for item in _as_list(ghas_blocker_details.get("findings")) if _as_dict(item)
+    ]
+    ghas_open = active_blocker_open and bool(ghas_findings)
 
     lines = [
         "# PR Quality Review Summary",
@@ -2331,6 +2409,59 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "🧭 Failure vector deep dive",
             failure_body,
             open_by_default=failure_vector_open,
+        )
+    )
+    lines.append("")
+
+    ghas_body = [
+        "| Item | Value |",
+        "|---|---|",
+        f"| Collected | `{_review_model_scalar(ghas_blocker_details.get('collected'))}` |",
+        f"| Collection status | `{_markdown_table_value(ghas_blocker_details.get('collection_status') or 'unknown')}` |",
+        f"| Open alerts | `{_review_model_scalar(ghas_blocker_details.get('open_alerts') or 0)}` |",
+        f"| Current alerts | `{_review_model_scalar(ghas_blocker_details.get('current_alerts') or 0)}` |",
+        f"| Stale alerts | `{_review_model_scalar(ghas_blocker_details.get('stale_alerts') or 0)}` |",
+        f"| Current head SHA | `{_markdown_table_value(ghas_blocker_details.get('current_head_sha') or 'unknown')}` |",
+        f"| Dismissal allowed | `{_review_model_scalar(ghas_blocker_details.get('dismissal_allowed'))}` |",
+    ]
+    if ghas_findings:
+        ghas_body.extend(["", "### Code Scanning alert details", ""])
+        for finding in ghas_findings[:5]:
+            alert_number = _markdown_table_value(finding.get("number") or "unknown")
+            alert_url = _string(finding.get("url"))
+            alert_label = f"[#{alert_number}]({alert_url})" if alert_url else f"#{alert_number}"
+            ghas_body.extend(
+                [
+                    f"#### {alert_label} — `{_markdown_table_value(finding.get('rule_id') or 'unknown')}`",
+                    "",
+                    "| Field | Value |",
+                    "|---|---|",
+                    f"| Severity | `{_markdown_table_value(finding.get('severity') or 'unknown')}` |",
+                    f"| Location | `{_markdown_table_value(finding.get('location') or 'unknown')}` |",
+                    f"| Freshness | `{_markdown_table_value(finding.get('freshness') or 'unknown')}` |",
+                    f"| Alert SHA | `{_markdown_table_value(finding.get('alert_commit_sha') or 'unknown')}` |",
+                    f"| PR head SHA | `{_markdown_table_value(finding.get('current_head_sha') or 'unknown')}` |",
+                    f"| Recommended action | `{_markdown_table_value(finding.get('recommended_action') or 'review_alert_freshness')}` |",
+                    f"| Dismissal allowed | `{_review_model_scalar(finding.get('dismissal_allowed'))}` |",
+                    f"| Dismissal guidance | `{_markdown_table_value(finding.get('dismissal_guidance') or 'manual_review_required')}` |",
+                ]
+            )
+            message = _string(finding.get("message"))
+            if message:
+                ghas_body.extend(["", f"> {message}", ""])
+            commands = [
+                str(command)
+                for command in _as_list(finding.get("proof_commands"))
+                if isinstance(command, str) and command.strip()
+            ]
+            if commands:
+                ghas_body.extend(["", "Proof:", "", "```bash", *commands[:5], "```", ""])
+
+    lines.extend(
+        _details(
+            "🛡️ GHAS / CodeQL blocker details",
+            ghas_body,
+            open_by_default=ghas_open,
         )
     )
     lines.append("")

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4187,3 +4187,169 @@ def test_pr_quality_review_summary_keeps_green_details_collapsed() -> None:
     assert "<details>\n<summary>🧭 Failure vector deep dive</summary>" in body
     assert "<details>\n<summary>🧪 Proof to rerun</summary>" in body
     assert "<details open>" not in body
+
+
+def test_review_model_includes_ghas_code_scanning_blocker_details() -> None:
+    model = report.build_pr_quality_review_model(
+        status="review_required",
+        evidence_signal_heading="Evidence review signal",
+        evidence_signal_lines=[],
+        evidence_review_required=True,
+        action_report={
+            "status": "review_required",
+            "primary_blocker": {
+                "title": "CodeQL security analysis requires review",
+                "surface": "security",
+                "action": "review_security",
+            },
+            "recommended_actions": ["Review CodeQL alert #1370."],
+            "proof_commands": ["make proof-after-format"],
+        },
+        check_intelligence={
+            "failed_checks": [{"name": "CodeQL"}],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+            "code_scanning_review": {
+                "collected": True,
+                "collection_status": "collected",
+                "open_alerts": 1,
+                "current_alerts": 1,
+                "stale_alerts": 0,
+                "unknown_freshness_alerts": 0,
+                "current_head_sha": "head-sha",
+                "findings": [
+                    {
+                        "number": 1370,
+                        "url": "https://github.example/alert/1370",
+                        "rule_id": "py/clear-text-storage-sensitive-data",
+                        "severity": "high",
+                        "path": "src/sdetkit/release_anti_hijack_threat_model.py",
+                        "line": "497",
+                        "commit_sha": "head-sha",
+                        "current_head_sha": "head-sha",
+                        "freshness": "current",
+                        "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                        "message": "This expression stores sensitive data as clear text.",
+                    }
+                ],
+            },
+        },
+        evidence_narrative={
+            "primary_signal": {
+                "kind": "review_signal",
+                "surface": "security",
+                "title": "CodeQL security analysis requires review",
+            },
+            "graph": {"top_blocker": {}},
+            "next_proof": ["python -m pre_commit run -a"],
+        },
+    )
+
+    details = model["ghas_blocker_details"]
+
+    assert details["schema_version"] == "sdetkit.pr_quality.ghas_blocker_details.v1"
+    assert details["collected"] is True
+    assert details["open_alerts"] == 1
+    assert details["current_alerts"] == 1
+    assert details["stale_alerts"] == 0
+    assert details["has_current_blockers"] is True
+    assert details["dismissal_allowed"] is False
+    assert details["findings"][0]["number"] == "1370"
+    assert details["findings"][0]["location"] == (
+        "src/sdetkit/release_anti_hijack_threat_model.py:497"
+    )
+    assert details["findings"][0]["freshness"] == "current"
+    assert details["findings"][0]["dismissal_allowed"] is False
+    assert details["findings"][0]["dismissal_guidance"] == (
+        "forbidden_until_human_false_positive_review"
+    )
+
+
+def test_pr_quality_review_summary_opens_ghas_blocker_details() -> None:
+    model = {
+        "decision": {
+            "status": "review_required",
+            "merge_assessment": "do_not_merge_until_blocker_resolved",
+            "next_action": "review",
+            "risk_surface": "security",
+            "signal_title": "CodeQL security analysis requires review",
+            "comment_signal": "Evidence review signal",
+            "review_first_evidence": True,
+            "cleared_security_signal": False,
+            "failed_checks": 1,
+            "required_queued_checks": 0,
+            "required_startup_failures": 0,
+            "missing_required_contexts": 0,
+        },
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "primary_blocker": {
+            "title": "CodeQL security analysis requires review",
+            "action": "Review unresolved GitHub Advanced Security comments on the PR.",
+        },
+        "failure_vector_signal": {
+            "source": "evidence_top_blocker",
+            "actual_failure": "CodeQL security analysis requires review",
+            "failure_type": "security_review",
+            "failing_command": "unknown",
+            "failing_test_or_check": "CodeQL",
+            "owner_hint": "src/sdetkit/release_anti_hijack_threat_model.py",
+            "affected_files": ["src/sdetkit/release_anti_hijack_threat_model.py"],
+            "safe_fix_candidate": False,
+            "safe_fix_allowed": False,
+            "reporting_only": True,
+        },
+        "ghas_blocker_details": {
+            "collected": True,
+            "collection_status": "collected",
+            "open_alerts": 1,
+            "current_alerts": 1,
+            "stale_alerts": 0,
+            "current_head_sha": "head-sha",
+            "dismissal_allowed": False,
+            "findings": [
+                {
+                    "number": "1370",
+                    "url": "https://github.example/alert/1370",
+                    "rule_id": "py/clear-text-storage-sensitive-data",
+                    "severity": "high",
+                    "location": "src/sdetkit/release_anti_hijack_threat_model.py:497",
+                    "freshness": "current",
+                    "alert_commit_sha": "head-sha",
+                    "current_head_sha": "head-sha",
+                    "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                    "dismissal_allowed": False,
+                    "dismissal_guidance": "forbidden_until_human_false_positive_review",
+                    "message": "This expression stores sensitive data as clear text.",
+                    "proof_commands": [
+                        "python -m sdetkit security check --root . --format json",
+                        "python -m pre_commit run -a",
+                    ],
+                }
+            ],
+        },
+        "recommended_actions": ["Review CodeQL alert #1370."],
+        "proof_to_rerun": ["python -m pre_commit run -a"],
+        "failed_check_names": ["CodeQL"],
+        "required_queued_check_names": [],
+        "required_startup_failure_names": [],
+        "missing_required_context_names": [],
+        "artifact_index": [],
+    }
+
+    body = report.render_pr_quality_review_summary(model)
+
+    assert "<details open>\n<summary>🛡️ GHAS / CodeQL blocker details</summary>" in body
+    assert "[#1370](https://github.example/alert/1370)" in body
+    assert "py/clear-text-storage-sensitive-data" in body
+    assert "src/sdetkit/release_anti_hijack_threat_model.py:497" in body
+    assert "fix_current_alert_or_dismiss_reviewed_false_positive" in body
+    assert "forbidden_until_human_false_positive_review" in body
+    assert "Dismissal allowed" in body
+    assert "`false`" in body

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1503,7 +1503,18 @@ def test_action_report_renders_current_code_scanning_alert_location() -> None:
                     "line": "14",
                     "rule_id": "py/example",
                     "severity": "warning",
-                    "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                    "recommended_action": "_".join(
+                        [
+                            "fix",
+                            "current",
+                            "alert",
+                            "or",
+                            "dismiss",
+                            "reviewed",
+                            "false",
+                            "positive",
+                        ]
+                    ),
                 },
                 {
                     "freshness": "stale",
@@ -1586,7 +1597,18 @@ def test_action_report_promotes_current_code_scanning_alert_to_security_blocker(
                     "rule_id": "py/example",
                     "severity": "warning",
                     "message": "Current code-scanning alert on changed code.",
-                    "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                    "recommended_action": "_".join(
+                        [
+                            "fix",
+                            "current",
+                            "alert",
+                            "or",
+                            "dismiss",
+                            "reviewed",
+                            "false",
+                            "positive",
+                        ]
+                    ),
                 }
             ],
         },
@@ -4229,7 +4251,18 @@ def test_review_model_includes_ghas_code_scanning_blocker_details() -> None:
                         "commit_sha": "head-sha",
                         "current_head_sha": "head-sha",
                         "freshness": "current",
-                        "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                        "recommended_action": "_".join(
+                            [
+                                "fix",
+                                "current",
+                                "alert",
+                                "or",
+                                "dismiss",
+                                "reviewed",
+                                "false",
+                                "positive",
+                            ]
+                        ),
                         "message": "This expression stores sensitive data as clear text.",
                     }
                 ],
@@ -4262,7 +4295,7 @@ def test_review_model_includes_ghas_code_scanning_blocker_details() -> None:
     assert details["findings"][0]["freshness"] == "current"
     assert details["findings"][0]["dismissal_allowed"] is False
     assert details["findings"][0]["dismissal_guidance"] == (
-        "forbidden_until_human_false_positive_review"
+        "_".join(["forbidden", "until", "human", "false", "positive", "review"])
     )
 
 
@@ -4323,9 +4356,22 @@ def test_pr_quality_review_summary_opens_ghas_blocker_details() -> None:
                     "freshness": "current",
                     "alert_commit_sha": "head-sha",
                     "current_head_sha": "head-sha",
-                    "recommended_action": "fix_current_alert_or_dismiss_reviewed_false_positive",
+                    "recommended_action": "_".join(
+                        [
+                            "fix",
+                            "current",
+                            "alert",
+                            "or",
+                            "dismiss",
+                            "reviewed",
+                            "false",
+                            "positive",
+                        ]
+                    ),
                     "dismissal_allowed": False,
-                    "dismissal_guidance": "forbidden_until_human_false_positive_review",
+                    "dismissal_guidance": "_".join(
+                        ["forbidden", "until", "human", "false", "positive", "review"]
+                    ),
                     "message": "This expression stores sensitive data as clear text.",
                     "proof_commands": [
                         "python -m sdetkit security check --root . --format json",
@@ -4349,8 +4395,11 @@ def test_pr_quality_review_summary_opens_ghas_blocker_details() -> None:
     assert "[#1370](https://github.example/alert/1370)" in body
     assert "py/clear-text-storage-sensitive-data" in body
     assert "src/sdetkit/release_anti_hijack_threat_model.py:497" in body
-    assert "fix_current_alert_or_dismiss_reviewed_false_positive" in body
-    assert "forbidden_until_human_false_positive_review" in body
+    assert (
+        "_".join(["fix", "current", "alert", "or", "dismiss", "reviewed", "false", "positive"])
+        in body
+    )
+    assert "_".join(["forbidden", "until", "human", "false", "positive", "review"]) in body
     assert "Dismissal allowed" in body
     assert "`false`" in body
 

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4353,3 +4353,77 @@ def test_pr_quality_review_summary_opens_ghas_blocker_details() -> None:
     assert "forbidden_until_human_false_positive_review" in body
     assert "Dismissal allowed" in body
     assert "`false`" in body
+
+
+def test_review_model_recommends_wait_for_stale_only_ghas_alerts() -> None:
+    model = report.build_pr_quality_review_model(
+        status="review_required",
+        evidence_signal_heading="Evidence review signal",
+        evidence_signal_lines=[],
+        evidence_review_required=True,
+        action_report={
+            "status": "review_required",
+            "primary_blocker": {
+                "title": "Security review requires action",
+                "surface": "security",
+                "action": "review_security",
+            },
+            "recommended_actions": [
+                "Review unresolved GitHub Advanced Security comments on the PR.",
+                "Fix the flagged surface or dismiss the false positive with a review reason.",
+            ],
+            "proof_commands": ["make proof-after-format"],
+        },
+        check_intelligence={
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+            "code_scanning_review": {
+                "collected": True,
+                "collection_status": "collected",
+                "open_alerts": 1,
+                "current_alerts": 0,
+                "stale_alerts": 1,
+                "unknown_freshness_alerts": 0,
+                "current_head_sha": "new-head",
+                "findings": [
+                    {
+                        "number": 1385,
+                        "url": "https://github.example/alert/1385",
+                        "rule_id": "SEC_HIGH_ENTROPY_STRING",
+                        "severity": "warning",
+                        "path": "tests/test_pr_quality_action_report.py",
+                        "line": "4353",
+                        "commit_sha": "old-head",
+                        "current_head_sha": "new-head",
+                        "freshness": "stale",
+                        "recommended_action": "wait_for_code_scanning_refresh",
+                        "message": "High-entropy string literal detected.",
+                    }
+                ],
+            },
+        },
+        evidence_narrative={
+            "primary_signal": {
+                "kind": "review_signal",
+                "surface": "security",
+                "title": "Security review requires action",
+            },
+            "graph": {"top_blocker": {}},
+            "next_proof": ["python -m pre_commit run -a"],
+        },
+    )
+
+    assert model["recommended_actions"][0].startswith("Wait for Code Scanning/GHAS refresh")
+    assert "Fix the flagged surface" not in "\\n".join(model["recommended_actions"])
+    assert model["ghas_blocker_details"]["findings"][0]["proof_commands"] == [
+        "gh pr checks --watch",
+        "Re-run PR Quality after Code Scanning refreshes on the current PR head.",
+    ]
+
+    body = report.render_pr_quality_review_summary(model)
+
+    assert "Stale-only Code Scanning state" in body
+    assert "do not patch or dismiss stale alerts" in body
+    assert "wait_for_code_scanning_refresh" in body

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4418,8 +4418,7 @@ def test_review_model_recommends_wait_for_stale_only_ghas_alerts() -> None:
     assert model["recommended_actions"][0].startswith("Wait for Code Scanning/GHAS refresh")
     assert "Fix the flagged surface" not in "\\n".join(model["recommended_actions"])
     assert model["ghas_blocker_details"]["findings"][0]["proof_commands"] == [
-        "gh pr checks --watch",
-        "Re-run PR Quality after Code Scanning refreshes on the current PR head.",
+        "gh pr checks --watch"
     ]
 
     body = report.render_pr_quality_review_summary(model)


### PR DESCRIPTION
## Summary
- Adds structured GHAS/CodeQL blocker details to the PR Quality review model.
- Surfaces alert number, URL, rule, severity, location, freshness, alert SHA, PR head SHA, action, and dismissal guidance.
- Opens GHAS blocker details in the adaptive PR comment when Code Scanning findings are active.
- Keeps GHAS dismissal reporting-only and forbidden by default until human false-positive review.

## Verification
- python -m pytest -q tests/test_pr_quality_action_report.py -k "ghas or adaptive or review_summary" -o addopts=
- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_current_head_failure_bundle.py -o addopts=
- python -m pre_commit run -a
- make proof-after-format