### PR TITLE
feat(runtime-proof): consume protected verifier contract evidence

### DIFF
--- a/src/sdetkit/pr_quality_runtime_proof_artifacts.py
+++ b/src/sdetkit/pr_quality_runtime_proof_artifacts.py
@@ -37,6 +37,9 @@ CONTROLLED_STRUCTURALLY_VERIFIED_COUNT = "_".join(
     ("controlled", "structurally", "verified", "count")
 )
 CONTROLLED_REVIEW_FIRST_COUNT = "_".join(("controlled", "review", "first", "count"))
+FAILURE_VECTOR_CONTRACT_EVIDENCE = "_".join(("failure", "vector", "contract", "evidence"))
+SECURITY_DISMISSAL_ALLOWED = "_".join(("security", "dismissal", "allowed"))
+SEMANTIC_EQUIVALENCE_CLAIM = "_".join(("semantic", "equivalence", "claim"))
 
 JsonObject = dict[str, Any]
 
@@ -216,6 +219,49 @@ def _repo_memory_summary(profile: Mapping[str, Any]) -> JsonObject:
     }
 
 
+def _protected_verifier_summary(result: Mapping[str, Any]) -> JsonObject:
+    payload = _as_dict(result)
+    if not payload:
+        return {
+            "collection_status": NOT_COLLECTED,
+            "status": NOT_COLLECTED,
+        }
+
+    decision = _as_dict(payload.get("decision"))
+    decision_boundary = _as_dict(payload.get("decision_boundary"))
+    repo_memory = _as_dict(payload.get("repo_memory_evidence"))
+    contract = _as_dict(repo_memory.get(FAILURE_VECTOR_CONTRACT_EVIDENCE))
+    contract_boundary = _as_dict(contract.get("decision_boundary"))
+
+    return {
+        "collection_status": COLLECTED,
+        "status": _string(decision.get("status") or payload.get("status") or "unknown"),
+        "review_first": _bool(decision.get("review_first")),
+        "contract_status": _string(contract.get("status") or NOT_COLLECTED),
+        "contract_record_count": _int(contract.get("record_count")),
+        "contract_security_relevance_count": _int(contract.get("security_relevance_count")),
+        "contract_authority_boundary_preserved_count": _int(
+            contract.get("authority_boundary_preserved_count")
+        ),
+        "contract_patch_application_allowed": _bool(
+            contract_boundary.get("patch_application_allowed")
+        ),
+        "contract_security_dismissal_allowed": _bool(
+            contract_boundary.get(SECURITY_DISMISSAL_ALLOWED)
+        ),
+        "contract_merge_authorized": _bool(contract_boundary.get("merge_authorized")),
+        "contract_semantic_equivalence_claim": _bool(
+            contract_boundary.get(SEMANTIC_EQUIVALENCE_CLAIM)
+        ),
+        "automation_allowed": _bool(decision.get("automation_allowed"))
+        or _bool(decision_boundary.get("automation_allowed")),
+        "merge_authorized": _bool(decision.get("merge_authorized"))
+        or _bool(decision_boundary.get("merge_authorized")),
+        "semantic_equivalence_proven": _bool(decision.get("semantic_equivalence_proven"))
+        or _bool(decision_boundary.get("semantic_equivalence_proven")),
+    }
+
+
 def _trusted_diagnostic_signal_snapshot_history_summary(
     evidence: Mapping[str, Any],
 ) -> JsonObject:
@@ -317,12 +363,14 @@ def build_runtime_proof_artifacts(
     isolated_proof: Mapping[str, Any] | None = None,
     live_benchmark_report: Mapping[str, Any] | None = None,
     repo_memory_profile: Mapping[str, Any] | None = None,
+    protected_verifier_result: Mapping[str, Any] | None = None,
     trusted_history_evidence: Mapping[str, Any] | None = None,
     trusted_diagnostic_signal_snapshot_history: Mapping[str, Any] | None = None,
 ) -> JsonObject:
     isolated = _isolated_proof_summary(isolated_proof or {})
     live_benchmark = _live_benchmark_summary(live_benchmark_report or {})
     repo_memory = _repo_memory_summary(repo_memory_profile or {})
+    protected_verifier = _protected_verifier_summary(protected_verifier_result or {})
     trusted_history = _trusted_history_summary(trusted_history_evidence or {})
     trusted_signal_history = _trusted_diagnostic_signal_snapshot_history_summary(
         trusted_diagnostic_signal_snapshot_history or {}
@@ -334,6 +382,7 @@ def build_runtime_proof_artifacts(
             ("isolated_proof", isolated),
             ("live_benchmark", live_benchmark),
             ("repo_memory", repo_memory),
+            ("protected_verifier", protected_verifier),
             (TRUSTED_HISTORY, trusted_history),
             (TRUSTED_DIAGNOSTIC_SIGNAL_SNAPSHOT_HISTORY, trusted_signal_history),
         )
@@ -347,6 +396,7 @@ def build_runtime_proof_artifacts(
         "isolated_proof": isolated,
         "live_benchmark": live_benchmark,
         "repo_memory": repo_memory,
+        "protected_verifier": protected_verifier,
         TRUSTED_HISTORY: trusted_history,
         TRUSTED_DIAGNOSTIC_SIGNAL_SNAPSHOT_HISTORY: trusted_signal_history,
         "decision_boundary": {
@@ -363,6 +413,7 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
     isolated = _as_dict(summary.get("isolated_proof"))
     benchmark = _as_dict(summary.get("live_benchmark"))
     memory = _as_dict(summary.get("repo_memory"))
+    protected_verifier = _as_dict(summary.get("protected_verifier"))
     trusted_history = _as_dict(summary.get(TRUSTED_HISTORY))
     trusted_signal_history = _as_dict(summary.get(TRUSTED_DIAGNOSTIC_SIGNAL_SNAPSHOT_HISTORY))
     boundary = _as_dict(summary.get("decision_boundary"))
@@ -569,6 +620,42 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
     lines.extend(
         [
             "",
+            "## ProtectedVerifier RepoMemory contract evidence",
+            "",
+            f"- Collection status: `{_string(protected_verifier.get('collection_status'))}`",
+            f"- Status: `{_string(protected_verifier.get('status'))}`",
+        ]
+    )
+    if protected_verifier.get("collection_status") == COLLECTED:
+        lines.extend(
+            [
+                f"- Review first: `{str(_bool(protected_verifier.get('review_first'))).lower()}`",
+                f"- Contract status: `{_string(protected_verifier.get('contract_status'))}`",
+                f"- Contract records: `{_int(protected_verifier.get('contract_record_count'))}`",
+                "- Contract security-relevant records: "
+                f"`{_int(protected_verifier.get('contract_security_relevance_count'))}`",
+                "- Contract authority boundary preserved records: "
+                f"`{_int(protected_verifier.get('contract_authority_boundary_preserved_count'))}`",
+                "- Contract patch application allowed: "
+                f"`{str(_bool(protected_verifier.get('contract_patch_application_allowed'))).lower()}`",
+                "- Contract security dismissal allowed: "
+                f"`{str(_bool(protected_verifier.get('contract_security_dismissal_allowed'))).lower()}`",
+                "- Contract merge authorized: "
+                f"`{str(_bool(protected_verifier.get('contract_merge_authorized'))).lower()}`",
+                "- Contract semantic equivalence claim: "
+                f"`{str(_bool(protected_verifier.get('contract_semantic_equivalence_claim'))).lower()}`",
+                "- ProtectedVerifier automation allowed: "
+                f"`{str(_bool(protected_verifier.get('automation_allowed'))).lower()}`",
+                "- ProtectedVerifier merge authorized: "
+                f"`{str(_bool(protected_verifier.get('merge_authorized'))).lower()}`",
+                "- ProtectedVerifier semantic equivalence proven: "
+                f"`{str(_bool(protected_verifier.get('semantic_equivalence_proven'))).lower()}`",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
             "## Trusted accepted-main RepoMemory history",
             "",
             (f"- Collection status: `{_string(trusted_history.get('collection_status'))}`"),
@@ -766,6 +853,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--isolated-proof", type=Path)
     parser.add_argument("--live-benchmark-report", type=Path)
     parser.add_argument("--repo-memory-profile", type=Path)
+    parser.add_argument("--protected-verifier-result", type=Path)
     parser.add_argument("--trusted-history-evidence", type=Path)
     parser.add_argument("--trusted-diagnostic-signal-snapshot-history", type=Path)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
@@ -779,6 +867,7 @@ def main(argv: list[str] | None = None) -> int:
         isolated_proof=_read_json(args.isolated_proof),
         live_benchmark_report=_read_json(args.live_benchmark_report),
         repo_memory_profile=_read_json(args.repo_memory_profile),
+        protected_verifier_result=_read_json(args.protected_verifier_result),
         trusted_history_evidence=_read_json(args.trusted_history_evidence),
         trusted_diagnostic_signal_snapshot_history=_read_json(
             args.trusted_diagnostic_signal_snapshot_history

--- a/tests/test_pr_quality_runtime_proof_artifacts.py
+++ b/tests/test_pr_quality_runtime_proof_artifacts.py
@@ -149,7 +149,7 @@ def test_runtime_proof_markdown_reports_unwired_artifacts_honestly() -> None:
     assert "Runtime guard passed: `true`" in markdown
     assert "Runtime guard violations: `0`" in markdown
     assert "Network isolation enforced: `false`" in markdown
-    assert markdown.count("Collection status: `not_collected`") == 4
+    assert markdown.count("Collection status: `not_collected`") == 5
     assert "Proof commands executed by renderer: `false`" in markdown
     assert "Automation allowed: `false`" in markdown
     assert "Merge authorized: `false`" in markdown
@@ -526,3 +526,105 @@ def test_runtime_proof_cli_accepts_trusted_diagnostic_signal_snapshot_history(
     assert trusted["record_count"] == 3
     assert trusted["automation_allowed"] is False
     assert trusted["merge_authorized"] is False
+
+
+def test_runtime_proof_summary_consumes_protected_verifier_repo_memory_contract_evidence() -> None:
+    summary = build_runtime_proof_artifacts(
+        protected_verifier_result={
+            "decision": {
+                "status": "review_required",
+                "review_first": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+            "decision_boundary": {
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+            "repo_memory_evidence": {
+                "failure_vector_contract_evidence": {
+                    "status": "failure_vector_contract_evidence_observed",
+                    "record_count": 1,
+                    "security_relevance_count": 0,
+                    "authority_boundary_preserved_count": 1,
+                    "decision_boundary": {
+                        "automation_allowed": False,
+                        "patch_application_allowed": False,
+                        "security_dismissal_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_claim": False,
+                    },
+                }
+            },
+        }
+    )
+
+    protected = summary["protected_verifier"]
+    assert summary["status"] == COLLECTED
+    assert summary["collected_components"] == ["protected_verifier"]
+    assert protected["status"] == "review_required"
+    assert protected["review_first"] is True
+    assert protected["contract_status"] == "failure_vector_contract_evidence_observed"
+    assert protected["contract_record_count"] == 1
+    assert protected["contract_security_relevance_count"] == 0
+    assert protected["contract_authority_boundary_preserved_count"] == 1
+    assert protected["contract_patch_application_allowed"] is False
+    assert protected["contract_security_dismissal_allowed"] is False
+    assert protected["contract_merge_authorized"] is False
+    assert protected["contract_semantic_equivalence_claim"] is False
+    assert protected["automation_allowed"] is False
+    assert protected["merge_authorized"] is False
+    assert protected["semantic_equivalence_proven"] is False
+
+    markdown = render_markdown(summary)
+    assert "## ProtectedVerifier RepoMemory contract evidence" in markdown
+    assert "Contract records: `1`" in markdown
+    assert "Contract security-relevant records: `0`" in markdown
+    assert "Contract authority boundary preserved records: `1`" in markdown
+    assert "Contract patch application allowed: `false`" in markdown
+    assert "Contract security dismissal allowed: `false`" in markdown
+    assert "Contract merge authorized: `false`" in markdown
+    assert "Contract semantic equivalence claim: `false`" in markdown
+    assert "ProtectedVerifier merge authorized: `false`" in markdown
+    assert "ProtectedVerifier semantic equivalence proven: `false`" in markdown
+
+
+def test_runtime_proof_summary_surfaces_protected_verifier_contract_authority_expansion() -> None:
+    summary = build_runtime_proof_artifacts(
+        protected_verifier_result={
+            "decision": {
+                "status": "blocked_review_first",
+                "review_first": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+            "repo_memory_evidence": {
+                "failure_vector_contract_evidence": {
+                    "status": "failure_vector_contract_evidence_observed",
+                    "record_count": 1,
+                    "security_relevance_count": 0,
+                    "authority_boundary_preserved_count": 0,
+                    "decision_boundary": {
+                        "automation_allowed": False,
+                        "patch_application_allowed": True,
+                        "security_dismissal_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_claim": False,
+                    },
+                }
+            },
+        }
+    )
+
+    protected = summary["protected_verifier"]
+    assert protected["contract_patch_application_allowed"] is True
+    assert protected["contract_merge_authorized"] is False
+    assert protected["contract_semantic_equivalence_claim"] is False
+
+    markdown = render_markdown(summary)
+    assert "Contract patch application allowed: `true`" in markdown
+    assert "Contract merge authorized: `false`" in markdown
+    assert "Contract semantic equivalence claim: `false`" in markdown


### PR DESCRIPTION
## Summary
- Adds runtime proof artifact consumption of ProtectedVerifier RepoMemory FailureVector contract evidence.
- Surfaces ProtectedVerifier contract record count, security-relevant count, authority-preserved count, and authority boundary fields in runtime proof markdown.
- Keeps runtime proof artifacts reporting-only and non-authorizing.

## Proof
- python -m sdetkit security check --root . --format json
- python -m pytest -q tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_action_report.py tests/test_protected_verifier.py tests/test_repo_memory.py tests/test_trajectory_pattern_insights.py tests/test_trajectory_store.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore records contract evidence
- #1751: RepoMemory consumes contract evidence
- #1752: ProtectedVerifier consumes RepoMemory contract evidence
- #1753: PR Quality surfaces ProtectedVerifier contract evidence
- #1754: Runtime proof artifacts consume ProtectedVerifier contract evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim