### PR TITLE
feat(trajectory): record review-first authority boundary

### DIFF
--- a/src/sdetkit/trajectory_store.py
+++ b/src/sdetkit/trajectory_store.py
@@ -82,6 +82,28 @@ def _failure_bundle_safety_evidence(value: Mapping[str, Any] | None) -> JsonObje
     }
 
 
+def _authority_boundary(
+    *,
+    source: str,
+    review_first: bool,
+    auto_fix_allowed: bool,
+    reason: str = "",
+) -> JsonObject:
+    return {
+        "source": source,
+        "reporting_only": True,
+        "review_first": review_first,
+        "auto_fix_allowed": auto_fix_allowed,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+        "reason": _string(reason),
+    }
+
+
 def _slug(value: str) -> str:
     slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.lower()).strip("-")
     return slug or "unknown"
@@ -414,6 +436,16 @@ def build_pr_quality_trajectory_records(
                         or check.get("title")
                     ),
                 },
+                "authority_boundary": _authority_boundary(
+                    source="pr_quality",
+                    review_first=review_first,
+                    auto_fix_allowed=auto_fix_allowed,
+                    reason=(
+                        _string(safe_remediation.get("reason"))
+                        or _string(automation.get("reason"))
+                        or _string(check.get("title"))
+                    ),
+                ),
                 "safety_gate": failure_bundle_safety,
                 "fix": {
                     "allowed_strategy": action,
@@ -525,6 +557,15 @@ def build_trajectory_records(
                     "reason": _string(plan.get("blocked_reason"))
                     or "safe mechanical remediation candidate",
                 },
+                "authority_boundary": _authority_boundary(
+                    source="trajectory_store",
+                    review_first=not auto_fix_allowed,
+                    auto_fix_allowed=auto_fix_allowed,
+                    reason=(
+                        _string(plan.get("blocked_reason"))
+                        or "safe mechanical remediation candidate"
+                    ),
+                ),
                 "fix": {
                     "allowed_strategy": action,
                     "patch_files": _string_list(plan.get("affected_files"))

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -100,6 +100,19 @@ def test_trajectory_records_capture_safe_candidate_and_review_first_decisions() 
     assert formatting["diagnosis"]["failure_class"] == "formatter_only"
     assert formatting["fix"]["patch_files"] == ["src/sdetkit/example.py"]
     assert formatting["final_result"] == "safe_fix_candidate"
+    assert formatting["authority_boundary"] == {
+        "source": "trajectory_store",
+        "reporting_only": True,
+        "review_first": False,
+        "auto_fix_allowed": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+        "reason": "safe mechanical remediation candidate",
+    }
     assert unknown["decision"]["auto_fix_allowed"] is False
     assert unknown["decision"]["review_first"] is True
     assert unknown["response"]["response_type"] == "unknown_review_required"
@@ -243,6 +256,19 @@ def test_pr_quality_trajectory_records_capture_safe_formatter_decision() -> None
     assert record["fix"]["patch_files"] == ["tools/maintenance_autopilot.py"]
     assert record["proof"]["commands"] == ["python -m pre_commit run -a"]
     assert record["final_result"] == "safe_fix_candidate"
+    assert record["authority_boundary"] == {
+        "source": "pr_quality",
+        "reporting_only": True,
+        "review_first": False,
+        "auto_fix_allowed": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+        "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+    }
 
 
 def test_pr_quality_trajectory_cli_writes_artifact(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Adds an explicit authority boundary to every TrajectoryStore record.

Trajectory records now carry a deterministic reporting-only boundary:

- reporting_only=true
- review_first is recorded
- auto_fix_allowed is recorded as evidence only
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false
- automatic_security_fix_allowed=false
- automatic_dismissal_allowed=false

This makes RepoMemory / TrajectoryStore evidence safer to consume because downstream tools can read the authority boundary directly from each memory record instead of inferring it from surrounding context.

## Proof

- `python -m pytest -q tests/test_trajectory_store.py tests/test_repo_memory.py tests/test_protected_verifier.py tests/test_patch_scorer.py tests/test_check_intelligence.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- reporting-only
- no automatic patch application
- no automatic GHAS dismissal
- no merge authorization
- no semantic-equivalence claim