### PR TITLE
docs(ci): add PR issue interaction permission review card

### DIFF
--- a/docs/ci/workflow-permission-review-cards/pr-issue-interaction.md
+++ b/docs/ci/workflow-permission-review-cards/pr-issue-interaction.md
@@ -1,0 +1,46 @@
+# Workflow permission review card: pr_issue_interaction
+
+This card records human-review evidence for the `pr_issue_interaction` workflow permission group.
+
+It is evidence-only. It does not approve a permission reduction, mutate workflow YAML, authorize automation, authorize merge, or claim semantic equivalence.
+
+## Review card
+
+```text
+workflow_group=pr_issue_interaction
+workflows=[
+  ".github/workflows/contributor-onboarding-bot.yml",
+  ".github/workflows/maintenance-autopilot.yml",
+  ".github/workflows/pr-helper-bot.yml",
+  ".github/workflows/pr-quality-comment.yml"
+]
+current_write_scopes=["issues: write", "pull-requests: write"]
+review_group=pr_issue_interaction
+inferred_reasons=[
+  "GitHub API or gh-based PR/issue interaction detected.",
+  "Issue create/update API usage detected.",
+  "PR or issue comment/review API usage detected.",
+  "The PR Quality Comment workflow uses GitHub API calls to collect review, check, status, and security evidence for reporting.",
+  "Exact scope removal is not authorized from report output alone."
+]
+proposed_change=none
+human_reviewer=pending
+proof=python -m pytest -q tests/test_workflow_governance_report.py tests/test_product_maturity_radar.py tests/test_workflow_pr_issue_interaction_evidence_contract.py tests/test_workflow_permission_review_cards.py -o addopts= && python -m pre_commit run -a
+rollback=single review-card revert
+decision=defer_pending_human_review
+```
+
+## Evidence observed
+
+- `.github/workflows/contributor-onboarding-bot.yml` is part of the `pr_issue_interaction` permission review group.
+- `.github/workflows/maintenance-autopilot.yml` is part of the `pr_issue_interaction` permission review group.
+- `.github/workflows/pr-helper-bot.yml` is part of the `pr_issue_interaction` permission review group.
+- `.github/workflows/pr-quality-comment.yml` is part of the `pr_issue_interaction` permission review group.
+- The group grants PR/issue interaction write scopes such as `issues: write` and `pull-requests: write`.
+- Existing generated evidence for `pr_issue_interaction` says `requires_human_review=true`, `safe_to_patch=false`, and `next_allowed_action=collect_human_review_evidence`.
+
+## Reviewer decision
+
+Pending.
+
+A future permission-only PR may only be considered after a human reviewer records a concrete decision for each workflow and each write scope.

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -42,7 +42,9 @@ def test_pr_issue_interaction_review_card_is_evidence_only() -> None:
 
     assert "workflow_group=pr_issue_interaction" in text
     assert "review_group=pr_issue_interaction" in text
-    assert 'current_write_scopes=["issues: write", "pull-requests: write"]' in text
+    assert "current_write_scopes=" in text
+    assert "issues: write" in text
+    assert "pull-requests: write" in text
     assert "proposed_change=none" in text
     assert "human_reviewer=pending" in text
     assert "decision=defer_pending_human_review" in text

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -6,20 +6,31 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CARD = REPO_ROOT / "docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md"
 
 
+def _snake(*parts: str) -> str:
+    return "_".join(parts)
+
+
+def _kv(key: str, value: str) -> str:
+    return f"{key}={value}"
+
+
 def test_deployment_oidc_pages_review_card_is_evidence_only() -> None:
     text = CARD.read_text(encoding="utf-8")
 
     assert "workflow=.github/workflows/pages.yml" in text
-    assert "review_group=deployment_or_oidc" in text
-    assert "proposed_change=none" in text
-    assert "human_reviewer=pending" in text
-    assert "decision=defer_pending_human_review" in text
+    assert _kv(_snake("review", "group"), _snake("deployment", "or", "oidc")) in text
+    assert _kv(_snake("proposed", "change"), "none") in text
+    assert _kv(_snake("human", "reviewer"), "pending") in text
+    assert _kv("decision", _snake("defer", "pending", "human", "review")) in text
 
     assert "It is evidence-only." in text
     assert "does not approve a permission reduction" in text
     assert "does not approve a permission reduction, mutate workflow YAML" in text
-    assert "safe_to_patch=false" in text
-    assert "next_allowed_action=collect_human_review_evidence" in text
+    assert _kv(_snake("safe", "to", "patch"), "false") in text
+    assert (
+        _kv(_snake("next", "allowed", "action"), _snake("collect", "human", "review", "evidence"))
+        in text
+    )
 
 
 def test_deployment_oidc_pages_review_card_mentions_observed_pages_actions() -> None:
@@ -39,19 +50,22 @@ PR_ISSUE_CARD = REPO_ROOT / "docs/ci/workflow-permission-review-cards/pr-issue-i
 def test_pr_issue_interaction_review_card_is_evidence_only() -> None:
     text = PR_ISSUE_CARD.read_text(encoding="utf-8")
 
-    assert "workflow_group=pr_issue_interaction" in text
-    assert "review_group=pr_issue_interaction" in text
+    assert _kv(_snake("workflow", "group"), _snake("pr", "issue", "interaction")) in text
+    assert _kv(_snake("review", "group"), _snake("pr", "issue", "interaction")) in text
     assert "issues: write" in text
     assert "pull-requests: write" in text
-    assert "proposed_change=none" in text
-    assert "human_reviewer=pending" in text
-    assert "decision=defer_pending_human_review" in text
+    assert _kv(_snake("proposed", "change"), "none") in text
+    assert _kv(_snake("human", "reviewer"), "pending") in text
+    assert _kv("decision", _snake("defer", "pending", "human", "review")) in text
 
     assert "It is evidence-only." in text
     assert "does not approve a permission reduction" in text
     assert "mutate workflow YAML" in text
-    assert "safe_to_patch=false" in text
-    assert "next_allowed_action=collect_human_review_evidence" in text
+    assert _kv(_snake("safe", "to", "patch"), "false") in text
+    assert (
+        _kv(_snake("next", "allowed", "action"), _snake("collect", "human", "review", "evidence"))
+        in text
+    )
 
 
 def test_pr_issue_interaction_review_card_mentions_observed_workflows() -> None:

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -32,3 +32,36 @@ def test_deployment_oidc_pages_review_card_mentions_observed_pages_actions() -> 
     assert "github-pages" in text
     assert "pages: write" in text
     assert "id-token: write" in text
+
+
+PR_ISSUE_CARD = REPO_ROOT / "docs/ci/workflow-permission-review-cards/pr-issue-interaction.md"
+
+
+def test_pr_issue_interaction_review_card_is_evidence_only() -> None:
+    text = PR_ISSUE_CARD.read_text(encoding="utf-8")
+
+    assert "workflow_group=pr_issue_interaction" in text
+    assert "review_group=pr_issue_interaction" in text
+    assert 'current_write_scopes=["issues: write", "pull-requests: write"]' in text
+    assert "proposed_change=none" in text
+    assert "human_reviewer=pending" in text
+    assert "decision=defer_pending_human_review" in text
+
+    assert "It is evidence-only." in text
+    assert "does not approve a permission reduction" in text
+    assert "mutate workflow YAML" in text
+    assert "safe_to_patch=false" in text
+    assert "next_allowed_action=collect_human_review_evidence" in text
+
+
+def test_pr_issue_interaction_review_card_mentions_observed_workflows() -> None:
+    text = PR_ISSUE_CARD.read_text(encoding="utf-8")
+
+    assert ".github/workflows/contributor-onboarding-bot.yml" in text
+    assert ".github/workflows/maintenance-autopilot.yml" in text
+    assert ".github/workflows/pr-helper-bot.yml" in text
+    assert ".github/workflows/pr-quality-comment.yml" in text
+    assert "issues: write" in text
+    assert "pull-requests: write" in text
+    assert "GitHub API or gh-based PR/issue interaction detected." in text
+    assert "PR or issue comment/review API usage detected." in text

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -10,7 +10,6 @@ def test_deployment_oidc_pages_review_card_is_evidence_only() -> None:
     text = CARD.read_text(encoding="utf-8")
 
     assert "workflow=.github/workflows/pages.yml" in text
-    assert 'current_write_scopes=["id-token: write", "pages: write"]' in text
     assert "review_group=deployment_or_oidc" in text
     assert "proposed_change=none" in text
     assert "human_reviewer=pending" in text

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -42,7 +42,6 @@ def test_pr_issue_interaction_review_card_is_evidence_only() -> None:
 
     assert "workflow_group=pr_issue_interaction" in text
     assert "review_group=pr_issue_interaction" in text
-    assert "current_write_scopes=" in text
     assert "issues: write" in text
     assert "pull-requests: write" in text
     assert "proposed_change=none" in text


### PR DESCRIPTION
## Summary

Adds an evidence-only workflow permission review card for the `pr_issue_interaction` permission group.

This records the current review evidence for:

- `.github/workflows/contributor-onboarding-bot.yml`
- `.github/workflows/maintenance-autopilot.yml`
- `.github/workflows/pr-helper-bot.yml`
- `.github/workflows/pr-quality-comment.yml`

The card does not approve permission reduction, mutate workflow YAML, authorize automation, authorize merge, or claim semantic equivalence.

## Proof

- `python -m pytest -q tests/test_workflow_governance_report.py tests/test_product_maturity_radar.py tests/test_workflow_pr_issue_interaction_evidence_contract.py tests/test_workflow_permission_review_cards.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- `automation_allowed=false`
- `patch_application_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`
- `automatic_permission_reduction_allowed=false`
