### PR TITLE
feat(pr-quality): render inventory verification

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2891,6 +2891,43 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         for artifact_path in expected_artifact_paths
     )
 
+    authority_evidence_source_paths = [
+        _string(item.get("path"))
+        for item in authority_evidence_sources
+        if _string(item.get("path"))
+    ]
+    missing_authority_evidence_paths = [
+        artifact_path
+        for artifact_path in authority_evidence_source_paths
+        if artifact_path not in expected_artifact_paths
+    ]
+    expected_inventory_status = (
+        "passed" if expected_artifact_paths and not missing_authority_evidence_paths else "failed"
+    )
+    expected_inventory_rows = [
+        ("Status", expected_inventory_status),
+        ("Non-empty", bool(expected_artifact_paths)),
+        ("Authority-aware", not missing_authority_evidence_paths),
+        ("Expected artifact count", len(expected_artifact_paths)),
+        ("Authority evidence source count", len(authority_evidence_source_paths)),
+        (
+            "Missing authority evidence paths",
+            ", ".join(missing_authority_evidence_paths)
+            if missing_authority_evidence_paths
+            else "none",
+        ),
+        ("Reporting only", True),
+        ("Patch automation", False),
+        ("Security dismissal", False),
+        ("Merge authorization", False),
+        ("Semantic equivalence claim", False),
+    ]
+
+    expected_inventory_table = "\n".join(
+        f"<tr><th>{_html_escape(label)}</th><td><code>{_html_escape(value)}</code></td></tr>"
+        for label, value in expected_inventory_rows
+    )
+
     def artifact_cards(rows: list[tuple[str, str, str]]) -> str:
         return "\n".join(
             '<article class="artifact-card">'
@@ -2966,6 +3003,11 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
         '      <div class="artifact-grid">\n'
         f"        {artifact_cards(artifact_rows)}\n"
         "      </div>\n"
+        "    </section>\n"
+        '    <section class="card">\n'
+        "      <h2>Expected artifact inventory verification</h2>\n"
+        '      <p class="boundary">Reporting-only verification. This verification explains expected artifact completeness and does not authorize merge, patch automation, security dismissal, or semantic-equivalence claims.</p>\n'
+        f"      <table>{expected_inventory_table}</table>\n"
         "    </section>\n"
         '    <section class="card">\n'
         "      <h2>Expected artifact inventory</h2>\n"

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -4877,3 +4877,47 @@ def test_artifacts_manifest_verifies_expected_inventory_is_authority_aware() -> 
     assert verification["authority_boundary"]["security_dismissal"] is False
     assert verification["authority_boundary"]["merge_authorization"] is False
     assert verification["authority_boundary"]["semantic_equivalence_claim"] is False
+
+
+def test_artifact_center_renders_expected_inventory_verification() -> None:
+    model = {
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "schema": {
+            "name": "sdetkit.pr_quality.review_model",
+            "version": 2,
+            "authority_boundary": "reporting_only",
+        },
+        "artifact_index": [],
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "decision": {
+            "status": "green",
+            "merge_assessment": "ready_for_review",
+            "next_action": "human_review",
+            "risk_surface": "authority",
+        },
+    }
+
+    html = report.render_pr_quality_artifact_index_html(model)
+
+    assert "Expected artifact inventory verification" in html
+    assert "Reporting-only verification" in html
+    assert "Status" in html
+    assert "passed" in html
+    assert "Non-empty" in html
+    assert "Authority-aware" in html
+    assert "Expected artifact count" in html
+    assert "Authority evidence source count" in html
+    assert "Missing authority evidence paths" in html
+    assert "none" in html
+    assert "Reporting only" in html
+    assert "Patch automation" in html
+    assert "Security dismissal" in html
+    assert "Merge authorization" in html
+    assert "Semantic equivalence claim" in html
+    assert "does not authorize merge" in html


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1744.

This PR renders the expected artifact inventory verification in the PR Quality artifact center.

The artifact center now shows:

- verification status
- non-empty inventory flag
- authority-aware flag
- expected artifact count
- authority evidence source count
- missing authority evidence paths
- reporting-only authority boundary fields

## Why this matters

#1744 added manifest-level verification that the expected artifact inventory is non-empty and authority-aware.
#1745 makes that verification visible to reviewers in the artifact center.

Reviewers no longer need to inspect only JSON to see whether expected artifact inventory verification passed.

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_comment_observability_workflow.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py -o addopts=
- make proof-after-format

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim
