### PR TITLE
docs: complete evidence circuit reporting bundle

### DIFF
--- a/docs/artifact-reference.md
+++ b/docs/artifact-reference.md
@@ -87,7 +87,7 @@ surfaces that reviewers should inspect first.
 | --- | --- | --- | --- |
 | What is the completed evidence path? | [`evidence-graph-summary.md`](evidence-graph-summary.md) | [`evidence-circuit-architecture-checkpoint.md`](evidence-circuit-architecture-checkpoint.md) | Reporting-only source map |
 | How should a reviewer read the evidence? | [`operator-evidence-review-guide.md`](operator-evidence-review-guide.md) | PR Quality, Runtime Proof, and ProtectedVerifier artifacts | Human review only |
-| Which artifact explains PR-facing evidence? | PR Quality action report or review dashboard | Runtime Proof summary and ProtectedVerifier decision | Does not authorize merge |
+| Which artifact explains PR-facing evidence? | PR Quality action report or review dashboard | [Dashboard and reporting polish](dashboard-reporting-polish.md), Runtime Proof summary, and ProtectedVerifier decision | Does not authorize merge |
 | Which artifact explains runtime evidence? | `runtime-proof/summary/runtime-proof-artifacts.json` | `runtime-proof/summary/runtime-proof-artifacts.md` | Does not authorize patching or dismissal |
 | Which artifact explains authority evidence? | PR Quality artifact manifest | authority evidence source map in the artifact center | Denied authority remains denied |
 | Which artifact explains replay evidence? | benchmark replay report or Runtime Proof benchmark section | ProtectedVerifier benchmark replay evidence | Replay supports review, not approval |
@@ -108,3 +108,17 @@ surfaces that reviewers should inspect first.
 
 This table is a navigation aid. It does not replace the proof command, PR
 review, or release-readiness checklist.
+
+## Evidence circuit review pack links
+
+After using the evidence circuit artifact source map, continue with:
+
+1. [Dashboard and reporting polish](dashboard-reporting-polish.md) for dashboard
+   reading order.
+2. [Evidence circuit review pack](evidence-circuit-review-pack.md) for the
+   complete reviewer path.
+3. [Release-readiness evidence handoff](release-readiness-evidence-handoff.md)
+   when evidence must be summarized for release review.
+
+These links are navigation aids only. They do not authorize patch automation,
+security dismissal, merge, or semantic-equivalence claims.

--- a/docs/ci-artifact-walkthrough.md
+++ b/docs/ci-artifact-walkthrough.md
@@ -52,3 +52,12 @@ Decision: <trust lane healthy / drift investigation required>
 ```
 
 For deeper troubleshooting, continue to [adoption-troubleshooting.md](adoption-troubleshooting.md).
+
+## Evidence circuit dashboard handoff
+
+When CI artifacts include PR Quality, Runtime Proof, ProtectedVerifier, or
+benchmark replay evidence, use the
+[Evidence circuit review pack](evidence-circuit-review-pack.md) after the raw
+artifact inspection. The pack maps the dashboard, artifact center, evidence
+graph, operator guide, and release-readiness handoff without granting merge,
+patch, dismissal, or semantic authority.

--- a/docs/dashboard-reporting-polish.md
+++ b/docs/dashboard-reporting-polish.md
@@ -1,0 +1,98 @@
+# Dashboard and reporting polish
+
+Use this guide when reviewing PR Quality dashboards, artifact centers, Runtime
+Proof summaries, or ProtectedVerifier output for the completed evidence circuit.
+
+The goal is to make the reporting surfaces easier to read without changing
+decision authority. This guide is documentation-only and reporting-only.
+
+## Reporting surfaces
+
+| Surface | Open when | Reviewer check |
+| --- | --- | --- |
+| PR Quality Review Dashboard | You need the fastest PR-facing summary | Confirm status, blocker, proof, artifact cards, and authority boundary |
+| PR Quality Artifact Center | You need the artifact bundle map | Confirm expected artifact inventory and authority evidence sources |
+| PR Quality Review Summary | You need markdown review context | Confirm the summary does not imply merge authorization |
+| Runtime Proof artifacts | You need runtime or benchmark evidence | Confirm denied authority fields are preserved in JSON and markdown |
+| ProtectedVerifier decision | Authority boundaries are disputed | Confirm expanded authority fields are absent or blocked |
+| Evidence graph summary | You need the completed circuit source map | Confirm evidence flow and stop condition before reading artifacts |
+
+## Dashboard reading order
+
+1. Start with the PR Quality Review Dashboard.
+2. Open the PR Quality Artifact Center when artifact completeness matters.
+3. Open Runtime Proof summaries when runtime or benchmark evidence is referenced.
+4. Open ProtectedVerifier output when the report mentions authority boundaries.
+5. Use the Evidence graph summary to confirm where each evidence source belongs.
+6. Return to the PR only after the authority boundary remains denied.
+
+## Healthy dashboard signals
+
+A healthy dashboard or reporting surface should show:
+
+- the current PR status or review status;
+- the primary blocker or an explicit no-blocker state;
+- proof commands or proof artifacts to verify;
+- artifact links or expected artifact inventory;
+- authority boundary fields;
+- reporting-only language;
+- no automatic patch application;
+- no automatic security dismissal;
+- no merge authorization;
+- no semantic-equivalence claim.
+
+## Unhealthy dashboard signals
+
+Treat a dashboard or report as blocked if it does any of these:
+
+- claims a PR is safe to merge automatically;
+- says a patch should be applied without a reviewed policy path;
+- says stale GHAS or Code Scanning alerts can be dismissed automatically;
+- claims semantic equivalence from replay evidence;
+- hides missing evidence instead of marking it not collected;
+- omits authority-boundary fields from a decision surface.
+
+## Reporting polish rules
+
+Dashboard and reporting changes should improve readability, navigation, or
+artifact discoverability. They should not create a new evidence consumer unless
+there is a distinct product surface and a concrete missing review artifact.
+
+Acceptable polish examples:
+
+- clearer dashboard section labels;
+- links from docs to the correct artifact surface;
+- explicit reading order for PR Quality, Runtime Proof, and ProtectedVerifier;
+- clearer authority-boundary language;
+- artifact inventory and source-map navigation.
+
+Non-goals:
+
+- automatic patch application;
+- automatic security dismissal;
+- automatic merge authorization;
+- semantic-equivalence proof;
+- another recursive consumer of the same benchmark replay evidence.
+
+## Related docs
+
+- [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map)
+- [Evidence graph summary](evidence-graph-summary.md)
+- [Operator evidence review guide](operator-evidence-review-guide.md)
+- [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md)
+- [CI artifact walkthrough](ci-artifact-walkthrough.md)
+
+## Complete documentation bundle
+
+Use this dashboard guide together with the full evidence review pack:
+
+- [Evidence circuit review pack](evidence-circuit-review-pack.md)
+- [Release-readiness evidence handoff](release-readiness-evidence-handoff.md)
+- [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map)
+- [Evidence graph summary](evidence-graph-summary.md)
+- [Operator evidence review guide](operator-evidence-review-guide.md)
+
+This bundle finishes the dashboard/reporting documentation layer for the
+completed evidence circuit. Future work should move to product behavior,
+artifact generation, dashboard UI polish, or release packaging rather than
+adding another recursive documentation-only consumer.

--- a/docs/docs-map.md
+++ b/docs/docs-map.md
@@ -66,3 +66,15 @@ External repositories remain learning targets, not patch targets. Default postur
 ## Diagnostic intelligence
 
 - [Cross-System Evidence Graph](evidence-graph.md)
+
+## Evidence circuit review bundle
+
+The completed evidence circuit documentation bundle consists of:
+
+- [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md)
+- [Evidence graph summary](evidence-graph-summary.md)
+- [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map)
+- [Operator evidence review guide](operator-evidence-review-guide.md)
+- [Dashboard and reporting polish](dashboard-reporting-polish.md)
+- [Evidence circuit review pack](evidence-circuit-review-pack.md)
+- [Release-readiness evidence handoff](release-readiness-evidence-handoff.md)

--- a/docs/evidence-circuit-review-pack.md
+++ b/docs/evidence-circuit-review-pack.md
@@ -1,0 +1,70 @@
+# Evidence circuit review pack
+
+This pack is the reviewer-facing landing page for the completed evidence circuit.
+Use it when a maintainer needs to move from a PR Quality dashboard to the
+supporting Runtime Proof, ProtectedVerifier, artifact, and release-readiness
+documents.
+
+This pack is documentation-only. It does not authorize automation, patch
+application, security dismissal, merge, or semantic-equivalence claims.
+
+## Open this pack when
+
+Use this page when:
+
+- a PR Quality dashboard references evidence from the completed circuit;
+- a Runtime Proof bundle includes benchmark or authority evidence;
+- a reviewer needs a compact path through the artifact source map;
+- release-readiness notes need to cite evidence without expanding authority;
+- a maintainer needs to distinguish reviewable evidence from approval.
+
+## Review path
+
+Follow this path before making a PR or release-readiness decision:
+
+1. Open [Dashboard and reporting polish](dashboard-reporting-polish.md).
+2. Open [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map).
+3. Open [Evidence graph summary](evidence-graph-summary.md).
+4. Open [Operator evidence review guide](operator-evidence-review-guide.md).
+5. Open [Release-readiness evidence handoff](release-readiness-evidence-handoff.md).
+6. Confirm that all authority boundaries remain denied.
+
+## Decision matrix
+
+| Situation | First doc | Safe outcome |
+| --- | --- | --- |
+| Reviewer needs a dashboard reading order | Dashboard and reporting polish | Continue human review |
+| Reviewer needs artifact paths | Artifact reference source map | Inspect artifacts before deciding |
+| Reviewer needs circuit context | Evidence graph summary | Confirm source and stop condition |
+| Reviewer sees authority fields | Operator evidence review guide | Block if authority expands |
+| Reviewer prepares release notes | Release-readiness evidence handoff | Cite evidence without granting authority |
+
+## Required authority checks
+
+Before accepting any dashboard or artifact summary, confirm:
+
+- patch application remains denied;
+- security dismissal remains denied;
+- merge authorization remains denied;
+- semantic-equivalence claims remain absent;
+- semantic-equivalence proof remains absent;
+- missing evidence is marked as not collected;
+- final decision remains with the human reviewer.
+
+## Finished-document checklist
+
+The documentation bundle is complete when these surfaces agree:
+
+- docs index links the review pack and dashboard polish guide;
+- roadmap points to the dashboard/reporting and release-readiness handoff;
+- artifact reference maps evidence-circuit artifacts to review actions;
+- evidence graph summary links to the dashboard and review pack;
+- operator guide explains authority-boundary review;
+- CI artifact walkthrough points reviewers back to this pack;
+- release-readiness handoff keeps evidence reporting-only.
+
+## Non-goals
+
+This pack does not add a new evidence consumer. It does not create a release
+gate. It does not replace PR review. It does not authorize automated fixes,
+dismissals, merges, or semantic-equivalence claims.

--- a/docs/evidence-graph-summary.md
+++ b/docs/evidence-graph-summary.md
@@ -118,4 +118,13 @@ without a distinct product surface.
 - [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md)
 - [Operator evidence review guide](operator-evidence-review-guide.md)
 - [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map)
+- [Dashboard and reporting polish](dashboard-reporting-polish.md)
 - [Investigation operator guide](investigation-operator-guide.md)
+
+## Review pack handoff
+
+When the evidence graph summary is not enough by itself, use the
+[Evidence circuit review pack](evidence-circuit-review-pack.md) to move from
+the source map to dashboard, artifact, operator, and release-readiness review.
+Use [Release-readiness evidence handoff](release-readiness-evidence-handoff.md)
+when the same evidence must be summarized for a release decision.

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,3 +175,6 @@ Historical and transition-era references remain intentionally secondary to first
 - [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md): documents the completed FailureVectorEngine → SafetyGate → TrajectoryStore → RepoMemory → ProtectedVerifier → PR Quality → Runtime Proof → benchmark replay circuit and the reporting-only stop condition.
 - [Operator evidence review guide](operator-evidence-review-guide.md): explains how reviewers should inspect the completed evidence circuit without granting patch, dismissal, merge, or semantic authority.
 - [Evidence graph summary](evidence-graph-summary.md): maps the completed evidence circuit into reviewer-facing source, authority, and artifact inspection steps.
+- [Dashboard and reporting polish](dashboard-reporting-polish.md): explains how to read PR Quality dashboards, artifact centers, Runtime Proof summaries, and ProtectedVerifier output without expanding authority.
+- [Evidence circuit review pack](evidence-circuit-review-pack.md): bundles the dashboard, artifact, graph, operator, and release-readiness docs into one reviewer path.
+- [Release-readiness evidence handoff](release-readiness-evidence-handoff.md): gives release reviewers a reporting-only template for PR Quality, Runtime Proof, and ProtectedVerifier evidence.

--- a/docs/operator-evidence-review-guide.md
+++ b/docs/operator-evidence-review-guide.md
@@ -153,3 +153,13 @@ Before accepting a PR that uses this evidence circuit, verify:
 ## Related source map
 
 Use [Evidence graph summary](evidence-graph-summary.md) when you need a compact source map of the completed evidence circuit before reading individual PR Quality, Runtime Proof, or ProtectedVerifier artifacts.
+
+## Documentation bundle handoff
+
+For complete reviewer navigation, pair this guide with:
+
+- [Evidence circuit review pack](evidence-circuit-review-pack.md)
+- [Dashboard and reporting polish](dashboard-reporting-polish.md)
+- [Release-readiness evidence handoff](release-readiness-evidence-handoff.md)
+
+The handoff remains review-first and reporting-only.

--- a/docs/release-readiness-evidence-handoff.md
+++ b/docs/release-readiness-evidence-handoff.md
@@ -1,0 +1,75 @@
+# Release-readiness evidence handoff
+
+Use this page when evidence from PR Quality, Runtime Proof, ProtectedVerifier,
+or the evidence graph needs to be summarized for release-readiness review.
+
+The handoff is reporting-only. It packages evidence for humans; it does not
+authorize release, merge, patch application, security dismissal, or
+semantic-equivalence claims.
+
+## Handoff inputs
+
+A complete release-readiness handoff may reference:
+
+- PR Quality Review Dashboard status;
+- PR Quality Artifact Center inventory;
+- Runtime Proof summary artifacts;
+- ProtectedVerifier decision output;
+- evidence graph summary;
+- artifact source map;
+- operator evidence review guide.
+
+## Handoff template
+
+Use this structure in release notes or command-center comments:
+
+```markdown
+### Evidence reviewed
+- PR Quality dashboard:
+- PR Quality artifact center:
+- Runtime Proof summary:
+- ProtectedVerifier decision:
+- Evidence graph/source map:
+
+### Authority boundary
+- Patch application allowed: false
+- Security dismissal allowed: false
+- Merge authorization: false
+- Semantic-equivalence claim: false
+- Semantic-equivalence proof: false
+
+### Human decision required
+- Reviewer:
+- Required proof:
+- Remaining blocker:
+```
+
+## Review rules
+
+Release-readiness language must stay factual:
+
+- say evidence is present, absent, or not collected;
+- say a blocker is reviewable or needs investigation;
+- cite artifact names or docs;
+- avoid saying evidence approves a merge;
+- avoid saying replay proves semantic equivalence;
+- avoid implying stale alerts can be dismissed automatically.
+
+## Blocked handoff
+
+A release-readiness handoff is blocked when:
+
+- any artifact grants merge authorization;
+- any report says patch application is automatic;
+- any report says security dismissal is automatic;
+- any replay evidence claims semantic equivalence;
+- missing evidence is hidden;
+- the human reviewer cannot identify the source artifact.
+
+## Related docs
+
+- [Evidence circuit review pack](evidence-circuit-review-pack.md)
+- [Dashboard and reporting polish](dashboard-reporting-polish.md)
+- [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map)
+- [Evidence graph summary](evidence-graph-summary.md)
+- [Operator evidence review guide](operator-evidence-review-guide.md)

--- a/docs/repo-health-dashboard.md
+++ b/docs/repo-health-dashboard.md
@@ -61,3 +61,11 @@ Notes:
 - **Week 4:** consolidate docs and remove stale repo artifacts
 
 Consistency beats one-time cleanup. Track trends, not just snapshots.
+
+## Evidence circuit dashboard handoff
+
+When repo-health review intersects with PR Quality, Runtime Proof, or
+ProtectedVerifier evidence, use
+[Dashboard and reporting polish](dashboard-reporting-polish.md) and
+[Evidence circuit review pack](evidence-circuit-review-pack.md) before making
+a maintenance or release-readiness decision.

--- a/docs/reporting-and-trends.md
+++ b/docs/reporting-and-trends.md
@@ -97,3 +97,11 @@ python scripts/legacy_burndown.py --format json
 The report includes grouped findings (`category`, `path`, `domain`), baseline delta math, and target tracking via `--target-reduction-pct`.
 
 `ci.sh` now runs this maturity sequence (`legacy analyzer -> burn-down -> scorecard -> scorecard contract`) in both quick and all modes for continuous governance feedback.
+
+## Evidence circuit reporting handoff
+
+For the completed evidence circuit, use
+[Dashboard and reporting polish](dashboard-reporting-polish.md) and
+[Evidence circuit review pack](evidence-circuit-review-pack.md) as the canonical
+reviewer-facing reporting path. These docs keep trend, dashboard, and artifact
+language reporting-only.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,3 +73,21 @@ The evidence propagation chain from #1748 through #1761 is documented in [Eviden
 The operator review flow for this completed circuit is documented in [Operator evidence review guide](operator-evidence-review-guide.md).
 The reviewer-facing source map for this completed circuit is documented in [Evidence graph summary](evidence-graph-summary.md).
 The artifact navigation layer for this circuit is documented in [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map).
+The dashboard/reporting review layer for this circuit is documented in [Dashboard and reporting polish](dashboard-reporting-polish.md).
+
+## Evidence circuit documentation bundle
+
+The completed #1748 through #1761 evidence circuit now has a bundled
+reviewer path:
+
+- [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md)
+- [Operator evidence review guide](operator-evidence-review-guide.md)
+- [Evidence graph summary](evidence-graph-summary.md)
+- [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map)
+- [Dashboard and reporting polish](dashboard-reporting-polish.md)
+- [Evidence circuit review pack](evidence-circuit-review-pack.md)
+- [Release-readiness evidence handoff](release-readiness-evidence-handoff.md)
+
+The next roadmap slice should move from documentation completion to a concrete
+product surface, artifact generation improvement, dashboard UI improvement, or
+release-readiness packaging task.


### PR DESCRIPTION
## Summary
- Adds the dashboard/reporting polish guide for PR Quality dashboards, artifact centers, Runtime Proof summaries, and ProtectedVerifier output.
- Adds the evidence circuit review pack as a single reviewer-facing landing path.
- Adds the release-readiness evidence handoff template.
- Cross-links the completed evidence-circuit docs through the docs index, roadmap, artifact reference, docs map, CI artifact walkthrough, reporting/trends, repo health dashboard, evidence graph summary, and operator evidence guide.

## Proof
- python -m sdetkit security check --root . --format json
- make proof-after-format

## Authority boundary
- Documentation-only
- Reporting-only
- No automatic patch application
- No automatic GHAS dismissal
- No merge authorization
- No semantic-equivalence claim