### PR TITLE
feat(runtime-proof): consume benchmark contract replay evidence

### DIFF
--- a/src/sdetkit/pr_quality_runtime_proof_artifacts.py
+++ b/src/sdetkit/pr_quality_runtime_proof_artifacts.py
@@ -22,6 +22,47 @@ REPLAY_MANIFEST_MERGE_AUTHORIZED = "_".join(("replay", "manifest", "merge", "aut
 REPLAY_MANIFEST_SEMANTIC_EQUIVALENCE_PROVEN = "_".join(
     ("replay", "manifest", "semantic", "equivalence", "proven")
 )
+BENCHMARK_RUNTIME_PROOF_CONTRACT_EVIDENCE = "_".join(
+    ("runtime", "proof", "protected", "verifier", "contract", "evidence")
+)
+BENCHMARK_RUNTIME_PROOF_CONTRACT_REPLAYED = "_".join(
+    (
+        "runtime",
+        "proof",
+        "protected",
+        "verifier",
+        "contract",
+        "evidence",
+        "replayed",
+    )
+)
+BENCHMARK_RUNTIME_CONTRACT_COLLECTION_STATUS = "_".join(
+    ("runtime", "contract", "collection", "status")
+)
+BENCHMARK_RUNTIME_CONTRACT_STATUS = "_".join(("runtime", "contract", "status"))
+BENCHMARK_RUNTIME_CONTRACT_SCENARIO_COUNT = "_".join(("runtime", "contract", "scenario", "count"))
+BENCHMARK_RUNTIME_CONTRACT_RECORD_COUNT = "_".join(("runtime", "contract", "record", "count"))
+BENCHMARK_RUNTIME_CONTRACT_SECURITY_RELEVANCE_COUNT = "_".join(
+    ("runtime", "contract", "security", "relevance", "count")
+)
+BENCHMARK_RUNTIME_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT = "_".join(
+    ("runtime", "contract", "authority", "boundary", "preserved", "count")
+)
+BENCHMARK_RUNTIME_CONTRACT_EXPANDED_AUTHORITY_FIELDS = "_".join(
+    ("runtime", "contract", "expanded", "authority", "fields")
+)
+BENCHMARK_RUNTIME_CONTRACT_PATCH_APPLICATION_ALLOWED = "_".join(
+    ("runtime", "contract", "patch", "application", "allowed")
+)
+BENCHMARK_RUNTIME_CONTRACT_SECURITY_DISMISSAL_ALLOWED = "_".join(
+    ("runtime", "contract", "security", "dismissal", "allowed")
+)
+BENCHMARK_RUNTIME_CONTRACT_MERGE_AUTHORIZED = "_".join(
+    ("runtime", "contract", "merge", "authorized")
+)
+BENCHMARK_RUNTIME_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM = "_".join(
+    ("runtime", "contract", "semantic", "equivalence", "claim")
+)
 TRUSTED_HISTORY = "_".join(("trusted", "history"))
 TRUSTED_DIAGNOSTIC_SIGNAL_SNAPSHOT_HISTORY = "_".join(
     ("trusted", "diagnostic", "signal", "snapshot", "history")
@@ -110,6 +151,10 @@ def _isolated_proof_summary(evidence: Mapping[str, Any]) -> JsonObject:
     }
 
 
+def _string_list(value: object) -> list[str]:
+    return [_string(item) for item in _as_list(value) if _string(item)]
+
+
 def _live_benchmark_summary(report: Mapping[str, Any]) -> JsonObject:
     payload = _as_dict(report)
     if not payload:
@@ -121,6 +166,8 @@ def _live_benchmark_summary(report: Mapping[str, Any]) -> JsonObject:
     live = _as_dict(payload.get("live_evidence"))
     boundary = _as_dict(payload.get("safety_boundary"))
     replay = _as_dict(payload.get(REPLAY_MANIFEST))
+    runtime_contract = _as_dict(payload.get(BENCHMARK_RUNTIME_PROOF_CONTRACT_EVIDENCE))
+    runtime_contract_boundary = _as_dict(runtime_contract.get("decision_boundary"))
     return {
         "collection_status": COLLECTED,
         "status": _string(payload.get("status") or "unknown"),
@@ -139,6 +186,34 @@ def _live_benchmark_summary(report: Mapping[str, Any]) -> JsonObject:
             boundary.get("semantic_equivalence_claimed_count")
         ),
         "boundary_preserved": _bool(boundary.get("preserved")),
+        BENCHMARK_RUNTIME_CONTRACT_COLLECTION_STATUS: _string(
+            runtime_contract.get("collection_status")
+        )
+        or NOT_COLLECTED,
+        BENCHMARK_RUNTIME_CONTRACT_STATUS: _string(runtime_contract.get("status")) or NOT_COLLECTED,
+        BENCHMARK_RUNTIME_CONTRACT_SCENARIO_COUNT: _int(runtime_contract.get("scenario_count")),
+        BENCHMARK_RUNTIME_CONTRACT_RECORD_COUNT: _int(runtime_contract.get("record_count")),
+        BENCHMARK_RUNTIME_CONTRACT_SECURITY_RELEVANCE_COUNT: _int(
+            runtime_contract.get("security_relevance_count")
+        ),
+        BENCHMARK_RUNTIME_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT: _int(
+            runtime_contract.get("authority_boundary_preserved_count")
+        ),
+        BENCHMARK_RUNTIME_CONTRACT_EXPANDED_AUTHORITY_FIELDS: _string_list(
+            runtime_contract.get("expanded_authority_fields")
+        ),
+        BENCHMARK_RUNTIME_CONTRACT_PATCH_APPLICATION_ALLOWED: _bool(
+            runtime_contract_boundary.get("patch_application_allowed")
+        ),
+        BENCHMARK_RUNTIME_CONTRACT_SECURITY_DISMISSAL_ALLOWED: _bool(
+            runtime_contract_boundary.get("security_dismissal_allowed")
+        ),
+        BENCHMARK_RUNTIME_CONTRACT_MERGE_AUTHORIZED: _bool(
+            runtime_contract_boundary.get("merge_authorized")
+        ),
+        BENCHMARK_RUNTIME_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM: _bool(
+            runtime_contract_boundary.get("semantic_equivalence_claim")
+        ),
         REPLAY_MANIFEST_PRESENT: bool(replay),
         REPLAY_MANIFEST_SCENARIO_COUNT: _int(replay.get("scenario_count")),
         REPLAY_MANIFEST_REPORTING_ONLY: _bool(replay.get("reporting_only")),
@@ -499,6 +574,44 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
                 (
                     "- Boundary preserved: "
                     f"`{str(_bool(benchmark.get('boundary_preserved'))).lower()}`"
+                ),
+                f"- Runtime proof contract collection: `{_string(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_COLLECTION_STATUS))}`",
+                f"- Runtime proof contract status: `{_string(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_STATUS))}`",
+                (
+                    "- Runtime proof contract scenarios: "
+                    f"`{_int(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_SCENARIO_COUNT))}`"
+                ),
+                (
+                    "- Runtime proof contract records: "
+                    f"`{_int(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_RECORD_COUNT))}`"
+                ),
+                (
+                    "- Runtime proof contract security-relevant records: "
+                    f"`{_int(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_SECURITY_RELEVANCE_COUNT))}`"
+                ),
+                (
+                    "- Runtime proof contract authority-preserved records: "
+                    f"`{_int(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT))}`"
+                ),
+                (
+                    "- Runtime proof contract expanded authority fields: "
+                    f"`{', '.join(_string_list(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_EXPANDED_AUTHORITY_FIELDS))) or 'none'}`"
+                ),
+                (
+                    "- Runtime proof contract patch application allowed: "
+                    f"`{str(_bool(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_PATCH_APPLICATION_ALLOWED))).lower()}`"
+                ),
+                (
+                    "- Runtime proof contract security dismissal allowed: "
+                    f"`{str(_bool(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_SECURITY_DISMISSAL_ALLOWED))).lower()}`"
+                ),
+                (
+                    "- Runtime proof contract merge authorized: "
+                    f"`{str(_bool(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_MERGE_AUTHORIZED))).lower()}`"
+                ),
+                (
+                    "- Runtime proof contract semantic equivalence claim: "
+                    f"`{str(_bool(benchmark.get(BENCHMARK_RUNTIME_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM))).lower()}`"
                 ),
                 (
                     "- Replay manifest present: "

--- a/tests/test_pr_quality_runtime_proof_artifacts.py
+++ b/tests/test_pr_quality_runtime_proof_artifacts.py
@@ -5,6 +5,19 @@ from pathlib import Path
 
 from sdetkit.pr_quality_runtime_proof_artifacts import (
     BASE_ANCESTRY_VERIFIED,
+    BENCHMARK_RUNTIME_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT,
+    BENCHMARK_RUNTIME_CONTRACT_COLLECTION_STATUS,
+    BENCHMARK_RUNTIME_CONTRACT_EXPANDED_AUTHORITY_FIELDS,
+    BENCHMARK_RUNTIME_CONTRACT_MERGE_AUTHORIZED,
+    BENCHMARK_RUNTIME_CONTRACT_PATCH_APPLICATION_ALLOWED,
+    BENCHMARK_RUNTIME_CONTRACT_RECORD_COUNT,
+    BENCHMARK_RUNTIME_CONTRACT_SCENARIO_COUNT,
+    BENCHMARK_RUNTIME_CONTRACT_SECURITY_DISMISSAL_ALLOWED,
+    BENCHMARK_RUNTIME_CONTRACT_SECURITY_RELEVANCE_COUNT,
+    BENCHMARK_RUNTIME_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM,
+    BENCHMARK_RUNTIME_CONTRACT_STATUS,
+    BENCHMARK_RUNTIME_PROOF_CONTRACT_EVIDENCE,
+    BENCHMARK_RUNTIME_PROOF_CONTRACT_REPLAYED,
     COLLECTED,
     CONTROLLED_REVIEW_FIRST_COUNT,
     CONTROLLED_STRUCTURALLY_VERIFIED_COUNT,
@@ -628,3 +641,118 @@ def test_runtime_proof_summary_surfaces_protected_verifier_contract_authority_ex
     assert "Contract patch application allowed: `true`" in markdown
     assert "Contract merge authorized: `false`" in markdown
     assert "Contract semantic equivalence claim: `false`" in markdown
+
+
+def test_runtime_proof_summary_consumes_benchmark_runtime_contract_replay_evidence() -> None:
+    summary = build_runtime_proof_artifacts(
+        live_benchmark_report={
+            "status": "passed",
+            "report_mode": "git_grounded_isolated_proof",
+            "scenario_count": 3,
+            "passed_count": 3,
+            "failed_count": 0,
+            "live_evidence": {
+                "git_inventory_verified_count": 3,
+                "expected_failed_evidence_count": 0,
+                "network_boundary_blocked_count": 0,
+                "anti_cheat_rejection_count": 0,
+                "network_isolation_enforced_count": 0,
+            },
+            "safety_boundary": {
+                "automation_allowed_count": 0,
+                "merge_authorized_count": 0,
+                "semantic_equivalence_claimed_count": 0,
+                "preserved": True,
+            },
+            BENCHMARK_RUNTIME_PROOF_CONTRACT_EVIDENCE: {
+                "collection_status": "collected",
+                "status": BENCHMARK_RUNTIME_PROOF_CONTRACT_REPLAYED,
+                "scenario_count": 1,
+                "record_count": 1,
+                "security_relevance_count": 0,
+                "authority_boundary_preserved_count": 1,
+                "expanded_authority_fields": [],
+                "decision_boundary": {
+                    "automation_allowed": False,
+                    "patch_application_allowed": False,
+                    "security_dismissal_allowed": False,
+                    "merge_authorized": False,
+                    "semantic_equivalence_claim": False,
+                },
+            },
+            REPLAY_MANIFEST: {
+                "scenario_count": 3,
+                "reporting_only": True,
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        },
+    )
+
+    benchmark = summary["live_benchmark"]
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_COLLECTION_STATUS] == "collected"
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_STATUS] == BENCHMARK_RUNTIME_PROOF_CONTRACT_REPLAYED
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_SCENARIO_COUNT] == 1
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_RECORD_COUNT] == 1
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_SECURITY_RELEVANCE_COUNT] == 0
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT] == 1
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_EXPANDED_AUTHORITY_FIELDS] == []
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_PATCH_APPLICATION_ALLOWED] is False
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_SECURITY_DISMISSAL_ALLOWED] is False
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_MERGE_AUTHORIZED] is False
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM] is False
+
+    markdown = render_markdown(summary)
+    assert "Runtime proof contract collection: `collected`" in markdown
+    assert (
+        f"Runtime proof contract status: `{BENCHMARK_RUNTIME_PROOF_CONTRACT_REPLAYED}`" in markdown
+    )
+    assert "Runtime proof contract records: `1`" in markdown
+    assert "Runtime proof contract authority-preserved records: `1`" in markdown
+    assert "Runtime proof contract expanded authority fields: `none`" in markdown
+    assert "Runtime proof contract merge authorized: `false`" in markdown
+    assert "Runtime proof contract semantic equivalence claim: `false`" in markdown
+
+
+def test_runtime_proof_summary_surfaces_benchmark_runtime_contract_authority_expansion() -> None:
+    summary = build_runtime_proof_artifacts(
+        live_benchmark_report={
+            "status": "failed",
+            "report_mode": "git_grounded_isolated_proof",
+            "scenario_count": 3,
+            "passed_count": 2,
+            "failed_count": 1,
+            "safety_boundary": {
+                "automation_allowed_count": 0,
+                "merge_authorized_count": 0,
+                "semantic_equivalence_claimed_count": 0,
+                "preserved": False,
+            },
+            BENCHMARK_RUNTIME_PROOF_CONTRACT_EVIDENCE: {
+                "collection_status": "collected",
+                "status": BENCHMARK_RUNTIME_PROOF_CONTRACT_REPLAYED,
+                "scenario_count": 1,
+                "record_count": 1,
+                "security_relevance_count": 0,
+                "authority_boundary_preserved_count": 0,
+                "expanded_authority_fields": ["merge_authorized"],
+                "decision_boundary": {
+                    "automation_allowed": False,
+                    "patch_application_allowed": False,
+                    "security_dismissal_allowed": False,
+                    "merge_authorized": False,
+                    "semantic_equivalence_claim": False,
+                },
+            },
+        },
+    )
+
+    benchmark = summary["live_benchmark"]
+    assert benchmark["boundary_preserved"] is False
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_EXPANDED_AUTHORITY_FIELDS] == ["merge_authorized"]
+    assert benchmark[BENCHMARK_RUNTIME_CONTRACT_MERGE_AUTHORIZED] is False
+
+    markdown = render_markdown(summary)
+    assert "Runtime proof contract expanded authority fields: `merge_authorized`" in markdown
+    assert "Boundary preserved: `false`" in markdown


### PR DESCRIPTION
## Summary
- Runtime proof artifacts now consume replayable benchmark contract replay evidence.
- Surfaces benchmark replay contract collection/status, scenario count, record count, security-relevant count, authority-preserved count, and expanded authority fields.
- Preserves reporting-only authority boundaries: no patch application, no security dismissal, no merge authorization, and no semantic-equivalence claim.

## Proof
- python -m sdetkit security check --root . --format json
- python -m pytest -q tests/test_pr_quality_runtime_proof_artifacts.py tests/test_replayable_benchmark_harness.py tests/test_protected_verifier.py tests/test_pr_quality_action_report.py tests/test_repo_memory.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore records contract evidence
- #1751: RepoMemory consumes contract evidence
- #1752: ProtectedVerifier consumes RepoMemory contract evidence
- #1753: PR Quality surfaces ProtectedVerifier contract evidence
- #1754: Runtime proof artifacts consume ProtectedVerifier contract evidence
- #1755: ProtectedVerifier consumes runtime proof contract evidence
- #1756: Replayable benchmark harness consumes ProtectedVerifier runtime-proof contract evidence
- #1757: Runtime proof artifacts consume replayable benchmark contract replay evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim