### PR TITLE
feat(pr-quality): consume verifier benchmark replay evidence

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -136,6 +136,18 @@ def _repo_memory_trajectory_authority_key(*parts: str) -> str:
     return "_".join(("repo", "memory", "trajectory", "authority", *parts))
 
 
+def _protected_verifier_evidence_key(*parts: str) -> str:
+    return "_".join(parts)
+
+
+PROTECTED_VERIFIER_RUNTIME_PROOF_EVIDENCE = _protected_verifier_evidence_key(
+    "runtime", "proof", "evidence"
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_REPLAY_EVIDENCE = _protected_verifier_evidence_key(
+    "benchmark", "contract", "replay", "evidence"
+)
+
+
 def _status_title(status: str) -> str:
     return {
         "green": "Green",
@@ -1453,6 +1465,15 @@ def _operator_safetygate_summary_lines(
         verifier_repo_memory.get("_".join(("failure", "vector", "contract", "evidence")))
     )
     verifier_contract_boundary = _as_dict(verifier_contract.get("decision_boundary"))
+    verifier_runtime_proof = _as_dict(
+        protected_verifier.get(PROTECTED_VERIFIER_RUNTIME_PROOF_EVIDENCE)
+    )
+    verifier_benchmark_contract = _as_dict(
+        verifier_runtime_proof.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_REPLAY_EVIDENCE)
+    )
+    verifier_benchmark_contract_boundary = _as_dict(
+        verifier_benchmark_contract.get("decision_boundary")
+    )
 
     benchmark = _as_dict(action_report.get("benchmark_report"))
     benchmark_safety = _as_dict(benchmark.get("safety_gate_evidence"))
@@ -1485,6 +1506,21 @@ def _operator_safetygate_summary_lines(
     verifier_contract_semantic_equivalence_claim = _operator_bool(
         verifier_contract_boundary.get("semantic_equivalence_claim")
     )
+    verifier_benchmark_contract_automation_allowed = _operator_bool(
+        verifier_benchmark_contract_boundary.get("automation_allowed")
+    )
+    verifier_benchmark_contract_patch_application_allowed = _operator_bool(
+        verifier_benchmark_contract_boundary.get("patch_application_allowed")
+    )
+    verifier_benchmark_contract_security_dismissal_allowed = _operator_bool(
+        verifier_benchmark_contract_boundary.get("security_dismissal_allowed")
+    )
+    verifier_benchmark_contract_merge_authorized = _operator_bool(
+        verifier_benchmark_contract_boundary.get("merge_authorized")
+    )
+    verifier_benchmark_contract_semantic_equivalence_claim = _operator_bool(
+        verifier_benchmark_contract_boundary.get("semantic_equivalence_claim")
+    )
 
     observed = any(
         [
@@ -1492,6 +1528,7 @@ def _operator_safetygate_summary_lines(
             patch_score,
             protected_verifier,
             verifier_contract,
+            verifier_benchmark_contract,
             benchmark_safety,
             memory_safety,
             trajectory_safety_records,
@@ -1508,6 +1545,7 @@ def _operator_safetygate_summary_lines(
             _operator_bool(verifier_decision.get("automation_allowed")),
             _operator_bool(verifier_boundary.get("automation_allowed")),
             verifier_contract_automation_allowed,
+            verifier_benchmark_contract_automation_allowed,
             _operator_bool(benchmark_boundary.get("automation_allowed")),
             _operator_bool(memory_boundary.get("automation_allowed")),
             _operator_bool(runtime_boundary.get("automation_allowed")),
@@ -1520,6 +1558,7 @@ def _operator_safetygate_summary_lines(
             _operator_bool(patch_boundary.get("patch_application_allowed")),
             _operator_bool(verifier_boundary.get("patch_application_allowed")),
             verifier_contract_patch_application_allowed,
+            verifier_benchmark_contract_patch_application_allowed,
             _operator_bool(benchmark_boundary.get("patch_application_allowed")),
             _operator_bool(memory_boundary.get("patch_application_allowed")),
             any(
@@ -1536,6 +1575,7 @@ def _operator_safetygate_summary_lines(
             _operator_bool(verifier_decision.get("merge_authorized")),
             _operator_bool(verifier_boundary.get("merge_authorized")),
             verifier_contract_merge_authorized,
+            verifier_benchmark_contract_merge_authorized,
             _operator_bool(benchmark_boundary.get("merge_authorized")),
             _operator_bool(memory_boundary.get("merge_authorized")),
             _operator_bool(runtime_boundary.get("merge_authorized")),
@@ -1570,6 +1610,10 @@ def _operator_safetygate_summary_lines(
                     result.append(text)
         return result
 
+    verifier_benchmark_contract_expanded_authority_fields = _operator_unique_strings(
+        verifier_benchmark_contract.get("expanded_authority_fields")
+    )
+
     allowed_files = _operator_unique_strings(
         failure_safety.get("allowed_files"),
         patch_score.get("allowed_files"),
@@ -1602,15 +1646,22 @@ def _operator_safetygate_summary_lines(
             failure_safety,
             patch_score,
             protected_verifier,
+            verifier_benchmark_contract,
             benchmark_safety,
             memory_safety,
             trajectory_safety_records,
         ]
     ) and any(
         [
-            automation_allowed and not verifier_contract_automation_allowed,
-            patch_application_allowed and not verifier_contract_patch_application_allowed,
-            merge_authorized and not verifier_contract_merge_authorized,
+            automation_allowed
+            and not verifier_contract_automation_allowed
+            and not verifier_benchmark_contract_automation_allowed,
+            patch_application_allowed
+            and not verifier_contract_patch_application_allowed
+            and not verifier_benchmark_contract_patch_application_allowed,
+            merge_authorized
+            and not verifier_contract_merge_authorized
+            and not verifier_benchmark_contract_merge_authorized,
             semantic_equivalence_proven,
         ]
     )
@@ -1623,9 +1674,21 @@ def _operator_safetygate_summary_lines(
             verifier_contract_semantic_equivalence_claim,
         ]
     )
+    benchmark_contract_authority_expanded = any(
+        [
+            verifier_benchmark_contract_automation_allowed,
+            verifier_benchmark_contract_patch_application_allowed,
+            verifier_benchmark_contract_security_dismissal_allowed,
+            verifier_benchmark_contract_merge_authorized,
+            verifier_benchmark_contract_semantic_equivalence_claim,
+            verifier_benchmark_contract_expanded_authority_fields,
+        ]
+    )
 
     if contract_authority_expanded:
         next_action = "Review-first: ProtectedVerifier RepoMemory contract evidence attempted to expand authority."
+    elif benchmark_contract_authority_expanded:
+        next_action = "Review-first: ProtectedVerifier benchmark replay contract evidence attempted to expand authority."
     elif safetygate_authority_expanded:
         next_action = "Review-first: a SafetyGate boundary attempted to expand authority."
     else:
@@ -1664,6 +1727,24 @@ def _operator_safetygate_summary_lines(
         f"`{str(verifier_contract_merge_authorized).lower()}`",
         "- ProtectedVerifier RepoMemory contract semantic equivalence claim: "
         f"`{str(verifier_contract_semantic_equivalence_claim).lower()}`",
+        "- ProtectedVerifier benchmark replay contract scenarios: "
+        f"`{_int(verifier_benchmark_contract.get('scenario_count'))}`",
+        "- ProtectedVerifier benchmark replay contract records: "
+        f"`{_int(verifier_benchmark_contract.get('record_count'))}`",
+        "- ProtectedVerifier benchmark replay contract security-relevant records: "
+        f"`{_int(verifier_benchmark_contract.get('security_relevance_count'))}`",
+        "- ProtectedVerifier benchmark replay contract authority preserved records: "
+        f"`{_int(verifier_benchmark_contract.get('authority_boundary_preserved_count'))}`",
+        "- ProtectedVerifier benchmark replay contract expanded authority fields: "
+        f"`{', '.join(verifier_benchmark_contract_expanded_authority_fields) if verifier_benchmark_contract_expanded_authority_fields else 'none'}`",
+        "- ProtectedVerifier benchmark replay contract patch application allowed: "
+        f"`{str(verifier_benchmark_contract_patch_application_allowed).lower()}`",
+        "- ProtectedVerifier benchmark replay contract security dismissal allowed: "
+        f"`{str(verifier_benchmark_contract_security_dismissal_allowed).lower()}`",
+        "- ProtectedVerifier benchmark replay contract merge authorized: "
+        f"`{str(verifier_benchmark_contract_merge_authorized).lower()}`",
+        "- ProtectedVerifier benchmark replay contract semantic equivalence claim: "
+        f"`{str(verifier_benchmark_contract_semantic_equivalence_claim).lower()}`",
         f"- Operator next action: `{next_action}`",
         f"- Operator summary automation allowed: `{str(automation_allowed).lower()}`",
         f"- Operator summary patch application allowed: `{str(patch_application_allowed).lower()}`",

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -5010,3 +5010,122 @@ def test_action_report_operator_summary_surfaces_protected_verifier_contract_aut
     assert "- ProtectedVerifier RepoMemory contract patch application allowed: `true`" in body
     assert "- Operator summary patch application allowed: `true`" in body
     assert "- Operator summary merge authorized: `false`" in body
+
+
+PV_RUNTIME_PROOF_EVIDENCE = "_".join(("runtime", "proof", "evidence"))
+PV_BENCHMARK_CONTRACT_REPLAY_EVIDENCE = "_".join(("benchmark", "contract", "replay", "evidence"))
+
+
+def _protected_verifier_benchmark_contract_replay_evidence(
+    *,
+    expanded: list[str] | None = None,
+    merge_authorized: bool = False,
+) -> dict:
+    return {
+        "collection_status": "collected",
+        "status": "_".join(("runtime", "proof", "benchmark", "contract", "replay", "observed")),
+        "scenario_count": 1,
+        "record_count": 1,
+        "security_relevance_count": 0,
+        "authority_boundary_preserved_count": 0 if expanded else 1,
+        "expanded_authority_fields": expanded or [],
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "security_dismissal_allowed": False,
+            "merge_authorized": merge_authorized,
+            "semantic_equivalence_claim": False,
+        },
+    }
+
+
+def test_action_report_operator_summary_surfaces_protected_verifier_benchmark_contract_replay_evidence() -> (
+    None
+):
+    action = {
+        "status": "safe_fix_available",
+        "primary_blocker": {},
+        "automation": {"allowed": False, "reason": "reporting only"},
+        "recommended_actions": ["Review the summary and run required proof."],
+        "protected_verifier_result": {
+            "decision": {
+                "status": "structurally_verified_candidate",
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+            PV_RUNTIME_PROOF_EVIDENCE: {
+                PV_BENCHMARK_CONTRACT_REPLAY_EVIDENCE: (
+                    _protected_verifier_benchmark_contract_replay_evidence()
+                )
+            },
+        },
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence={"checks_seen": 1, "failed_checks": []},
+    )
+
+    assert "<summary><strong>Operator SafetyGate summary</strong></summary>" in body
+    assert "- ProtectedVerifier benchmark replay contract scenarios: `1`" in body
+    assert "- ProtectedVerifier benchmark replay contract records: `1`" in body
+    assert "- ProtectedVerifier benchmark replay contract security-relevant records: `0`" in body
+    assert "- ProtectedVerifier benchmark replay contract authority preserved records: `1`" in body
+    assert "- ProtectedVerifier benchmark replay contract expanded authority fields: `none`" in body
+    assert (
+        "- ProtectedVerifier benchmark replay contract patch application allowed: `false`" in body
+    )
+    assert (
+        "- ProtectedVerifier benchmark replay contract security dismissal allowed: `false`" in body
+    )
+    assert "- ProtectedVerifier benchmark replay contract merge authorized: `false`" in body
+    assert (
+        "- ProtectedVerifier benchmark replay contract semantic equivalence claim: `false`" in body
+    )
+    assert "- Operator summary patch application allowed: `false`" in body
+    assert "- Operator summary merge authorized: `false`" in body
+
+
+def test_action_report_operator_summary_surfaces_protected_verifier_benchmark_contract_replay_authority_expansion() -> (
+    None
+):
+    action = {
+        "status": "review_first",
+        "primary_blocker": {},
+        "automation": {"allowed": False, "reason": "reporting only"},
+        "recommended_actions": ["Keep review-first."],
+        "protected_verifier_result": {
+            "decision": {
+                "status": "blocked_review_first",
+                "automation_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+            PV_RUNTIME_PROOF_EVIDENCE: {
+                PV_BENCHMARK_CONTRACT_REPLAY_EVIDENCE: (
+                    _protected_verifier_benchmark_contract_replay_evidence(
+                        expanded=["merge_authorized"],
+                        merge_authorized=True,
+                    )
+                )
+            },
+        },
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence={"checks_seen": 1, "failed_checks": []},
+    )
+
+    assert "<summary><strong>Operator SafetyGate summary</strong></summary>" in body
+    assert (
+        "- Operator next action: `Review-first: ProtectedVerifier benchmark replay contract evidence attempted to expand authority.`"
+        in body
+    )
+    assert (
+        "- ProtectedVerifier benchmark replay contract expanded authority fields: `merge_authorized`"
+        in body
+    )
+    assert "- ProtectedVerifier benchmark replay contract merge authorized: `true`" in body
+    assert "- Operator summary merge authorized: `true`" in body


### PR DESCRIPTION
## Summary
- PR Quality now consumes ProtectedVerifier benchmark replay contract evidence.
- Surfaces replay scenario count, record count, security-relevant count, authority-preserved count, expanded authority fields, and authority flags in the operator summary.
- Detects benchmark replay contract authority expansion and keeps the action review-first.
- Preserves reporting-only authority boundaries: no patch application, no security dismissal, no merge authorization, and no semantic-equivalence claim.

## Proof
- python -m sdetkit security check --root . --format json
- python -m pytest -q tests/test_pr_quality_action_report.py tests/test_protected_verifier.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_replayable_benchmark_harness.py tests/test_repo_memory.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore records contract evidence
- #1751: RepoMemory consumes contract evidence
- #1752: ProtectedVerifier consumes RepoMemory contract evidence
- #1753: PR Quality surfaces ProtectedVerifier contract evidence
- #1754: Runtime proof artifacts consume ProtectedVerifier contract evidence
- #1755: ProtectedVerifier consumes runtime proof contract evidence
- #1756: Replayable benchmark harness consumes ProtectedVerifier runtime-proof contract evidence
- #1757: Runtime proof artifacts consume replayable benchmark contract replay evidence
- #1758: ProtectedVerifier consumes runtime proof benchmark replay evidence
- #1759: PR Quality consumes ProtectedVerifier benchmark replay evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim