### PR TITLE
feat(pr-quality): render authority evidence sources

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2824,6 +2824,29 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         if _string(item.get("path")) != "pr-quality-comment"
     ]
 
+    authority_evidence_sources = [
+        item
+        for item in (
+            _as_dict(candidate) for candidate in _as_list(model.get("authority_evidence_sources"))
+        )
+        if _string(item.get("path"))
+    ]
+    if not authority_evidence_sources:
+        authority_evidence_sources = _authority_evidence_source_index()
+
+    authority_source_rows = [
+        (
+            _string(item.get("path")),
+            "Open " + _string(item.get("title") or item.get("path")),
+            _string(
+                item.get("description")
+                or item.get("surface")
+                or "PR Quality authority evidence source."
+            ),
+        )
+        for item in authority_evidence_sources
+    ]
+
     def artifact_cards(rows: list[tuple[str, str, str]]) -> str:
         return "\n".join(
             '<article class="artifact-card">'
@@ -2898,6 +2921,13 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         "      <h2>Artifact entry points</h2>\n"
         '      <div class="artifact-grid">\n'
         f"        {artifact_cards(artifact_rows)}\n"
+        "      </div>\n"
+        "    </section>\n"
+        '    <section class="card">\n'
+        "      <h2>Authority evidence sources</h2>\n"
+        '      <p class="boundary">Reporting-only source map. This source map explains authority evidence and does not authorize patch automation, security dismissal, merge, or semantic-equivalence claims.</p>\n'
+        '      <div class="artifact-grid">\n'
+        f"        {artifact_cards(authority_source_rows)}\n"
         "      </div>\n"
         "    </section>\n"
         '    <section class="card">\n'

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4719,3 +4719,44 @@ def test_artifacts_manifest_indexes_authority_evidence_sources() -> None:
     assert all(
         source["authority_boundary"]["semantic_equivalence_claim"] is False for source in sources
     )
+
+
+def test_artifact_center_renders_authority_evidence_sources() -> None:
+    model = {
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "schema": {
+            "name": "sdetkit.pr_quality.review_model",
+            "version": 2,
+            "authority_boundary": "reporting_only",
+        },
+        "artifact_index": [],
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "decision": {
+            "status": "green",
+            "merge_assessment": "ready_for_review",
+            "next_action": "human_review",
+            "risk_surface": "authority",
+        },
+    }
+
+    html = report.render_pr_quality_artifact_index_html(model)
+
+    assert "Authority evidence sources" in html
+    assert "Reporting-only source map" in html
+    assert "does not authorize patch automation" in html
+    assert "Trajectory authority boundary records" in html
+    assert "trajectory/trajectory.jsonl" in html
+    assert "Trajectory authority evidence rollup" in html
+    assert "trajectory-pattern-insights/pattern-insights.json" in html
+    assert "RepoMemory trajectory authority evidence" in html
+    assert "repo-memory/repo-memory-profile.json" in html
+    assert "Runtime proof authority summary" in html
+    assert "runtime-proof/summary/runtime-proof-artifacts.json" in html
+    assert "PR comment authority metadata" in html
+    assert "pr-comment-metadata.json" in html


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1740.

This PR renders the authority evidence source map in the PR Quality artifact center HTML.

It shows reviewer-facing links for:

- TrajectoryStore authority boundary records
- TrajectoryPatternInsights authority evidence rollup
- RepoMemory trajectory authority evidence
- Runtime-proof authority JSON summary
- Runtime-proof authority markdown summary
- PR comment authority metadata

## Why this matters

#1740 indexed the authority evidence sources in the artifact manifest.
#1741 makes those sources visible in the human-facing artifact center.

Reviewers can now inspect the authority evidence chain from the artifact center without hunting through raw artifact paths manually.

## Proof

- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_comment_observability_workflow.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim