### PR TITLE
docs: polish evidence circuit artifact source map

### DIFF
--- a/docs/artifact-reference.md
+++ b/docs/artifact-reference.md
@@ -76,3 +76,35 @@ Quick rules:
 3. For recurring maintenance failures, open the `maintenance-autopilot` upload and read the report, adaptive diagnosis, safe-fix plan, and learning memory together.
 4. For human remediation steps, use [`remediation-cookbook.md`](remediation-cookbook.md) after the investigation or artifact summary points to a specific failure class.
 5. For CI upload interpretation, use [`ci-artifact-walkthrough.md`](ci-artifact-walkthrough.md).
+
+## Evidence circuit artifact source map
+
+Use this source map when a PR or workflow run references the completed #1748
+through #1761 evidence circuit. It connects the human docs to the artifact
+surfaces that reviewers should inspect first.
+
+| Review question | Open first | Then inspect | Authority posture |
+| --- | --- | --- | --- |
+| What is the completed evidence path? | [`evidence-graph-summary.md`](evidence-graph-summary.md) | [`evidence-circuit-architecture-checkpoint.md`](evidence-circuit-architecture-checkpoint.md) | Reporting-only source map |
+| How should a reviewer read the evidence? | [`operator-evidence-review-guide.md`](operator-evidence-review-guide.md) | PR Quality, Runtime Proof, and ProtectedVerifier artifacts | Human review only |
+| Which artifact explains PR-facing evidence? | PR Quality action report or review dashboard | Runtime Proof summary and ProtectedVerifier decision | Does not authorize merge |
+| Which artifact explains runtime evidence? | `runtime-proof/summary/runtime-proof-artifacts.json` | `runtime-proof/summary/runtime-proof-artifacts.md` | Does not authorize patching or dismissal |
+| Which artifact explains authority evidence? | PR Quality artifact manifest | authority evidence source map in the artifact center | Denied authority remains denied |
+| Which artifact explains replay evidence? | benchmark replay report or Runtime Proof benchmark section | ProtectedVerifier benchmark replay evidence | Replay supports review, not approval |
+
+### Evidence circuit reading order
+
+1. Start with [Evidence graph summary](evidence-graph-summary.md) for the
+   reviewer-facing source map.
+2. Use [Operator evidence review guide](operator-evidence-review-guide.md) to
+   decide which evidence source needs inspection.
+3. Open PR Quality artifacts for the maintainer-facing summary.
+4. Open Runtime Proof artifacts when runtime evidence or benchmark replay is
+   referenced.
+5. Open ProtectedVerifier output when authority boundaries are disputed.
+6. Return to the PR only after confirming patch application, security
+   dismissal, merge authorization, and semantic-equivalence claims remain
+   denied.
+
+This table is a navigation aid. It does not replace the proof command, PR
+review, or release-readiness checklist.

--- a/docs/evidence-graph-summary.md
+++ b/docs/evidence-graph-summary.md
@@ -117,5 +117,5 @@ without a distinct product surface.
 
 - [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md)
 - [Operator evidence review guide](operator-evidence-review-guide.md)
-- [Artifact reference and generated sample map](artifact-reference.md)
+- [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map)
 - [Investigation operator guide](investigation-operator-guide.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ SDETKit can now run read-only adoption and learning lanes against cloned externa
 
 - Start with [Adopt in your repository](adoption.md) for external-repo readiness and adoption-surface evidence.
 - Use [Artifact reference and generated sample map](artifact-reference.md) to understand machine-readable outputs and evidence bundles.
+- Use [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map) to map evidence-circuit docs to PR Quality, Runtime Proof, and ProtectedVerifier artifacts.
 - Use [Investigation operator guide](investigation-operator-guide.md) when a CI log, repo shape, or proof command needs review-first diagnosis.
 - Use this docs homepage and [Docs map and organization](docs-map.md) to keep radar, report, and governance tools connected to the broader roadmap.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,3 +72,4 @@ This creates a repeatable maintenance loop: **detect weak spots → summarize GH
 The evidence propagation chain from #1748 through #1761 is documented in [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md). Future work should treat that chain as complete and move toward architecture, operator review, dashboard, or release-readiness slices rather than adding another recursive consumer.
 The operator review flow for this completed circuit is documented in [Operator evidence review guide](operator-evidence-review-guide.md).
 The reviewer-facing source map for this completed circuit is documented in [Evidence graph summary](evidence-graph-summary.md).
+The artifact navigation layer for this circuit is documented in [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map).


### PR DESCRIPTION
## Summary
- Adds an evidence circuit artifact source map to the artifact reference.
- Connects evidence-circuit docs to PR Quality, Runtime Proof, ProtectedVerifier, and benchmark replay artifacts.
- Links the artifact source map from docs index, roadmap, and evidence graph summary.
- Keeps the artifact navigation layer review-first and reporting-only.

## Proof
- python -m sdetkit security check --root . --format json
- make proof-after-format

## Authority boundary
- Documentation-only
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim