### PR TITLE
feat(safety-gate): consume failure vector contract

### DIFF
--- a/src/sdetkit/safety_gate.py
+++ b/src/sdetkit/safety_gate.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Protocol
 
 SCHEMA_VERSION = "sdetkit.safety_gate.v1"
+
+FALSE_AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "security_dismissal_allowed",
+    "merge_authorized",
+    "semantic_equivalence_claim",
+)
 
 
 class FailureVectorLike(Protocol):
@@ -32,6 +41,18 @@ class SafetyGateDecision:
     failure_class: str
     risk: str
     scope: str
+    failure_kind: str
+    affected_surface: str
+    ownership_area: str
+    retryability: str
+    security_relevance: bool
+    recommended_next_human_action: str
+    reporting_only: bool
+    automation_allowed: bool
+    patch_application_allowed: bool
+    security_dismissal_allowed: bool
+    merge_authorized: bool
+    semantic_equivalence_claim: bool
     safe_fix_allowed: bool
     review_first: bool
     reason: str
@@ -49,15 +70,28 @@ class SafetyGateDecision:
 
 
 def evaluate_failure_vector(vector: FailureVectorLike) -> SafetyGateDecision:
-    safe_fix_allowed = _safe_fix_allowed(vector)
+    contract = _normalized_contract(vector)
+    safe_fix_allowed = _safe_fix_allowed(vector, contract)
 
     return SafetyGateDecision(
         failure_class=vector.failure_class,
         risk=vector.risk,
         scope=vector.scope,
+        failure_kind=str(contract["failure_kind"]),
+        affected_surface=str(contract["affected_surface"]),
+        ownership_area=str(contract["ownership_area"]),
+        retryability=str(contract["retryability"]),
+        security_relevance=bool(contract["security_relevance"]),
+        recommended_next_human_action=str(contract["recommended_next_human_action"]),
+        reporting_only=bool(contract["reporting_only"]),
+        automation_allowed=bool(contract["automation_allowed"]),
+        patch_application_allowed=bool(contract["patch_application_allowed"]),
+        security_dismissal_allowed=bool(contract["security_dismissal_allowed"]),
+        merge_authorized=bool(contract["merge_authorized"]),
+        semantic_equivalence_claim=bool(contract["semantic_equivalence_claim"]),
         safe_fix_allowed=safe_fix_allowed,
         review_first=not safe_fix_allowed,
-        reason=_decision_reason(vector, safe_fix_allowed),
+        reason=_decision_reason(vector, contract, safe_fix_allowed),
         allowed_files=vector.affected_files if safe_fix_allowed else (),
         blocked_actions=GENERAL_BLOCKED_ACTIONS,
         proof_commands=_proof_commands(vector),
@@ -75,6 +109,8 @@ def write_safety_gate_decision(decision: SafetyGateDecision, path: Path) -> None
 def render_safety_gate_decision_report(decision: SafetyGateDecision) -> str:
     allowed = "yes" if decision.safe_fix_allowed else "no"
     review_first = "yes" if decision.review_first else "no"
+    security_relevance = "yes" if decision.security_relevance else "no"
+    reporting_only = "yes" if decision.reporting_only else "no"
     allowed_files = ", ".join(decision.allowed_files) if decision.allowed_files else "none"
     proof_commands = ", ".join(decision.proof_commands) if decision.proof_commands else "none"
 
@@ -86,19 +122,38 @@ def render_safety_gate_decision_report(decision: SafetyGateDecision) -> str:
             f"- failure_class: `{decision.failure_class}`",
             f"- risk: `{decision.risk}`",
             f"- scope: `{decision.scope}`",
+            f"- failure_kind: `{decision.failure_kind}`",
+            f"- affected_surface: `{decision.affected_surface}`",
+            f"- ownership_area: `{decision.ownership_area}`",
+            f"- retryability: `{decision.retryability}`",
+            f"- security_relevance: `{security_relevance}`",
+            (f"- recommended_next_human_action: `{decision.recommended_next_human_action}`"),
+            f"- reporting_only: `{reporting_only}`",
             f"- safe_fix_allowed: `{allowed}`",
             f"- review_first: `{review_first}`",
             f"- reason: `{decision.reason}`",
             f"- allowed_files: `{allowed_files}`",
             f"- proof_commands: `{proof_commands}`",
+            "- automation_allowed: `false`",
+            "- patch_application_allowed: `false`",
+            "- security_dismissal_allowed: `false`",
+            "- merge_authorized: `false`",
+            "- semantic_equivalence_claim: `false`",
             "",
         ]
     )
 
 
-def _safe_fix_allowed(vector: FailureVectorLike) -> bool:
+def _safe_fix_allowed(
+    vector: FailureVectorLike,
+    contract: Mapping[str, object],
+) -> bool:
     return (
-        vector.safe_fix_candidate
+        _contract_preserves_authority_boundary(contract)
+        and not bool(contract["security_relevance"])
+        and str(contract["failure_kind"]) in SAFE_FIX_CLASSES
+        and str(contract["retryability"]) != "human_review_required"
+        and vector.safe_fix_candidate
         and vector.failure_class in SAFE_FIX_CLASSES
         and vector.risk == "low"
         and vector.scope == "pr_owned_only"
@@ -107,9 +162,25 @@ def _safe_fix_allowed(vector: FailureVectorLike) -> bool:
     )
 
 
-def _decision_reason(vector: FailureVectorLike, safe_fix_allowed: bool) -> str:
+def _decision_reason(
+    vector: FailureVectorLike,
+    contract: Mapping[str, object],
+    safe_fix_allowed: bool,
+) -> str:
     if safe_fix_allowed:
-        return "failure vector is low-risk, PR-owned, mechanically eligible, and has required proof"
+        return (
+            "normalized failure-vector contract is low-risk, PR-owned, "
+            "mechanically eligible, and has required proof"
+        )
+    if not _contract_preserves_authority_boundary(contract):
+        return "normalized failure-vector contract does not preserve authority boundary"
+    if bool(contract["security_relevance"]):
+        return "normalized failure-vector contract marks this security-relevant"
+    if str(contract["retryability"]) == "human_review_required":
+        return (
+            f"failure_class {vector.failure_class!r} requires human review "
+            "by normalized failure-vector contract"
+        )
     if not vector.safe_fix_candidate:
         return (
             f"failure_class {vector.failure_class!r} is review-first or not mechanically eligible"
@@ -131,3 +202,126 @@ def _proof_commands(vector: FailureVectorLike) -> tuple[str, ...]:
         commands.append(vector.local_repro_command)
     commands.append("make proof-after-format")
     return tuple(commands)
+
+
+def _normalized_contract(vector: FailureVectorLike) -> dict[str, object]:
+    raw = _contract_from_vector(vector)
+    return {
+        "failure_kind": _contract_text(raw, "failure_kind", vector.failure_class),
+        "affected_surface": _contract_text(
+            raw,
+            "affected_surface",
+            _affected_surface(vector.affected_files),
+        ),
+        "ownership_area": _contract_text(
+            raw,
+            "ownership_area",
+            _ownership_area(vector),
+        ),
+        "retryability": _contract_text(
+            raw,
+            "retryability",
+            _retryability(vector.failure_class),
+        ),
+        "security_relevance": _contract_bool(
+            raw,
+            "security_relevance",
+            vector.failure_class == "security",
+        ),
+        "recommended_next_human_action": _contract_text(
+            raw,
+            "recommended_next_human_action",
+            "triage failure and rerun focused proof",
+        ),
+        "reporting_only": _contract_bool(raw, "reporting_only", True),
+        "automation_allowed": _contract_bool(raw, "automation_allowed", False),
+        "patch_application_allowed": _contract_bool(
+            raw,
+            "patch_application_allowed",
+            False,
+        ),
+        "security_dismissal_allowed": _contract_bool(
+            raw,
+            "security_dismissal_allowed",
+            False,
+        ),
+        "merge_authorized": _contract_bool(raw, "merge_authorized", False),
+        "semantic_equivalence_claim": _contract_bool(
+            raw,
+            "semantic_equivalence_claim",
+            False,
+        ),
+    }
+
+
+def _contract_from_vector(vector: FailureVectorLike) -> Mapping[str, object]:
+    to_dict = getattr(vector, "to_dict", None)
+    if callable(to_dict):
+        payload = to_dict()
+        if isinstance(payload, Mapping):
+            contract = payload.get("contract")
+            if isinstance(contract, Mapping):
+                return contract
+
+    contract = getattr(vector, "contract", None)
+    if isinstance(contract, Mapping):
+        return contract
+
+    return {}
+
+
+def _contract_text(
+    contract: Mapping[str, object],
+    key: str,
+    default: str,
+) -> str:
+    value = contract.get(key)
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _contract_bool(
+    contract: Mapping[str, object],
+    key: str,
+    default: bool,
+) -> bool:
+    value = contract.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _contract_preserves_authority_boundary(contract: Mapping[str, object]) -> bool:
+    return bool(contract["reporting_only"]) and all(
+        not bool(contract[field]) for field in FALSE_AUTHORITY_FIELDS
+    )
+
+
+def _affected_surface(affected_files: tuple[str, ...]) -> str:
+    if not affected_files:
+        return "unknown"
+    if all(path.startswith("tests/") for path in affected_files):
+        return "tests"
+    if all(path.startswith("src/") for path in affected_files):
+        return "source"
+    if all(path.startswith(("src/", "tests/")) for path in affected_files):
+        return "code"
+    return "repo_wide"
+
+
+def _ownership_area(vector: FailureVectorLike) -> str:
+    if vector.affected_files:
+        return vector.affected_files[0]
+    return "unknown"
+
+
+def _retryability(failure_class: str) -> str:
+    if failure_class in {"dependency", "merge_conflict", "release", "security", "unknown"}:
+        return "human_review_required"
+    return "not_retryable_without_change"

--- a/tests/test_safety_gate.py
+++ b/tests/test_safety_gate.py
@@ -123,3 +123,81 @@ def test_safety_gate_report_and_json_are_deterministic(tmp_path: Path) -> None:
     assert "# Safety Gate Decision" in report
     assert "- safe_fix_allowed: `yes`" in report
     assert "- allowed_files: `tests/test_widget.py`" in report
+
+
+def test_safety_gate_decision_consumes_normalized_failure_vector_contract() -> None:
+    vector = extract_failure_vector(
+        """
+        ruff format..............................................................Failed
+        tests/test_widget.py
+        1 file would be reformatted
+        """,
+        check="pre-commit / ruff format",
+    )
+
+    decision = evaluate_failure_vector(vector)
+
+    assert decision.failure_kind == "formatter_only"
+    assert decision.affected_surface == "tests"
+    assert decision.ownership_area == "tests/test_widget.py"
+    assert decision.retryability == "not_retryable_without_change"
+    assert decision.security_relevance is False
+    assert decision.reporting_only is True
+    assert decision.automation_allowed is False
+    assert decision.patch_application_allowed is False
+    assert decision.security_dismissal_allowed is False
+    assert decision.merge_authorized is False
+    assert decision.semantic_equivalence_claim is False
+    assert decision.safe_fix_allowed is True
+    assert "normalized failure-vector contract" in decision.reason
+
+    payload = decision.to_dict()
+    assert payload["failure_kind"] == "formatter_only"
+    assert payload["affected_surface"] == "tests"
+    assert payload["ownership_area"] == "tests/test_widget.py"
+
+    report = render_safety_gate_decision_report(decision)
+    assert "- failure_kind: `formatter_only`" in report
+    assert "- affected_surface: `tests`" in report
+    assert "- ownership_area: `tests/test_widget.py`" in report
+    assert "- retryability: `not_retryable_without_change`" in report
+    assert "- reporting_only: `yes`" in report
+    assert "- security_dismissal_allowed: `false`" in report
+    assert "- merge_authorized: `false`" in report
+    assert "- semantic_equivalence_claim: `false`" in report
+
+
+def test_safety_gate_blocks_contract_that_weakens_authority_boundary() -> None:
+    class UnsafeContractVector:
+        failure_class = "formatter_only"
+        risk = "low"
+        scope = "pr_owned_only"
+        safe_fix_candidate = True
+        affected_files = ("tests/test_widget.py",)
+        local_repro_command = "python -m ruff format --check tests/test_widget.py"
+
+        def to_dict(self) -> dict[str, object]:
+            return {
+                "contract": {
+                    "failure_kind": "formatter_only",
+                    "affected_surface": "tests",
+                    "ownership_area": "tests/test_widget.py",
+                    "retryability": "not_retryable_without_change",
+                    "security_relevance": False,
+                    "recommended_next_human_action": "review generated fix",
+                    "reporting_only": True,
+                    "automation_allowed": True,
+                    "patch_application_allowed": False,
+                    "security_dismissal_allowed": False,
+                    "merge_authorized": False,
+                    "semantic_equivalence_claim": False,
+                }
+            }
+
+    decision = evaluate_failure_vector(UnsafeContractVector())
+
+    assert decision.safe_fix_allowed is False
+    assert decision.review_first is True
+    assert decision.allowed_files == ()
+    assert "authority boundary" in decision.reason
+    assert decision.automation_allowed is True


### PR DESCRIPTION
## Summary
- Updates SafetyGate to consume the normalized failure-vector contract.
- Carries failure kind, affected surface, ownership area, retryability, security relevance, recommended human action, and authority-boundary fields into the SafetyGate decision.
- Blocks safe-fix eligibility if the normalized contract weakens the authority boundary.

## Proof
- python -m sdetkit security check --root . --format json
- focused pytest subset
- make proof-after-format

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim