### PR TITLE
feat(protected-verifier): consume runtime pr quality benchmark evidence

### DIFF
--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -73,6 +73,9 @@ RUNTIME_PROOF_PROTECTED_VERIFIER_CONTRACT_AUTHORITY_VIOLATION = "_".join(
 RUNTIME_PROOF_BENCHMARK_CONTRACT_REPLAY_AUTHORITY_VIOLATION = "_".join(
     ("RUNTIME", "PROOF", "BENCHMARK", "CONTRACT", "REPLAY", "AUTHORITY", "VIOLATION")
 )
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_AUTHORITY_VIOLATION = "_".join(
+    ("RUNTIME", "PROOF", "PR", "QUALITY", "BENCHMARK", "REPLAY", "AUTHORITY", "VIOLATION")
+)
 RUNTIME_PROOF_LIVE_BENCHMARK = "_".join(("live", "benchmark"))
 RUNTIME_PROOF_BENCHMARK_CONTRACT_EVIDENCE = "_".join(
     ("runtime", "proof", "protected", "verifier", "contract", "evidence")
@@ -109,6 +112,85 @@ BENCHMARK_RUNTIME_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM = "_".join(
 )
 RUNTIME_PROOF_BENCHMARK_CONTRACT_REPLAY_OBSERVED = "_".join(
     ("runtime", "proof", "benchmark", "contract", "replay", "observed")
+)
+RUNTIME_PROOF_PROTECTED_VERIFIER = "_".join(("protected", "verifier"))
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_EVIDENCE = "_".join(
+    ("benchmark", "contract", "replay", "evidence")
+)
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_SOURCE = ".".join(
+    (
+        "runtime_proof",
+        RUNTIME_PROOF_PROTECTED_VERIFIER,
+        RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_EVIDENCE,
+    )
+)
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OBSERVED = "_".join(
+    ("runtime", "proof", "pr", "quality", "benchmark", "replay", "observed")
+)
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OUTPUT_KEY = "_".join(
+    ("pr", "quality", "benchmark", "contract", "replay", "evidence")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_COLLECTION_STATUS = "_".join(
+    ("benchmark", "contract", "collection", "status")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_STATUS = "_".join(("benchmark", "contract", "status"))
+PR_QUALITY_BENCHMARK_CONTRACT_SCENARIO_COUNT = "_".join(
+    ("benchmark", "contract", "scenario", "count")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_RECORD_COUNT = "_".join(("benchmark", "contract", "record", "count"))
+PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT = "_".join(
+    ("benchmark", "contract", "security", "relevance", "count")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT = "_".join(
+    ("benchmark", "contract", "authority", "boundary", "preserved", "count")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS = "_".join(
+    ("benchmark", "contract", "expanded", "authority", "fields")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED = "_".join(
+    ("benchmark", "contract", "patch", "application", "allowed")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED = "_".join(
+    ("benchmark", "contract", "security", "dismissal", "allowed")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_MERGE_AUTHORIZED = "_".join(
+    ("benchmark", "contract", "merge", "authorized")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM = "_".join(
+    ("benchmark", "contract", "semantic", "equivalence", "claim")
+)
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_HEADING = " ".join(
+    ("Runtime", "proof", "PR", "Quality", "benchmark", "replay", "evidence")
+)
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_AUTHORITY_MESSAGE = " ".join(
+    (
+        "Runtime",
+        "proof",
+        "PR",
+        "Quality",
+        "benchmark",
+        "replay",
+        "evidence",
+        "attempted",
+        "to",
+        "expand",
+        "verifier",
+        "authority.",
+    )
+)
+RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_MERGE_AUTHORIZED_LABEL = " ".join(
+    (
+        "Merge",
+        "authorized",
+        "by",
+        "runtime",
+        "proof",
+        "PR",
+        "Quality",
+        "benchmark",
+        "replay",
+        "evidence:",
+    )
 )
 STRUCTURALLY_VERIFIED_CANDIDATE = "_".join(("structurally", "verified", "candidate"))
 
@@ -341,6 +423,76 @@ def _runtime_proof_benchmark_contract_replay_evidence(
     }
 
 
+def _runtime_proof_pr_quality_benchmark_contract_replay_evidence(
+    runtime_proof: Mapping[str, Any],
+) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_claim": False,
+    }
+    protected_verifier = _as_dict(runtime_proof.get(RUNTIME_PROOF_PROTECTED_VERIFIER))
+    collection_status = _string(
+        protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_COLLECTION_STATUS)
+    )
+
+    if not protected_verifier or collection_status == "not_collected":
+        return {
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_SOURCE,
+            "scenario_count": 0,
+            "record_count": 0,
+            "security_relevance_count": 0,
+            "authority_boundary_preserved_count": 0,
+            "expanded_authority_fields": [],
+            "decision_boundary": denied,
+        }
+
+    boundary = {
+        "automation_allowed": False,
+        "patch_application_allowed": _bool(
+            protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED)
+        ),
+        "security_dismissal_allowed": _bool(
+            protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED)
+        ),
+        "merge_authorized": _bool(
+            protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_MERGE_AUTHORIZED)
+        ),
+        "semantic_equivalence_claim": _bool(
+            protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM)
+        ),
+    }
+    expanded = _string_list(
+        protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS)
+    )
+    for key in denied:
+        if _bool(boundary.get(key)) and key not in expanded:
+            expanded.append(key)
+
+    return {
+        "collection_status": collection_status or "collected",
+        "status": _string(protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_STATUS))
+        or RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OBSERVED,
+        "source": RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_SOURCE,
+        "scenario_count": _int(
+            protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_SCENARIO_COUNT)
+        ),
+        "record_count": _int(protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_RECORD_COUNT)),
+        "security_relevance_count": _int(
+            protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT)
+        ),
+        "authority_boundary_preserved_count": _int(
+            protected_verifier.get(PR_QUALITY_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT)
+        ),
+        "expanded_authority_fields": expanded,
+        "decision_boundary": denied,
+    }
+
+
 def _repo_memory_failure_vector_contract_evidence(
     repo_memory_profile: Mapping[str, Any],
 ) -> JsonObject:
@@ -418,6 +570,9 @@ def verify_patch(
     repo_memory = _as_dict(repo_memory_profile)
     runtime_proof_contract_evidence = _runtime_proof_protected_verifier_contract_evidence(runtime)
     benchmark_contract_replay_evidence = _runtime_proof_benchmark_contract_replay_evidence(runtime)
+    pr_quality_benchmark_contract_replay_evidence = (
+        _runtime_proof_pr_quality_benchmark_contract_replay_evidence(runtime)
+    )
     failure_vector_contract_evidence = _repo_memory_failure_vector_contract_evidence(repo_memory)
     patch_decision = _as_dict(patch_score.get("decision"))
 
@@ -462,6 +617,20 @@ def verify_patch(
                 "blocking": True,
                 "source": RUNTIME_PROOF_BENCHMARK_CONTRACT_REPLAY_SOURCE,
                 "fields": expanded_benchmark_contract_fields,
+            }
+        )
+
+    expanded_pr_quality_benchmark_contract_fields = _string_list(
+        pr_quality_benchmark_contract_replay_evidence.get("expanded_authority_fields")
+    )
+    if expanded_pr_quality_benchmark_contract_fields:
+        flags.append(
+            {
+                "code": RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_AUTHORITY_VIOLATION,
+                "message": RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_AUTHORITY_MESSAGE,
+                "blocking": True,
+                "source": RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_SOURCE,
+                "fields": expanded_pr_quality_benchmark_contract_fields,
             }
         )
 
@@ -545,6 +714,9 @@ def verify_patch(
         "runtime_proof_evidence": {
             "protected_verifier_contract_evidence": runtime_proof_contract_evidence,
             "benchmark_contract_replay_evidence": benchmark_contract_replay_evidence,
+            RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OUTPUT_KEY: (
+                pr_quality_benchmark_contract_replay_evidence
+            ),
         },
         "repo_memory_evidence": {
             "failure_vector_contract_evidence": failure_vector_contract_evidence,
@@ -837,6 +1009,10 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
     runtime_boundary = _as_dict(runtime_contract.get("decision_boundary"))
     benchmark_contract = _as_dict(runtime_proof.get("benchmark_contract_replay_evidence"))
     benchmark_boundary = _as_dict(benchmark_contract.get("decision_boundary"))
+    pr_quality_benchmark_contract = _as_dict(
+        runtime_proof.get(RUNTIME_PROOF_PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OUTPUT_KEY)
+    )
+    pr_quality_benchmark_boundary = _as_dict(pr_quality_benchmark_contract.get("decision_boundary"))
     repo_memory = _as_dict(payload.get("repo_memory_evidence"))
     vector_contract = _as_dict(repo_memory.get("failure_vector_contract_evidence"))
     vector_boundary = _as_dict(vector_contract.get("decision_boundary"))
@@ -943,6 +1119,41 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
             (
                 "- Semantic equivalence claimed by runtime proof benchmark contract replay evidence: "
                 f"`{str(_bool(benchmark_boundary.get('semantic_equivalence_claim'))).lower()}`"
+            ),
+            "",
+            f"## {RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_HEADING}",
+            "",
+            f"- Collection status: `{_string(pr_quality_benchmark_contract.get('collection_status'))}`",
+            f"- Status: `{_string(pr_quality_benchmark_contract.get('status'))}`",
+            f"- Scenarios with evidence: `{_int(pr_quality_benchmark_contract.get('scenario_count'))}`",
+            f"- Records: `{_int(pr_quality_benchmark_contract.get('record_count'))}`",
+            (
+                "- Security-relevant records: "
+                f"`{_int(pr_quality_benchmark_contract.get('security_relevance_count'))}`"
+            ),
+            (
+                "- Authority boundary preserved records: "
+                f"`{_int(pr_quality_benchmark_contract.get('authority_boundary_preserved_count'))}`"
+            ),
+            (
+                "- Expanded authority fields: "
+                f"`{', '.join(_string_list(pr_quality_benchmark_contract.get('expanded_authority_fields'))) or 'none'}`"
+            ),
+            (
+                "- Patch application allowed by runtime proof PR Quality benchmark replay evidence: "
+                f"`{str(_bool(pr_quality_benchmark_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Security dismissal allowed by runtime proof PR Quality benchmark replay evidence: "
+                f"`{str(_bool(pr_quality_benchmark_boundary.get('security_dismissal_allowed'))).lower()}`"
+            ),
+            (
+                f"- {RUNTIME_PROOF_PR_QUALITY_BENCHMARK_REPLAY_MERGE_AUTHORIZED_LABEL} "
+                f"`{str(_bool(pr_quality_benchmark_boundary.get('merge_authorized'))).lower()}`"
+            ),
+            (
+                "- Semantic equivalence claimed by runtime proof PR Quality benchmark replay evidence: "
+                f"`{str(_bool(pr_quality_benchmark_boundary.get('semantic_equivalence_claim'))).lower()}`"
             ),
             "",
             "## RepoMemory FailureVector contract evidence",

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -494,3 +494,137 @@ def test_protected_verifier_blocks_authority_expanding_runtime_proof_benchmark_c
     assert (
         "Merge authorized by runtime proof benchmark contract replay evidence: `false`" in markdown
     )
+
+
+PR_QUALITY_BENCHMARK_CONTRACT_COLLECTION_STATUS = _key(
+    ("benchmark", "contract", "collection", "status")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_STATUS = _key(("benchmark", "contract", "status"))
+PR_QUALITY_BENCHMARK_CONTRACT_SCENARIO_COUNT = _key(("benchmark", "contract", "scenario", "count"))
+PR_QUALITY_BENCHMARK_CONTRACT_RECORD_COUNT = _key(("benchmark", "contract", "record", "count"))
+PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT = _key(
+    ("benchmark", "contract", "security", "relevance", "count")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT = _key(
+    ("benchmark", "contract", "authority", "boundary", "preserved", "count")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS = _key(
+    ("benchmark", "contract", "expanded", "authority", "fields")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED = _key(
+    ("benchmark", "contract", "patch", "application", "allowed")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED = _key(
+    ("benchmark", "contract", "security", "dismissal", "allowed")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_MERGE_AUTHORIZED = _key(
+    ("benchmark", "contract", "merge", "authorized")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM = _key(
+    ("benchmark", "contract", "semantic", "equivalence", "claim")
+)
+PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OUTPUT_KEY = _key(
+    ("pr", "quality", "benchmark", "contract", "replay", "evidence")
+)
+PR_QUALITY_BENCHMARK_REPLAY_HEADING = " ".join(
+    ("Runtime", "proof", "PR", "Quality", "benchmark", "replay", "evidence")
+)
+PR_QUALITY_BENCHMARK_REPLAY_MERGE_FALSE_LINE = " ".join(
+    (
+        "Merge",
+        "authorized",
+        "by",
+        "runtime",
+        "proof",
+        "PR",
+        "Quality",
+        "benchmark",
+        "replay",
+        "evidence:",
+        "`false`",
+    )
+)
+
+
+def _runtime_proof_with_pr_quality_benchmark_contract_replay() -> dict:
+    runtime = _runtime_proof_with_protected_verifier_contract()
+    runtime["protected_verifier"].update(
+        {
+            PR_QUALITY_BENCHMARK_CONTRACT_COLLECTION_STATUS: "collected",
+            PR_QUALITY_BENCHMARK_CONTRACT_STATUS: _key(
+                ("runtime", "proof", "pr", "quality", "benchmark", "replay", "observed")
+            ),
+            PR_QUALITY_BENCHMARK_CONTRACT_SCENARIO_COUNT: 1,
+            PR_QUALITY_BENCHMARK_CONTRACT_RECORD_COUNT: 1,
+            PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_RELEVANCE_COUNT: 0,
+            PR_QUALITY_BENCHMARK_CONTRACT_AUTHORITY_BOUNDARY_PRESERVED_COUNT: 1,
+            PR_QUALITY_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS: [],
+            PR_QUALITY_BENCHMARK_CONTRACT_PATCH_APPLICATION_ALLOWED: False,
+            PR_QUALITY_BENCHMARK_CONTRACT_SECURITY_DISMISSAL_ALLOWED: False,
+            PR_QUALITY_BENCHMARK_CONTRACT_MERGE_AUTHORIZED: False,
+            PR_QUALITY_BENCHMARK_CONTRACT_SEMANTIC_EQUIVALENCE_CLAIM: False,
+        }
+    )
+    return runtime
+
+
+def test_protected_verifier_consumes_runtime_proof_pr_quality_benchmark_replay_evidence() -> None:
+    payload = verify_patch(
+        patch_score=_candidate_patch_score(),
+        runtime_proof=_runtime_proof_with_pr_quality_benchmark_contract_replay(),
+    )
+
+    evidence = payload["runtime_proof_evidence"][PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OUTPUT_KEY]
+    assert evidence["collection_status"] == "collected"
+    assert evidence["scenario_count"] == 1
+    assert evidence["record_count"] == 1
+    assert evidence["security_relevance_count"] == 0
+    assert evidence["authority_boundary_preserved_count"] == 1
+    assert evidence["expanded_authority_fields"] == []
+    assert evidence["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_claim": False,
+    }
+    assert payload["decision"]["patch_application_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+
+    markdown = render_markdown(payload)
+    assert PR_QUALITY_BENCHMARK_REPLAY_HEADING in markdown
+    assert "Scenarios with evidence: `1`" in markdown
+    assert "Expanded authority fields: `none`" in markdown
+    assert PR_QUALITY_BENCHMARK_REPLAY_MERGE_FALSE_LINE in markdown
+
+
+def test_protected_verifier_blocks_authority_expanding_runtime_proof_pr_quality_benchmark_replay_evidence() -> (
+    None
+):
+    runtime = _runtime_proof_with_pr_quality_benchmark_contract_replay()
+    runtime["protected_verifier"][PR_QUALITY_BENCHMARK_CONTRACT_EXPANDED_AUTHORITY_FIELDS] = [
+        "merge_authorized"
+    ]
+    runtime["protected_verifier"][PR_QUALITY_BENCHMARK_CONTRACT_MERGE_AUTHORIZED] = True
+
+    payload = verify_patch(
+        patch_score=_candidate_patch_score(),
+        runtime_proof=runtime,
+    )
+
+    evidence = payload["runtime_proof_evidence"][PR_QUALITY_BENCHMARK_CONTRACT_REPLAY_OUTPUT_KEY]
+    assert evidence["expanded_authority_fields"] == ["merge_authorized"]
+    assert evidence["decision_boundary"]["merge_authorized"] is False
+    assert payload["decision"]["patch_application_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False
+    assert any(
+        flag["source"].startswith("runtime_proof.protected_verifier")
+        and flag["fields"] == ["merge_authorized"]
+        for flag in payload["risk_flags"]
+    )
+
+    markdown = render_markdown(payload)
+    assert "Expanded authority fields: `merge_authorized`" in markdown
+    assert PR_QUALITY_BENCHMARK_REPLAY_MERGE_FALSE_LINE in markdown


### PR DESCRIPTION
## Summary
- ProtectedVerifier now consumes runtime proof PR Quality benchmark replay evidence.
- Surfaces PR Quality benchmark replay collection/status, scenario count, record count, security-relevant count, authority-preserved count, expanded authority fields, and authority flags.
- Blocks authority-expanding PR Quality benchmark replay evidence as review-first evidence.
- Preserves reporting-only boundaries: no patch application, no security dismissal, no merge authorization, and no semantic-equivalence claim.

## Proof
- python -m sdetkit security check --root . --format json
- python -m pytest -q tests/test_protected_verifier.py tests/test_pr_quality_runtime_proof_artifacts.py tests/test_pr_quality_action_report.py tests/test_replayable_benchmark_harness.py tests/test_repo_memory.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py -o addopts=
- make proof-after-format

## Roadmap position
- #1748: FailureVectorEngine normalized contract
- #1749: SafetyGate consumes contract
- #1750: TrajectoryStore records contract evidence
- #1751: RepoMemory consumes contract evidence
- #1752: ProtectedVerifier consumes RepoMemory contract evidence
- #1753: PR Quality surfaces ProtectedVerifier contract evidence
- #1754: Runtime proof artifacts consume ProtectedVerifier contract evidence
- #1755: ProtectedVerifier consumes runtime proof contract evidence
- #1756: Replayable benchmark harness consumes ProtectedVerifier runtime-proof contract evidence
- #1757: Runtime proof artifacts consume replayable benchmark contract replay evidence
- #1758: ProtectedVerifier consumes runtime proof benchmark replay evidence
- #1759: PR Quality consumes ProtectedVerifier benchmark replay evidence
- #1760: Runtime proof artifacts consume PR Quality verifier benchmark replay evidence
- #1761: ProtectedVerifier consumes runtime proof PR Quality benchmark replay evidence

## Authority boundary
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim