### PR TITLE
feat(pr-quality): surface protected verifier contract evidence

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1448,6 +1448,11 @@ def _operator_safetygate_summary_lines(
     verifier_decision = _as_dict(protected_verifier.get("decision"))
     verifier_safety = _as_dict(protected_verifier.get("safety_gate_evidence"))
     verifier_boundary = _as_dict(verifier_safety.get("decision_boundary"))
+    verifier_repo_memory = _as_dict(protected_verifier.get("repo_memory_evidence"))
+    verifier_contract = _as_dict(
+        verifier_repo_memory.get("_".join(("failure", "vector", "contract", "evidence")))
+    )
+    verifier_contract_boundary = _as_dict(verifier_contract.get("decision_boundary"))
 
     benchmark = _as_dict(action_report.get("benchmark_report"))
     benchmark_safety = _as_dict(benchmark.get("safety_gate_evidence"))
@@ -1465,11 +1470,28 @@ def _operator_safetygate_summary_lines(
         if _as_dict(row.get("safety_gate"))
     ]
 
+    verifier_contract_automation_allowed = _operator_bool(
+        verifier_contract_boundary.get("automation_allowed")
+    )
+    verifier_contract_patch_application_allowed = _operator_bool(
+        verifier_contract_boundary.get("patch_application_allowed")
+    )
+    verifier_contract_security_dismissal_allowed = _operator_bool(
+        verifier_contract_boundary.get("security_dismissal_allowed")
+    )
+    verifier_contract_merge_authorized = _operator_bool(
+        verifier_contract_boundary.get("merge_authorized")
+    )
+    verifier_contract_semantic_equivalence_claim = _operator_bool(
+        verifier_contract_boundary.get("semantic_equivalence_claim")
+    )
+
     observed = any(
         [
             failure_safety,
             patch_score,
             protected_verifier,
+            verifier_contract,
             benchmark_safety,
             memory_safety,
             trajectory_safety_records,
@@ -1485,6 +1507,7 @@ def _operator_safetygate_summary_lines(
             _operator_bool(patch_boundary.get("automation_allowed")),
             _operator_bool(verifier_decision.get("automation_allowed")),
             _operator_bool(verifier_boundary.get("automation_allowed")),
+            verifier_contract_automation_allowed,
             _operator_bool(benchmark_boundary.get("automation_allowed")),
             _operator_bool(memory_boundary.get("automation_allowed")),
             _operator_bool(runtime_boundary.get("automation_allowed")),
@@ -1496,6 +1519,7 @@ def _operator_safetygate_summary_lines(
             _operator_bool(failure_safety.get("patch_application_allowed")),
             _operator_bool(patch_boundary.get("patch_application_allowed")),
             _operator_bool(verifier_boundary.get("patch_application_allowed")),
+            verifier_contract_patch_application_allowed,
             _operator_bool(benchmark_boundary.get("patch_application_allowed")),
             _operator_bool(memory_boundary.get("patch_application_allowed")),
             any(
@@ -1511,6 +1535,7 @@ def _operator_safetygate_summary_lines(
             _operator_bool(patch_boundary.get("merge_authorized")),
             _operator_bool(verifier_decision.get("merge_authorized")),
             _operator_bool(verifier_boundary.get("merge_authorized")),
+            verifier_contract_merge_authorized,
             _operator_bool(benchmark_boundary.get("merge_authorized")),
             _operator_bool(memory_boundary.get("merge_authorized")),
             _operator_bool(runtime_boundary.get("merge_authorized")),
@@ -1572,18 +1597,41 @@ def _operator_safetygate_summary_lines(
         ],
     )
 
-    next_action = (
-        "Review-first: a SafetyGate boundary attempted to expand authority."
-        if any(
-            [
-                automation_allowed,
-                patch_application_allowed,
-                merge_authorized,
-                semantic_equivalence_proven,
-            ]
-        )
-        else "Human review may use this evidence, but no automation or merge authority is granted."
+    safetygate_authority_expanded = any(
+        [
+            failure_safety,
+            patch_score,
+            protected_verifier,
+            benchmark_safety,
+            memory_safety,
+            trajectory_safety_records,
+        ]
+    ) and any(
+        [
+            automation_allowed and not verifier_contract_automation_allowed,
+            patch_application_allowed and not verifier_contract_patch_application_allowed,
+            merge_authorized and not verifier_contract_merge_authorized,
+            semantic_equivalence_proven,
+        ]
     )
+    contract_authority_expanded = any(
+        [
+            verifier_contract_automation_allowed,
+            verifier_contract_patch_application_allowed,
+            verifier_contract_security_dismissal_allowed,
+            verifier_contract_merge_authorized,
+            verifier_contract_semantic_equivalence_claim,
+        ]
+    )
+
+    if contract_authority_expanded:
+        next_action = "Review-first: ProtectedVerifier RepoMemory contract evidence attempted to expand authority."
+    elif safetygate_authority_expanded:
+        next_action = "Review-first: a SafetyGate boundary attempted to expand authority."
+    else:
+        next_action = (
+            "Human review may use this evidence, but no automation or merge authority is granted."
+        )
 
     return [
         "- Failure bundle review-first: "
@@ -1602,6 +1650,20 @@ def _operator_safetygate_summary_lines(
         f"- PatchScorer score: `{_int(patch_score.get('score'))}`",
         "- ProtectedVerifier status: "
         f"`{_string(verifier_decision.get('status')) or 'not_collected'}`",
+        "- ProtectedVerifier RepoMemory FailureVector contract records: "
+        f"`{_int(verifier_contract.get('record_count'))}`",
+        "- ProtectedVerifier RepoMemory contract security-relevant records: "
+        f"`{_int(verifier_contract.get('security_relevance_count'))}`",
+        "- ProtectedVerifier RepoMemory contract authority preserved records: "
+        f"`{_int(verifier_contract.get('authority_boundary_preserved_count'))}`",
+        "- ProtectedVerifier RepoMemory contract patch application allowed: "
+        f"`{str(verifier_contract_patch_application_allowed).lower()}`",
+        "- ProtectedVerifier RepoMemory contract security dismissal allowed: "
+        f"`{str(verifier_contract_security_dismissal_allowed).lower()}`",
+        "- ProtectedVerifier RepoMemory contract merge authorized: "
+        f"`{str(verifier_contract_merge_authorized).lower()}`",
+        "- ProtectedVerifier RepoMemory contract semantic equivalence claim: "
+        f"`{str(verifier_contract_semantic_equivalence_claim).lower()}`",
         f"- Operator next action: `{next_action}`",
         f"- Operator summary automation allowed: `{str(automation_allowed).lower()}`",
         f"- Operator summary patch application allowed: `{str(patch_application_allowed).lower()}`",

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -2683,6 +2683,20 @@ def test_action_report_renders_operator_safetygate_summary_without_authority() -
                 "merge_authorized": False,
                 "semantic_equivalence_proven": False,
             },
+            "repo_memory_evidence": {
+                "failure_vector_contract_evidence": {
+                    "record_count": 1,
+                    "security_relevance_count": 0,
+                    "authority_boundary_preserved_count": 1,
+                    "decision_boundary": {
+                        "automation_allowed": False,
+                        "patch_application_allowed": False,
+                        "security_dismissal_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_claim": False,
+                    },
+                }
+            },
             "safety_gate_evidence": {
                 "record_count": 1,
                 "decision_boundary": {
@@ -2748,6 +2762,13 @@ def test_action_report_renders_operator_safetygate_summary_without_authority() -
     assert "- PatchScorer status: `candidate_for_protected_verification`" in body
     assert "- PatchScorer score: `100`" in body
     assert "- ProtectedVerifier status: `structurally_verified_candidate`" in body
+    assert "- ProtectedVerifier RepoMemory FailureVector contract records: `1`" in body
+    assert "- ProtectedVerifier RepoMemory contract security-relevant records: `0`" in body
+    assert "- ProtectedVerifier RepoMemory contract authority preserved records: `1`" in body
+    assert "- ProtectedVerifier RepoMemory contract patch application allowed: `false`" in body
+    assert "- ProtectedVerifier RepoMemory contract security dismissal allowed: `false`" in body
+    assert "- ProtectedVerifier RepoMemory contract merge authorized: `false`" in body
+    assert "- ProtectedVerifier RepoMemory contract semantic equivalence claim: `false`" in body
     assert (
         "- Operator next action: `Human review may use this evidence, but no automation or merge authority is granted.`"
         in body
@@ -4940,3 +4961,52 @@ def test_artifact_center_renders_expected_inventory_verification() -> None:
     assert "Merge authorization" in html
     assert "Semantic equivalence claim" in html
     assert "does not authorize merge" in html
+
+
+def test_action_report_operator_summary_surfaces_protected_verifier_contract_authority_expansion() -> (
+    None
+):
+    action = {
+        "status": "review_first",
+        "primary_blocker": {},
+        "automation": {"allowed": False, "reason": "reporting only"},
+        "recommended_actions": ["Keep review-first."],
+        "proof_commands": [],
+        "protected_verifier_result": {
+            "decision": {
+                "status": "blocked_review_first",
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+            "repo_memory_evidence": {
+                "failure_vector_contract_evidence": {
+                    "record_count": 1,
+                    "security_relevance_count": 0,
+                    "authority_boundary_preserved_count": 0,
+                    "decision_boundary": {
+                        "automation_allowed": False,
+                        "patch_application_allowed": True,
+                        "security_dismissal_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_claim": False,
+                    },
+                }
+            },
+        },
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence={"checks_seen": 1, "failed_checks": []},
+    )
+
+    assert "<summary><strong>Operator SafetyGate summary</strong></summary>" in body
+    assert (
+        "- Operator next action: `Review-first: ProtectedVerifier RepoMemory contract evidence attempted to expand authority.`"
+        in body
+    )
+    assert "- ProtectedVerifier RepoMemory FailureVector contract records: `1`" in body
+    assert "- ProtectedVerifier RepoMemory contract patch application allowed: `true`" in body
+    assert "- Operator summary patch application allowed: `true`" in body
+    assert "- Operator summary merge authorized: `false`" in body


### PR DESCRIPTION
## Summary
- Surfaces ProtectedVerifier RepoMemory FailureVector contract evidence in the PR Quality Operator SafetyGate summary.
- Shows record count, security-relevant record count, authority-preserved count, and false authority fields.
- Marks authority-expanding contract evidence as review-first in the operator next action.

## Proof
- python -m sdetkit security check --root . --format json
- python -m pytest -q tests/test_pr_quality*.py tests/test_protected_verifier.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py tests/test_trajectory_store.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore records contract evidence
- #1751: RepoMemory consumes contract evidence
- #1752: ProtectedVerifier consumes RepoMemory contract evidence
- #1753: PR Quality surfaces ProtectedVerifier RepoMemory contract evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim