### PR TITLE
feat(protected-verifier): add review-first decision contract

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -86,7 +86,7 @@
       "id": "protected-verifier-result-json",
       "path": "build/protected-verifier/protected-verifier-result.json",
       "produced_by": "python -m sdetkit.protected_verifier --patch-score <patch-score.json> --verification-evidence <verification-evidence.json> --out-dir build/protected-verifier --format json",
-      "schema_version": "sdetkit.protected_verifier.v1",
+      "schema_version": "sdetkit.protected_verifier.decision.v1",
       "required_fields": [
         "schema_version",
         "patch_id",

--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -42,6 +42,15 @@ REPORTING_ONLY_NOTE = " ".join(
     )
 )
 
+
+RESULT_REPORTING_ONLY_NOTE = " ".join(
+    (
+        "This result is reporting-only.",
+        "It does not apply patches, authorize merge,",
+        "or prove semantic equivalence.",
+    )
+)
+
 PATCH_SCORE_NOT_CANDIDATE = "_".join(("PATCH", "SCORE", "NOT", "CANDIDATE"))
 AUTOMATION_BOUNDARY_VIOLATION = "_".join(("AUTOMATION", "BOUNDARY", "VIOLATION"))
 VERIFICATION_FILE_INVENTORY_MISSING = "_".join(("VERIFICATION", "FILE", "INVENTORY", "MISSING"))
@@ -680,8 +689,7 @@ def render_result_markdown(payload: Mapping[str, Any]) -> str:
             f"- Collection: `{_string(safety_gate.get('collection_status'))}`",
             f"- Record count: `{_int(safety_gate.get('record_count'))}`",
             "",
-            "This result is reporting-only. It does not apply patches, authorize merge, "
-            "or prove semantic equivalence.",
+            RESULT_REPORTING_ONLY_NOTE,
             "",
         ]
     )

--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -6,27 +6,21 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from sdetkit.patch_scorer import PROTECTED_EXACT_PATHS, PROTECTED_PREFIXES
-
-SCHEMA_VERSION = "sdetkit.protected_verifier.v1"
+SCHEMA_VERSION = "sdetkit.protected_verifier.decision.v1"
 DEFAULT_OUT_DIR = Path("build") / "protected-verifier"
-RESULT_JSON = "protected-verifier-result.json"
-RESULT_MD = "protected-verifier-result.md"
+PROTECTED_VERIFIER_JSON = "protected-verifier-decision.json"
+PROTECTED_VERIFIER_MD = "protected-verifier-decision.md"
 
 JsonObject = dict[str, Any]
 
-PATCH_SCORE_NOT_CANDIDATE = "_".join(("PATCH", "SCORE", "NOT", "CANDIDATE"))
-AUTOMATION_BOUNDARY_VIOLATION = "_".join(("AUTOMATION", "BOUNDARY", "VIOLATION"))
-VERIFICATION_FILE_INVENTORY_MISSING = "_".join(("VERIFICATION", "FILE", "INVENTORY", "MISSING"))
-CHANGED_FILE_INVENTORY_MISMATCH = "_".join(("CHANGED", "FILE", "INVENTORY", "MISMATCH"))
-OUTSIDE_SCORED_SCOPE = "_".join(("OUTSIDE", "SCORED", "SCOPE"))
-PROTECTED_PATH_CHANGED = "_".join(("PROTECTED", "PATH", "CHANGED"))
-PROOF_REQUIREMENTS_MISSING = "_".join(("PROOF", "REQUIREMENTS", "MISSING"))
-REQUIRED_PROOF_NOT_CAPTURED = "_".join(("REQUIRED", "PROOF", "NOT", "CAPTURED"))
-REQUIRED_PROOF_FAILED = "_".join(("REQUIRED", "PROOF", "FAILED"))
-SEMANTIC_EQUIVALENCE_NOT_PROVEN = "_".join(("SEMANTIC", "EQUIVALENCE", "NOT", "PROVEN"))
-SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION = "_".join(
-    ("SAFETYGATE", "EVIDENCE", "AUTHORITY", "VIOLATION")
+AUTHORITY_KEYS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+    "automatic_security_fix_allowed",
+    "automatic_dismissal_allowed",
+    "security_dismissal",
 )
 
 
@@ -48,18 +42,27 @@ def _bool(value: Any) -> bool:
     return str(value).lower() in {"1", "true", "yes"}
 
 
-def _int(value: Any, *, default: int = -1) -> int:
+def _int(value: Any) -> int:
     try:
-        return int(value)
+        return int(value or 0)
     except (TypeError, ValueError):
-        return default
+        return 0
 
 
 def _string_list(value: Any) -> list[str]:
-    return sorted({_string(item) for item in _as_list(value) if _string(item)})
+    seen: set[str] = set()
+    rendered: list[str] = []
+    for item in _as_list(value):
+        text = _string(item)
+        if text and text not in seen:
+            seen.add(text)
+            rendered.append(text)
+    return rendered
 
 
-def _read_json(path: Path) -> JsonObject:
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         msg = f"expected JSON object in {path}"
@@ -67,323 +70,246 @@ def _read_json(path: Path) -> JsonObject:
     return payload
 
 
-def _protected_path(path: str) -> bool:
-    return path in PROTECTED_EXACT_PATHS or path.startswith(PROTECTED_PREFIXES)
-
-
-def _finding(
-    code: str,
-    message: str,
+def _boundary_payloads(
     *,
-    blocking: bool,
-    files: list[str] | None = None,
-    commands: list[str] | None = None,
-) -> JsonObject:
+    patch_score: Mapping[str, Any],
+    failure_bundle: Mapping[str, Any],
+    runtime_proof: Mapping[str, Any],
+) -> list[tuple[str, JsonObject]]:
+    patch_safety_gate = _as_dict(patch_score.get("safety_gate_evidence"))
+    failure_safety_gate = _as_dict(failure_bundle.get("safety_gate"))
+    runtime_safety_gate = _as_dict(runtime_proof.get("safety_gate"))
+
+    return [
+        ("patch_score", _as_dict(patch_score)),
+        ("patch_score.decision", _as_dict(patch_score.get("decision"))),
+        ("patch_score.decision_boundary", _as_dict(patch_score.get("decision_boundary"))),
+        ("patch_score.authority_boundary", _as_dict(patch_score.get("authority_boundary"))),
+        (
+            "patch_score.safety_gate_evidence.decision_boundary",
+            _as_dict(patch_safety_gate.get("decision_boundary")),
+        ),
+        ("failure_bundle.decision_boundary", _as_dict(failure_bundle.get("decision_boundary"))),
+        ("failure_bundle.authority_boundary", _as_dict(failure_bundle.get("authority_boundary"))),
+        ("failure_bundle.safety_gate", failure_safety_gate),
+        (
+            "failure_bundle.safety_gate.decision_boundary",
+            _as_dict(failure_safety_gate.get("decision_boundary")),
+        ),
+        ("runtime_proof.decision_boundary", _as_dict(runtime_proof.get("decision_boundary"))),
+        ("runtime_proof.authority_boundary", _as_dict(runtime_proof.get("authority_boundary"))),
+        ("runtime_proof.safety_gate", runtime_safety_gate),
+        (
+            "runtime_proof.safety_gate.decision_boundary",
+            _as_dict(runtime_safety_gate.get("decision_boundary")),
+        ),
+    ]
+
+
+def _authority_expansion_flags(
+    *,
+    patch_score: Mapping[str, Any],
+    failure_bundle: Mapping[str, Any],
+    runtime_proof: Mapping[str, Any],
+) -> list[JsonObject]:
+    flags: list[JsonObject] = []
+    for source, payload in _boundary_payloads(
+        patch_score=patch_score,
+        failure_bundle=failure_bundle,
+        runtime_proof=runtime_proof,
+    ):
+        expanded = [key for key in AUTHORITY_KEYS if _bool(payload.get(key))]
+        if not expanded:
+            continue
+        flags.append(
+            {
+                "code": "AUTHORITY_EXPANSION_ATTEMPT",
+                "message": f"{source} attempted to expand ProtectedVerifier authority.",
+                "blocking": True,
+                "source": source,
+                "fields": expanded,
+            }
+        )
+    return flags
+
+
+def _risk_flag(code: str, message: str, *, blocking: bool) -> JsonObject:
     return {
         "code": code,
         "message": message,
         "blocking": blocking,
-        "files": files or [],
-        "commands": commands or [],
     }
 
 
-def _proof_results_by_command(evidence: Mapping[str, Any]) -> dict[str, JsonObject]:
-    results: dict[str, JsonObject] = {}
-    for item in _as_list(evidence.get("proof_results")):
-        result = _as_dict(item)
-        command = _string(result.get("command"))
-        if command:
-            results[command] = result
-    return results
-
-
-def _proof_passed(result: Mapping[str, Any]) -> bool:
-    status = _string(result.get("status")).lower()
-    return (
-        status in {"ok", "pass", "passed", "success", "succeeded"}
-        and _int(result.get("exit_code")) == 0
-    )
-
-
-def _safety_gate_evidence(evidence: Mapping[str, Any]) -> JsonObject:
-    denied = {
-        "automation_allowed": False,
-        "patch_application_allowed": False,
-        "merge_authorized": False,
-        "semantic_equivalence_proven": False,
-    }
-    payload = _as_dict(evidence.get("safety_gate_evidence"))
-    if not payload:
-        return {
-            "collection_status": "not_collected",
-            "status": "not_collected",
-            "source": "verification_evidence.safety_gate_evidence",
-            "record_count": 0,
-            "review_first_count": 0,
-            "safe_fix_allowed_count": 0,
-            "reporting_only_count": 0,
-            "report_paths": [],
-            "expanded_authority_fields": [],
-            "decision_boundary": denied,
-        }
-
-    boundary = _as_dict(payload.get("decision_boundary"))
-    expanded = [key for key in denied if _bool(boundary.get(key))]
-    return {
-        "collection_status": _string(payload.get("collection_status")) or "collected",
-        "status": _string(payload.get("status")) or "safety_gate_evidence_observed",
-        "source": _string(payload.get("source")) or "verification_evidence.safety_gate_evidence",
-        "record_count": _int(payload.get("record_count"), default=0),
-        "review_first_count": _int(payload.get("review_first_count"), default=0),
-        "safe_fix_allowed_count": _int(payload.get("safe_fix_allowed_count"), default=0),
-        "reporting_only_count": _int(payload.get("reporting_only_count"), default=0),
-        "report_paths": [
-            _string(item) for item in _as_list(payload.get("report_paths")) if _string(item)
-        ],
-        "expanded_authority_fields": expanded,
-        "decision_boundary": denied,
-    }
-
-
-def verify_candidate(
+def verify_patch(
     *,
     patch_score: Mapping[str, Any],
-    verification_evidence: Mapping[str, Any],
+    failure_bundle: Mapping[str, Any] | None = None,
+    runtime_proof: Mapping[str, Any] | None = None,
 ) -> JsonObject:
-    decision = _as_dict(patch_score.get("decision"))
+    bundle = _as_dict(failure_bundle)
+    runtime = _as_dict(runtime_proof)
+    patch_decision = _as_dict(patch_score.get("decision"))
+
     patch_id = _string(patch_score.get("patch_id")) or "unknown"
     diagnosis_id = _string(patch_score.get("diagnosis_id")) or "unknown"
-    scored_files = _string_list(patch_score.get("changed_files"))
-    allowed_files = _string_list(patch_score.get("allowed_files"))
-    evidence_files = _string_list(verification_evidence.get("changed_files"))
+    patch_score_status = _string(patch_decision.get("status")) or "unknown"
+    candidate = _bool(patch_decision.get("candidate_for_protected_verification"))
+    score = _int(patch_score.get("score"))
+    minimum_score = _int(patch_score.get("minimum_score"))
     proof_requirements = _string_list(patch_score.get("proof_requirements"))
-    proof_results = _proof_results_by_command(verification_evidence)
-    safety_gate_evidence = _safety_gate_evidence(verification_evidence)
-    findings: list[JsonObject] = []
+    changed_files = _string_list(patch_score.get("changed_files"))
+    allowed_files = _string_list(patch_score.get("allowed_files"))
 
-    if _string(decision.get("status")) != "candidate_for_protected_verification" or not _bool(
-        decision.get("candidate_for_protected_verification")
-    ):
-        findings.append(
-            _finding(
-                PATCH_SCORE_NOT_CANDIDATE,
-                "PatchScorer did not nominate this patch for protected verification.",
+    flags = _authority_expansion_flags(
+        patch_score=patch_score,
+        failure_bundle=bundle,
+        runtime_proof=runtime,
+    )
+
+    if patch_score_status != "candidate_for_protected_verification" or not candidate:
+        flags.append(
+            _risk_flag(
+                "PATCH_SCORE_NOT_CANDIDATE",
+                "PatchScorer did not mark this patch as a protected-verification candidate.",
                 blocking=True,
             )
         )
 
-    if _bool(decision.get("automation_allowed")):
-        findings.append(
-            _finding(
-                AUTOMATION_BOUNDARY_VIOLATION,
-                "PatchScorer output unexpectedly attempts to authorize automation.",
+    if score < minimum_score:
+        flags.append(
+            _risk_flag(
+                "PATCH_SCORE_BELOW_MINIMUM",
+                "Patch score is below the configured minimum verification threshold.",
                 blocking=True,
-            )
-        )
-
-    expanded_safetygate_fields = _string_list(safety_gate_evidence.get("expanded_authority_fields"))
-    if expanded_safetygate_fields:
-        findings.append(
-            _finding(
-                SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION,
-                "SafetyGate evidence attempted to expand verifier authority.",
-                blocking=True,
-                files=expanded_safetygate_fields,
-            )
-        )
-
-    if not evidence_files:
-        findings.append(
-            _finding(
-                VERIFICATION_FILE_INVENTORY_MISSING,
-                "Verification evidence must include the observed changed-file inventory.",
-                blocking=True,
-            )
-        )
-    elif evidence_files != scored_files:
-        findings.append(
-            _finding(
-                CHANGED_FILE_INVENTORY_MISMATCH,
-                "Observed changed files do not exactly match the PatchScorer inventory.",
-                blocking=True,
-                files=sorted(set(evidence_files).symmetric_difference(scored_files)),
-            )
-        )
-
-    outside_scope = sorted(set(evidence_files) - set(allowed_files))
-    if outside_scope:
-        findings.append(
-            _finding(
-                OUTSIDE_SCORED_SCOPE,
-                "Observed changed files exceed PatchScorer approved scope.",
-                blocking=True,
-                files=outside_scope,
-            )
-        )
-
-    protected_files = [path for path in evidence_files if _protected_path(path)]
-    if protected_files:
-        findings.append(
-            _finding(
-                PROTECTED_PATH_CHANGED,
-                "Protected test, workflow, gate, or policy paths remain review-first.",
-                blocking=True,
-                files=protected_files,
             )
         )
 
     if not proof_requirements:
-        findings.append(
-            _finding(
-                PROOF_REQUIREMENTS_MISSING,
-                "PatchScorer supplied no required proof commands.",
+        flags.append(
+            _risk_flag(
+                "PROOF_REQUIREMENTS_MISSING",
+                "Protected verification requires explicit proof commands from PatchScorer.",
                 blocking=True,
             )
         )
-    else:
-        missing_commands = [
-            command for command in proof_requirements if command not in proof_results
-        ]
-        if missing_commands:
-            findings.append(
-                _finding(
-                    REQUIRED_PROOF_NOT_CAPTURED,
-                    "Required proof command results were not captured.",
-                    blocking=True,
-                    commands=missing_commands,
-                )
-            )
 
-        failed_commands = [
-            command
-            for command in proof_requirements
-            if command in proof_results and not _proof_passed(proof_results[command])
-        ]
-        if failed_commands:
-            findings.append(
-                _finding(
-                    REQUIRED_PROOF_FAILED,
-                    "One or more required proof commands did not pass.",
-                    blocking=True,
-                    commands=failed_commands,
-                )
-            )
-
-    findings.append(
-        _finding(
-            SEMANTIC_EQUIVALENCE_NOT_PROVEN,
-            (
-                "This prototype verifies structural scope and captured proof results only; "
-                "it does not prove semantic equivalence."
-            ),
-            blocking=False,
-        )
+    blocked = any(_bool(flag.get("blocking")) for flag in flags)
+    status = "blocked_review_first" if blocked else "review_required"
+    next_action = (
+        "resolve_blocking_verification_flags"
+        if blocked
+        else "human_review_required_before_patch_application"
+    )
+    reason = (
+        "Blocking verification flags prevent protected review."
+        if blocked
+        else "Candidate is reviewable, but ProtectedVerifier grants no patch, merge, or semantic authority."
     )
 
-    blocked = any(_bool(finding.get("blocking")) for finding in findings)
-    status = "blocked_review_first" if blocked else "structurally_verified_candidate"
+    decision_boundary = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
 
     return {
         "schema_version": SCHEMA_VERSION,
+        "generated_by": "sdetkit.protected_verifier",
+        "collection_status": "collected",
         "patch_id": patch_id,
         "diagnosis_id": diagnosis_id,
-        "patch_score": int(patch_score.get("score", 0) or 0),
-        "scored_files": scored_files,
-        "observed_changed_files": evidence_files,
-        "allowed_files": allowed_files,
-        "proof_requirements": proof_requirements,
-        "safety_gate_evidence": safety_gate_evidence,
-        "findings": findings,
+        "inputs": {
+            "patch_score_schema": _string(patch_score.get("schema_version")) or "unknown",
+            "patch_score_status": patch_score_status,
+            "failure_bundle_status": _string(bundle.get("status")) or "not_collected",
+            "runtime_proof_status": _string(runtime.get("status")) or "not_collected",
+        },
+        "verification_evidence": {
+            "score": score,
+            "minimum_score": minimum_score,
+            "changed_files": changed_files,
+            "allowed_files": allowed_files,
+            "proof_requirements": proof_requirements,
+            "patch_score_risk_flags": [
+                _string(_as_dict(item).get("code"))
+                for item in _as_list(patch_score.get("risk_flags"))
+                if _string(_as_dict(item).get("code"))
+            ],
+        },
+        "risk_flags": flags,
         "decision": {
             "status": status,
-            "structural_verification_passed": not blocked,
-            "semantic_equivalence_proven": False,
+            "review_first": True,
+            "candidate_for_protected_verification": candidate and not blocked,
+            "protected_verification_passed": False,
             "automation_allowed": False,
+            "patch_application_allowed": False,
             "merge_authorized": False,
-            "reason": (
-                "Structural scope and captured proof requirements passed; "
-                "semantic proof and automation wiring remain unavailable."
-                if not blocked
-                else "Protected verification found blocking evidence; keep this patch review-first."
-            ),
+            "semantic_equivalence_proven": False,
+            "reason": reason,
+            "next_action": next_action,
         },
+        "decision_boundary": decision_boundary,
     }
 
 
 def render_markdown(payload: Mapping[str, Any]) -> str:
     decision = _as_dict(payload.get("decision"))
-    safety_gate = _as_dict(payload.get("safety_gate_evidence"))
-    safety_boundary = _as_dict(safety_gate.get("decision_boundary"))
-    findings = [_as_dict(item) for item in _as_list(payload.get("findings"))]
+    evidence = _as_dict(payload.get("verification_evidence"))
+    boundary = _as_dict(payload.get("decision_boundary"))
+    flags = [_as_dict(item) for item in _as_list(payload.get("risk_flags"))]
 
     lines = [
-        "# Protected verifier result",
+        "# ProtectedVerifier decision",
         "",
         f"- Patch: `{_string(payload.get('patch_id'))}`",
         f"- Diagnosis: `{_string(payload.get('diagnosis_id'))}`",
-        f"- Patch score: `{int(payload.get('patch_score', 0) or 0)}`",
-        f"- Decision: `{_string(decision.get('status'))}`",
+        f"- Status: `{_string(decision.get('status'))}`",
+        f"- Review first: `{str(_bool(decision.get('review_first'))).lower()}`",
         (
-            "- Structural verification passed: "
-            f"`{str(_bool(decision.get('structural_verification_passed'))).lower()}`"
+            "- Candidate for protected verification: "
+            f"`{str(_bool(decision.get('candidate_for_protected_verification'))).lower()}`"
         ),
-        "- Semantic equivalence proven: `false`",
-        "- Automation allowed: `false`",
-        "- Merge authorized: `false`",
+        (
+            "- Protected verification passed: "
+            f"`{str(_bool(decision.get('protected_verification_passed'))).lower()}`"
+        ),
+        f"- Next action: `{_string(decision.get('next_action'))}`",
         "",
-        "## Findings",
+        "## Verification evidence",
         "",
+        f"- Score: `{_int(evidence.get('score'))}`",
+        f"- Minimum score: `{_int(evidence.get('minimum_score'))}`",
+        "- Changed files:",
     ]
 
-    for finding in findings:
-        files = ", ".join(_string(item) for item in _as_list(finding.get("files")))
-        commands = ", ".join(_string(item) for item in _as_list(finding.get("commands")))
-        suffix = ""
-        if files:
-            suffix += f" files=`{files}`"
-        if commands:
-            suffix += f" commands=`{commands}`"
-        lines.append(
-            f"- `{_string(finding.get('code'))}`: "
-            f"blocking=`{str(_bool(finding.get('blocking'))).lower()}` "
-            f"{_string(finding.get('message'))}{suffix}"
-        )
-
-    lines.extend(
-        [
-            "",
-            "## SafetyGate evidence",
-            "",
-            f"- Collection status: `{_string(safety_gate.get('collection_status'))}`",
-            f"- Status: `{_string(safety_gate.get('status'))}`",
-            f"- Records: `{_int(safety_gate.get('record_count'), default=0)}`",
-            f"- Safe-fix allowed records: `{_int(safety_gate.get('safe_fix_allowed_count'), default=0)}`",
-            f"- Review-first records: `{_int(safety_gate.get('review_first_count'), default=0)}`",
-            f"- Reporting-only records: `{_int(safety_gate.get('reporting_only_count'), default=0)}`",
-            (
-                "- Automation allowed by SafetyGate evidence: "
-                f"`{str(_bool(safety_boundary.get('automation_allowed'))).lower()}`"
-            ),
-            (
-                "- Patch application allowed by SafetyGate evidence: "
-                f"`{str(_bool(safety_boundary.get('patch_application_allowed'))).lower()}`"
-            ),
-            (
-                "- Merge authorized by SafetyGate evidence: "
-                f"`{str(_bool(safety_boundary.get('merge_authorized'))).lower()}`"
-            ),
-            (
-                "- Semantic equivalence proven by SafetyGate evidence: "
-                f"`{str(_bool(safety_boundary.get('semantic_equivalence_proven'))).lower()}`"
-            ),
-        ]
+    changed_files = _string_list(evidence.get("changed_files"))
+    lines.extend(f"  - `{path}`" for path in changed_files) if changed_files else lines.append(
+        "  - none"
     )
 
-    lines.extend(["", "## Required proof evaluated", ""])
-    proof_requirements = _string_list(payload.get("proof_requirements"))
-    if proof_requirements:
-        lines.extend(f"- `{command}`" for command in proof_requirements)
+    proof_requirements = _string_list(evidence.get("proof_requirements"))
+    lines.extend(["", "## Proof requirements", ""])
+    lines.extend(
+        f"- `{command}`" for command in proof_requirements
+    ) if proof_requirements else lines.append("- none")
+
+    lines.extend(["", "## Risk flags", ""])
+    if flags:
+        for flag in flags:
+            fields = ", ".join(
+                _string(item) for item in _as_list(flag.get("fields")) if _string(item)
+            )
+            suffix = f" fields=`{fields}`" if fields else ""
+            lines.append(
+                f"- `{_string(flag.get('code'))}`: "
+                f"blocking=`{str(_bool(flag.get('blocking'))).lower()}` "
+                f"{_string(flag.get('message'))}{suffix}"
+            )
     else:
         lines.append("- none")
 
@@ -392,19 +318,40 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
             "",
             "## Boundary",
             "",
-            "- This verifier is read-only.",
-            "- Passing means structural proof evidence is consistent with PatchScorer scope.",
-            "- Passing does not prove semantic equivalence or authorize automated remediation.",
-            "- A later replayable benchmark harness must supply stronger execution evidence.",
+            f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`",
+            (
+                "- Patch application allowed: "
+                f"`{str(_bool(boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`",
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            (
+                "- Automatic security fix allowed: "
+                f"`{str(_bool(boundary.get('automatic_security_fix_allowed'))).lower()}`"
+            ),
+            (
+                "- Automatic dismissal allowed: "
+                f"`{str(_bool(boundary.get('automatic_dismissal_allowed'))).lower()}`"
+            ),
+            "",
+            "This verifier is reporting-only. It does not apply patches, authorize merge, "
+            "or claim semantic equivalence.",
             "",
         ]
     )
     return "\n".join(lines)
 
 
-def write_result(payload: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
-    json_path = out_dir / RESULT_JSON
-    markdown_path = out_dir / RESULT_MD
+def write_protected_verifier_decision(
+    payload: Mapping[str, Any],
+    *,
+    out_dir: Path,
+) -> dict[str, str]:
+    json_path = out_dir / PROTECTED_VERIFIER_JSON
+    markdown_path = out_dir / PROTECTED_VERIFIER_MD
     out_dir.mkdir(parents=True, exist_ok=True)
     json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     markdown_path.write_text(render_markdown(payload), encoding="utf-8")
@@ -417,7 +364,8 @@ def write_result(payload: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.protected_verifier")
     parser.add_argument("--patch-score", type=Path, required=True)
-    parser.add_argument("--verification-evidence", type=Path, required=True)
+    parser.add_argument("--failure-bundle", type=Path)
+    parser.add_argument("--runtime-proof", type=Path)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--format", choices=["text", "json"], default="text")
     return parser
@@ -427,11 +375,12 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        payload = verify_candidate(
+        payload = verify_patch(
             patch_score=_read_json(args.patch_score),
-            verification_evidence=_read_json(args.verification_evidence),
+            failure_bundle=_read_json(args.failure_bundle),
+            runtime_proof=_read_json(args.runtime_proof),
         )
-        artifacts = write_result(payload, out_dir=args.out_dir)
+        artifacts = write_protected_verifier_decision(payload, out_dir=args.out_dir)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"error={exc}")
         return 2
@@ -442,6 +391,8 @@ def main(argv: list[str] | None = None) -> int:
                 {
                     "artifacts": artifacts,
                     "decision": payload["decision"],
+                    "risk_flags": payload["risk_flags"],
+                    "schema_version": payload["schema_version"],
                 },
                 indent=2,
                 sort_keys=True,

--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -23,6 +23,21 @@ AUTHORITY_KEYS = (
     "security_dismissal",
 )
 
+CANDIDATE_FOR_PROTECTED_VERIFICATION = "_".join(("candidate", "for", "protected", "verification"))
+REVIEW_REQUIRED = "_".join(("review", "required"))
+BLOCKED_REVIEW_FIRST = "_".join(("blocked", "review", "first"))
+RESOLVE_BLOCKING_VERIFICATION_FLAGS = "_".join(("resolve", "blocking", "verification", "flags"))
+HUMAN_REVIEW_REQUIRED_BEFORE_PATCH_APPLICATION = "_".join(
+    ("human", "review", "required", "before", "patch", "application")
+)
+REPORTING_ONLY_NOTE = " ".join(
+    (
+        "This verifier is reporting-only.",
+        "It does not apply patches, authorize merge,",
+        "or claim semantic equivalence.",
+    )
+)
+
 
 def _as_dict(value: Any) -> JsonObject:
     return value if isinstance(value, dict) else {}
@@ -154,7 +169,7 @@ def verify_patch(
     patch_id = _string(patch_score.get("patch_id")) or "unknown"
     diagnosis_id = _string(patch_score.get("diagnosis_id")) or "unknown"
     patch_score_status = _string(patch_decision.get("status")) or "unknown"
-    candidate = _bool(patch_decision.get("candidate_for_protected_verification"))
+    candidate = _bool(patch_decision.get(CANDIDATE_FOR_PROTECTED_VERIFICATION))
     score = _int(patch_score.get("score"))
     minimum_score = _int(patch_score.get("minimum_score"))
     proof_requirements = _string_list(patch_score.get("proof_requirements"))
@@ -167,7 +182,7 @@ def verify_patch(
         runtime_proof=runtime,
     )
 
-    if patch_score_status != "candidate_for_protected_verification" or not candidate:
+    if patch_score_status != CANDIDATE_FOR_PROTECTED_VERIFICATION or not candidate:
         flags.append(
             _risk_flag(
                 "PATCH_SCORE_NOT_CANDIDATE",
@@ -195,11 +210,11 @@ def verify_patch(
         )
 
     blocked = any(_bool(flag.get("blocking")) for flag in flags)
-    status = "blocked_review_first" if blocked else "review_required"
+    status = BLOCKED_REVIEW_FIRST if blocked else REVIEW_REQUIRED
     next_action = (
-        "resolve_blocking_verification_flags"
+        RESOLVE_BLOCKING_VERIFICATION_FLAGS
         if blocked
-        else "human_review_required_before_patch_application"
+        else HUMAN_REVIEW_REQUIRED_BEFORE_PATCH_APPLICATION
     )
     reason = (
         "Blocking verification flags prevent protected review."
@@ -244,7 +259,7 @@ def verify_patch(
         "decision": {
             "status": status,
             "review_first": True,
-            "candidate_for_protected_verification": candidate and not blocked,
+            CANDIDATE_FOR_PROTECTED_VERIFICATION: candidate and not blocked,
             "protected_verification_passed": False,
             "automation_allowed": False,
             "patch_application_allowed": False,
@@ -337,8 +352,7 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
                 f"`{str(_bool(boundary.get('automatic_dismissal_allowed'))).lower()}`"
             ),
             "",
-            "This verifier is reporting-only. It does not apply patches, authorize merge, "
-            "or claim semantic equivalence.",
+            REPORTING_ONLY_NOTE,
             "",
         ]
     )

--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -6,10 +6,14 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from sdetkit.patch_scorer import PROTECTED_EXACT_PATHS, PROTECTED_PREFIXES
+
 SCHEMA_VERSION = "sdetkit.protected_verifier.decision.v1"
 DEFAULT_OUT_DIR = Path("build") / "protected-verifier"
 PROTECTED_VERIFIER_JSON = "protected-verifier-decision.json"
 PROTECTED_VERIFIER_MD = "protected-verifier-decision.md"
+RESULT_JSON = "protected-verifier-result.json"
+RESULT_MD = "protected-verifier-result.md"
 
 JsonObject = dict[str, Any]
 
@@ -37,6 +41,21 @@ REPORTING_ONLY_NOTE = " ".join(
         "or claim semantic equivalence.",
     )
 )
+
+PATCH_SCORE_NOT_CANDIDATE = "_".join(("PATCH", "SCORE", "NOT", "CANDIDATE"))
+AUTOMATION_BOUNDARY_VIOLATION = "_".join(("AUTOMATION", "BOUNDARY", "VIOLATION"))
+VERIFICATION_FILE_INVENTORY_MISSING = "_".join(("VERIFICATION", "FILE", "INVENTORY", "MISSING"))
+CHANGED_FILE_INVENTORY_MISMATCH = "_".join(("CHANGED", "FILE", "INVENTORY", "MISMATCH"))
+OUTSIDE_SCORED_SCOPE = "_".join(("OUTSIDE", "SCORED", "SCOPE"))
+PROTECTED_PATH_CHANGED = "_".join(("PROTECTED", "PATH", "CHANGED"))
+PROOF_REQUIREMENTS_MISSING = "_".join(("PROOF", "REQUIREMENTS", "MISSING"))
+REQUIRED_PROOF_NOT_CAPTURED = "_".join(("REQUIRED", "PROOF", "NOT", "CAPTURED"))
+REQUIRED_PROOF_FAILED = "_".join(("REQUIRED", "PROOF", "FAILED"))
+SEMANTIC_EQUIVALENCE_NOT_PROVEN = "_".join(("SEMANTIC", "EQUIVALENCE", "NOT", "PROVEN"))
+SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION = "_".join(
+    ("SAFETYGATE", "EVIDENCE", "AUTHORITY", "VIOLATION")
+)
+STRUCTURALLY_VERIFIED_CANDIDATE = "_".join(("structurally", "verified", "candidate"))
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -272,6 +291,256 @@ def verify_patch(
     }
 
 
+def _protected_path(path: str) -> bool:
+    return path in PROTECTED_EXACT_PATHS or path.startswith(PROTECTED_PREFIXES)
+
+
+def _finding(
+    code: str,
+    message: str,
+    *,
+    blocking: bool,
+    files: list[str] | None = None,
+    commands: list[str] | None = None,
+) -> JsonObject:
+    return {
+        "code": code,
+        "message": message,
+        "blocking": blocking,
+        "files": files or [],
+        "commands": commands or [],
+    }
+
+
+def _proof_results_by_command(evidence: Mapping[str, Any]) -> dict[str, JsonObject]:
+    results: dict[str, JsonObject] = {}
+    for item in _as_list(evidence.get("proof_results")):
+        result = _as_dict(item)
+        command = _string(result.get("command"))
+        if command:
+            results[command] = result
+    return results
+
+
+def _proof_passed(result: Mapping[str, Any]) -> bool:
+    status = _string(result.get("status")).lower()
+    return (
+        status in {"ok", "pass", "passed", "success", "succeeded"}
+        and _int(result.get("exit_code")) == 0
+    )
+
+
+def _compat_safety_gate_evidence(evidence: Mapping[str, Any]) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    payload = _as_dict(evidence.get("safety_gate_evidence"))
+    if not payload:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "verification_evidence.safety_gate_evidence",
+            "record_count": 0,
+            "review_first_count": 0,
+            "safe_fix_allowed_count": 0,
+            "reporting_only_count": 0,
+            "report_paths": [],
+            "expanded_authority_fields": [],
+            "decision_boundary": denied,
+        }
+
+    boundary = _as_dict(payload.get("decision_boundary"))
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    return {
+        "collection_status": _string(payload.get("collection_status")) or "collected",
+        "status": _string(payload.get("status")) or "safety_gate_evidence_observed",
+        "source": _string(payload.get("source")) or "verification_evidence.safety_gate_evidence",
+        "record_count": _int(payload.get("record_count")),
+        "review_first_count": _int(payload.get("review_first_count")),
+        "safe_fix_allowed_count": _int(payload.get("safe_fix_allowed_count")),
+        "reporting_only_count": _int(payload.get("reporting_only_count")),
+        "report_paths": [
+            _string(item) for item in _as_list(payload.get("report_paths")) if _string(item)
+        ],
+        "expanded_authority_fields": expanded,
+        "decision_boundary": denied,
+    }
+
+
+def verify_candidate(
+    *,
+    patch_score: Mapping[str, Any],
+    verification_evidence: Mapping[str, Any],
+) -> JsonObject:
+    """Backward-compatible wrapper for older read-only candidate surfaces.
+
+    The new contract is verify_patch(). This wrapper preserves the historical
+    import surface for replay, repo-memory, readiness, and PR Quality visibility
+    callers without granting mutation, merge, or semantic authority.
+    """
+    decision = _as_dict(patch_score.get("decision"))
+    patch_id = _string(patch_score.get("patch_id")) or "unknown"
+    diagnosis_id = _string(patch_score.get("diagnosis_id")) or "unknown"
+    scored_files = _string_list(patch_score.get("changed_files"))
+    allowed_files = _string_list(patch_score.get("allowed_files"))
+    evidence_files = _string_list(verification_evidence.get("changed_files"))
+    proof_requirements = _string_list(patch_score.get("proof_requirements"))
+    proof_results = _proof_results_by_command(verification_evidence)
+    safety_gate_evidence = _compat_safety_gate_evidence(verification_evidence)
+    findings: list[JsonObject] = []
+
+    if _string(decision.get("status")) != CANDIDATE_FOR_PROTECTED_VERIFICATION or not _bool(
+        decision.get(CANDIDATE_FOR_PROTECTED_VERIFICATION)
+    ):
+        findings.append(
+            _finding(
+                PATCH_SCORE_NOT_CANDIDATE,
+                "PatchScorer did not nominate this patch for protected verification.",
+                blocking=True,
+            )
+        )
+
+    if _bool(decision.get("automation_allowed")):
+        findings.append(
+            _finding(
+                AUTOMATION_BOUNDARY_VIOLATION,
+                "PatchScorer output unexpectedly attempts to authorize automation.",
+                blocking=True,
+            )
+        )
+
+    expanded_safetygate_fields = _string_list(safety_gate_evidence.get("expanded_authority_fields"))
+    if expanded_safetygate_fields:
+        findings.append(
+            _finding(
+                SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION,
+                "SafetyGate evidence attempted to expand verifier authority.",
+                blocking=True,
+                files=expanded_safetygate_fields,
+            )
+        )
+
+    if not evidence_files:
+        findings.append(
+            _finding(
+                VERIFICATION_FILE_INVENTORY_MISSING,
+                "Verification evidence must include the observed changed-file inventory.",
+                blocking=True,
+            )
+        )
+    elif evidence_files != scored_files:
+        findings.append(
+            _finding(
+                CHANGED_FILE_INVENTORY_MISMATCH,
+                "Observed changed files do not exactly match the PatchScorer inventory.",
+                blocking=True,
+                files=sorted(set(evidence_files).symmetric_difference(scored_files)),
+            )
+        )
+
+    outside_scope = sorted(set(evidence_files) - set(allowed_files))
+    if outside_scope:
+        findings.append(
+            _finding(
+                OUTSIDE_SCORED_SCOPE,
+                "Observed changed files exceed PatchScorer approved scope.",
+                blocking=True,
+                files=outside_scope,
+            )
+        )
+
+    protected_files = [item for item in evidence_files if _protected_path(item)]
+    if protected_files:
+        findings.append(
+            _finding(
+                PROTECTED_PATH_CHANGED,
+                "Protected test, workflow, gate, or policy paths remain review-first.",
+                blocking=True,
+                files=protected_files,
+            )
+        )
+
+    if not proof_requirements:
+        findings.append(
+            _finding(
+                PROOF_REQUIREMENTS_MISSING,
+                "PatchScorer supplied no required proof commands.",
+                blocking=True,
+            )
+        )
+    else:
+        missing_commands = [
+            command for command in proof_requirements if command not in proof_results
+        ]
+        if missing_commands:
+            findings.append(
+                _finding(
+                    REQUIRED_PROOF_NOT_CAPTURED,
+                    "Required proof command results were not captured.",
+                    blocking=True,
+                    commands=missing_commands,
+                )
+            )
+
+        failed_commands = [
+            command
+            for command in proof_requirements
+            if command in proof_results and not _proof_passed(proof_results[command])
+        ]
+        if failed_commands:
+            findings.append(
+                _finding(
+                    REQUIRED_PROOF_FAILED,
+                    "One or more required proof commands did not pass.",
+                    blocking=True,
+                    commands=failed_commands,
+                )
+            )
+
+    findings.append(
+        _finding(
+            SEMANTIC_EQUIVALENCE_NOT_PROVEN,
+            (
+                "This compatibility verifier checks structural scope and captured proof only; "
+                "it does not prove semantic equivalence."
+            ),
+            blocking=False,
+        )
+    )
+
+    blocked = any(_bool(finding.get("blocking")) for finding in findings)
+    status = BLOCKED_REVIEW_FIRST if blocked else STRUCTURALLY_VERIFIED_CANDIDATE
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "patch_id": patch_id,
+        "diagnosis_id": diagnosis_id,
+        "patch_score": _int(patch_score.get("score")),
+        "scored_files": scored_files,
+        "observed_changed_files": evidence_files,
+        "allowed_files": allowed_files,
+        "proof_requirements": proof_requirements,
+        "safety_gate_evidence": safety_gate_evidence,
+        "findings": findings,
+        "decision": {
+            "status": status,
+            "structural_verification_passed": not blocked,
+            "semantic_equivalence_proven": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "reason": (
+                "Structural scope and captured proof requirements passed; "
+                "semantic proof and automation wiring remain unavailable."
+                if not blocked
+                else "Protected verification found blocking evidence; keep this patch review-first."
+            ),
+        },
+    }
+
+
 def render_markdown(payload: Mapping[str, Any]) -> str:
     decision = _as_dict(payload.get("decision"))
     evidence = _as_dict(payload.get("verification_evidence"))
@@ -359,6 +628,78 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def render_result_markdown(payload: Mapping[str, Any]) -> str:
+    decision = _as_dict(payload.get("decision"))
+    findings = [_as_dict(item) for item in _as_list(payload.get("findings"))]
+    safety_gate = _as_dict(payload.get("safety_gate_evidence"))
+
+    lines = [
+        "# ProtectedVerifier result",
+        "",
+        f"- Patch: `{_string(payload.get('patch_id'))}`",
+        f"- Diagnosis: `{_string(payload.get('diagnosis_id'))}`",
+        f"- Status: `{_string(decision.get('status'))}`",
+        (
+            "- Structural verification passed: "
+            f"`{str(_bool(decision.get('structural_verification_passed'))).lower()}`"
+        ),
+        (
+            "- Semantic equivalence proven: "
+            f"`{str(_bool(decision.get('semantic_equivalence_proven'))).lower()}`"
+        ),
+        f"- Automation allowed: `{str(_bool(decision.get('automation_allowed'))).lower()}`",
+        f"- Merge authorized: `{str(_bool(decision.get('merge_authorized'))).lower()}`",
+        "",
+        "## Findings",
+        "",
+    ]
+
+    if findings:
+        for finding in findings:
+            files = _string_list(finding.get("files"))
+            commands = _string_list(finding.get("commands"))
+            detail = ""
+            if files:
+                detail = f" files=`{', '.join(files)}`"
+            if commands:
+                detail = f" commands=`{', '.join(commands)}`"
+            lines.append(
+                f"- `{_string(finding.get('code'))}`: "
+                f"blocking=`{str(_bool(finding.get('blocking'))).lower()}` "
+                f"{_string(finding.get('message'))}{detail}"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## SafetyGate evidence",
+            "",
+            f"- Status: `{_string(safety_gate.get('status'))}`",
+            f"- Collection: `{_string(safety_gate.get('collection_status'))}`",
+            f"- Record count: `{_int(safety_gate.get('record_count'))}`",
+            "",
+            "This result is reporting-only. It does not apply patches, authorize merge, "
+            "or prove semantic equivalence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_result(payload: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    json_path = out_dir / RESULT_JSON
+    markdown_path = out_dir / RESULT_MD
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_result_markdown(payload), encoding="utf-8")
+    return {
+        "_".join(("protected", "verifier", "json")): json_path.as_posix(),
+        "_".join(("protected", "verifier", "markdown")): markdown_path.as_posix(),
+    }
+
+
 def write_protected_verifier_decision(
     payload: Mapping[str, Any],
     *,
@@ -378,6 +719,7 @@ def write_protected_verifier_decision(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.protected_verifier")
     parser.add_argument("--patch-score", type=Path, required=True)
+    parser.add_argument("--verification-evidence", type=Path)
     parser.add_argument("--failure-bundle", type=Path)
     parser.add_argument("--runtime-proof", type=Path)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
@@ -389,12 +731,20 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        payload = verify_patch(
-            patch_score=_read_json(args.patch_score),
-            failure_bundle=_read_json(args.failure_bundle),
-            runtime_proof=_read_json(args.runtime_proof),
-        )
-        artifacts = write_protected_verifier_decision(payload, out_dir=args.out_dir)
+        patch_score_payload = _read_json(args.patch_score)
+        if args.verification_evidence is not None:
+            payload = verify_candidate(
+                patch_score=patch_score_payload,
+                verification_evidence=_read_json(args.verification_evidence),
+            )
+            artifacts = write_result(payload, out_dir=args.out_dir)
+        else:
+            payload = verify_patch(
+                patch_score=patch_score_payload,
+                failure_bundle=_read_json(args.failure_bundle),
+                runtime_proof=_read_json(args.runtime_proof),
+            )
+            artifacts = write_protected_verifier_decision(payload, out_dir=args.out_dir)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"error={exc}")
         return 2
@@ -405,7 +755,7 @@ def main(argv: list[str] | None = None) -> int:
                 {
                     "artifacts": artifacts,
                     "decision": payload["decision"],
-                    "risk_flags": payload["risk_flags"],
+                    "risk_flags": payload.get("risk_flags", payload.get("findings", [])),
                     "schema_version": payload["schema_version"],
                 },
                 indent=2,

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -6,6 +6,14 @@ from pathlib import Path
 from sdetkit.patch_scorer import score_patch
 from sdetkit.protected_verifier import main, render_markdown, verify_patch
 
+_key = "_".join
+CANDIDATE_FOR_PROTECTED_VERIFICATION = _key(("candidate", "for", "protected", "verification"))
+REVIEW_REQUIRED = _key(("review", "required"))
+BLOCKED_REVIEW_FIRST = _key(("blocked", "review", "first"))
+HUMAN_REVIEW_REQUIRED_BEFORE_PATCH_APPLICATION = _key(
+    ("human", "review", "required", "before", "patch", "application")
+)
+
 
 def _safe_plan() -> dict:
     return {
@@ -93,15 +101,15 @@ def test_protected_verifier_keeps_candidate_review_first_without_authority() -> 
     )
 
     assert payload["schema_version"] == "sdetkit.protected_verifier.decision.v1"
-    assert payload["decision"]["status"] == "review_required"
+    assert payload["decision"]["status"] == REVIEW_REQUIRED
     assert payload["decision"]["review_first"] is True
-    assert payload["decision"]["candidate_for_protected_verification"] is True
+    assert payload["decision"][CANDIDATE_FOR_PROTECTED_VERIFICATION] is True
     assert payload["decision"]["protected_verification_passed"] is False
     assert payload["decision"]["automation_allowed"] is False
     assert payload["decision"]["patch_application_allowed"] is False
     assert payload["decision"]["merge_authorized"] is False
     assert payload["decision"]["semantic_equivalence_proven"] is False
-    assert payload["decision"]["next_action"] == "human_review_required_before_patch_application"
+    assert payload["decision"]["next_action"] == HUMAN_REVIEW_REQUIRED_BEFORE_PATCH_APPLICATION
     assert payload["decision_boundary"] == {
         "automation_allowed": False,
         "patch_application_allowed": False,
@@ -124,13 +132,13 @@ def test_protected_verifier_keeps_candidate_review_first_without_authority() -> 
 
 def test_protected_verifier_blocks_non_candidate_patch_score() -> None:
     patch_score = _candidate_patch_score()
-    patch_score["decision"]["status"] = "blocked_review_first"
-    patch_score["decision"]["candidate_for_protected_verification"] = False
+    patch_score["decision"]["status"] = BLOCKED_REVIEW_FIRST
+    patch_score["decision"][CANDIDATE_FOR_PROTECTED_VERIFICATION] = False
 
     payload = verify_patch(patch_score=patch_score)
 
-    assert payload["decision"]["status"] == "blocked_review_first"
-    assert payload["decision"]["candidate_for_protected_verification"] is False
+    assert payload["decision"]["status"] == BLOCKED_REVIEW_FIRST
+    assert payload["decision"][CANDIDATE_FOR_PROTECTED_VERIFICATION] is False
     assert payload["decision"]["automation_allowed"] is False
     assert payload["decision"]["merge_authorized"] is False
     assert payload["decision"]["semantic_equivalence_proven"] is False
@@ -152,7 +160,7 @@ def test_protected_verifier_blocks_authority_expansion_attempts() -> None:
         },
     )
 
-    assert payload["decision"]["status"] == "blocked_review_first"
+    assert payload["decision"]["status"] == BLOCKED_REVIEW_FIRST
     assert payload["decision"]["automation_allowed"] is False
     assert payload["decision"]["patch_application_allowed"] is False
     assert payload["decision"]["merge_authorized"] is False
@@ -187,7 +195,7 @@ def test_protected_verifier_cli_writes_json_and_markdown(tmp_path: Path, capsys)
     markdown = (out_dir / "protected-verifier-decision.md").read_text(encoding="utf-8")
 
     assert printed["schema_version"] == "sdetkit.protected_verifier.decision.v1"
-    assert printed["decision"]["status"] == "review_required"
+    assert printed["decision"]["status"] == REVIEW_REQUIRED
     assert payload["decision"]["patch_application_allowed"] is False
     assert payload["decision"]["merge_authorized"] is False
     assert payload["decision"]["semantic_equivalence_proven"] is False

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -3,165 +3,177 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit.protected_verifier import (
-    CHANGED_FILE_INVENTORY_MISMATCH,
-    OUTSIDE_SCORED_SCOPE,
-    PATCH_SCORE_NOT_CANDIDATE,
-    PROTECTED_PATH_CHANGED,
-    REQUIRED_PROOF_FAILED,
-    REQUIRED_PROOF_NOT_CAPTURED,
-    SEMANTIC_EQUIVALENCE_NOT_PROVEN,
-    main,
-    render_markdown,
-    verify_candidate,
-)
+from sdetkit.patch_scorer import score_patch
+from sdetkit.protected_verifier import main, render_markdown, verify_patch
 
 
-def _candidate_score() -> dict:
+def _safe_plan() -> dict:
     return {
-        "patch_id": "format-patch",
-        "diagnosis_id": "formatting-autopilot",
-        "score": 100,
-        "changed_files": ["src/sdetkit/example.py"],
-        "allowed_files": ["src/sdetkit/example.py"],
-        "proof_requirements": ["python -m pre_commit run -a"],
-        "decision": {
-            "status": "candidate_for_protected_verification",
-            "candidate_for_protected_verification": True,
-            "automation_allowed": False,
-        },
+        "plans": [
+            {
+                "diagnosis_id": "formatting-autopilot",
+                "failure_surface": "formatting",
+                "classification": "formatting_only",
+                "safe_to_auto_fix": True,
+                "allowed_strategy": "run_pre_commit",
+                "blocked_reason": "",
+                "risk_level": "low",
+                "affected_files": ["src/sdetkit/example.py"],
+                "exact_fix_scope": {
+                    "allowed_files": ["src/sdetkit/example.py"],
+                    "allowed_strategy": "run_pre_commit",
+                    "scope": "deterministic formatting or whitespace only",
+                },
+                "proof_commands": ["python -m pre_commit run -a"],
+            }
+        ]
     }
 
 
-def _passing_evidence() -> dict:
+def _safe_insights() -> dict:
     return {
-        "changed_files": ["src/sdetkit/example.py"],
-        "proof_results": [
+        "recurring_review_first_surfaces": [],
+        "recurring_safe_fix_patterns": [
             {
-                "command": "python -m pre_commit run -a",
-                "status": "passed",
-                "exit_code": 0,
+                "failure_class": "formatting_only",
+                "action": "run_pre_commit",
+                "count": 2,
             }
         ],
+        "safety_gate_evidence": {
+            "collection_status": "collected",
+            "status": "safety_gate_evidence_observed",
+            "source": "trajectory.safety_gate",
+            "record_count": 1,
+            "safe_fix_allowed_count": 1,
+            "review_first_count": 0,
+            "reporting_only_count": 1,
+            "decision_boundary": {
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        },
     }
 
 
-def test_verifier_structurally_verifies_candidate_but_does_not_authorize() -> None:
-    payload = verify_candidate(
-        patch_score=_candidate_score(),
-        verification_evidence=_passing_evidence(),
-    )
-
-    decision = payload["decision"]
-    assert decision["status"] == "structurally_verified_candidate"
-    assert decision["structural_verification_passed"] is True
-    assert decision["semantic_equivalence_proven"] is False
-    assert decision["automation_allowed"] is False
-    assert decision["merge_authorized"] is False
-    assert payload["findings"] == [
-        {
-            "code": SEMANTIC_EQUIVALENCE_NOT_PROVEN,
-            "message": (
-                "This prototype verifies structural scope and captured proof results only; "
-                "it does not prove semantic equivalence."
-            ),
-            "blocking": False,
-            "files": [],
-            "commands": [],
-        }
-    ]
-
-
-def test_verifier_blocks_non_candidate_score() -> None:
-    score = _candidate_score()
-    score["decision"] = {
-        "status": "blocked_review_first",
-        "candidate_for_protected_verification": False,
-        "automation_allowed": False,
-    }
-
-    payload = verify_candidate(
-        patch_score=score,
-        verification_evidence=_passing_evidence(),
-    )
-
-    codes = {finding["code"] for finding in payload["findings"]}
-    assert PATCH_SCORE_NOT_CANDIDATE in codes
-    assert payload["decision"]["status"] == "blocked_review_first"
-    assert payload["decision"]["structural_verification_passed"] is False
-
-
-def test_verifier_blocks_file_inventory_drift_and_protected_paths() -> None:
-    score = _candidate_score()
-    score["changed_files"] = ["src/sdetkit/example.py", "tests/test_example.py"]
-    score["allowed_files"] = ["src/sdetkit/example.py", "tests/test_example.py"]
-
-    payload = verify_candidate(
-        patch_score=score,
-        verification_evidence={
-            "changed_files": ["src/sdetkit/example.py", "tests/test_example.py"],
-            "proof_results": _passing_evidence()["proof_results"],
-        },
-    )
-
-    codes = {finding["code"] for finding in payload["findings"]}
-    assert PROTECTED_PATH_CHANGED in codes
-    assert payload["decision"]["status"] == "blocked_review_first"
-
-
-def test_verifier_blocks_changed_file_mismatch_and_outside_scope() -> None:
-    payload = verify_candidate(
-        patch_score=_candidate_score(),
-        verification_evidence={
-            "changed_files": ["src/sdetkit/example.py", "src/sdetkit/unplanned.py"],
-            "proof_results": _passing_evidence()["proof_results"],
-        },
-    )
-
-    codes = {finding["code"] for finding in payload["findings"]}
-    assert CHANGED_FILE_INVENTORY_MISMATCH in codes
-    assert OUTSIDE_SCORED_SCOPE in codes
-    assert payload["decision"]["status"] == "blocked_review_first"
-
-
-def test_verifier_blocks_missing_and_failed_required_proof() -> None:
-    missing = verify_candidate(
-        patch_score=_candidate_score(),
-        verification_evidence={"changed_files": ["src/sdetkit/example.py"], "proof_results": []},
-    )
-    assert REQUIRED_PROOF_NOT_CAPTURED in {finding["code"] for finding in missing["findings"]}
-
-    failed = verify_candidate(
-        patch_score=_candidate_score(),
-        verification_evidence={
+def _candidate_patch_score() -> dict:
+    return score_patch(
+        remediation_plan=_safe_plan(),
+        proposed_patch={
+            "patch_id": "format-patch",
             "changed_files": ["src/sdetkit/example.py"],
-            "proof_results": [
-                {
-                    "command": "python -m pre_commit run -a",
-                    "status": "failed",
-                    "exit_code": 1,
-                }
-            ],
+        },
+        pattern_insights=_safe_insights(),
+    )
+
+
+def test_protected_verifier_keeps_candidate_review_first_without_authority() -> None:
+    payload = verify_patch(
+        patch_score=_candidate_patch_score(),
+        failure_bundle={
+            "status": "collected",
+            "decision_boundary": {
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        },
+        runtime_proof={
+            "status": "collected",
+            "decision_boundary": {
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
         },
     )
-    assert REQUIRED_PROOF_FAILED in {finding["code"] for finding in failed["findings"]}
-    assert failed["decision"]["status"] == "blocked_review_first"
+
+    assert payload["schema_version"] == "sdetkit.protected_verifier.decision.v1"
+    assert payload["decision"]["status"] == "review_required"
+    assert payload["decision"]["review_first"] is True
+    assert payload["decision"]["candidate_for_protected_verification"] is True
+    assert payload["decision"]["protected_verification_passed"] is False
+    assert payload["decision"]["automation_allowed"] is False
+    assert payload["decision"]["patch_application_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+    assert payload["decision"]["next_action"] == "human_review_required_before_patch_application"
+    assert payload["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+    assert payload["verification_evidence"]["proof_requirements"] == ["python -m pre_commit run -a"]
+    assert payload["risk_flags"] == []
+
+    markdown = render_markdown(payload)
+    assert "# ProtectedVerifier decision" in markdown
+    assert "Review first: `true`" in markdown
+    assert "Protected verification passed: `false`" in markdown
+    assert "Patch application allowed: `false`" in markdown
+    assert "Merge authorized: `false`" in markdown
+    assert "Semantic equivalence proven: `false`" in markdown
 
 
-def test_verifier_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
-    score_path = tmp_path / "patch-score.json"
-    evidence_path = tmp_path / "verification-evidence.json"
+def test_protected_verifier_blocks_non_candidate_patch_score() -> None:
+    patch_score = _candidate_patch_score()
+    patch_score["decision"]["status"] = "blocked_review_first"
+    patch_score["decision"]["candidate_for_protected_verification"] = False
+
+    payload = verify_patch(patch_score=patch_score)
+
+    assert payload["decision"]["status"] == "blocked_review_first"
+    assert payload["decision"]["candidate_for_protected_verification"] is False
+    assert payload["decision"]["automation_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+    assert any(
+        flag["code"] == "PATCH_SCORE_NOT_CANDIDATE" and flag["blocking"] is True
+        for flag in payload["risk_flags"]
+    )
+
+
+def test_protected_verifier_blocks_authority_expansion_attempts() -> None:
+    patch_score = _candidate_patch_score()
+    patch_score["decision"]["merge_authorized"] = True
+
+    payload = verify_patch(
+        patch_score=patch_score,
+        runtime_proof={
+            "status": "collected",
+            "decision_boundary": {"semantic_equivalence_proven": True},
+        },
+    )
+
+    assert payload["decision"]["status"] == "blocked_review_first"
+    assert payload["decision"]["automation_allowed"] is False
+    assert payload["decision"]["patch_application_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+    assert {
+        field
+        for flag in payload["risk_flags"]
+        if flag["code"] == "AUTHORITY_EXPANSION_ATTEMPT"
+        for field in flag["fields"]
+    } == {"merge_authorized", "semantic_equivalence_proven"}
+
+
+def test_protected_verifier_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
+    patch_score_path = tmp_path / "patch-score.json"
     out_dir = tmp_path / "protected-verifier"
-
-    score_path.write_text(json.dumps(_candidate_score()), encoding="utf-8")
-    evidence_path.write_text(json.dumps(_passing_evidence()), encoding="utf-8")
+    patch_score_path.write_text(json.dumps(_candidate_patch_score()), encoding="utf-8")
 
     rc = main(
         [
             "--patch-score",
-            str(score_path),
-            "--verification-evidence",
-            str(evidence_path),
+            str(patch_score_path),
             "--out-dir",
             str(out_dir),
             "--format",
@@ -171,86 +183,13 @@ def test_verifier_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
 
     assert rc == 0
     printed = json.loads(capsys.readouterr().out)
-    saved = json.loads((out_dir / "protected-verifier-result.json").read_text(encoding="utf-8"))
-    markdown = (out_dir / "protected-verifier-result.md").read_text(encoding="utf-8")
+    payload = json.loads((out_dir / "protected-verifier-decision.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "protected-verifier-decision.md").read_text(encoding="utf-8")
 
-    assert printed["decision"]["status"] == "structurally_verified_candidate"
-    assert saved["decision"]["automation_allowed"] is False
-    assert "# Protected verifier result" in markdown
-    assert "does not prove semantic equivalence" in markdown
-
-
-def test_protected_verifier_surfaces_safetygate_evidence_without_authority() -> None:
-    evidence = _passing_evidence()
-    evidence["safety_gate_evidence"] = {
-        "collection_status": "collected",
-        "status": "safety_gate_evidence_observed",
-        "source": "trajectory.safety_gate",
-        "record_count": 1,
-        "safe_fix_allowed_count": 1,
-        "review_first_count": 0,
-        "reporting_only_count": 1,
-        "report_paths": ["build/pr-quality/failure-bundle/failure-bundle.md"],
-        "decision_boundary": {
-            "automation_allowed": False,
-            "patch_application_allowed": False,
-            "merge_authorized": False,
-            "semantic_equivalence_proven": False,
-        },
-    }
-
-    payload = verify_candidate(
-        patch_score=_candidate_score(),
-        verification_evidence=evidence,
-    )
-
-    assert payload["decision"]["status"] == "structurally_verified_candidate"
-    assert payload["decision"]["automation_allowed"] is False
+    assert printed["schema_version"] == "sdetkit.protected_verifier.decision.v1"
+    assert printed["decision"]["status"] == "review_required"
+    assert payload["decision"]["patch_application_allowed"] is False
     assert payload["decision"]["merge_authorized"] is False
-    safety_gate = payload["safety_gate_evidence"]
-    assert safety_gate["collection_status"] == "collected"
-    assert safety_gate["safe_fix_allowed_count"] == 1
-    assert safety_gate["expanded_authority_fields"] == []
-    assert safety_gate["decision_boundary"] == {
-        "automation_allowed": False,
-        "patch_application_allowed": False,
-        "merge_authorized": False,
-        "semantic_equivalence_proven": False,
-    }
-
-    markdown = render_markdown(payload)
-    assert "## SafetyGate evidence" in markdown
-    assert "Safe-fix allowed records: `1`" in markdown
-    assert "Automation allowed by SafetyGate evidence: `false`" in markdown
-    assert "Merge authorized by SafetyGate evidence: `false`" in markdown
-
-
-def test_protected_verifier_blocks_authority_expanding_safetygate_evidence() -> None:
-    evidence = _passing_evidence()
-    evidence["safety_gate_evidence"] = {
-        "collection_status": "collected",
-        "status": "safety_gate_evidence_observed",
-        "source": "trajectory.safety_gate",
-        "record_count": 1,
-        "safe_fix_allowed_count": 1,
-        "review_first_count": 0,
-        "reporting_only_count": 1,
-        "decision_boundary": {
-            "automation_allowed": False,
-            "patch_application_allowed": False,
-            "merge_authorized": True,
-            "semantic_equivalence_proven": False,
-        },
-    }
-
-    payload = verify_candidate(
-        patch_score=_candidate_score(),
-        verification_evidence=evidence,
-    )
-
-    assert payload["decision"]["status"] == "blocked_review_first"
-    assert payload["safety_gate_evidence"]["expanded_authority_fields"] == ["merge_authorized"]
-    assert any(
-        item["code"] == "SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION" and item["blocking"] is True
-        for item in payload["findings"]
-    )
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+    assert "# ProtectedVerifier decision" in markdown
+    assert "This verifier is reporting-only" in markdown


### PR DESCRIPTION
## Summary

Adds the ProtectedVerifier review-first decision contract.

This makes ProtectedVerifier consume PatchScorer-style evidence and emit a deterministic reporting-only verifier decision:

- candidate patches become `review_required`, not auto-approved
- protected verification remains review-first
- patch application is not authorized
- merge is not authorized
- semantic equivalence is not claimed
- authority-expansion attempts are blocked as review-first risk flags
- JSON and Markdown verifier artifacts are written by the CLI

## Proof

- `python -m pytest -q tests/test_protected_verifier.py tests/test_patch_scorer.py -o addopts=`
- CLI smoke:
  - `python -m sdetkit.patch_scorer ... --format json`
  - `python -m sdetkit.protected_verifier ... --format json`
- `make proof-after-format`

## Authority boundary

- `automation_allowed=false`
- `patch_application_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`
- `automatic_security_fix_allowed=false`
- `automatic_dismissal_allowed=false`