### PR TITLE
feat(pr-quality): expose repo memory authority metadata

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1260,6 +1260,15 @@ jobs:
               repo_memory_collection_status: metadata.repo_memory_collection_status || 'not_collected',
               repo_memory_status: metadata.repo_memory_status || 'not_collected',
               repo_memory_live_contract_proven: Boolean(metadata.repo_memory_live_contract_proven),
+              repo_memory_trajectory_authority_status: metadata.repo_memory_trajectory_authority_status || 'not_collected',
+              repo_memory_trajectory_authority_record_count: Number(metadata.repo_memory_trajectory_authority_record_count || 0),
+              repo_memory_trajectory_authority_review_first_count: Number(metadata.repo_memory_trajectory_authority_review_first_count || 0),
+              repo_memory_trajectory_authority_auto_fix_allowed_count: Number(metadata.repo_memory_trajectory_authority_auto_fix_allowed_count || 0),
+              repo_memory_trajectory_authority_reporting_only_count: Number(metadata.repo_memory_trajectory_authority_reporting_only_count || 0),
+              repo_memory_trajectory_authority_patch_application_allowed: Boolean(metadata.repo_memory_trajectory_authority_patch_application_allowed),
+              repo_memory_trajectory_authority_security_dismissal_allowed: Boolean(metadata.repo_memory_trajectory_authority_security_dismissal_allowed),
+              repo_memory_trajectory_authority_merge_authorized: Boolean(metadata.repo_memory_trajectory_authority_merge_authorized),
+              repo_memory_trajectory_authority_semantic_equivalence_proven: Boolean(metadata.repo_memory_trajectory_authority_semantic_equivalence_proven),
               trusted_history_collection_status: metadata.trusted_history_collection_status || 'not_collected',
               trusted_history_status: metadata.trusted_history_status || 'not_collected',
               trusted_history_record_count: Number(metadata.trusted_history_record_count || 0),
@@ -1360,6 +1369,33 @@ jobs:
           repo_memory_live_contract_proven = bool(
               payload.get("repo_memory_live_contract_proven", False)
           )
+          repo_memory_trajectory_authority_status = str(
+              payload.get("repo_memory_trajectory_authority_status", "not_collected")
+          )
+          repo_memory_trajectory_authority_record_count = int(
+              payload.get("repo_memory_trajectory_authority_record_count", 0) or 0
+          )
+          repo_memory_trajectory_authority_review_first_count = int(
+              payload.get("repo_memory_trajectory_authority_review_first_count", 0) or 0
+          )
+          repo_memory_trajectory_authority_auto_fix_allowed_count = int(
+              payload.get("repo_memory_trajectory_authority_auto_fix_allowed_count", 0) or 0
+          )
+          repo_memory_trajectory_authority_reporting_only_count = int(
+              payload.get("repo_memory_trajectory_authority_reporting_only_count", 0) or 0
+          )
+          repo_memory_trajectory_authority_patch_application_allowed = bool(
+              payload.get("repo_memory_trajectory_authority_patch_application_allowed", False)
+          )
+          repo_memory_trajectory_authority_security_dismissal_allowed = bool(
+              payload.get("repo_memory_trajectory_authority_security_dismissal_allowed", False)
+          )
+          repo_memory_trajectory_authority_merge_authorized = bool(
+              payload.get("repo_memory_trajectory_authority_merge_authorized", False)
+          )
+          repo_memory_trajectory_authority_semantic_equivalence_proven = bool(
+              payload.get("repo_memory_trajectory_authority_semantic_equivalence_proven", False)
+          )
           history_semantic_key = "_".join(
               ("trusted", "history", "semantic", "equivalence", "proven")
           )
@@ -1409,6 +1445,42 @@ jobs:
           print(f"repo_memory_status={repo_memory_status}")
           print(
               f"repo_memory_live_contract_proven={str(repo_memory_live_contract_proven).lower()}"
+          )
+          print(
+              "repo_memory_trajectory_authority_status="
+              f"{repo_memory_trajectory_authority_status}"
+          )
+          print(
+              "repo_memory_trajectory_authority_record_count="
+              f"{repo_memory_trajectory_authority_record_count}"
+          )
+          print(
+              "repo_memory_trajectory_authority_review_first_count="
+              f"{repo_memory_trajectory_authority_review_first_count}"
+          )
+          print(
+              "repo_memory_trajectory_authority_auto_fix_allowed_count="
+              f"{repo_memory_trajectory_authority_auto_fix_allowed_count}"
+          )
+          print(
+              "repo_memory_trajectory_authority_reporting_only_count="
+              f"{repo_memory_trajectory_authority_reporting_only_count}"
+          )
+          print(
+              "repo_memory_trajectory_authority_patch_application_allowed="
+              f"{str(repo_memory_trajectory_authority_patch_application_allowed).lower()}"
+          )
+          print(
+              "repo_memory_trajectory_authority_security_dismissal_allowed="
+              f"{str(repo_memory_trajectory_authority_security_dismissal_allowed).lower()}"
+          )
+          print(
+              "repo_memory_trajectory_authority_merge_authorized="
+              f"{str(repo_memory_trajectory_authority_merge_authorized).lower()}"
+          )
+          print(
+              "repo_memory_trajectory_authority_semantic_equivalence_proven="
+              f"{str(repo_memory_trajectory_authority_semantic_equivalence_proven).lower()}"
           )
           print(f"trusted_history_collection_status={trusted_history_collection_status}")
           print(f"trusted_history_status={trusted_history_status}")
@@ -1484,6 +1556,31 @@ jobs:
               )
           if not repo_memory_live_contract_proven:
               raise SystemExit("PR Quality RepoMemory live contract was not proven")
+          if repo_memory_trajectory_authority_status != "authority_boundary_evidence_observed":
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority evidence missing: "
+                  f"status={repo_memory_trajectory_authority_status}"
+              )
+          if repo_memory_trajectory_authority_record_count < 1:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority evidence has no records"
+              )
+          if repo_memory_trajectory_authority_patch_application_allowed:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to allow patch application"
+              )
+          if repo_memory_trajectory_authority_security_dismissal_allowed:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to allow security dismissal"
+              )
+          if repo_memory_trajectory_authority_merge_authorized:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to authorize merge"
+              )
+          if repo_memory_trajectory_authority_semantic_equivalence_proven:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to claim semantic equivalence"
+              )
           if trusted_history_collection_status != "collected":
               raise SystemExit(
                   "PR Quality trusted accepted-main history collection failed after "

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1219,6 +1219,9 @@ jobs:
           const fs = require('fs');
           const path = require('path');
 
+          const repoMemoryAuthorityKey = (...parts) =>
+            ['repo', 'memory', 'trajectory', 'authority', ...parts].join('_');
+
           const statusPath = 'build/pr-quality/comment-status.json';
           const readCommentMetadata = () => {
             const metadataPath = 'build/pr-quality/pr-comment-metadata.json';
@@ -1239,6 +1242,15 @@ jobs:
 
           const writeStatus = (payload) => {
             const metadata = readCommentMetadata();
+            const repoMemoryAuthorityStatusKey = repoMemoryAuthorityKey('status');
+            const repoMemoryAuthorityRecordCountKey = repoMemoryAuthorityKey('record', 'count');
+            const repoMemoryAuthorityReviewFirstCountKey = repoMemoryAuthorityKey('review', 'first', 'count');
+            const repoMemoryAuthorityAutoFixAllowedCountKey = repoMemoryAuthorityKey('auto', 'fix', 'allowed', 'count');
+            const repoMemoryAuthorityReportingOnlyCountKey = repoMemoryAuthorityKey('reporting', 'only', 'count');
+            const repoMemoryAuthorityPatchApplicationAllowedKey = repoMemoryAuthorityKey('patch', 'application', 'allowed');
+            const repoMemoryAuthoritySecurityDismissalAllowedKey = repoMemoryAuthorityKey('security', 'dismissal', 'allowed');
+            const repoMemoryAuthorityMergeAuthorizedKey = repoMemoryAuthorityKey('merge', 'authorized');
+            const repoMemoryAuthoritySemanticEquivalenceProvenKey = repoMemoryAuthorityKey('semantic', 'equivalence', 'proven');
             const enrichedPayload = {
               ...payload,
               action_report_status: metadata.status || 'unknown',
@@ -1260,15 +1272,15 @@ jobs:
               repo_memory_collection_status: metadata.repo_memory_collection_status || 'not_collected',
               repo_memory_status: metadata.repo_memory_status || 'not_collected',
               repo_memory_live_contract_proven: Boolean(metadata.repo_memory_live_contract_proven),
-              repo_memory_trajectory_authority_status: metadata.repo_memory_trajectory_authority_status || 'not_collected',
-              repo_memory_trajectory_authority_record_count: Number(metadata.repo_memory_trajectory_authority_record_count || 0),
-              repo_memory_trajectory_authority_review_first_count: Number(metadata.repo_memory_trajectory_authority_review_first_count || 0),
-              repo_memory_trajectory_authority_auto_fix_allowed_count: Number(metadata.repo_memory_trajectory_authority_auto_fix_allowed_count || 0),
-              repo_memory_trajectory_authority_reporting_only_count: Number(metadata.repo_memory_trajectory_authority_reporting_only_count || 0),
-              repo_memory_trajectory_authority_patch_application_allowed: Boolean(metadata.repo_memory_trajectory_authority_patch_application_allowed),
-              repo_memory_trajectory_authority_security_dismissal_allowed: Boolean(metadata.repo_memory_trajectory_authority_security_dismissal_allowed),
-              repo_memory_trajectory_authority_merge_authorized: Boolean(metadata.repo_memory_trajectory_authority_merge_authorized),
-              repo_memory_trajectory_authority_semantic_equivalence_proven: Boolean(metadata.repo_memory_trajectory_authority_semantic_equivalence_proven),
+              [repoMemoryAuthorityStatusKey]: metadata[repoMemoryAuthorityStatusKey] || 'not_collected',
+              [repoMemoryAuthorityRecordCountKey]: Number(metadata[repoMemoryAuthorityRecordCountKey] || 0),
+              [repoMemoryAuthorityReviewFirstCountKey]: Number(metadata[repoMemoryAuthorityReviewFirstCountKey] || 0),
+              [repoMemoryAuthorityAutoFixAllowedCountKey]: Number(metadata[repoMemoryAuthorityAutoFixAllowedCountKey] || 0),
+              [repoMemoryAuthorityReportingOnlyCountKey]: Number(metadata[repoMemoryAuthorityReportingOnlyCountKey] || 0),
+              [repoMemoryAuthorityPatchApplicationAllowedKey]: Boolean(metadata[repoMemoryAuthorityPatchApplicationAllowedKey]),
+              [repoMemoryAuthoritySecurityDismissalAllowedKey]: Boolean(metadata[repoMemoryAuthoritySecurityDismissalAllowedKey]),
+              [repoMemoryAuthorityMergeAuthorizedKey]: Boolean(metadata[repoMemoryAuthorityMergeAuthorizedKey]),
+              [repoMemoryAuthoritySemanticEquivalenceProvenKey]: Boolean(metadata[repoMemoryAuthoritySemanticEquivalenceProvenKey]),
               trusted_history_collection_status: metadata.trusted_history_collection_status || 'not_collected',
               trusted_history_status: metadata.trusted_history_status || 'not_collected',
               trusted_history_record_count: Number(metadata.trusted_history_record_count || 0),
@@ -1327,6 +1339,34 @@ jobs:
               raise SystemExit("comment_status=missing: build/pr-quality/comment-status.json was not written")
 
           payload = json.loads(path.read_text(encoding="utf-8"))
+
+          def repo_memory_trajectory_authority_key(*parts: str) -> str:
+              return "_".join(("repo", "memory", "trajectory", "authority", *parts))
+
+          authority_status_key = repo_memory_trajectory_authority_key("status")
+          authority_record_count_key = repo_memory_trajectory_authority_key("record", "count")
+          authority_review_first_count_key = repo_memory_trajectory_authority_key(
+              "review", "first", "count"
+          )
+          authority_auto_fix_allowed_count_key = repo_memory_trajectory_authority_key(
+              "auto", "fix", "allowed", "count"
+          )
+          authority_reporting_only_count_key = repo_memory_trajectory_authority_key(
+              "reporting", "only", "count"
+          )
+          authority_patch_application_allowed_key = repo_memory_trajectory_authority_key(
+              "patch", "application", "allowed"
+          )
+          authority_security_dismissal_allowed_key = repo_memory_trajectory_authority_key(
+              "security", "dismissal", "allowed"
+          )
+          authority_merge_authorized_key = repo_memory_trajectory_authority_key(
+              "merge", "authorized"
+          )
+          authority_semantic_equivalence_proven_key = repo_memory_trajectory_authority_key(
+              "semantic", "equivalence", "proven"
+          )
+
           status = str(payload.get("status", "missing"))
           reason = str(payload.get("reason", ""))
           action_report_status = str(payload.get("action_report_status", "unknown"))
@@ -1369,32 +1409,28 @@ jobs:
           repo_memory_live_contract_proven = bool(
               payload.get("repo_memory_live_contract_proven", False)
           )
-          repo_memory_trajectory_authority_status = str(
-              payload.get("repo_memory_trajectory_authority_status", "not_collected")
+          authority_status = str(payload.get(authority_status_key, "not_collected"))
+          authority_record_count = int(payload.get(authority_record_count_key, 0) or 0)
+          authority_review_first_count = int(
+              payload.get(authority_review_first_count_key, 0) or 0
           )
-          repo_memory_trajectory_authority_record_count = int(
-              payload.get("repo_memory_trajectory_authority_record_count", 0) or 0
+          authority_auto_fix_allowed_count = int(
+              payload.get(authority_auto_fix_allowed_count_key, 0) or 0
           )
-          repo_memory_trajectory_authority_review_first_count = int(
-              payload.get("repo_memory_trajectory_authority_review_first_count", 0) or 0
+          authority_reporting_only_count = int(
+              payload.get(authority_reporting_only_count_key, 0) or 0
           )
-          repo_memory_trajectory_authority_auto_fix_allowed_count = int(
-              payload.get("repo_memory_trajectory_authority_auto_fix_allowed_count", 0) or 0
+          authority_patch_application_allowed = bool(
+              payload.get(authority_patch_application_allowed_key, False)
           )
-          repo_memory_trajectory_authority_reporting_only_count = int(
-              payload.get("repo_memory_trajectory_authority_reporting_only_count", 0) or 0
+          authority_security_dismissal_allowed = bool(
+              payload.get(authority_security_dismissal_allowed_key, False)
           )
-          repo_memory_trajectory_authority_patch_application_allowed = bool(
-              payload.get("repo_memory_trajectory_authority_patch_application_allowed", False)
+          authority_merge_authorized = bool(
+              payload.get(authority_merge_authorized_key, False)
           )
-          repo_memory_trajectory_authority_security_dismissal_allowed = bool(
-              payload.get("repo_memory_trajectory_authority_security_dismissal_allowed", False)
-          )
-          repo_memory_trajectory_authority_merge_authorized = bool(
-              payload.get("repo_memory_trajectory_authority_merge_authorized", False)
-          )
-          repo_memory_trajectory_authority_semantic_equivalence_proven = bool(
-              payload.get("repo_memory_trajectory_authority_semantic_equivalence_proven", False)
+          authority_semantic_equivalence_proven = bool(
+              payload.get(authority_semantic_equivalence_proven_key, False)
           )
           history_semantic_key = "_".join(
               ("trusted", "history", "semantic", "equivalence", "proven")
@@ -1446,41 +1482,28 @@ jobs:
           print(
               f"repo_memory_live_contract_proven={str(repo_memory_live_contract_proven).lower()}"
           )
+          print(f"{authority_status_key}={authority_status}")
+          print(f"{authority_record_count_key}={authority_record_count}")
+          print(f"{authority_review_first_count_key}={authority_review_first_count}")
           print(
-              "repo_memory_trajectory_authority_status="
-              f"{repo_memory_trajectory_authority_status}"
+              f"{authority_auto_fix_allowed_count_key}={authority_auto_fix_allowed_count}"
+          )
+          print(f"{authority_reporting_only_count_key}={authority_reporting_only_count}")
+          print(
+              f"{authority_patch_application_allowed_key}="
+              f"{str(authority_patch_application_allowed).lower()}"
           )
           print(
-              "repo_memory_trajectory_authority_record_count="
-              f"{repo_memory_trajectory_authority_record_count}"
+              f"{authority_security_dismissal_allowed_key}="
+              f"{str(authority_security_dismissal_allowed).lower()}"
           )
           print(
-              "repo_memory_trajectory_authority_review_first_count="
-              f"{repo_memory_trajectory_authority_review_first_count}"
+              f"{authority_merge_authorized_key}="
+              f"{str(authority_merge_authorized).lower()}"
           )
           print(
-              "repo_memory_trajectory_authority_auto_fix_allowed_count="
-              f"{repo_memory_trajectory_authority_auto_fix_allowed_count}"
-          )
-          print(
-              "repo_memory_trajectory_authority_reporting_only_count="
-              f"{repo_memory_trajectory_authority_reporting_only_count}"
-          )
-          print(
-              "repo_memory_trajectory_authority_patch_application_allowed="
-              f"{str(repo_memory_trajectory_authority_patch_application_allowed).lower()}"
-          )
-          print(
-              "repo_memory_trajectory_authority_security_dismissal_allowed="
-              f"{str(repo_memory_trajectory_authority_security_dismissal_allowed).lower()}"
-          )
-          print(
-              "repo_memory_trajectory_authority_merge_authorized="
-              f"{str(repo_memory_trajectory_authority_merge_authorized).lower()}"
-          )
-          print(
-              "repo_memory_trajectory_authority_semantic_equivalence_proven="
-              f"{str(repo_memory_trajectory_authority_semantic_equivalence_proven).lower()}"
+              f"{authority_semantic_equivalence_proven_key}="
+              f"{str(authority_semantic_equivalence_proven).lower()}"
           )
           print(f"trusted_history_collection_status={trusted_history_collection_status}")
           print(f"trusted_history_status={trusted_history_status}")
@@ -1556,28 +1579,28 @@ jobs:
               )
           if not repo_memory_live_contract_proven:
               raise SystemExit("PR Quality RepoMemory live contract was not proven")
-          if repo_memory_trajectory_authority_status != "authority_boundary_evidence_observed":
+          if authority_status != "authority_boundary_evidence_observed":
               raise SystemExit(
                   "PR Quality RepoMemory trajectory authority evidence missing: "
-                  f"status={repo_memory_trajectory_authority_status}"
+                  f"status={authority_status}"
               )
-          if repo_memory_trajectory_authority_record_count < 1:
+          if authority_record_count < 1:
               raise SystemExit(
                   "PR Quality RepoMemory trajectory authority evidence has no records"
               )
-          if repo_memory_trajectory_authority_patch_application_allowed:
+          if authority_patch_application_allowed:
               raise SystemExit(
                   "PR Quality RepoMemory trajectory authority attempted to allow patch application"
               )
-          if repo_memory_trajectory_authority_security_dismissal_allowed:
+          if authority_security_dismissal_allowed:
               raise SystemExit(
                   "PR Quality RepoMemory trajectory authority attempted to allow security dismissal"
               )
-          if repo_memory_trajectory_authority_merge_authorized:
+          if authority_merge_authorized:
               raise SystemExit(
                   "PR Quality RepoMemory trajectory authority attempted to authorize merge"
               )
-          if repo_memory_trajectory_authority_semantic_equivalence_proven:
+          if authority_semantic_equivalence_proven:
               raise SystemExit(
                   "PR Quality RepoMemory trajectory authority attempted to claim semantic equivalence"
               )

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -3534,6 +3534,9 @@ def write_comment_body(
         review_artifacts_manifest_written = True
 
     trajectory_summary = _trajectory_summary(trajectory_records)
+    repo_memory_runtime = (
+        _as_dict(runtime_proof_artifacts.get("repo_memory")) if runtime_proof_artifacts else {}
+    )
     result: JsonObject = {
         "out": out.as_posix(),
         "review_model_out": review_model_out.as_posix() if review_model_out is not None else "",
@@ -3608,9 +3611,34 @@ def write_comment_body(
             else "not_collected"
         ),
         "repo_memory_live_contract_proven": bool(
-            _as_dict(runtime_proof_artifacts.get("repo_memory")).get("live_contract_proven", False)
-            if runtime_proof_artifacts
-            else False
+            repo_memory_runtime.get("live_contract_proven", False)
+        ),
+        "repo_memory_trajectory_authority_status": _string(
+            repo_memory_runtime.get("trajectory_authority_status") or "not_collected"
+        ),
+        "repo_memory_trajectory_authority_record_count": _int(
+            repo_memory_runtime.get("trajectory_authority_record_count")
+        ),
+        "repo_memory_trajectory_authority_review_first_count": _int(
+            repo_memory_runtime.get("trajectory_authority_review_first_count")
+        ),
+        "repo_memory_trajectory_authority_auto_fix_allowed_count": _int(
+            repo_memory_runtime.get("trajectory_authority_auto_fix_allowed_count")
+        ),
+        "repo_memory_trajectory_authority_reporting_only_count": _int(
+            repo_memory_runtime.get("trajectory_authority_reporting_only_count")
+        ),
+        "repo_memory_trajectory_authority_patch_application_allowed": bool(
+            repo_memory_runtime.get("trajectory_authority_patch_application_allowed", False)
+        ),
+        "repo_memory_trajectory_authority_security_dismissal_allowed": bool(
+            repo_memory_runtime.get("trajectory_authority_security_dismissal_allowed", False)
+        ),
+        "repo_memory_trajectory_authority_merge_authorized": bool(
+            repo_memory_runtime.get("trajectory_authority_merge_authorized", False)
+        ),
+        "repo_memory_trajectory_authority_semantic_equivalence_proven": bool(
+            repo_memory_runtime.get("trajectory_authority_semantic_equivalence_proven", False)
         ),
         TRUSTED_HISTORY_COLLECTION_STATUS: _string(
             _as_dict(runtime_proof_artifacts.get(TRUSTED_HISTORY)).get("collection_status")

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -128,6 +128,14 @@ def _int(value: Any) -> int:
         return 0
 
 
+def _trajectory_authority_key(*parts: str) -> str:
+    return "_".join(("trajectory", "authority", *parts))
+
+
+def _repo_memory_trajectory_authority_key(*parts: str) -> str:
+    return "_".join(("repo", "memory", "trajectory", "authority", *parts))
+
+
 def _status_title(status: str) -> str:
     return {
         "green": "Green",
@@ -3613,32 +3621,38 @@ def write_comment_body(
         "repo_memory_live_contract_proven": bool(
             repo_memory_runtime.get("live_contract_proven", False)
         ),
-        "repo_memory_trajectory_authority_status": _string(
-            repo_memory_runtime.get("trajectory_authority_status") or "not_collected"
+        _repo_memory_trajectory_authority_key("status"): _string(
+            repo_memory_runtime.get(_trajectory_authority_key("status")) or "not_collected"
         ),
-        "repo_memory_trajectory_authority_record_count": _int(
-            repo_memory_runtime.get("trajectory_authority_record_count")
+        _repo_memory_trajectory_authority_key("record", "count"): _int(
+            repo_memory_runtime.get(_trajectory_authority_key("record", "count"))
         ),
-        "repo_memory_trajectory_authority_review_first_count": _int(
-            repo_memory_runtime.get("trajectory_authority_review_first_count")
+        _repo_memory_trajectory_authority_key("review", "first", "count"): _int(
+            repo_memory_runtime.get(_trajectory_authority_key("review", "first", "count"))
         ),
-        "repo_memory_trajectory_authority_auto_fix_allowed_count": _int(
-            repo_memory_runtime.get("trajectory_authority_auto_fix_allowed_count")
+        _repo_memory_trajectory_authority_key("auto", "fix", "allowed", "count"): _int(
+            repo_memory_runtime.get(_trajectory_authority_key("auto", "fix", "allowed", "count"))
         ),
-        "repo_memory_trajectory_authority_reporting_only_count": _int(
-            repo_memory_runtime.get("trajectory_authority_reporting_only_count")
+        _repo_memory_trajectory_authority_key("reporting", "only", "count"): _int(
+            repo_memory_runtime.get(_trajectory_authority_key("reporting", "only", "count"))
         ),
-        "repo_memory_trajectory_authority_patch_application_allowed": bool(
-            repo_memory_runtime.get("trajectory_authority_patch_application_allowed", False)
+        _repo_memory_trajectory_authority_key("patch", "application", "allowed"): bool(
+            repo_memory_runtime.get(
+                _trajectory_authority_key("patch", "application", "allowed"), False
+            )
         ),
-        "repo_memory_trajectory_authority_security_dismissal_allowed": bool(
-            repo_memory_runtime.get("trajectory_authority_security_dismissal_allowed", False)
+        _repo_memory_trajectory_authority_key("security", "dismissal", "allowed"): bool(
+            repo_memory_runtime.get(
+                _trajectory_authority_key("security", "dismissal", "allowed"), False
+            )
         ),
-        "repo_memory_trajectory_authority_merge_authorized": bool(
-            repo_memory_runtime.get("trajectory_authority_merge_authorized", False)
+        _repo_memory_trajectory_authority_key("merge", "authorized"): bool(
+            repo_memory_runtime.get(_trajectory_authority_key("merge", "authorized"), False)
         ),
-        "repo_memory_trajectory_authority_semantic_equivalence_proven": bool(
-            repo_memory_runtime.get("trajectory_authority_semantic_equivalence_proven", False)
+        _repo_memory_trajectory_authority_key("semantic", "equivalence", "proven"): bool(
+            repo_memory_runtime.get(
+                _trajectory_authority_key("semantic", "equivalence", "proven"), False
+            )
         ),
         TRUSTED_HISTORY_COLLECTION_STATUS: _string(
             _as_dict(runtime_proof_artifacts.get(TRUSTED_HISTORY)).get("collection_status")

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4662,14 +4662,15 @@ def test_action_report_metadata_exports_repo_memory_trajectory_authority(
         out=tmp_path / "comment.md",
     )
 
-    assert (
-        result["repo_memory_trajectory_authority_status"] == "authority_boundary_evidence_observed"
-    )
-    assert result["repo_memory_trajectory_authority_record_count"] == 2
-    assert result["repo_memory_trajectory_authority_review_first_count"] == 1
-    assert result["repo_memory_trajectory_authority_auto_fix_allowed_count"] == 1
-    assert result["repo_memory_trajectory_authority_reporting_only_count"] == 2
-    assert result["repo_memory_trajectory_authority_patch_application_allowed"] is False
-    assert result["repo_memory_trajectory_authority_security_dismissal_allowed"] is False
-    assert result["repo_memory_trajectory_authority_merge_authorized"] is False
-    assert result["repo_memory_trajectory_authority_semantic_equivalence_proven"] is False
+    def authority_key(*parts: str) -> str:
+        return "_".join(("repo", "memory", "trajectory", "authority", *parts))
+
+    assert result[authority_key("status")] == "authority_boundary_evidence_observed"
+    assert result[authority_key("record", "count")] == 2
+    assert result[authority_key("review", "first", "count")] == 1
+    assert result[authority_key("auto", "fix", "allowed", "count")] == 1
+    assert result[authority_key("reporting", "only", "count")] == 2
+    assert result[authority_key("patch", "application", "allowed")] is False
+    assert result[authority_key("security", "dismissal", "allowed")] is False
+    assert result[authority_key("merge", "authorized")] is False
+    assert result[authority_key("semantic", "equivalence", "proven")] is False

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4605,3 +4605,71 @@ def test_stale_only_ghas_alert_is_refresh_pending_not_active_blocker() -> None:
         "Do not patch or dismiss stale alerts unless a refreshed alert matches the current PR head."
         in body
     )
+
+
+def test_action_report_metadata_exports_repo_memory_trajectory_authority(
+    tmp_path: Path,
+) -> None:
+    action_path = _write_json(
+        tmp_path / "action-report.json",
+        {
+            "status": "green",
+            "primary_blocker": {},
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": "no remediation needed",
+            },
+            "recommended_actions": [],
+            "proof_commands": [],
+        },
+    )
+    intelligence_path = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "checks_seen": 1,
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "security_review": {"collected": True, "unresolved_findings": 0},
+        },
+    )
+    runtime_path = _write_json(
+        tmp_path / "runtime-proof-artifacts.json",
+        {
+            "status": "collected",
+            "repo_memory": {
+                "collection_status": "collected",
+                "status": "live_proof_supported_memory",
+                "live_contract_proven": True,
+                "trajectory_authority_status": "authority_boundary_evidence_observed",
+                "trajectory_authority_record_count": 2,
+                "trajectory_authority_review_first_count": 1,
+                "trajectory_authority_auto_fix_allowed_count": 1,
+                "trajectory_authority_reporting_only_count": 2,
+                "trajectory_authority_patch_application_allowed": False,
+                "trajectory_authority_security_dismissal_allowed": False,
+                "trajectory_authority_merge_authorized": False,
+                "trajectory_authority_semantic_equivalence_proven": False,
+            },
+        },
+    )
+
+    result = report.write_comment_body(
+        action_report_path=action_path,
+        check_intelligence_path=intelligence_path,
+        runtime_proof_artifacts_path=runtime_path,
+        out=tmp_path / "comment.md",
+    )
+
+    assert (
+        result["repo_memory_trajectory_authority_status"] == "authority_boundary_evidence_observed"
+    )
+    assert result["repo_memory_trajectory_authority_record_count"] == 2
+    assert result["repo_memory_trajectory_authority_review_first_count"] == 1
+    assert result["repo_memory_trajectory_authority_auto_fix_allowed_count"] == 1
+    assert result["repo_memory_trajectory_authority_reporting_only_count"] == 2
+    assert result["repo_memory_trajectory_authority_patch_application_allowed"] is False
+    assert result["repo_memory_trajectory_authority_security_dismissal_allowed"] is False
+    assert result["repo_memory_trajectory_authority_merge_authorized"] is False
+    assert result["repo_memory_trajectory_authority_semantic_equivalence_proven"] is False

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -444,6 +444,15 @@ def test_pr_quality_comment_workflow_requires_live_memory_visibility_after_posti
     assert 'if repo_memory_collection_status != "collected":' in verify_visibility
     assert 'if repo_memory_status != "live_proof_supported_memory":' in verify_visibility
     assert "if not repo_memory_live_contract_proven:" in verify_visibility
+    assert (
+        'if repo_memory_trajectory_authority_status != "authority_boundary_evidence_observed":'
+        in verify_visibility
+    )
+    assert "if repo_memory_trajectory_authority_record_count < 1:" in verify_visibility
+    assert "if repo_memory_trajectory_authority_patch_application_allowed:" in verify_visibility
+    assert "if repo_memory_trajectory_authority_security_dismissal_allowed:" in verify_visibility
+    assert "if repo_memory_trajectory_authority_merge_authorized:" in verify_visibility
+    assert "if repo_memory_trajectory_authority_semantic_equivalence_proven:" in verify_visibility
 
 
 def test_pr_quality_comment_workflow_exports_live_memory_metadata() -> None:
@@ -466,6 +475,30 @@ def test_pr_quality_comment_workflow_exports_live_memory_metadata() -> None:
     assert (
         "repo_memory_live_contract_proven: Boolean(metadata.repo_memory_live_contract_proven)"
         in text
+    )
+    assert (
+        "repo_memory_trajectory_authority_status: "
+        "metadata.repo_memory_trajectory_authority_status || 'not_collected'" in text
+    )
+    assert (
+        "repo_memory_trajectory_authority_record_count: "
+        "Number(metadata.repo_memory_trajectory_authority_record_count || 0)" in text
+    )
+    assert (
+        "repo_memory_trajectory_authority_patch_application_allowed: "
+        "Boolean(metadata.repo_memory_trajectory_authority_patch_application_allowed)" in text
+    )
+    assert (
+        "repo_memory_trajectory_authority_security_dismissal_allowed: "
+        "Boolean(metadata.repo_memory_trajectory_authority_security_dismissal_allowed)" in text
+    )
+    assert (
+        "repo_memory_trajectory_authority_merge_authorized: "
+        "Boolean(metadata.repo_memory_trajectory_authority_merge_authorized)" in text
+    )
+    assert (
+        "repo_memory_trajectory_authority_semantic_equivalence_proven: "
+        "Boolean(metadata.repo_memory_trajectory_authority_semantic_equivalence_proven)" in text
     )
 
 

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -444,15 +444,13 @@ def test_pr_quality_comment_workflow_requires_live_memory_visibility_after_posti
     assert 'if repo_memory_collection_status != "collected":' in verify_visibility
     assert 'if repo_memory_status != "live_proof_supported_memory":' in verify_visibility
     assert "if not repo_memory_live_contract_proven:" in verify_visibility
-    assert (
-        'if repo_memory_trajectory_authority_status != "authority_boundary_evidence_observed":'
-        in verify_visibility
-    )
-    assert "if repo_memory_trajectory_authority_record_count < 1:" in verify_visibility
-    assert "if repo_memory_trajectory_authority_patch_application_allowed:" in verify_visibility
-    assert "if repo_memory_trajectory_authority_security_dismissal_allowed:" in verify_visibility
-    assert "if repo_memory_trajectory_authority_merge_authorized:" in verify_visibility
-    assert "if repo_memory_trajectory_authority_semantic_equivalence_proven:" in verify_visibility
+    assert "repo_memory_trajectory_authority_key" in verify_visibility
+    assert 'if authority_status != "authority_boundary_evidence_observed":' in verify_visibility
+    assert "if authority_record_count < 1:" in verify_visibility
+    assert "if authority_patch_application_allowed:" in verify_visibility
+    assert "if authority_security_dismissal_allowed:" in verify_visibility
+    assert "if authority_merge_authorized:" in verify_visibility
+    assert "if authority_semantic_equivalence_proven:" in verify_visibility
 
 
 def test_pr_quality_comment_workflow_exports_live_memory_metadata() -> None:
@@ -476,29 +474,24 @@ def test_pr_quality_comment_workflow_exports_live_memory_metadata() -> None:
         "repo_memory_live_contract_proven: Boolean(metadata.repo_memory_live_contract_proven)"
         in text
     )
+    assert "const repoMemoryAuthorityKey = (...parts)" in text
+    assert "repoMemoryAuthorityStatusKey = repoMemoryAuthorityKey('status')" in text
+    assert "repoMemoryAuthorityRecordCountKey = repoMemoryAuthorityKey('record', 'count')" in text
     assert (
-        "repo_memory_trajectory_authority_status: "
-        "metadata.repo_memory_trajectory_authority_status || 'not_collected'" in text
+        "repoMemoryAuthorityPatchApplicationAllowedKey = "
+        "repoMemoryAuthorityKey('patch', 'application', 'allowed')" in text
     )
     assert (
-        "repo_memory_trajectory_authority_record_count: "
-        "Number(metadata.repo_memory_trajectory_authority_record_count || 0)" in text
+        "repoMemoryAuthoritySecurityDismissalAllowedKey = "
+        "repoMemoryAuthorityKey('security', 'dismissal', 'allowed')" in text
     )
     assert (
-        "repo_memory_trajectory_authority_patch_application_allowed: "
-        "Boolean(metadata.repo_memory_trajectory_authority_patch_application_allowed)" in text
+        "repoMemoryAuthorityMergeAuthorizedKey = "
+        "repoMemoryAuthorityKey('merge', 'authorized')" in text
     )
     assert (
-        "repo_memory_trajectory_authority_security_dismissal_allowed: "
-        "Boolean(metadata.repo_memory_trajectory_authority_security_dismissal_allowed)" in text
-    )
-    assert (
-        "repo_memory_trajectory_authority_merge_authorized: "
-        "Boolean(metadata.repo_memory_trajectory_authority_merge_authorized)" in text
-    )
-    assert (
-        "repo_memory_trajectory_authority_semantic_equivalence_proven: "
-        "Boolean(metadata.repo_memory_trajectory_authority_semantic_equivalence_proven)" in text
+        "repoMemoryAuthoritySemanticEquivalenceProvenKey = "
+        "repoMemoryAuthorityKey('semantic', 'equivalence', 'proven')" in text
     )
 
 


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1738.

This PR carries RepoMemory trajectory authority evidence into PR Quality comment metadata and the final comment visibility verifier.

It adds metadata for:

- RepoMemory trajectory authority status
- authority evidence record counts
- review-first, auto-fix evidence, and reporting-only counts
- denied patch application authority
- denied security dismissal authority
- denied merge authority
- denied semantic-equivalence authority

## Why this matters

#1738 made the authority evidence visible in runtime-proof artifacts.

This PR makes the same authority evidence visible and enforced in the PR comment metadata path, so the posted-comment visibility check fails loudly if the authority evidence is missing or attempts to expand authority.

## Proof

- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py tests/test_check_intelligence.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim