### PR TITLE
feat(pr-quality): render expected artifact inventory

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2851,6 +2851,17 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         for item in authority_evidence_sources
     ]
 
+    expected_artifact_paths: list[str] = []
+    for item in [*artifact_index, *authority_evidence_sources]:
+        artifact_path = _string(item.get("path"))
+        if artifact_path and artifact_path not in expected_artifact_paths:
+            expected_artifact_paths.append(artifact_path)
+
+    expected_artifact_items = "\n".join(
+        f"<li><code>{_html_escape(artifact_path)}</code></li>"
+        for artifact_path in expected_artifact_paths
+    )
+
     def artifact_cards(rows: list[tuple[str, str, str]]) -> str:
         return "\n".join(
             '<article class="artifact-card">'
@@ -2900,7 +2911,7 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         "    .summary-card { border: 1px solid var(--border); border-radius: 14px; background: rgba(13,17,23,0.48); padding: 1rem; }\n"
         "    .artifact-card a { color: var(--text); font-size: 1.05rem; font-weight: 800; text-decoration: none; }\n"
         "    .artifact-card a:hover { color: var(--accent); text-decoration: underline; }\n"
-        "    .artifact-card p { color: var(--muted); margin-bottom: 0; }\n"
+        "    .artifact-card p { color: var(--muted); margin-bottom: 0; }\n    .path-list { margin: 0; padding-left: 1.2rem; color: var(--muted); }\n    .path-list li { margin: 0.35rem 0; }\n"
         "    table { width: 100%; border-collapse: collapse; }\n"
         "    th, td { border-bottom: 1px solid var(--border); padding: 0.65rem; text-align: left; vertical-align: top; }\n"
         "    th { width: 38%; color: var(--muted); }\n"
@@ -2926,6 +2937,13 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         '      <div class="artifact-grid">\n'
         f"        {artifact_cards(artifact_rows)}\n"
         "      </div>\n"
+        "    </section>\n"
+        '    <section class="card">\n'
+        "      <h2>Expected artifact inventory</h2>\n"
+        '      <p class="boundary">Reporting-only expected-path inventory. This inventory describes review artifacts and does not authorize merge, patch automation, security dismissal, or semantic-equivalence claims.</p>\n'
+        '      <ul class="path-list">\n'
+        f"        {expected_artifact_items}\n"
+        "      </ul>\n"
         "    </section>\n"
         '    <section class="card">\n'
         "      <h2>Authority evidence sources</h2>\n"

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4797,3 +4797,42 @@ def test_artifacts_manifest_expected_paths_include_authority_evidence_sources() 
     assert "runtime-proof/summary/runtime-proof-artifacts.md" in expected_paths
     assert "pr-comment-metadata.json" in expected_paths
     assert len(expected_paths) == len(set(expected_paths))
+
+
+def test_artifact_center_renders_expected_artifact_inventory() -> None:
+    model = {
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "schema": {
+            "name": "sdetkit.pr_quality.review_model",
+            "version": 2,
+            "authority_boundary": "reporting_only",
+        },
+        "artifact_index": [],
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "decision": {
+            "status": "green",
+            "merge_assessment": "ready_for_review",
+            "next_action": "human_review",
+            "risk_surface": "authority",
+        },
+    }
+
+    html = report.render_pr_quality_artifact_index_html(model)
+
+    assert "Expected artifact inventory" in html
+    assert "Reporting-only expected-path inventory" in html
+    assert "does not authorize merge" in html
+    assert "index.html" in html
+    assert "pr-review-artifacts-manifest.json" in html
+    assert "trajectory/trajectory.jsonl" in html
+    assert "trajectory-pattern-insights/pattern-insights.json" in html
+    assert "repo-memory/repo-memory-profile.json" in html
+    assert "runtime-proof/summary/runtime-proof-artifacts.json" in html
+    assert "runtime-proof/summary/runtime-proof-artifacts.md" in html
+    assert "pr-comment-metadata.json" in html


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1742.

This PR renders the expected artifact inventory in the PR Quality artifact center HTML.

It shows reviewer-facing expected paths for normal PR Quality artifacts and authority evidence artifacts, including:

- Artifact center
- Artifact manifest
- Review model
- Runtime proof artifacts
- Trajectory authority records
- TrajectoryPatternInsights authority evidence
- RepoMemory authority evidence
- PR comment metadata

## Why this matters

#1742 made authority evidence source paths part of the manifest expected-path inventory.
#1743 makes that expected inventory visible in the reviewer-facing artifact center.

Reviewers can now see what the artifact bundle expects to exist, not only which links are available.

## Proof

- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_comment_observability_workflow.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py -o addopts=`
- `make proof-after-format`

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim