### PR TITLE
feat(runtime-proof): consume verifier benchmark replay evidence

### DIFF
--- a/src/sdetkit/pr_quality_runtime_proof_artifacts.py
+++ b/src/sdetkit/pr_quality_runtime_proof_artifacts.py
@@ -81,6 +81,41 @@ CONTROLLED_REVIEW_FIRST_COUNT = "_".join(("controlled", "review", "first", "coun
 FAILURE_VECTOR_CONTRACT_EVIDENCE = "_".join(("failure", "vector", "contract", "evidence"))
 SECURITY_DISMISSAL_ALLOWED = "_".join(("security", "dismissal", "allowed"))
 SEMANTIC_EQUIVALENCE_CLAIM = "_".join(("semantic", "equivalence", "claim"))
+PROTECTED_VERIFIER_RUNTIME_PROOF_EVIDENCE = "_".join(("runtime", "proof", "evidence"))
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_REPLAY_EVIDENCE = "_".join(
+    ("benchmark", "contract", "replay", "evidence")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_COLLECTION_STATUS = "_".join(
+    ("benchmark", "contract", "collection", "status")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_STATUS = "_".join(("benchmark", "contract", "status"))
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SCENARIO_COUNT = "_".join(
+    ("benchmark", "contract", "scenario", "count")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_RECORD_COUNT = "_".join(
+    ("benchmark", "contract", "record", "count")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT = "_".join(
+    ("benchmark", "contract", "security", "relevance", "count")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT = "_".join(
+    ("benchmark", "contract", "authority", "boundary", "preserved", "count")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS = "_".join(
+    ("benchmark", "contract", "expanded", "authority", "fields")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED = "_".join(
+    ("benchmark", "contract", "patch", "application", "allowed")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED = "_".join(
+    ("benchmark", "contract", "security", "dismissal", "allowed")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_MERGE_AUTHORIZED = "_".join(
+    ("benchmark", "contract", "merge", "authorized")
+)
+PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM = "_".join(
+    ("benchmark", "contract", "semantic", "equivalence", "claim")
+)
 
 JsonObject = dict[str, Any]
 
@@ -307,6 +342,11 @@ def _protected_verifier_summary(result: Mapping[str, Any]) -> JsonObject:
     repo_memory = _as_dict(payload.get("repo_memory_evidence"))
     contract = _as_dict(repo_memory.get(FAILURE_VECTOR_CONTRACT_EVIDENCE))
     contract_boundary = _as_dict(contract.get("decision_boundary"))
+    runtime_proof = _as_dict(payload.get(PROTECTED_VERIFIER_RUNTIME_PROOF_EVIDENCE))
+    benchmark_contract = _as_dict(
+        runtime_proof.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_REPLAY_EVIDENCE)
+    )
+    benchmark_contract_boundary = _as_dict(benchmark_contract.get("decision_boundary"))
 
     return {
         "collection_status": COLLECTED,
@@ -327,6 +367,39 @@ def _protected_verifier_summary(result: Mapping[str, Any]) -> JsonObject:
         "contract_merge_authorized": _bool(contract_boundary.get("merge_authorized")),
         "contract_semantic_equivalence_claim": _bool(
             contract_boundary.get(SEMANTIC_EQUIVALENCE_CLAIM)
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_COLLECTION_STATUS: _string(
+            benchmark_contract.get("collection_status")
+        )
+        or NOT_COLLECTED,
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_STATUS: _string(benchmark_contract.get("status"))
+        or NOT_COLLECTED,
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SCENARIO_COUNT: _int(
+            benchmark_contract.get("scenario_count")
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_RECORD_COUNT: _int(
+            benchmark_contract.get("record_count")
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT: _int(
+            benchmark_contract.get("security_relevance_count")
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT: _int(
+            benchmark_contract.get("authority_boundary_preserved_count")
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS: _string_list(
+            benchmark_contract.get("expanded_authority_fields")
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED: _bool(
+            benchmark_contract_boundary.get("patch_application_allowed")
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED: _bool(
+            benchmark_contract_boundary.get(SECURITY_DISMISSAL_ALLOWED)
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_MERGE_AUTHORIZED: _bool(
+            benchmark_contract_boundary.get("merge_authorized")
+        ),
+        PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM: _bool(
+            benchmark_contract_boundary.get(SEMANTIC_EQUIVALENCE_CLAIM)
         ),
         "automation_allowed": _bool(decision.get("automation_allowed"))
         or _bool(decision_boundary.get("automation_allowed")),
@@ -757,6 +830,28 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
                 f"`{str(_bool(protected_verifier.get('contract_merge_authorized'))).lower()}`",
                 "- Contract semantic equivalence claim: "
                 f"`{str(_bool(protected_verifier.get('contract_semantic_equivalence_claim'))).lower()}`",
+                "- Benchmark replay contract collection: "
+                f"`{_string(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_COLLECTION_STATUS))}`",
+                "- Benchmark replay contract status: "
+                f"`{_string(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_STATUS))}`",
+                "- Benchmark replay contract scenarios: "
+                f"`{_int(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SCENARIO_COUNT))}`",
+                "- Benchmark replay contract records: "
+                f"`{_int(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_RECORD_COUNT))}`",
+                "- Benchmark replay contract security-relevant records: "
+                f"`{_int(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT))}`",
+                "- Benchmark replay contract authority-preserved records: "
+                f"`{_int(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT))}`",
+                "- Benchmark replay contract expanded authority fields: "
+                f"`{', '.join(_string_list(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS))) or 'none'}`",
+                "- Benchmark replay contract patch application allowed: "
+                f"`{str(_bool(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED))).lower()}`",
+                "- Benchmark replay contract security dismissal allowed: "
+                f"`{str(_bool(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED))).lower()}`",
+                "- Benchmark replay contract merge authorized: "
+                f"`{str(_bool(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_MERGE_AUTHORIZED))).lower()}`",
+                "- Benchmark replay contract semantic equivalence claim: "
+                f"`{str(_bool(protected_verifier.get(PROTECTED_VERIFIER_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM))).lower()}`",
                 "- ProtectedVerifier automation allowed: "
                 f"`{str(_bool(protected_verifier.get('automation_allowed'))).lower()}`",
                 "- ProtectedVerifier merge authorized: "

--- a/tests/test_pr_quality_runtime_proof_artifacts.py
+++ b/tests/test_pr_quality_runtime_proof_artifacts.py
@@ -756,3 +756,125 @@ def test_runtime_proof_summary_surfaces_benchmark_runtime_contract_authority_exp
     markdown = render_markdown(summary)
     assert "Runtime proof contract expanded authority fields: `merge_authorized`" in markdown
     assert "Boundary preserved: `false`" in markdown
+
+
+PV_RUNTIME_PROOF_EVIDENCE = "_".join(("runtime", "proof", "evidence"))
+PV_BENCHMARK_CONTRACT_REPLAY_EVIDENCE = "_".join(("benchmark", "contract", "replay", "evidence"))
+PV_BENCHMARK_CONTRACT_COLLECTION_STATUS = "_".join(
+    ("benchmark", "contract", "collection", "status")
+)
+PV_BENCHMARK_CONTRACT_STATUS = "_".join(("benchmark", "contract", "status"))
+PV_BENCHMARK_CONTRACT_SCENARIO_COUNT = "_".join(("benchmark", "contract", "scenario", "count"))
+PV_BENCHMARK_CONTRACT_RECORD_COUNT = "_".join(("benchmark", "contract", "record", "count"))
+PV_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT = "_".join(
+    ("benchmark", "contract", "security", "relevance", "count")
+)
+PV_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT = "_".join(
+    ("benchmark", "contract", "authority", "boundary", "preserved", "count")
+)
+PV_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS = "_".join(
+    ("benchmark", "contract", "expanded", "authority", "fields")
+)
+PV_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED = "_".join(
+    ("benchmark", "contract", "patch", "application", "allowed")
+)
+PV_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED = "_".join(
+    ("benchmark", "contract", "security", "dismissal", "allowed")
+)
+PV_BENCHMARK_CONTRACT_MERGE_AUTHORIZED = "_".join(("benchmark", "contract", "merge", "authorized"))
+PV_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM = "_".join(
+    ("benchmark", "contract", "semantic", "equivalence", "claim")
+)
+
+
+def _protected_verifier_result_with_benchmark_replay_contract(
+    *,
+    expanded: list[str] | None = None,
+    merge_authorized: bool = False,
+) -> dict:
+    return {
+        "decision": {
+            "status": "structurally_verified_candidate",
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+        "decision_boundary": {
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+        PV_RUNTIME_PROOF_EVIDENCE: {
+            PV_BENCHMARK_CONTRACT_REPLAY_EVIDENCE: {
+                "collection_status": "collected",
+                "status": "_".join(
+                    ("runtime", "proof", "benchmark", "contract", "replay", "observed")
+                ),
+                "scenario_count": 1,
+                "record_count": 1,
+                "security_relevance_count": 0,
+                "authority_boundary_preserved_count": 0 if expanded else 1,
+                "expanded_authority_fields": expanded or [],
+                "decision_boundary": {
+                    "automation_allowed": False,
+                    "patch_application_allowed": False,
+                    "security_dismissal_allowed": False,
+                    "merge_authorized": merge_authorized,
+                    "semantic_equivalence_claim": False,
+                },
+            }
+        },
+    }
+
+
+def test_runtime_proof_summary_consumes_protected_verifier_benchmark_replay_contract_evidence() -> (
+    None
+):
+    summary = build_runtime_proof_artifacts(
+        protected_verifier_result=_protected_verifier_result_with_benchmark_replay_contract()
+    )
+
+    protected = summary["protected_verifier"]
+    assert protected[PV_BENCHMARK_CONTRACT_COLLECTION_STATUS] == "collected"
+    assert protected[PV_BENCHMARK_CONTRACT_SCENARIO_COUNT] == 1
+    assert protected[PV_BENCHMARK_CONTRACT_RECORD_COUNT] == 1
+    assert protected[PV_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT] == 0
+    assert protected[PV_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT] == 1
+    assert protected[PV_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS] == []
+    assert protected[PV_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED] is False
+    assert protected[PV_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED] is False
+    assert protected[PV_BENCHMARK_CONTRACT_MERGE_AUTHORIZED] is False
+    assert protected[PV_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM] is False
+    assert summary["decision_boundary"]["automation_allowed"] is False
+    assert summary["decision_boundary"]["merge_authorized"] is False
+    assert summary["decision_boundary"]["semantic_equivalence_proven"] is False
+
+    markdown = render_markdown(summary)
+    assert "Benchmark replay contract collection: `collected`" in markdown
+    assert "Benchmark replay contract scenarios: `1`" in markdown
+    assert "Benchmark replay contract expanded authority fields: `none`" in markdown
+    assert "Benchmark replay contract merge authorized: `false`" in markdown
+
+
+def test_runtime_proof_summary_surfaces_protected_verifier_benchmark_replay_contract_authority_expansion() -> (
+    None
+):
+    summary = build_runtime_proof_artifacts(
+        protected_verifier_result=_protected_verifier_result_with_benchmark_replay_contract(
+            expanded=["merge_authorized"],
+            merge_authorized=True,
+        )
+    )
+
+    protected = summary["protected_verifier"]
+    assert protected[PV_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT] == 0
+    assert protected[PV_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS] == ["merge_authorized"]
+    assert protected[PV_BENCHMARK_CONTRACT_MERGE_AUTHORIZED] is True
+    assert summary["decision_boundary"]["automation_allowed"] is False
+    assert summary["decision_boundary"]["merge_authorized"] is False
+    assert summary["decision_boundary"]["semantic_equivalence_proven"] is False
+
+    markdown = render_markdown(summary)
+    assert "Benchmark replay contract expanded authority fields: `merge_authorized`" in markdown
+    assert "Benchmark replay contract merge authorized: `true`" in markdown
+    assert "- Merge authorized: `false`" in markdown


### PR DESCRIPTION
## Summary
- Runtime proof artifacts now consume ProtectedVerifier benchmark replay contract evidence.
- Surfaces replay collection/status, scenario count, record count, security-relevant count, authority-preserved count, expanded authority fields, and authority flags.
- Keeps runtime proof output reporting-only even when upstream replay evidence reports an authority expansion.
- Preserves no patch application, no security dismissal, no merge authorization, and no semantic-equivalence claim.

## Proof
- python -m sdetkit security check --root . --format json
- python -m pytest -q tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_action_report.py tests/test_protected_verifier.py tests/test_replayable_benchmark_harness.py tests/test_repo_memory.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore records contract evidence
- #1751: RepoMemory consumes contract evidence
- #1752: ProtectedVerifier consumes RepoMemory contract evidence
- #1753: PR Quality surfaces ProtectedVerifier contract evidence
- #1754: Runtime proof artifacts consume ProtectedVerifier contract evidence
- #1755: ProtectedVerifier consumes runtime proof contract evidence
- #1756: Replayable benchmark harness consumes ProtectedVerifier runtime-proof contract evidence
- #1757: Runtime proof artifacts consume replayable benchmark contract replay evidence
- #1758: ProtectedVerifier consumes runtime proof benchmark replay evidence
- #1759: PR Quality consumes ProtectedVerifier benchmark replay evidence
- #1760: Runtime proof artifacts consume PR Quality verifier benchmark replay evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim