### PR TITLE
feat(trajectory): record failure vector contract evidence

### DIFF
--- a/src/sdetkit/trajectory_pattern_insights.py
+++ b/src/sdetkit/trajectory_pattern_insights.py
@@ -199,6 +199,56 @@ def _safety_gate_evidence(rows: list[JsonObject]) -> JsonObject:
     }
 
 
+def _failure_vector_contract_evidence(rows: list[JsonObject]) -> JsonObject:
+    contract_rows = [
+        _as_dict(row.get("failure_vector_contract"))
+        for row in rows
+        if _as_dict(row.get("failure_vector_contract"))
+    ]
+    denied_keys = (
+        "automation_allowed",
+        "patch_application_allowed",
+        "security_dismissal_allowed",
+        "merge_authorized",
+        "semantic_equivalence_claim",
+    )
+    denied = {key: False for key in denied_keys}
+    if not contract_rows:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "trajectory.failure_vector_contract",
+            "record_count": 0,
+            "security_relevance_count": 0,
+            "authority_boundary_preserved_count": 0,
+            "failure_kinds": [],
+            "affected_surfaces": [],
+            "decision_boundary": denied,
+        }
+
+    return {
+        "collection_status": "collected",
+        "status": "failure_vector_contract_evidence_observed",
+        "source": "trajectory.failure_vector_contract",
+        "record_count": len(contract_rows),
+        "security_relevance_count": sum(
+            1 for row in contract_rows if _bool(row.get("security_relevance"))
+        ),
+        "authority_boundary_preserved_count": sum(
+            1 for row in contract_rows if _bool(row.get("authority_boundary_preserved"))
+        ),
+        "failure_kinds": _counter_rows(
+            Counter(_string(row.get("failure_kind")) for row in contract_rows)
+        ),
+        "affected_surfaces": _counter_rows(
+            Counter(_string(row.get("affected_surface")) for row in contract_rows)
+        ),
+        "decision_boundary": {
+            key: any(_bool(row.get(key)) for row in contract_rows) for key in denied_keys
+        },
+    }
+
+
 def _operator_focus(
     *,
     record_count: int,
@@ -301,6 +351,7 @@ def build_pattern_insights(
         "recurring_safe_fix_patterns": recurring_safe_fixes,
         "safety_gate_evidence": _safety_gate_evidence(rows),
         "authority_boundary_evidence": _authority_boundary_evidence(rows),
+        "failure_vector_contract_evidence": _failure_vector_contract_evidence(rows),
         "operator_focus": _operator_focus(
             record_count=len(rows),
             recurring_review_surfaces=recurring_review_surfaces,
@@ -318,6 +369,8 @@ def render_pattern_markdown(insights: Mapping[str, Any]) -> str:
     boundary = _as_dict(safety_gate.get("decision_boundary"))
     authority = _as_dict(insights.get("authority_boundary_evidence"))
     authority_boundary = _as_dict(authority.get("decision_boundary"))
+    vector_contract = _as_dict(insights.get("failure_vector_contract_evidence"))
+    vector_boundary = _as_dict(vector_contract.get("decision_boundary"))
 
     lines = [
         "# Trajectory pattern insights",
@@ -390,6 +443,32 @@ def render_pattern_markdown(insights: Mapping[str, Any]) -> str:
 
     lines.extend(
         [
+            "",
+            "## FailureVector contract evidence",
+            "",
+            f"- Collection status: `{_string(vector_contract.get('collection_status'))}`",
+            f"- Status: `{_string(vector_contract.get('status'))}`",
+            f"- Records: `{int(vector_contract.get('record_count', 0) or 0)}`",
+            (
+                "- Authority boundary preserved records: "
+                f"`{int(vector_contract.get('authority_boundary_preserved_count', 0) or 0)}`"
+            ),
+            (
+                "- Security-relevant records: "
+                f"`{int(vector_contract.get('security_relevance_count', 0) or 0)}`"
+            ),
+            (
+                "- Patch application allowed by FailureVector contract evidence: "
+                f"`{str(_bool(vector_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Security dismissal allowed by FailureVector contract evidence: "
+                f"`{str(_bool(vector_boundary.get('security_dismissal_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by FailureVector contract evidence: "
+                f"`{str(_bool(vector_boundary.get('merge_authorized'))).lower()}`"
+            ),
             "",
             "## Trajectory authority boundary evidence",
             "",

--- a/src/sdetkit/trajectory_store.py
+++ b/src/sdetkit/trajectory_store.py
@@ -104,6 +104,35 @@ def _authority_boundary(
     }
 
 
+def _failure_vector_contract_evidence(failure_vector: Mapping[str, Any]) -> JsonObject:
+    contract = _as_dict(failure_vector.get("contract"))
+    if not contract:
+        return {}
+
+    false_authority = {
+        "automation_allowed": _bool(contract.get("automation_allowed")),
+        "patch_application_allowed": _bool(contract.get("patch_application_allowed")),
+        "security_dismissal_allowed": _bool(contract.get("security_dismissal_allowed")),
+        "merge_authorized": _bool(contract.get("merge_authorized")),
+        "semantic_equivalence_claim": _bool(contract.get("semantic_equivalence_claim")),
+    }
+
+    return {
+        "source": "failure_vector.contract",
+        "schema_version": _string(contract.get("schema_version")),
+        "failure_kind": _string(contract.get("failure_kind")) or "unknown",
+        "affected_surface": _string(contract.get("affected_surface")) or "unknown",
+        "ownership_area": _string(contract.get("ownership_area")) or "unknown",
+        "retryability": _string(contract.get("retryability")) or "unknown",
+        "security_relevance": _bool(contract.get("security_relevance")),
+        "recommended_next_human_action": _string(contract.get("recommended_next_human_action")),
+        "reporting_only": _bool(contract.get("reporting_only")),
+        **false_authority,
+        "authority_boundary_preserved": _bool(contract.get("reporting_only"))
+        and not any(false_authority.values()),
+    }
+
+
 def _slug(value: str) -> str:
     slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.lower()).strip("-")
     return slug or "unknown"
@@ -499,6 +528,7 @@ def build_trajectory_records(
         diagnosis_id = _string(plan.get("diagnosis_id")) or "unknown"
         diagnosis = diagnoses.get(diagnosis_id, {})
         failure_vector = _as_dict(diagnosis.get("failure_vector"))
+        failure_vector_contract = _failure_vector_contract_evidence(failure_vector)
         action = _string(plan.get("allowed_strategy")) or "collect_logs_and_classify"
         auto_fix_allowed = _bool(plan.get("safe_to_auto_fix"))
         proof_commands = _string_list(plan.get("proof_commands"))
@@ -566,6 +596,7 @@ def build_trajectory_records(
                         or "safe mechanical remediation candidate"
                     ),
                 ),
+                "failure_vector_contract": failure_vector_contract,
                 "fix": {
                     "allowed_strategy": action,
                     "patch_files": _string_list(plan.get("affected_files"))
@@ -598,6 +629,21 @@ def summarize_trajectory_records(records: list[Mapping[str, Any]]) -> JsonObject
             1
             for record in records
             if _as_dict(record.get("decision")).get("auto_fix_allowed") is True
+        ),
+        "failure_vector_contract_count": sum(
+            1 for record in records if _as_dict(record.get("failure_vector_contract"))
+        ),
+        "failure_vector_contract_boundary_preserved_count": sum(
+            1
+            for record in records
+            if _bool(
+                _as_dict(record.get("failure_vector_contract")).get("authority_boundary_preserved")
+            )
+        ),
+        "security_relevant_failure_vector_contract_count": sum(
+            1
+            for record in records
+            if _bool(_as_dict(record.get("failure_vector_contract")).get("security_relevance"))
         ),
     }
 

--- a/tests/test_trajectory_pattern_insights.py
+++ b/tests/test_trajectory_pattern_insights.py
@@ -273,3 +273,47 @@ def test_pattern_insights_summarizes_trajectory_authority_boundary_evidence() ->
     assert "## Trajectory authority boundary evidence" in markdown
     assert "Auto-fix evidence records: `1`" in markdown
     assert "Security dismissal allowed by trajectory authority evidence: `false`" in markdown
+
+
+def test_pattern_insights_summarizes_failure_vector_contract_evidence() -> None:
+    rows = _records()[:1]
+    rows[0]["failure_vector_contract"] = {
+        "source": "failure_vector.contract",
+        "schema_version": "sdetkit.failure_vector.contract.v1",
+        "failure_kind": "test",
+        "affected_surface": "tests",
+        "ownership_area": "tests/test_widget.py",
+        "retryability": "not_retryable_without_change",
+        "security_relevance": False,
+        "recommended_next_human_action": "inspect failing test and affected file",
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_claim": False,
+        "authority_boundary_preserved": True,
+    }
+
+    insights = build_pattern_insights(rows, minimum_repeat=1)
+    evidence = insights["failure_vector_contract_evidence"]
+
+    assert evidence["collection_status"] == "collected"
+    assert evidence["status"] == "failure_vector_contract_evidence_observed"
+    assert evidence["record_count"] == 1
+    assert evidence["security_relevance_count"] == 0
+    assert evidence["authority_boundary_preserved_count"] == 1
+    assert evidence["failure_kinds"] == [{"value": "test", "count": 1}]
+    assert evidence["affected_surfaces"] == [{"value": "tests", "count": 1}]
+    assert evidence["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_claim": False,
+    }
+
+    markdown = render_pattern_markdown(insights)
+    assert "## FailureVector contract evidence" in markdown
+    assert "Authority boundary preserved records: `1`" in markdown
+    assert "Security dismissal allowed by FailureVector contract evidence: `false`" in markdown

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit.trajectory_store import build_trajectory_records, main, write_trajectory_records
+from sdetkit.trajectory_store import (
+    build_trajectory_records,
+    main,
+    summarize_trajectory_records,
+    write_trajectory_records,
+)
 
 
 def _diagnostic_vector() -> dict:
@@ -28,6 +33,21 @@ def _diagnostic_vector() -> dict:
                     "environment": "github_actions",
                     "exit_code": 1,
                     "first_failing_line": "ruff format..............................Failed",
+                    "contract": {
+                        "schema_version": "sdetkit.failure_vector.contract.v1",
+                        "failure_kind": "formatter_only",
+                        "affected_surface": "source",
+                        "ownership_area": "src/sdetkit/example.py",
+                        "retryability": "not_retryable_without_change",
+                        "security_relevance": False,
+                        "recommended_next_human_action": "review generated fix",
+                        "reporting_only": True,
+                        "automation_allowed": False,
+                        "patch_application_allowed": False,
+                        "security_dismissal_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_claim": False,
+                    },
                 },
             },
             {
@@ -100,6 +120,25 @@ def test_trajectory_records_capture_safe_candidate_and_review_first_decisions() 
     assert formatting["diagnosis"]["failure_class"] == "formatter_only"
     assert formatting["fix"]["patch_files"] == ["src/sdetkit/example.py"]
     assert formatting["final_result"] == "safe_fix_candidate"
+    contract = formatting["failure_vector_contract"]
+    assert contract["source"] == "failure_vector.contract"
+    assert contract["schema_version"] == "sdetkit.failure_vector.contract.v1"
+    assert contract["failure_kind"] == "formatter_only"
+    assert contract["affected_surface"] == "source"
+    assert contract["ownership_area"] == "src/sdetkit/example.py"
+    assert contract["retryability"] == "not_retryable_without_change"
+    assert contract["security_relevance"] is False
+    assert contract["reporting_only"] is True
+    assert contract["automation_allowed"] is False
+    assert contract["patch_application_allowed"] is False
+    assert contract["security_dismissal_allowed"] is False
+    assert contract["merge_authorized"] is False
+    assert contract["semantic_equivalence_claim"] is False
+    assert contract["authority_boundary_preserved"] is True
+    summary = summarize_trajectory_records(records)
+    assert summary["failure_vector_contract_count"] == 1
+    assert summary["failure_vector_contract_boundary_preserved_count"] == 1
+    assert summary["security_relevant_failure_vector_contract_count"] == 0
     assert formatting["authority_boundary"] == {
         "source": "trajectory_store",
         "reporting_only": True,


### PR DESCRIPTION
## Summary
- Records normalized Failure Vector contract evidence in trajectory records.
- Adds contract evidence summaries to trajectory pattern insights.
- Tracks failure kind, affected surface, ownership area, retryability, security relevance, and preserved authority-boundary fields.

## Proof
- python -m pytest -q tests/test_trajectory_store.py tests/test_trajectory_pattern_insights.py tests/test_repo_memory.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- python -m sdetkit security check --root . --format json
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore / RepoMemory records contract evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim