### PR TITLE
feat(protected-verifier): consume runtime proof contract evidence

### DIFF
--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -67,6 +67,9 @@ SAFETYGATE_EVIDENCE_AUTHORITY_VIOLATION = "_".join(
 FAILURE_VECTOR_CONTRACT_EVIDENCE_AUTHORITY_VIOLATION = "_".join(
     ("FAILURE", "VECTOR", "CONTRACT", "EVIDENCE", "AUTHORITY", "VIOLATION")
 )
+RUNTIME_PROOF_PROTECTED_VERIFIER_CONTRACT_AUTHORITY_VIOLATION = "_".join(
+    ("RUNTIME", "PROOF", "PROTECTED", "VERIFIER", "CONTRACT", "AUTHORITY", "VIOLATION")
+)
 STRUCTURALLY_VERIFIED_CANDIDATE = "_".join(("structurally", "verified", "candidate"))
 
 
@@ -179,6 +182,61 @@ def _authority_expansion_flags(
     return flags
 
 
+def _runtime_proof_protected_verifier_contract_evidence(
+    runtime_proof: Mapping[str, Any],
+) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_claim": False,
+    }
+    protected_verifier = _as_dict(runtime_proof.get("protected_verifier"))
+    if not protected_verifier:
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": "runtime_proof.protected_verifier.failure_vector_contract_evidence",
+            "record_count": 0,
+            "security_relevance_count": 0,
+            "authority_boundary_preserved_count": 0,
+            "expanded_authority_fields": [],
+            "decision_boundary": denied,
+        }
+
+    boundary = {
+        "automation_allowed": _bool(protected_verifier.get("automation_allowed")),
+        "patch_application_allowed": _bool(
+            protected_verifier.get("contract_patch_application_allowed")
+        ),
+        "security_dismissal_allowed": _bool(
+            protected_verifier.get("contract_security_dismissal_allowed")
+        ),
+        "merge_authorized": _bool(protected_verifier.get("contract_merge_authorized")),
+        "semantic_equivalence_claim": _bool(
+            protected_verifier.get("contract_semantic_equivalence_claim")
+        ),
+    }
+    expanded = [key for key in denied if _bool(boundary.get(key))]
+    return {
+        "collection_status": _string(protected_verifier.get("collection_status")) or "collected",
+        "status": _string(protected_verifier.get("contract_status"))
+        or _string(protected_verifier.get("status"))
+        or "failure_vector_contract_evidence_observed",
+        "source": "runtime_proof.protected_verifier.failure_vector_contract_evidence",
+        "record_count": _int(protected_verifier.get("contract_record_count")),
+        "security_relevance_count": _int(
+            protected_verifier.get("contract_security_relevance_count")
+        ),
+        "authority_boundary_preserved_count": _int(
+            protected_verifier.get("contract_authority_boundary_preserved_count")
+        ),
+        "expanded_authority_fields": expanded,
+        "decision_boundary": denied,
+    }
+
+
 def _repo_memory_failure_vector_contract_evidence(
     repo_memory_profile: Mapping[str, Any],
 ) -> JsonObject:
@@ -254,6 +312,7 @@ def verify_patch(
     bundle = _as_dict(failure_bundle)
     runtime = _as_dict(runtime_proof)
     repo_memory = _as_dict(repo_memory_profile)
+    runtime_proof_contract_evidence = _runtime_proof_protected_verifier_contract_evidence(runtime)
     failure_vector_contract_evidence = _repo_memory_failure_vector_contract_evidence(repo_memory)
     patch_decision = _as_dict(patch_score.get("decision"))
 
@@ -272,6 +331,20 @@ def verify_patch(
         failure_bundle=bundle,
         runtime_proof=runtime,
     )
+
+    expanded_runtime_contract_fields = _string_list(
+        runtime_proof_contract_evidence.get("expanded_authority_fields")
+    )
+    if expanded_runtime_contract_fields:
+        flags.append(
+            {
+                "code": RUNTIME_PROOF_PROTECTED_VERIFIER_CONTRACT_AUTHORITY_VIOLATION,
+                "message": "Runtime proof ProtectedVerifier contract evidence attempted to expand verifier authority.",
+                "blocking": True,
+                "source": "runtime_proof.protected_verifier.failure_vector_contract_evidence",
+                "fields": expanded_runtime_contract_fields,
+            }
+        )
 
     expanded_contract_fields = _string_list(
         failure_vector_contract_evidence.get("expanded_authority_fields")
@@ -349,6 +422,9 @@ def verify_patch(
             "runtime_proof_status": _string(runtime.get("status")) or "not_collected",
             "repo_memory_profile_status": _string(repo_memory.get("profile_status"))
             or "not_collected",
+        },
+        "runtime_proof_evidence": {
+            "protected_verifier_contract_evidence": runtime_proof_contract_evidence,
         },
         "repo_memory_evidence": {
             "failure_vector_contract_evidence": failure_vector_contract_evidence,
@@ -636,6 +712,9 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
     decision = _as_dict(payload.get("decision"))
     evidence = _as_dict(payload.get("verification_evidence"))
     boundary = _as_dict(payload.get("decision_boundary"))
+    runtime_proof = _as_dict(payload.get("runtime_proof_evidence"))
+    runtime_contract = _as_dict(runtime_proof.get("protected_verifier_contract_evidence"))
+    runtime_boundary = _as_dict(runtime_contract.get("decision_boundary"))
     repo_memory = _as_dict(payload.get("repo_memory_evidence"))
     vector_contract = _as_dict(repo_memory.get("failure_vector_contract_evidence"))
     vector_boundary = _as_dict(vector_contract.get("decision_boundary"))
@@ -678,6 +757,36 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
 
     lines.extend(
         [
+            "",
+            "## Runtime proof ProtectedVerifier contract evidence",
+            "",
+            f"- Collection status: `{_string(runtime_contract.get('collection_status'))}`",
+            f"- Status: `{_string(runtime_contract.get('status'))}`",
+            f"- Records: `{_int(runtime_contract.get('record_count'))}`",
+            (
+                "- Security-relevant records: "
+                f"`{_int(runtime_contract.get('security_relevance_count'))}`"
+            ),
+            (
+                "- Authority boundary preserved records: "
+                f"`{_int(runtime_contract.get('authority_boundary_preserved_count'))}`"
+            ),
+            (
+                "- Patch application allowed by runtime proof ProtectedVerifier contract evidence: "
+                f"`{str(_bool(runtime_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Security dismissal allowed by runtime proof ProtectedVerifier contract evidence: "
+                f"`{str(_bool(runtime_boundary.get('security_dismissal_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by runtime proof ProtectedVerifier contract evidence: "
+                f"`{str(_bool(runtime_boundary.get('merge_authorized'))).lower()}`"
+            ),
+            (
+                "- Semantic equivalence claimed by runtime proof ProtectedVerifier contract evidence: "
+                f"`{str(_bool(runtime_boundary.get('semantic_equivalence_claim'))).lower()}`"
+            ),
             "",
             "## RepoMemory FailureVector contract evidence",
             "",

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -286,3 +286,99 @@ def test_protected_verifier_blocks_authority_expanding_repo_memory_contract_evid
         and flag["fields"] == ["merge_authorized"]
         for flag in payload["risk_flags"]
     )
+
+
+def _runtime_proof_with_protected_verifier_contract() -> dict:
+    return {
+        "schema_version": "sdetkit.pr_quality_runtime_proof_artifacts.v1",
+        "status": "collected",
+        "protected_verifier": {
+            "collection_status": "collected",
+            "status": "review_required",
+            "review_first": True,
+            "contract_status": "failure_vector_contract_evidence_observed",
+            "contract_record_count": 1,
+            "contract_security_relevance_count": 0,
+            "contract_authority_boundary_preserved_count": 1,
+            "contract_patch_application_allowed": False,
+            "contract_security_dismissal_allowed": False,
+            "contract_merge_authorized": False,
+            "contract_semantic_equivalence_claim": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+        "decision_boundary": {
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def test_protected_verifier_consumes_runtime_proof_protected_verifier_contract_evidence() -> None:
+    payload = verify_patch(
+        patch_score=_candidate_patch_score(),
+        runtime_proof=_runtime_proof_with_protected_verifier_contract(),
+    )
+
+    evidence = payload["runtime_proof_evidence"]["protected_verifier_contract_evidence"]
+    assert evidence["collection_status"] == "collected"
+    assert evidence["status"] == "failure_vector_contract_evidence_observed"
+    assert evidence["source"] == "runtime_proof.protected_verifier.failure_vector_contract_evidence"
+    assert evidence["record_count"] == 1
+    assert evidence["security_relevance_count"] == 0
+    assert evidence["authority_boundary_preserved_count"] == 1
+    assert evidence["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_claim": False,
+    }
+    assert payload["decision"]["status"] == REVIEW_REQUIRED
+    assert payload["decision"]["patch_application_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+    assert payload["risk_flags"] == []
+
+    markdown = render_markdown(payload)
+    assert "## Runtime proof ProtectedVerifier contract evidence" in markdown
+    assert "Authority boundary preserved records: `1`" in markdown
+    assert (
+        "Patch application allowed by runtime proof ProtectedVerifier contract evidence: `false`"
+        in markdown
+    )
+    assert (
+        "Security dismissal allowed by runtime proof ProtectedVerifier contract evidence: `false`"
+        in markdown
+    )
+    assert (
+        "Merge authorized by runtime proof ProtectedVerifier contract evidence: `false`" in markdown
+    )
+    assert (
+        "Semantic equivalence claimed by runtime proof ProtectedVerifier contract evidence: `false`"
+        in markdown
+    )
+
+
+def test_protected_verifier_blocks_authority_expanding_runtime_proof_contract_evidence() -> None:
+    runtime = _runtime_proof_with_protected_verifier_contract()
+    runtime["protected_verifier"]["contract_patch_application_allowed"] = True
+    runtime["protected_verifier"]["contract_semantic_equivalence_claim"] = True
+
+    payload = verify_patch(
+        patch_score=_candidate_patch_score(),
+        runtime_proof=runtime,
+    )
+
+    assert payload["decision"]["status"] == BLOCKED_REVIEW_FIRST
+    assert payload["decision"]["patch_application_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+    assert any(
+        flag["code"] == "RUNTIME_PROOF_PROTECTED_VERIFIER_CONTRACT_AUTHORITY_VIOLATION"
+        and flag["blocking"] is True
+        and flag["fields"] == ["patch_application_allowed", "semantic_equivalence_claim"]
+        for flag in payload["risk_flags"]
+    )


### PR DESCRIPTION
## Summary
- Adds ProtectedVerifier consumption of runtime proof ProtectedVerifier contract evidence.
- Surfaces runtime proof ProtectedVerifier contract record count, security-relevant count, authority-preserved count, and authority boundary fields.
- Blocks authority expansion from runtime proof contract evidence while keeping ProtectedVerifier reporting-only and non-authorizing.

## Proof
- python -m sdetkit security check --root . --format json
- python -m pytest -q tests/test_protected_verifier.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_action_report.py tests/test_repo_memory.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore records contract evidence
- #1751: RepoMemory consumes contract evidence
- #1752: ProtectedVerifier consumes RepoMemory contract evidence
- #1753: PR Quality surfaces ProtectedVerifier contract evidence
- #1754: Runtime proof artifacts consume ProtectedVerifier contract evidence
- #1755: ProtectedVerifier consumes runtime proof contract evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim