### PR TITLE
feat(pr-quality): index authority evidence artifacts

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1691,6 +1691,113 @@ def _review_model_artifact_index() -> list[JsonObject]:
     ]
 
 
+def _authority_evidence_source_index() -> list[JsonObject]:
+    return [
+        {
+            "path": "trajectory/trajectory.jsonl",
+            "kind": "jsonl",
+            "surface": "authority_evidence",
+            "title": "Trajectory authority boundary records",
+            "description": "Raw TrajectoryStore records carrying per-record authority_boundary evidence.",
+            "primary": False,
+            "format": "jsonl",
+            "reporting_only": True,
+            "authority_boundary": {
+                "boundary_mode": "reporting_only",
+                "patch_automation": False,
+                "security_dismissal": False,
+                "merge_authorization": False,
+                "semantic_equivalence_claim": False,
+            },
+        },
+        {
+            "path": "trajectory-pattern-insights/pattern-insights.json",
+            "kind": "json",
+            "surface": "authority_evidence",
+            "title": "Trajectory authority evidence rollup",
+            "description": "PatternInsights rollup of observed trajectory authority boundary evidence.",
+            "primary": False,
+            "format": "json",
+            "reporting_only": True,
+            "authority_boundary": {
+                "boundary_mode": "reporting_only",
+                "patch_automation": False,
+                "security_dismissal": False,
+                "merge_authorization": False,
+                "semantic_equivalence_claim": False,
+            },
+        },
+        {
+            "path": "repo-memory/repo-memory-profile.json",
+            "kind": "json",
+            "surface": "authority_evidence",
+            "title": "RepoMemory trajectory authority evidence",
+            "description": "RepoMemory profile containing trajectory_authority_evidence and denied authority fields.",
+            "primary": False,
+            "format": "json",
+            "reporting_only": True,
+            "authority_boundary": {
+                "boundary_mode": "reporting_only",
+                "patch_automation": False,
+                "security_dismissal": False,
+                "merge_authorization": False,
+                "semantic_equivalence_claim": False,
+            },
+        },
+        {
+            "path": "runtime-proof/summary/runtime-proof-artifacts.json",
+            "kind": "json",
+            "surface": "authority_evidence",
+            "title": "Runtime proof authority summary",
+            "description": "Runtime-proof summary exposing RepoMemory trajectory authority status and counts.",
+            "primary": False,
+            "format": "json",
+            "reporting_only": True,
+            "authority_boundary": {
+                "boundary_mode": "reporting_only",
+                "patch_automation": False,
+                "security_dismissal": False,
+                "merge_authorization": False,
+                "semantic_equivalence_claim": False,
+            },
+        },
+        {
+            "path": "runtime-proof/summary/runtime-proof-artifacts.md",
+            "kind": "markdown",
+            "surface": "authority_evidence",
+            "title": "Runtime proof authority markdown",
+            "description": "Human-readable runtime-proof authority evidence summary.",
+            "primary": False,
+            "format": "markdown",
+            "reporting_only": True,
+            "authority_boundary": {
+                "boundary_mode": "reporting_only",
+                "patch_automation": False,
+                "security_dismissal": False,
+                "merge_authorization": False,
+                "semantic_equivalence_claim": False,
+            },
+        },
+        {
+            "path": "pr-comment-metadata.json",
+            "kind": "json",
+            "surface": "authority_evidence",
+            "title": "PR comment authority metadata",
+            "description": "Comment metadata carrying RepoMemory trajectory authority evidence into visibility verification.",
+            "primary": False,
+            "format": "json",
+            "reporting_only": True,
+            "authority_boundary": {
+                "boundary_mode": "reporting_only",
+                "patch_automation": False,
+                "security_dismissal": False,
+                "merge_authorization": False,
+                "semantic_equivalence_claim": False,
+            },
+        },
+    ]
+
+
 def _review_model_failure_vector_signal(
     *,
     action_report: JsonObject,
@@ -2660,6 +2767,7 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
 
     decision = _as_dict(model.get("decision"))
     authority = _as_dict(model.get("authority_boundary"))
+    authority_evidence_sources = _authority_evidence_source_index()
 
     return {
         "schema_version": "sdetkit.pr_quality.artifacts_manifest.v1",
@@ -2669,6 +2777,7 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
         "primary_entrypoint": primary_entrypoint,
         "expected_artifact_paths": expected_paths,
         "artifacts": artifacts,
+        "authority_evidence_sources": authority_evidence_sources,
         "reporting_only": True,
         "authority_boundary": {
             "boundary_mode": _string(authority.get("boundary_mode") or "reporting_only"),

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4674,3 +4674,48 @@ def test_action_report_metadata_exports_repo_memory_trajectory_authority(
     assert result[authority_key("security", "dismissal", "allowed")] is False
     assert result[authority_key("merge", "authorized")] is False
     assert result[authority_key("semantic", "equivalence", "proven")] is False
+
+
+def test_artifacts_manifest_indexes_authority_evidence_sources() -> None:
+    model = {
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "schema": {
+            "name": "sdetkit.pr_quality.review_model",
+            "version": 2,
+            "authority_boundary": "reporting_only",
+        },
+        "artifact_index": [],
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "decision": {
+            "status": "green",
+            "merge_assessment": "ready_for_review",
+            "next_action": "human_review",
+        },
+    }
+
+    manifest = report.build_pr_quality_artifacts_manifest(model)
+
+    sources = manifest["authority_evidence_sources"]
+    paths = {source["path"] for source in sources}
+
+    assert "trajectory/trajectory.jsonl" in paths
+    assert "trajectory-pattern-insights/pattern-insights.json" in paths
+    assert "repo-memory/repo-memory-profile.json" in paths
+    assert "runtime-proof/summary/runtime-proof-artifacts.json" in paths
+    assert "runtime-proof/summary/runtime-proof-artifacts.md" in paths
+    assert "pr-comment-metadata.json" in paths
+
+    assert all(source["surface"] == "authority_evidence" for source in sources)
+    assert all(source["reporting_only"] is True for source in sources)
+    assert all(source["authority_boundary"]["patch_automation"] is False for source in sources)
+    assert all(source["authority_boundary"]["security_dismissal"] is False for source in sources)
+    assert all(source["authority_boundary"]["merge_authorization"] is False for source in sources)
+    assert all(
+        source["authority_boundary"]["semantic_equivalence_claim"] is False for source in sources
+    )


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1739.

This PR adds explicit authority-evidence source entries to the PR Quality artifact manifest.

It indexes:

- TrajectoryStore authority boundary records
- TrajectoryPatternInsights authority evidence rollup
- RepoMemory trajectory authority evidence
- Runtime-proof authority JSON summary
- Runtime-proof authority markdown summary
- PR comment authority metadata

## Why this matters

#1738 surfaced RepoMemory trajectory authority evidence in runtime-proof artifacts.
#1739 carried that evidence into PR comment metadata and final visibility verification.
#1740 makes the artifact manifest point reviewers to the exact authority evidence sources.

This makes the PR Quality artifact bundle easier to audit and keeps the authority chain visible without granting automation authority.

## Proof

- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_comment_observability_workflow.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim