### PR TITLE
feat(pr-quality): expose inventory verification metadata

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1221,6 +1221,8 @@ jobs:
 
           const repoMemoryAuthorityKey = (...parts) =>
             ['repo', 'memory', 'trajectory', 'authority', ...parts].join('_');
+          const expectedInventoryKey = (...parts) =>
+            ['expected', 'artifact', 'inventory', ...parts].join('_');
 
           const statusPath = 'build/pr-quality/comment-status.json';
           const readCommentMetadata = () => {
@@ -1242,6 +1244,17 @@ jobs:
 
           const writeStatus = (payload) => {
             const metadata = readCommentMetadata();
+            const expectedInventoryStatusKey = expectedInventoryKey('status');
+            const expectedInventoryNonEmptyKey = expectedInventoryKey('non', 'empty');
+            const expectedInventoryAuthorityAwareKey = expectedInventoryKey('authority', 'aware');
+            const expectedInventoryExpectedArtifactCountKey = expectedInventoryKey('expected', 'artifact', 'count');
+            const expectedInventoryAuthorityEvidenceSourceCountKey = expectedInventoryKey('authority', 'evidence', 'source', 'count');
+            const expectedInventoryMissingAuthorityEvidencePathCountKey = expectedInventoryKey('missing', 'authority', 'evidence', 'path', 'count');
+            const expectedInventoryReportingOnlyKey = expectedInventoryKey('reporting', 'only');
+            const expectedInventoryPatchAutomationKey = expectedInventoryKey('patch', 'automation');
+            const expectedInventorySecurityDismissalKey = expectedInventoryKey('security', 'dismissal');
+            const expectedInventoryMergeAuthorizationKey = expectedInventoryKey('merge', 'authorization');
+            const expectedInventorySemanticEquivalenceClaimKey = expectedInventoryKey('semantic', 'equivalence', 'claim');
             const repoMemoryAuthorityStatusKey = repoMemoryAuthorityKey('status');
             const repoMemoryAuthorityRecordCountKey = repoMemoryAuthorityKey('record', 'count');
             const repoMemoryAuthorityReviewFirstCountKey = repoMemoryAuthorityKey('review', 'first', 'count');
@@ -1272,6 +1285,17 @@ jobs:
               repo_memory_collection_status: metadata.repo_memory_collection_status || 'not_collected',
               repo_memory_status: metadata.repo_memory_status || 'not_collected',
               repo_memory_live_contract_proven: Boolean(metadata.repo_memory_live_contract_proven),
+              [expectedInventoryStatusKey]: metadata[expectedInventoryStatusKey] || 'not_collected',
+              [expectedInventoryNonEmptyKey]: Boolean(metadata[expectedInventoryNonEmptyKey]),
+              [expectedInventoryAuthorityAwareKey]: Boolean(metadata[expectedInventoryAuthorityAwareKey]),
+              [expectedInventoryExpectedArtifactCountKey]: Number(metadata[expectedInventoryExpectedArtifactCountKey] || 0),
+              [expectedInventoryAuthorityEvidenceSourceCountKey]: Number(metadata[expectedInventoryAuthorityEvidenceSourceCountKey] || 0),
+              [expectedInventoryMissingAuthorityEvidencePathCountKey]: Number(metadata[expectedInventoryMissingAuthorityEvidencePathCountKey] || 0),
+              [expectedInventoryReportingOnlyKey]: Boolean(metadata[expectedInventoryReportingOnlyKey]),
+              [expectedInventoryPatchAutomationKey]: Boolean(metadata[expectedInventoryPatchAutomationKey]),
+              [expectedInventorySecurityDismissalKey]: Boolean(metadata[expectedInventorySecurityDismissalKey]),
+              [expectedInventoryMergeAuthorizationKey]: Boolean(metadata[expectedInventoryMergeAuthorizationKey]),
+              [expectedInventorySemanticEquivalenceClaimKey]: Boolean(metadata[expectedInventorySemanticEquivalenceClaimKey]),
               [repoMemoryAuthorityStatusKey]: metadata[repoMemoryAuthorityStatusKey] || 'not_collected',
               [repoMemoryAuthorityRecordCountKey]: Number(metadata[repoMemoryAuthorityRecordCountKey] || 0),
               [repoMemoryAuthorityReviewFirstCountKey]: Number(metadata[repoMemoryAuthorityReviewFirstCountKey] || 0),
@@ -1343,6 +1367,33 @@ jobs:
           def repo_memory_trajectory_authority_key(*parts: str) -> str:
               return "_".join(("repo", "memory", "trajectory", "authority", *parts))
 
+          def expected_inventory_key(*parts: str) -> str:
+              return "_".join(("expected", "artifact", "inventory", *parts))
+
+          expected_inventory_status_key = expected_inventory_key("status")
+          expected_inventory_non_empty_key = expected_inventory_key("non", "empty")
+          expected_inventory_authority_aware_key = expected_inventory_key("authority", "aware")
+          expected_inventory_expected_artifact_count_key = expected_inventory_key(
+              "expected", "artifact", "count"
+          )
+          expected_inventory_authority_evidence_source_count_key = expected_inventory_key(
+              "authority", "evidence", "source", "count"
+          )
+          expected_inventory_missing_authority_evidence_path_count_key = expected_inventory_key(
+              "missing", "authority", "evidence", "path", "count"
+          )
+          expected_inventory_reporting_only_key = expected_inventory_key("reporting", "only")
+          expected_inventory_patch_automation_key = expected_inventory_key("patch", "automation")
+          expected_inventory_security_dismissal_key = expected_inventory_key(
+              "security", "dismissal"
+          )
+          expected_inventory_merge_authorization_key = expected_inventory_key(
+              "merge", "authorization"
+          )
+          expected_inventory_semantic_equivalence_claim_key = expected_inventory_key(
+              "semantic", "equivalence", "claim"
+          )
+
           authority_status_key = repo_memory_trajectory_authority_key("status")
           authority_record_count_key = repo_memory_trajectory_authority_key("record", "count")
           authority_review_first_count_key = repo_memory_trajectory_authority_key(
@@ -1408,6 +1459,40 @@ jobs:
           )
           repo_memory_live_contract_proven = bool(
               payload.get("repo_memory_live_contract_proven", False)
+          )
+          expected_artifact_inventory_status = str(
+              payload.get(expected_inventory_status_key, "not_collected")
+          )
+          expected_artifact_inventory_non_empty = bool(
+              payload.get(expected_inventory_non_empty_key, False)
+          )
+          expected_artifact_inventory_authority_aware = bool(
+              payload.get(expected_inventory_authority_aware_key, False)
+          )
+          expected_artifact_inventory_expected_artifact_count = int(
+              payload.get(expected_inventory_expected_artifact_count_key, 0) or 0
+          )
+          expected_artifact_inventory_authority_evidence_source_count = int(
+              payload.get(expected_inventory_authority_evidence_source_count_key, 0) or 0
+          )
+          expected_artifact_inventory_missing_authority_evidence_path_count = int(
+              payload.get(expected_inventory_missing_authority_evidence_path_count_key, 0)
+              or 0
+          )
+          expected_artifact_inventory_reporting_only = bool(
+              payload.get(expected_inventory_reporting_only_key, False)
+          )
+          expected_artifact_inventory_patch_automation = bool(
+              payload.get(expected_inventory_patch_automation_key, False)
+          )
+          expected_artifact_inventory_security_dismissal = bool(
+              payload.get(expected_inventory_security_dismissal_key, False)
+          )
+          expected_artifact_inventory_merge_authorization = bool(
+              payload.get(expected_inventory_merge_authorization_key, False)
+          )
+          expected_artifact_inventory_semantic_equivalence_claim = bool(
+              payload.get(expected_inventory_semantic_equivalence_claim_key, False)
           )
           authority_status = str(payload.get(authority_status_key, "not_collected"))
           authority_record_count = int(payload.get(authority_record_count_key, 0) or 0)
@@ -1481,6 +1566,47 @@ jobs:
           print(f"repo_memory_status={repo_memory_status}")
           print(
               f"repo_memory_live_contract_proven={str(repo_memory_live_contract_proven).lower()}"
+          )
+          print(f"expected_artifact_inventory_status={expected_artifact_inventory_status}")
+          print(
+              "expected_artifact_inventory_non_empty="
+              f"{str(expected_artifact_inventory_non_empty).lower()}"
+          )
+          print(
+              "expected_artifact_inventory_authority_aware="
+              f"{str(expected_artifact_inventory_authority_aware).lower()}"
+          )
+          print(
+              expected_inventory_expected_artifact_count_key + '='
+              f"{expected_artifact_inventory_expected_artifact_count}"
+          )
+          print(
+              expected_inventory_authority_evidence_source_count_key + '='
+              f"{expected_artifact_inventory_authority_evidence_source_count}"
+          )
+          print(
+              expected_inventory_missing_authority_evidence_path_count_key + '='
+              f"{expected_artifact_inventory_missing_authority_evidence_path_count}"
+          )
+          print(
+              f"{expected_inventory_reporting_only_key}="
+              f"{str(expected_artifact_inventory_reporting_only).lower()}"
+          )
+          print(
+              f"{expected_inventory_patch_automation_key}="
+              f"{str(expected_artifact_inventory_patch_automation).lower()}"
+          )
+          print(
+              f"{expected_inventory_security_dismissal_key}="
+              f"{str(expected_artifact_inventory_security_dismissal).lower()}"
+          )
+          print(
+              f"{expected_inventory_merge_authorization_key}="
+              f"{str(expected_artifact_inventory_merge_authorization).lower()}"
+          )
+          print(
+              f"{expected_inventory_semantic_equivalence_claim_key}="
+              f"{str(expected_artifact_inventory_semantic_equivalence_claim).lower()}"
           )
           print(f"{authority_status_key}={authority_status}")
           print(f"{authority_record_count_key}={authority_record_count}")
@@ -1579,6 +1705,46 @@ jobs:
               )
           if not repo_memory_live_contract_proven:
               raise SystemExit("PR Quality RepoMemory live contract was not proven")
+          if expected_artifact_inventory_status != "passed":
+              raise SystemExit(
+                  "PR Quality expected artifact inventory verification failed: "
+                  f"status={expected_artifact_inventory_status}"
+              )
+          if not expected_artifact_inventory_non_empty:
+              raise SystemExit("PR Quality expected artifact inventory was empty")
+          if not expected_artifact_inventory_authority_aware:
+              raise SystemExit("PR Quality expected artifact inventory was not authority-aware")
+          if expected_artifact_inventory_expected_artifact_count < 1:
+              raise SystemExit("PR Quality expected artifact inventory had no artifacts")
+          if expected_artifact_inventory_authority_evidence_source_count < 1:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory had no authority evidence sources"
+              )
+          if expected_artifact_inventory_missing_authority_evidence_path_count:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory is missing authority evidence paths: "
+                  f"count={expected_artifact_inventory_missing_authority_evidence_path_count}"
+              )
+          if not expected_artifact_inventory_reporting_only:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory verification was not reporting-only"
+              )
+          if expected_artifact_inventory_patch_automation:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to allow patch automation"
+              )
+          if expected_artifact_inventory_security_dismissal:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to allow security dismissal"
+              )
+          if expected_artifact_inventory_merge_authorization:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to authorize merge"
+              )
+          if expected_artifact_inventory_semantic_equivalence_claim:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to claim semantic equivalence"
+              )
           if authority_status != "authority_boundary_evidence_observed":
               raise SystemExit(
                   "PR Quality RepoMemory trajectory authority evidence missing: "

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -3759,12 +3759,13 @@ def write_comment_body(
         )
         review_index_written = True
 
+    review_artifacts_manifest = build_pr_quality_artifacts_manifest(review_model)
     review_artifacts_manifest_written = False
     if review_artifacts_manifest_out is not None:
         review_artifacts_manifest_out.parent.mkdir(parents=True, exist_ok=True)
         review_artifacts_manifest_out.write_text(
             json.dumps(
-                build_pr_quality_artifacts_manifest(review_model),
+                review_artifacts_manifest,
                 indent=2,
                 sort_keys=True,
             )
@@ -3777,6 +3778,16 @@ def write_comment_body(
     repo_memory_runtime = (
         _as_dict(runtime_proof_artifacts.get("repo_memory")) if runtime_proof_artifacts else {}
     )
+    expected_inventory_verification = _as_dict(
+        review_artifacts_manifest.get("expected_artifact_inventory_verification")
+    )
+    expected_inventory_authority = _as_dict(
+        expected_inventory_verification.get("authority_boundary")
+    )
+
+    def expected_inventory_key(*parts: str) -> str:
+        return "_".join(("expected", "artifact", "inventory", *parts))
+
     result: JsonObject = {
         "out": out.as_posix(),
         "review_model_out": review_model_out.as_posix() if review_model_out is not None else "",
@@ -3794,6 +3805,39 @@ def write_comment_body(
         if review_artifacts_manifest_out is not None
         else "",
         "review_artifacts_manifest_written": review_artifacts_manifest_written,
+        expected_inventory_key("status"): _string(
+            expected_inventory_verification.get("status") or "not_collected"
+        ),
+        expected_inventory_key("non", "empty"): bool(
+            expected_inventory_verification.get("non_empty", False)
+        ),
+        expected_inventory_key("authority", "aware"): bool(
+            expected_inventory_verification.get("authority_aware", False)
+        ),
+        expected_inventory_key("expected", "artifact", "count"): _int(
+            expected_inventory_verification.get("expected_artifact_count")
+        ),
+        expected_inventory_key("authority", "evidence", "source", "count"): _int(
+            expected_inventory_verification.get("authority_evidence_source_count")
+        ),
+        expected_inventory_key("missing", "authority", "evidence", "path", "count"): len(
+            _as_list(expected_inventory_verification.get("missing_authority_evidence_paths"))
+        ),
+        expected_inventory_key("reporting", "only"): bool(
+            expected_inventory_verification.get("reporting_only", False)
+        ),
+        expected_inventory_key("patch", "automation"): bool(
+            expected_inventory_authority.get("patch_automation", False)
+        ),
+        expected_inventory_key("security", "dismissal"): bool(
+            expected_inventory_authority.get("security_dismissal", False)
+        ),
+        expected_inventory_key("merge", "authorization"): bool(
+            expected_inventory_authority.get("merge_authorization", False)
+        ),
+        expected_inventory_key("semantic", "equivalence", "claim"): bool(
+            expected_inventory_authority.get("semantic_equivalence_claim", False)
+        ),
         "status": status,
         "result_title": _result_title(
             status,

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3927,6 +3927,25 @@ def test_write_comment_body_writes_review_artifacts_manifest(tmp_path: Path) -> 
     assert "pr-review-artifacts-manifest.json" in manifest["expected_artifact_paths"]
     assert manifest["authority_boundary"]["merge_authorization"] is False
 
+    def expected_inventory_key(*parts: str) -> str:
+        return "_".join(("expected", "artifact", "inventory", *parts))
+
+    assert result[expected_inventory_key("status")] == "passed"
+    assert result[expected_inventory_key("non", "empty")] is True
+    assert result[expected_inventory_key("authority", "aware")] is True
+    assert result[expected_inventory_key("expected", "artifact", "count")] == len(
+        manifest["expected_artifact_paths"]
+    )
+    assert result[expected_inventory_key("authority", "evidence", "source", "count")] == len(
+        manifest["authority_evidence_sources"]
+    )
+    assert result[expected_inventory_key("missing", "authority", "evidence", "path", "count")] == 0
+    assert result[expected_inventory_key("reporting", "only")] is True
+    assert result[expected_inventory_key("patch", "automation")] is False
+    assert result[expected_inventory_key("security", "dismissal")] is False
+    assert result[expected_inventory_key("merge", "authorization")] is False
+    assert result[expected_inventory_key("semantic", "equivalence", "claim")] is False
+
 
 def test_review_model_includes_failure_vector_signal_from_failed_check() -> None:
     model = report.build_pr_quality_review_model(

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1168,3 +1168,63 @@ def test_pr_quality_comment_workflow_builds_artifact_manifest() -> None:
     assert text.index("build/pr-quality/index.html") < text.index(
         "build/pr-quality/pr-review-artifacts-manifest.json"
     )
+
+
+def test_pr_quality_comment_workflow_exports_expected_inventory_verification_metadata() -> None:
+    text = _workflow_text()
+
+    assert "[expectedInventoryStatusKey]: metadata[expectedInventoryStatusKey]" in text
+    assert "[expectedInventoryNonEmptyKey]: Boolean(metadata[expectedInventoryNonEmptyKey])" in text
+    assert (
+        "[expectedInventoryAuthorityAwareKey]: "
+        "Boolean(metadata[expectedInventoryAuthorityAwareKey])" in text
+    )
+    assert (
+        "[expectedInventoryExpectedArtifactCountKey]: "
+        "Number(metadata[expectedInventoryExpectedArtifactCountKey] || 0)" in text
+    )
+    assert (
+        "[expectedInventoryAuthorityEvidenceSourceCountKey]: "
+        "Number(metadata[expectedInventoryAuthorityEvidenceSourceCountKey] || 0)" in text
+    )
+    assert (
+        "[expectedInventoryMissingAuthorityEvidencePathCountKey]: "
+        "Number(metadata[expectedInventoryMissingAuthorityEvidencePathCountKey] || 0)" in text
+    )
+
+
+def test_pr_quality_comment_workflow_verifies_expected_inventory_visibility_after_posting() -> None:
+    text = _workflow_text()
+    verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
+
+    def expected_inventory_key(*parts: str) -> str:
+        return "_".join(("expected", "artifact", "inventory", *parts))
+
+    status_name = expected_inventory_key("status")
+    non_empty_name = expected_inventory_key("non", "empty")
+    authority_aware_name = expected_inventory_key("authority", "aware")
+    expected_artifact_count_name = expected_inventory_key("expected", "artifact", "count")
+    reporting_only_name = expected_inventory_key("reporting", "only")
+    patch_automation_name = expected_inventory_key("patch", "automation")
+    security_dismissal_name = expected_inventory_key("security", "dismissal")
+    merge_authorization_name = expected_inventory_key("merge", "authorization")
+    semantic_claim_name = expected_inventory_key("semantic", "equivalence", "claim")
+
+    assert "expected_inventory_status_key" in verify_visibility
+    assert f'if {status_name} != "passed":' in verify_visibility
+    assert f"if not {non_empty_name}:" in verify_visibility
+    assert f"if not {authority_aware_name}:" in verify_visibility
+    assert f"{expected_artifact_count_name} < 1" in verify_visibility
+    authority_source_key_name = "expected_inventory_" + "_".join(
+        ("authority", "evidence", "source", "count", "key")
+    )
+    missing_authority_key_name = "expected_inventory_" + "_".join(
+        ("missing", "authority", "evidence", "path", "count", "key")
+    )
+    assert authority_source_key_name in verify_visibility
+    assert missing_authority_key_name in verify_visibility
+    assert f"if not {reporting_only_name}:" in verify_visibility
+    assert f"if {patch_automation_name}:" in verify_visibility
+    assert f"if {security_dismissal_name}:" in verify_visibility
+    assert f"if {merge_authorization_name}:" in verify_visibility
+    assert f"if {semantic_claim_name}:" in verify_visibility


### PR DESCRIPTION
## Summary

Continues the discovered-growth chain after #1745.

This PR carries expected artifact inventory verification into PR Quality comment metadata and the final comment visibility verifier.

It adds metadata for:

- inventory verification status
- non-empty inventory flag
- authority-aware flag
- expected artifact count
- authority evidence source count
- missing authority evidence path count
- reporting-only authority boundary fields

The workflow now fails final comment visibility verification if the expected inventory verification is missing, failed, empty, not authority-aware, missing authority evidence paths, or attempts to grant patch/security/merge/semantic authority.

## Why this matters

#1744 added manifest-level expected inventory verification.
#1745 rendered that verification in the artifact center.
#1746 makes the PR comment metadata and final visibility verifier prove that this verification reached the reviewer-facing PR Quality surface.

## Proof

- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_comment_observability_workflow.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py -o addopts=
- make proof-after-format

## Authority boundary

- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim
