### PR TITLE
feat(repo-memory): consume trajectory authority evidence

### DIFF
--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -180,6 +180,47 @@ def _controlled_candidate_validation(evidence: Mapping[str, Any]) -> JsonObject:
     }
 
 
+def _trajectory_authority_evidence(pattern_insights: Mapping[str, Any]) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+    payload = _as_dict(pattern_insights.get("authority_boundary_evidence"))
+    if not payload:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "trajectory.authority_boundary",
+            "record_count": 0,
+            "review_first_count": 0,
+            "auto_fix_allowed_count": 0,
+            "reporting_only_count": 0,
+            "sources": [],
+            "decision_boundary": denied,
+        }
+
+    boundary = _as_dict(payload.get("decision_boundary"))
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    if expanded:
+        raise ValueError("trajectory authority evidence expands authority: " + ", ".join(expanded))
+
+    return {
+        "collection_status": _string(payload.get("collection_status")) or "collected",
+        "status": _string(payload.get("status")) or "authority_boundary_evidence_observed",
+        "source": _string(payload.get("source")) or "trajectory.authority_boundary",
+        "record_count": _int(payload.get("record_count")),
+        "review_first_count": _int(payload.get("review_first_count")),
+        "auto_fix_allowed_count": _int(payload.get("auto_fix_allowed_count")),
+        "reporting_only_count": _int(payload.get("reporting_only_count")),
+        "sources": [_string(item) for item in _as_list(payload.get("sources")) if _string(item)],
+        "decision_boundary": denied,
+    }
+
+
 def _safety_gate_evidence(pattern_insights: Mapping[str, Any]) -> JsonObject:
     denied = {
         "automation_allowed": False,
@@ -641,6 +682,7 @@ def build_repo_memory_profile(
         controlled_candidate_validation_evidence or {}
     )
     safety_gate_evidence = _safety_gate_evidence(pattern_insights)
+    trajectory_authority_evidence = _trajectory_authority_evidence(pattern_insights)
     benchmark_proven = _benchmark_contract_proven(benchmark_report)
     live_proven = _live_contract_proven(live_report)
     safe_fix_history = _safe_fix_history(
@@ -697,6 +739,9 @@ def build_repo_memory_profile(
             "live_report_mode": _string(live_report.get("report_mode")),
             "live_contract_proven": live_proven,
             "safety_gate_evidence_record_count": _int(safety_gate_evidence.get("record_count")),
+            "trajectory_authority_record_count": _int(
+                trajectory_authority_evidence.get("record_count")
+            ),
         },
         "command_profile": {
             "source": "replayable_benchmark_harness",
@@ -736,6 +781,7 @@ def build_repo_memory_profile(
         "live_safe_candidate_count": len(live_supported_candidates),
         "controlled_candidate_validation": controlled_validation,
         "safety_gate_evidence": safety_gate_evidence,
+        "trajectory_authority_evidence": trajectory_authority_evidence,
         "flaky_test_registry": flaky_registry,
         "escalation_rules": _escalation_rules(),
         "unproven_boundaries": unproven_boundaries,
@@ -764,6 +810,8 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
     controlled = _as_dict(profile.get("controlled_candidate_validation"))
     safety_gate = _as_dict(profile.get("safety_gate_evidence"))
     safety_boundary = _as_dict(safety_gate.get("decision_boundary"))
+    trajectory_authority = _as_dict(profile.get("trajectory_authority_evidence"))
+    trajectory_authority_boundary = _as_dict(trajectory_authority.get("decision_boundary"))
     flaky = _as_dict(profile.get("flaky_test_registry"))
     flaky_source = _as_dict(flaky.get("source"))
     boundary = _as_dict(profile.get("decision_boundary"))
@@ -929,6 +977,33 @@ def render_markdown(profile: Mapping[str, Any]) -> str:
 
     lines.extend(
         [
+            "",
+            "## Trajectory authority boundary evidence",
+            "",
+            f"- Collection status: `{_string(trajectory_authority.get('collection_status'))}`",
+            f"- Status: `{_string(trajectory_authority.get('status'))}`",
+            f"- Records: `{_int(trajectory_authority.get('record_count'))}`",
+            f"- Review-first records: `{_int(trajectory_authority.get('review_first_count'))}`",
+            (
+                "- Auto-fix evidence records: "
+                f"`{_int(trajectory_authority.get('auto_fix_allowed_count'))}`"
+            ),
+            (
+                "- Reporting-only records: "
+                f"`{_int(trajectory_authority.get('reporting_only_count'))}`"
+            ),
+            (
+                "- Patch automation allowed by trajectory authority: "
+                f"`{str(_bool(trajectory_authority_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Security dismissal allowed by trajectory authority: "
+                f"`{str(_bool(trajectory_authority_boundary.get('automatic_dismissal_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by trajectory authority: "
+                f"`{str(_bool(trajectory_authority_boundary.get('merge_authorized'))).lower()}`"
+            ),
             "",
             "## Flaky test registry",
             "",

--- a/src/sdetkit/trajectory_pattern_insights.py
+++ b/src/sdetkit/trajectory_pattern_insights.py
@@ -98,6 +98,55 @@ def _safe_fix_patterns(
     ]
 
 
+def _authority_boundary_evidence(rows: list[JsonObject]) -> JsonObject:
+    authority_rows = [
+        _as_dict(row.get("authority_boundary"))
+        for row in rows
+        if _as_dict(row.get("authority_boundary"))
+    ]
+    denied_keys = (
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "automatic_security_fix_allowed",
+        "automatic_dismissal_allowed",
+    )
+    denied = {key: False for key in denied_keys}
+    if not authority_rows:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "trajectory.authority_boundary",
+            "record_count": 0,
+            "review_first_count": 0,
+            "auto_fix_allowed_count": 0,
+            "reporting_only_count": 0,
+            "sources": [],
+            "decision_boundary": denied,
+        }
+
+    return {
+        "collection_status": "collected",
+        "status": "authority_boundary_evidence_observed",
+        "source": "trajectory.authority_boundary",
+        "record_count": len(authority_rows),
+        "review_first_count": sum(1 for row in authority_rows if _bool(row.get("review_first"))),
+        "auto_fix_allowed_count": sum(
+            1 for row in authority_rows if _bool(row.get("auto_fix_allowed"))
+        ),
+        "reporting_only_count": sum(
+            1 for row in authority_rows if _bool(row.get("reporting_only"))
+        ),
+        "sources": sorted(
+            {_string(row.get("source")) for row in authority_rows if _string(row.get("source"))}
+        ),
+        "decision_boundary": {
+            key: any(_bool(row.get(key)) for row in authority_rows) for key in denied_keys
+        },
+    }
+
+
 def _safety_gate_evidence(rows: list[JsonObject]) -> JsonObject:
     safety_rows = [
         _as_dict(row.get("safety_gate")) for row in rows if _as_dict(row.get("safety_gate"))
@@ -251,6 +300,7 @@ def build_pattern_insights(
         "recurring_review_first_surfaces": recurring_review_surfaces,
         "recurring_safe_fix_patterns": recurring_safe_fixes,
         "safety_gate_evidence": _safety_gate_evidence(rows),
+        "authority_boundary_evidence": _authority_boundary_evidence(rows),
         "operator_focus": _operator_focus(
             record_count=len(rows),
             recurring_review_surfaces=recurring_review_surfaces,
@@ -266,6 +316,8 @@ def render_pattern_markdown(insights: Mapping[str, Any]) -> str:
     focus = _as_dict(insights.get("operator_focus"))
     safety_gate = _as_dict(insights.get("safety_gate_evidence"))
     boundary = _as_dict(safety_gate.get("decision_boundary"))
+    authority = _as_dict(insights.get("authority_boundary_evidence"))
+    authority_boundary = _as_dict(authority.get("decision_boundary"))
 
     lines = [
         "# Trajectory pattern insights",
@@ -338,6 +390,27 @@ def render_pattern_markdown(insights: Mapping[str, Any]) -> str:
 
     lines.extend(
         [
+            "",
+            "## Trajectory authority boundary evidence",
+            "",
+            f"- Collection status: `{_string(authority.get('collection_status'))}`",
+            f"- Status: `{_string(authority.get('status'))}`",
+            f"- Records: `{int(authority.get('record_count', 0) or 0)}`",
+            f"- Review-first records: `{int(authority.get('review_first_count', 0) or 0)}`",
+            f"- Auto-fix evidence records: `{int(authority.get('auto_fix_allowed_count', 0) or 0)}`",
+            f"- Reporting-only records: `{int(authority.get('reporting_only_count', 0) or 0)}`",
+            (
+                "- Patch automation allowed by trajectory authority evidence: "
+                f"`{str(_bool(authority_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Security dismissal allowed by trajectory authority evidence: "
+                f"`{str(_bool(authority_boundary.get('automatic_dismissal_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by trajectory authority evidence: "
+                f"`{str(_bool(authority_boundary.get('merge_authorized'))).lower()}`"
+            ),
             "",
             "## Operator focus",
             "",

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -824,3 +824,85 @@ def test_repo_memory_rejects_authority_expanding_safety_gate_evidence() -> None:
         assert "SafetyGate evidence expands authority: automation_allowed" in str(exc)
     else:
         raise AssertionError("expected authority-expanding SafetyGate evidence to fail")
+
+
+def test_repo_memory_surfaces_trajectory_authority_evidence_without_authority() -> None:
+    insights = _pattern_insights()
+    insights["authority_boundary_evidence"] = {
+        "collection_status": "collected",
+        "status": "authority_boundary_evidence_observed",
+        "source": "trajectory.authority_boundary",
+        "record_count": 2,
+        "review_first_count": 1,
+        "auto_fix_allowed_count": 1,
+        "reporting_only_count": 2,
+        "sources": ["pr_quality", "trajectory_store"],
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "automatic_security_fix_allowed": False,
+            "automatic_dismissal_allowed": False,
+        },
+    }
+
+    profile = build_repo_memory_profile(
+        pattern_insights=insights,
+        benchmark_report=_benchmark_report(),
+    )
+
+    authority = profile["trajectory_authority_evidence"]
+    assert profile["inputs"]["trajectory_authority_record_count"] == 2
+    assert authority["collection_status"] == "collected"
+    assert authority["status"] == "authority_boundary_evidence_observed"
+    assert authority["record_count"] == 2
+    assert authority["review_first_count"] == 1
+    assert authority["auto_fix_allowed_count"] == 1
+    assert authority["reporting_only_count"] == 2
+    assert authority["sources"] == ["pr_quality", "trajectory_store"]
+    assert authority["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+
+    markdown = render_markdown(profile)
+    assert "## Trajectory authority boundary evidence" in markdown
+    assert "Patch automation allowed by trajectory authority: `false`" in markdown
+    assert "Security dismissal allowed by trajectory authority: `false`" in markdown
+
+
+def test_repo_memory_rejects_authority_expanding_trajectory_authority_evidence() -> None:
+    insights = _pattern_insights()
+    insights["authority_boundary_evidence"] = {
+        "collection_status": "collected",
+        "status": "authority_boundary_evidence_observed",
+        "source": "trajectory.authority_boundary",
+        "record_count": 1,
+        "review_first_count": 0,
+        "auto_fix_allowed_count": 1,
+        "reporting_only_count": 1,
+        "sources": ["pr_quality"],
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": True,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "automatic_security_fix_allowed": False,
+            "automatic_dismissal_allowed": False,
+        },
+    }
+
+    try:
+        build_repo_memory_profile(
+            pattern_insights=insights,
+            benchmark_report=_benchmark_report(),
+        )
+    except ValueError as exc:
+        assert "trajectory authority evidence expands authority" in str(exc)
+    else:
+        raise AssertionError("expected authority expansion to be rejected")

--- a/tests/test_trajectory_pattern_insights.py
+++ b/tests/test_trajectory_pattern_insights.py
@@ -221,3 +221,55 @@ def test_pattern_insights_summarizes_safety_gate_evidence() -> None:
     assert "## SafetyGate evidence" in markdown
     assert "Safe-fix allowed records: `1`" in markdown
     assert "Automation allowed by SafetyGate evidence: `false`" in markdown
+
+
+def test_pattern_insights_summarizes_trajectory_authority_boundary_evidence() -> None:
+    rows = _records()[:2]
+    rows[0]["authority_boundary"] = {
+        "source": "pr_quality",
+        "reporting_only": True,
+        "review_first": True,
+        "auto_fix_allowed": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+    rows[1]["authority_boundary"] = {
+        "source": "trajectory_store",
+        "reporting_only": True,
+        "review_first": False,
+        "auto_fix_allowed": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+
+    insights = build_pattern_insights(rows, minimum_repeat=1)
+    authority = insights["authority_boundary_evidence"]
+
+    assert authority["collection_status"] == "collected"
+    assert authority["status"] == "authority_boundary_evidence_observed"
+    assert authority["record_count"] == 2
+    assert authority["review_first_count"] == 1
+    assert authority["auto_fix_allowed_count"] == 1
+    assert authority["reporting_only_count"] == 2
+    assert authority["sources"] == ["pr_quality", "trajectory_store"]
+    assert authority["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+
+    markdown = render_pattern_markdown(insights)
+    assert "## Trajectory authority boundary evidence" in markdown
+    assert "Auto-fix evidence records: `1`" in markdown
+    assert "Security dismissal allowed by trajectory authority evidence: `false`" in markdown


### PR DESCRIPTION
## Summary

Continues the roadmap chain after #1736.

This PR connects TrajectoryStore per-record authority boundaries into downstream memory:

- TrajectoryPatternInsights now aggregates `authority_boundary_evidence`
- RepoMemory now consumes that evidence as `trajectory_authority_evidence`
- RepoMemory rejects any trajectory authority evidence that expands automation, patch, security-dismissal, merge, or semantic-equivalence authority

## Why this matters

TrajectoryStore now records authority boundaries per record. This PR makes that evidence visible to RepoMemory so memory consumers do not need to infer safety/authority from context.

The chain is now:

TrajectoryStore record `authority_boundary`
→ TrajectoryPatternInsights `authority_boundary_evidence`
→ RepoMemory `trajectory_authority_evidence`

## Proof

- `python -m pytest -q tests/test_trajectory_store.py tests/test_trajectory_pattern_insights.py tests/test_repo_memory.py tests/test_repo_memory_profile_history.py tests/test_pr_quality_runtime_proof_artifacts.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- reporting-only
- no automatic patch application
- no automatic GHAS dismissal
- no merge authorization
- no semantic-equivalence claim