### PR TITLE
feat(pr-quality): verify expected artifact inventory

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2761,6 +2761,34 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
         artifact_path = _string(item.get("path"))
         if artifact_path and artifact_path not in expected_paths:
             expected_paths.append(artifact_path)
+    authority_evidence_source_paths = [
+        _string(item.get("path"))
+        for item in authority_evidence_sources
+        if _string(item.get("path"))
+    ]
+    missing_authority_evidence_paths = [
+        artifact_path
+        for artifact_path in authority_evidence_source_paths
+        if artifact_path not in expected_paths
+    ]
+    expected_artifact_inventory_verification = {
+        "status": (
+            "passed" if expected_paths and not missing_authority_evidence_paths else "failed"
+        ),
+        "non_empty": bool(expected_paths),
+        "authority_aware": not missing_authority_evidence_paths,
+        "expected_artifact_count": len(expected_paths),
+        "authority_evidence_source_count": len(authority_evidence_source_paths),
+        "missing_authority_evidence_paths": missing_authority_evidence_paths,
+        "reporting_only": True,
+        "authority_boundary": {
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+    }
+
     primary_entrypoint = next(
         (
             _string(item.get("path"))
@@ -2780,6 +2808,7 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
         "generated_by": "sdetkit.pr_quality_action_report",
         "primary_entrypoint": primary_entrypoint,
         "expected_artifact_paths": expected_paths,
+        "expected_artifact_inventory_verification": expected_artifact_inventory_verification,
         "artifacts": artifacts,
         "authority_evidence_sources": authority_evidence_sources,
         "reporting_only": True,

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4836,3 +4836,44 @@ def test_artifact_center_renders_expected_artifact_inventory() -> None:
     assert "runtime-proof/summary/runtime-proof-artifacts.json" in html
     assert "runtime-proof/summary/runtime-proof-artifacts.md" in html
     assert "pr-comment-metadata.json" in html
+
+
+def test_artifacts_manifest_verifies_expected_inventory_is_authority_aware() -> None:
+    model = {
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "schema": {
+            "name": "sdetkit.pr_quality.review_model",
+            "version": 2,
+            "authority_boundary": "reporting_only",
+        },
+        "artifact_index": [],
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "decision": {
+            "status": "green",
+            "merge_assessment": "ready_for_review",
+            "next_action": "human_review",
+        },
+    }
+
+    manifest = report.build_pr_quality_artifacts_manifest(model)
+    verification = manifest["expected_artifact_inventory_verification"]
+
+    assert verification["status"] == "passed"
+    assert verification["non_empty"] is True
+    assert verification["authority_aware"] is True
+    assert verification["expected_artifact_count"] == len(manifest["expected_artifact_paths"])
+    assert verification["authority_evidence_source_count"] == len(
+        manifest["authority_evidence_sources"]
+    )
+    assert verification["missing_authority_evidence_paths"] == []
+    assert verification["reporting_only"] is True
+    assert verification["authority_boundary"]["patch_automation"] is False
+    assert verification["authority_boundary"]["security_dismissal"] is False
+    assert verification["authority_boundary"]["merge_authorization"] is False
+    assert verification["authority_boundary"]["semantic_equivalence_claim"] is False


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1743.

This PR adds a self-verification block to the PR Quality artifact manifest for the expected artifact inventory.

The verification records:

- whether expected_artifact_paths is non-empty
- whether authority evidence source paths are included
- expected artifact count
- authority evidence source count
- missing authority evidence paths
- reporting-only authority boundary

## Why this matters

#1742 made authority evidence source paths part of the manifest expected-path inventory.
#1743 rendered that inventory in the reviewer-facing artifact center.
#1744 makes the manifest verify that the expected inventory remains non-empty and authority-aware.

This helps catch future drift if authority evidence artifacts are accidentally dropped from the expected review bundle.

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_comment_observability_workflow.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py -o addopts=
- make proof-after-format

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim
