### PR TITLE
fix(pr-quality): treat merge-candidate GHAS alerts as current

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -288,12 +288,18 @@ jobs:
             --checks-json build/pr-quality/checks/check-runs.json \
             --out-dir build/pr-quality/check-logs
 
+          MERGE_CANDIDATE_SHA="$(
+            gh api "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME/pulls/$PR_NUMBER" \
+              --jq '.merge_commit_sha // ""' 2>/dev/null || true
+          )"
+
           PYTHONPATH=src python -m sdetkit.check_intelligence \
             --checks-json build/pr-quality/checks/check-runs.json \
             --logs-dir build/pr-quality/check-logs/failed-check-logs \
             --review-threads-json build/pr-quality/security-review/review-threads.json \
             --code-scanning-alerts-json build/pr-quality/code-scanning/alerts.json \
             --current-head-sha "$HEAD_SHA" \
+            --merge-candidate-sha "$MERGE_CANDIDATE_SHA" \
             --out-dir build/pr-quality/check-intelligence
 
 

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -1332,6 +1332,7 @@ def _empty_code_scanning_review(
     source: str,
     collection_reason: str,
     current_head_sha: str,
+    merge_candidate_sha: str = "",
 ) -> JsonObject:
     return {
         "collected": collected,
@@ -1343,6 +1344,7 @@ def _empty_code_scanning_review(
         "stale_alerts": 0,
         "unknown_freshness_alerts": 0,
         "current_head_sha": current_head_sha,
+        "merge_candidate_sha": merge_candidate_sha,
         "rule_counts": {},
         "findings": [],
     }
@@ -1352,6 +1354,7 @@ def _code_scanning_review_summary(
     alerts_json: Path | None,
     *,
     current_head_sha: str = "",
+    merge_candidate_sha: str = "",
 ) -> JsonObject:
     if alerts_json is None:
         return _empty_code_scanning_review(
@@ -1360,6 +1363,7 @@ def _code_scanning_review_summary(
             collection_reason="No code-scanning alert collection artifact was provided.",
             source="",
             current_head_sha=current_head_sha,
+            merge_candidate_sha=merge_candidate_sha,
         )
 
     if not alerts_json.exists():
@@ -1369,6 +1373,7 @@ def _code_scanning_review_summary(
             collection_reason="The code-scanning alert collection artifact was not found.",
             source=alerts_json.as_posix(),
             current_head_sha=current_head_sha,
+            merge_candidate_sha=merge_candidate_sha,
         )
 
     payload = json.loads(alerts_json.read_text(encoding="utf-8"))
@@ -1385,6 +1390,7 @@ def _code_scanning_review_summary(
             ),
             source=alerts_json.as_posix(),
             current_head_sha=current_head_sha,
+            merge_candidate_sha=merge_candidate_sha,
         )
 
     findings: list[JsonObject] = []
@@ -1397,12 +1403,18 @@ def _code_scanning_review_summary(
         message = _as_dict(instance.get("message"))
         commit_sha = _string(instance.get("commit_sha"))
 
-        if not commit_sha or not current_head_sha:
+        if not commit_sha or not (current_head_sha or merge_candidate_sha):
             freshness = "unknown"
-        elif commit_sha == current_head_sha:
+            freshness_basis = "unknown"
+        elif current_head_sha and commit_sha == current_head_sha:
             freshness = "current"
+            freshness_basis = "pr_head"
+        elif merge_candidate_sha and commit_sha == merge_candidate_sha:
+            freshness = "current"
+            freshness_basis = "merge_candidate"
         else:
             freshness = "stale"
+            freshness_basis = "none"
 
         if freshness == "current":
             action = "fix_current_alert_or_dismiss_reviewed_false_positive"
@@ -1426,7 +1438,9 @@ def _code_scanning_review_summary(
                 "line": _string(location.get("start_line")),
                 "commit_sha": commit_sha,
                 "current_head_sha": current_head_sha,
+                "merge_candidate_sha": merge_candidate_sha,
                 "freshness": freshness,
+                "freshness_basis": freshness_basis,
                 "recommended_action": action,
                 "message": _string(message.get("text")),
             }
@@ -1444,6 +1458,7 @@ def _code_scanning_review_summary(
             [item for item in findings if item["freshness"] == "unknown"]
         ),
         "current_head_sha": current_head_sha,
+        "merge_candidate_sha": merge_candidate_sha,
         "rule_counts": dict(sorted(rule_counts.items())),
         "findings": findings,
     }
@@ -1581,6 +1596,7 @@ def build_check_intelligence(
     review_threads_json: Path | None = None,
     code_scanning_alerts_json: Path | None = None,
     current_head_sha: str = "",
+    merge_candidate_sha: str = "",
 ) -> JsonObject:
     payload = _read_json(checks_json)
     records = _iter_check_records(payload)
@@ -1652,8 +1668,10 @@ def build_check_intelligence(
         "code_scanning_review": _code_scanning_review_summary(
             code_scanning_alerts_json,
             current_head_sha=current_head_sha,
+            merge_candidate_sha=merge_candidate_sha,
         ),
         "current_head_sha": current_head_sha,
+        "merge_candidate_sha": merge_candidate_sha,
     }
 
 
@@ -2156,6 +2174,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--review-threads-json", type=Path)
     parser.add_argument("--code-scanning-alerts-json", type=Path)
     parser.add_argument("--current-head-sha", default="")
+    parser.add_argument("--merge-candidate-sha", default="")
     parser.add_argument("--out-dir", type=Path, default=Path("build/pr-quality"))
     return parser
 
@@ -2168,6 +2187,7 @@ def main(argv: list[str] | None = None) -> int:
         review_threads_json=args.review_threads_json,
         code_scanning_alerts_json=args.code_scanning_alerts_json,
         current_head_sha=args.current_head_sha,
+        merge_candidate_sha=args.merge_candidate_sha,
     )
     action_report = build_action_report(intelligence)
     artifacts = write_artifacts(

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -573,6 +573,60 @@ def test_check_intelligence_reports_code_scanning_freshness_counts(
     assert action["evidence"]["code_scanning_review"]["current_alerts"] == 1
 
 
+def test_check_intelligence_treats_merge_candidate_code_scanning_alert_as_current(
+    tmp_path: Path,
+) -> None:
+    pr_head_sha = "pr-head-sha"
+    merge_candidate_sha = "merge-candidate-sha"
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {"check_runs": [{"name": "CI", "status": "completed", "conclusion": "success"}]},
+    )
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        {
+            "collection_status": "collected",
+            "alerts": [
+                {
+                    "number": 1390,
+                    "state": "open",
+                    "html_url": "https://example.test/code-scanning/1390",
+                    "rule": {"id": "py/implicit-string-concatenation-in-list"},
+                    "most_recent_instance": {
+                        "commit_sha": merge_candidate_sha,
+                        "message": {"text": "Implicit string concatenation."},
+                        "location": {
+                            "path": "src/sdetkit/protected_verifier.py",
+                            "start_line": 683,
+                        },
+                    },
+                }
+            ],
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        code_scanning_alerts_json=alerts,
+        current_head_sha=pr_head_sha,
+        merge_candidate_sha=merge_candidate_sha,
+    )
+    review = intelligence["code_scanning_review"]
+    finding = review["findings"][0]
+
+    assert review["current_alerts"] == 1
+    assert review["stale_alerts"] == 0
+    assert review["merge_candidate_sha"] == merge_candidate_sha
+    assert finding["freshness"] == "current"
+    assert finding["freshness_basis"] == "merge_candidate"
+    assert finding["merge_candidate_sha"] == merge_candidate_sha
+
+    action = check_intelligence.build_action_report(intelligence)
+    assert action["status"] == "review_required"
+    assert action["primary_blocker"]["surface"] == "security"
+    assert action["primary_blocker"]["code"] == check_intelligence.CODE_SCANNING_CURRENT_ALERT
+
+
 def test_check_intelligence_preserves_unresolved_security_review_findings(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Codifies the #1734 GHAS lesson in PR Quality.

PR Quality now compares Code Scanning alert SHAs against both:

- the PR head SHA
- the GitHub merge-candidate SHA

If an alert matches either SHA, PR Quality treats it as current/blocking. Only alerts matching neither are stale/refresh-pending.

This prevents a visible GHAS/CodeQL review comment on the merge candidate from being misclassified as stale-only just because it does not match the PR head SHA.

## Proof

- `python -m pytest -q tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- reporting-only
- no automatic GHAS dismissal
- no automatic patch application
- no merge authorization
- no semantic-equivalence claim