### PR TITLE
feat(pr-quality): include authority sources in expected artifacts

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2755,7 +2755,12 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
     if not artifacts:
         artifacts = _review_model_artifact_index()
 
-    expected_paths = [_string(item.get("path")) for item in artifacts if _string(item.get("path"))]
+    authority_evidence_sources = _authority_evidence_source_index()
+    expected_paths: list[str] = []
+    for item in [*artifacts, *authority_evidence_sources]:
+        artifact_path = _string(item.get("path"))
+        if artifact_path and artifact_path not in expected_paths:
+            expected_paths.append(artifact_path)
     primary_entrypoint = next(
         (
             _string(item.get("path"))
@@ -2767,7 +2772,6 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
 
     decision = _as_dict(model.get("decision"))
     authority = _as_dict(model.get("authority_boundary"))
-    authority_evidence_sources = _authority_evidence_source_index()
 
     return {
         "schema_version": "sdetkit.pr_quality.artifacts_manifest.v1",

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4760,3 +4760,40 @@ def test_artifact_center_renders_authority_evidence_sources() -> None:
     assert "runtime-proof/summary/runtime-proof-artifacts.json" in html
     assert "PR comment authority metadata" in html
     assert "pr-comment-metadata.json" in html
+
+
+def test_artifacts_manifest_expected_paths_include_authority_evidence_sources() -> None:
+    model = {
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "schema": {
+            "name": "sdetkit.pr_quality.review_model",
+            "version": 2,
+            "authority_boundary": "reporting_only",
+        },
+        "artifact_index": [],
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "decision": {
+            "status": "green",
+            "merge_assessment": "ready_for_review",
+            "next_action": "human_review",
+        },
+    }
+
+    manifest = report.build_pr_quality_artifacts_manifest(model)
+    expected_paths = manifest["expected_artifact_paths"]
+
+    assert "index.html" in expected_paths
+    assert "pr-review-artifacts-manifest.json" in expected_paths
+    assert "trajectory/trajectory.jsonl" in expected_paths
+    assert "trajectory-pattern-insights/pattern-insights.json" in expected_paths
+    assert "repo-memory/repo-memory-profile.json" in expected_paths
+    assert "runtime-proof/summary/runtime-proof-artifacts.json" in expected_paths
+    assert "runtime-proof/summary/runtime-proof-artifacts.md" in expected_paths
+    assert "pr-comment-metadata.json" in expected_paths
+    assert len(expected_paths) == len(set(expected_paths))


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1741.

This PR includes authority evidence source paths in the PR Quality artifact manifest expected-path inventory.

It keeps the normal artifact entrypoints and adds the authority evidence sources:

- TrajectoryStore authority boundary records
- TrajectoryPatternInsights authority evidence rollup
- RepoMemory trajectory authority evidence
- Runtime-proof authority JSON summary
- Runtime-proof authority markdown summary
- PR comment authority metadata

## Why this matters

#1740 indexed the authority evidence sources in the artifact manifest.
#1741 rendered those sources in the reviewer-facing artifact center.
#1742 makes the manifest expected-path inventory treat those authority evidence sources as expected review artifacts.

This strengthens artifact completeness without granting automation authority.

## Proof

- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_comment_observability_workflow.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim