### PR TITLE
feat(pr-quality): surface repo memory authority evidence

### DIFF
--- a/src/sdetkit/pr_quality_runtime_proof_artifacts.py
+++ b/src/sdetkit/pr_quality_runtime_proof_artifacts.py
@@ -158,6 +158,8 @@ def _repo_memory_summary(profile: Mapping[str, Any]) -> JsonObject:
     provenance = _as_dict(payload.get("proof_provenance"))
     safety_gate = _as_dict(payload.get("safety_gate_evidence"))
     safety_boundary = _as_dict(safety_gate.get("decision_boundary"))
+    trajectory_authority = _as_dict(payload.get("trajectory_authority_evidence"))
+    trajectory_authority_boundary = _as_dict(trajectory_authority.get("decision_boundary"))
     boundary = _as_dict(payload.get("decision_boundary"))
     return {
         "collection_status": COLLECTED,
@@ -181,6 +183,32 @@ def _repo_memory_summary(profile: Mapping[str, Any]) -> JsonObject:
         "safety_gate_merge_authorized": _bool(safety_boundary.get("merge_authorized")),
         "safety_gate_semantic_equivalence_proven": _bool(
             safety_boundary.get("semantic_equivalence_proven")
+        ),
+        "trajectory_authority_status": _string(trajectory_authority.get("status") or NOT_COLLECTED),
+        "trajectory_authority_record_count": _int(trajectory_authority.get("record_count")),
+        "trajectory_authority_review_first_count": _int(
+            trajectory_authority.get("review_first_count")
+        ),
+        "trajectory_authority_auto_fix_allowed_count": _int(
+            trajectory_authority.get("auto_fix_allowed_count")
+        ),
+        "trajectory_authority_reporting_only_count": _int(
+            trajectory_authority.get("reporting_only_count")
+        ),
+        "trajectory_authority_automation_allowed": _bool(
+            trajectory_authority_boundary.get("automation_allowed")
+        ),
+        "trajectory_authority_patch_application_allowed": _bool(
+            trajectory_authority_boundary.get("patch_application_allowed")
+        ),
+        "trajectory_authority_security_dismissal_allowed": _bool(
+            trajectory_authority_boundary.get("automatic_dismissal_allowed")
+        ),
+        "trajectory_authority_merge_authorized": _bool(
+            trajectory_authority_boundary.get("merge_authorized")
+        ),
+        "trajectory_authority_semantic_equivalence_proven": _bool(
+            trajectory_authority_boundary.get("semantic_equivalence_proven")
         ),
         "automation_allowed": _bool(boundary.get("automation_allowed")),
         "merge_authorized": _bool(boundary.get("merge_authorized")),
@@ -498,6 +526,42 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
                 (
                     "- RepoMemory SafetyGate semantic equivalence proven: "
                     f"`{str(_bool(memory.get('safety_gate_semantic_equivalence_proven'))).lower()}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority status: "
+                    f"`{_string(memory.get('trajectory_authority_status'))}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority records: "
+                    f"`{_int(memory.get('trajectory_authority_record_count'))}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority review-first records: "
+                    f"`{_int(memory.get('trajectory_authority_review_first_count'))}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority auto-fix evidence records: "
+                    f"`{_int(memory.get('trajectory_authority_auto_fix_allowed_count'))}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority reporting-only records: "
+                    f"`{_int(memory.get('trajectory_authority_reporting_only_count'))}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority patch application allowed: "
+                    f"`{str(_bool(memory.get('trajectory_authority_patch_application_allowed'))).lower()}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority security dismissal allowed: "
+                    f"`{str(_bool(memory.get('trajectory_authority_security_dismissal_allowed'))).lower()}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority merge authorized: "
+                    f"`{str(_bool(memory.get('trajectory_authority_merge_authorized'))).lower()}`"
+                ),
+                (
+                    "- RepoMemory trajectory authority semantic equivalence proven: "
+                    f"`{str(_bool(memory.get('trajectory_authority_semantic_equivalence_proven'))).lower()}`"
                 ),
             ]
         )

--- a/tests/test_pr_quality_runtime_proof_artifacts.py
+++ b/tests/test_pr_quality_runtime_proof_artifacts.py
@@ -237,6 +237,21 @@ def test_runtime_proof_markdown_renders_collected_live_benchmark_and_memory() ->
                     "semantic_equivalence_proven": False,
                 },
             },
+            "trajectory_authority_evidence": {
+                "status": "authority_boundary_evidence_observed",
+                "record_count": 2,
+                "review_first_count": 1,
+                "auto_fix_allowed_count": 1,
+                "reporting_only_count": 2,
+                "decision_boundary": {
+                    "automation_allowed": False,
+                    "patch_application_allowed": False,
+                    "merge_authorized": False,
+                    "semantic_equivalence_proven": False,
+                    "automatic_security_fix_allowed": False,
+                    "automatic_dismissal_allowed": False,
+                },
+            },
             "decision_boundary": {
                 "automation_allowed": False,
                 "merge_authorized": False,
@@ -263,6 +278,18 @@ def test_runtime_proof_markdown_renders_collected_live_benchmark_and_memory() ->
     assert summary["repo_memory"]["safety_gate_safe_fix_allowed_count"] == 1
     assert summary["repo_memory"]["safety_gate_review_first_count"] == 2
     assert summary["repo_memory"]["safety_gate_automation_allowed"] is False
+    assert (
+        summary["repo_memory"]["trajectory_authority_status"]
+        == "authority_boundary_evidence_observed"
+    )
+    assert summary["repo_memory"]["trajectory_authority_record_count"] == 2
+    assert summary["repo_memory"]["trajectory_authority_review_first_count"] == 1
+    assert summary["repo_memory"]["trajectory_authority_auto_fix_allowed_count"] == 1
+    assert summary["repo_memory"]["trajectory_authority_reporting_only_count"] == 2
+    assert summary["repo_memory"]["trajectory_authority_patch_application_allowed"] is False
+    assert summary["repo_memory"]["trajectory_authority_security_dismissal_allowed"] is False
+    assert summary["repo_memory"]["trajectory_authority_merge_authorized"] is False
+    assert summary["repo_memory"]["trajectory_authority_semantic_equivalence_proven"] is False
     assert "RepoMemory SafetyGate status: `safety_gate_evidence_observed`" in markdown
     assert "RepoMemory SafetyGate records: `3`" in markdown
     assert "RepoMemory SafetyGate safe-fix allowed records: `1`" in markdown
@@ -270,6 +297,14 @@ def test_runtime_proof_markdown_renders_collected_live_benchmark_and_memory() ->
     assert "RepoMemory SafetyGate automation allowed: `false`" in markdown
     assert "RepoMemory SafetyGate merge authorized: `false`" in markdown
     assert "RepoMemory SafetyGate semantic equivalence proven: `false`" in markdown
+    assert (
+        "RepoMemory trajectory authority status: `authority_boundary_evidence_observed`"
+    ) in markdown
+    assert "RepoMemory trajectory authority records: `2`" in markdown
+    assert ("RepoMemory trajectory authority patch application allowed: `false`") in markdown
+    assert ("RepoMemory trajectory authority security dismissal allowed: `false`") in markdown
+    assert "RepoMemory trajectory authority merge authorized: `false`" in markdown
+    assert ("RepoMemory trajectory authority semantic equivalence proven: `false`") in markdown
 
 
 def _trusted_diagnostic_signal_snapshot_history() -> dict:


### PR DESCRIPTION
## Summary

Continues the roadmap chain after #1737.

This PR surfaces RepoMemory trajectory authority evidence in PR Quality runtime proof artifacts:

- reads `trajectory_authority_evidence` from RepoMemory profile
- exposes authority counts and denied authority fields in runtime proof summary JSON
- renders trajectory authority evidence in the PR Quality runtime proof markdown
- keeps all authority denied: no patch application, no GHAS dismissal, no merge authorization, no semantic-equivalence claim

## Roadmap chain

TrajectoryStore record `authority_boundary`
→ TrajectoryPatternInsights `authority_boundary_evidence`
→ RepoMemory `trajectory_authority_evidence`
→ PR Quality runtime proof artifacts

## Proof

- `python -m pytest -q tests/test_pr_quality_runtime_proof_artifacts.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py tests/test_check_intelligence.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim