### PR TITLE
feat(job-queue): add deterministic local diagnostic job queue

### DIFF
--- a/src/sdetkit/job_queue.py
+++ b/src/sdetkit/job_queue.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.diagnostic_job import EXECUTION_MODE, validate_job
+
+SCHEMA_VERSION = "sdetkit.local_diagnostic_job_queue.v1"
+
+PENDING = "pending"
+CLAIMED = "claimed"
+COMPLETED = "completed"
+FAILED = "failed"
+ALLOWED_STATES = frozenset({PENDING, CLAIMED, COMPLETED, FAILED})
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _boundary() -> JsonObject:
+    return {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "proof_commands_executed": False,
+    }
+
+
+def _assert_boundary(payload: Mapping[str, Any], *, source: str) -> None:
+    denied = (
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "proof_commands_executed",
+    )
+    expanded = [key for key in denied if _bool(payload.get(key))]
+    if expanded:
+        raise ValueError(f"{source} expands authority: " + ", ".join(expanded))
+
+
+def _empty_queue() -> JsonObject:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_mode": EXECUTION_MODE,
+        "jobs": [],
+        "decision_boundary": _boundary(),
+    }
+
+
+def _record_sort_key(record: Mapping[str, Any]) -> tuple[str, str]:
+    job = _as_dict(record.get("job"))
+    return (_string(job.get("created_at")), _string(record.get("job_id")))
+
+
+def _normalize_artifacts(value: Mapping[str, str]) -> dict[str, str]:
+    return {
+        _string(name): _string(path)
+        for name, path in sorted(value.items())
+        if _string(name) and _string(path)
+    }
+
+
+def _sanitize_failure_reason(reason: str) -> str:
+    normalized = " ".join(_string(reason).split())
+    if not normalized:
+        raise ValueError("failed diagnostic job requires a failure reason")
+    return normalized[:500]
+
+
+def _record_for_job(job: Mapping[str, Any], *, enqueued_at: str) -> JsonObject:
+    validate_job(job)
+    job_id = _string(job.get("job_id"))
+    if not job_id:
+        raise ValueError("diagnostic job id is required")
+
+    timestamp = _string(enqueued_at) or _string(job.get("created_at"))
+    if not timestamp:
+        raise ValueError("diagnostic queue enqueue timestamp is required")
+
+    return {
+        "job_id": job_id,
+        "state": PENDING,
+        "enqueued_at": timestamp,
+        "claimed_at": "",
+        "completed_at": "",
+        "failed_at": "",
+        "job": copy.deepcopy(dict(job)),
+        "result_artifacts": {},
+        "failure_reason": "",
+        "decision_boundary": _boundary(),
+    }
+
+
+def _validate_record(record: Mapping[str, Any]) -> None:
+    job = _as_dict(record.get("job"))
+    validate_job(job)
+
+    job_id = _string(record.get("job_id"))
+    if not job_id:
+        raise ValueError("diagnostic queue record requires a job id")
+    if job_id != _string(job.get("job_id")):
+        raise ValueError("diagnostic queue record job id does not match job")
+
+    state = _string(record.get("state"))
+    if state not in ALLOWED_STATES:
+        raise ValueError(f"diagnostic queue state is not supported: {state or 'missing'}")
+
+    if not _string(record.get("enqueued_at")):
+        raise ValueError("diagnostic queue record requires enqueued_at")
+
+    _assert_boundary(
+        _as_dict(record.get("decision_boundary")),
+        source=f"diagnostic queue record {job_id}",
+    )
+
+    claimed_at = _string(record.get("claimed_at"))
+    completed_at = _string(record.get("completed_at"))
+    failed_at = _string(record.get("failed_at"))
+    result_artifacts = _as_dict(record.get("result_artifacts"))
+    failure_reason = _string(record.get("failure_reason"))
+
+    if state == PENDING:
+        if claimed_at or completed_at or failed_at or result_artifacts or failure_reason:
+            raise ValueError("pending diagnostic queue record contains terminal state evidence")
+    elif state == CLAIMED:
+        if not claimed_at:
+            raise ValueError("claimed diagnostic queue record requires claimed_at")
+        if completed_at or failed_at or result_artifacts or failure_reason:
+            raise ValueError("claimed diagnostic queue record contains terminal state evidence")
+    elif state == COMPLETED:
+        if not claimed_at or not completed_at:
+            raise ValueError(
+                "completed diagnostic queue record requires claim and completion times"
+            )
+        if not result_artifacts:
+            raise ValueError("completed diagnostic queue record requires result artifacts")
+        if failed_at or failure_reason:
+            raise ValueError("completed diagnostic queue record contains failure evidence")
+    elif state == FAILED:
+        if not claimed_at or not failed_at:
+            raise ValueError("failed diagnostic queue record requires claim and failure times")
+        if not failure_reason:
+            raise ValueError("failed diagnostic queue record requires a failure reason")
+        if completed_at or result_artifacts:
+            raise ValueError("failed diagnostic queue record contains completion evidence")
+
+
+def validate_queue(queue: Mapping[str, Any]) -> None:
+    if _string(queue.get("schema_version")) != SCHEMA_VERSION:
+        raise ValueError("diagnostic job queue schema is not supported")
+    if _string(queue.get("execution_mode")) != EXECUTION_MODE:
+        raise ValueError("diagnostic job queue execution mode must be local read-only")
+
+    _assert_boundary(
+        _as_dict(queue.get("decision_boundary")),
+        source="diagnostic job queue",
+    )
+
+    raw_jobs = queue.get("jobs")
+    if not isinstance(raw_jobs, list):
+        raise ValueError("diagnostic job queue jobs must be a list")
+
+    records = [_as_dict(item) for item in raw_jobs]
+    if any(not record for record in records):
+        raise ValueError("diagnostic job queue contains a malformed record")
+
+    seen: set[str] = set()
+    for record in records:
+        _validate_record(record)
+        job_id = _string(record.get("job_id"))
+        if job_id in seen:
+            raise ValueError(f"diagnostic job queue contains duplicate job id: {job_id}")
+        seen.add(job_id)
+
+    if records != sorted(records, key=_record_sort_key):
+        raise ValueError("diagnostic job queue records are not in deterministic order")
+
+
+def load_queue(path: Path) -> JsonObject:
+    if not path.exists():
+        return _empty_queue()
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unable to read diagnostic job queue: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in diagnostic job queue: {path}")
+
+    validate_queue(payload)
+    return copy.deepcopy(payload)
+
+
+def _write_queue(path: Path, queue: Mapping[str, Any]) -> None:
+    normalized = copy.deepcopy(dict(queue))
+    normalized["jobs"] = sorted(
+        [_as_dict(item) for item in _as_list(normalized.get("jobs"))],
+        key=_record_sort_key,
+    )
+    validate_queue(normalized)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(normalized, indent=2, sort_keys=True) + "\n"
+
+    fd, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _record_index(queue: Mapping[str, Any], job_id: str) -> int:
+    normalized_job_id = _string(job_id)
+    for index, item in enumerate(_as_list(queue.get("jobs"))):
+        record = _as_dict(item)
+        if _string(record.get("job_id")) == normalized_job_id:
+            return index
+    raise ValueError(f"unknown diagnostic queue job: {normalized_job_id or 'missing'}")
+
+
+def enqueue_job(
+    path: Path,
+    job: Mapping[str, Any],
+    *,
+    enqueued_at: str = "",
+) -> JsonObject:
+    queue = load_queue(path)
+    job_id = _string(job.get("job_id"))
+
+    if any(_string(_as_dict(item).get("job_id")) == job_id for item in _as_list(queue.get("jobs"))):
+        raise ValueError(f"duplicate diagnostic queue job: {job_id}")
+
+    record = _record_for_job(job, enqueued_at=enqueued_at)
+    jobs = _as_list(queue.get("jobs"))
+    jobs.append(record)
+    queue["jobs"] = jobs
+    _write_queue(path, queue)
+    return copy.deepcopy(record)
+
+
+def claim_job(
+    path: Path,
+    *,
+    claimed_at: str,
+    job_id: str = "",
+) -> JsonObject:
+    timestamp = _string(claimed_at)
+    if not timestamp:
+        raise ValueError("diagnostic queue claim timestamp is required")
+
+    queue = load_queue(path)
+    records = [_as_dict(item) for item in _as_list(queue.get("jobs"))]
+
+    if _string(job_id):
+        index = _record_index(queue, job_id)
+        record = records[index]
+        if _string(record.get("state")) != PENDING:
+            raise ValueError("diagnostic queue job can only be claimed from pending state")
+    else:
+        pending = [
+            (index, record)
+            for index, record in enumerate(records)
+            if _string(record.get("state")) == PENDING
+        ]
+        if not pending:
+            raise ValueError("diagnostic job queue has no pending jobs")
+        index, record = min(pending, key=lambda item: _record_sort_key(item[1]))
+
+    record["state"] = CLAIMED
+    record["claimed_at"] = timestamp
+    records[index] = record
+    queue["jobs"] = records
+    _write_queue(path, queue)
+    return copy.deepcopy(record)
+
+
+def complete_job(
+    path: Path,
+    job_id: str,
+    *,
+    result_artifacts: Mapping[str, str],
+    completed_at: str,
+) -> JsonObject:
+    timestamp = _string(completed_at)
+    if not timestamp:
+        raise ValueError("diagnostic queue completion timestamp is required")
+
+    artifacts = _normalize_artifacts(result_artifacts)
+    if not artifacts:
+        raise ValueError("completed diagnostic queue job requires result artifacts")
+
+    queue = load_queue(path)
+    records = [_as_dict(item) for item in _as_list(queue.get("jobs"))]
+    index = _record_index(queue, job_id)
+    record = records[index]
+
+    if _string(record.get("state")) != CLAIMED:
+        raise ValueError("diagnostic queue job can only complete from claimed state")
+
+    record["state"] = COMPLETED
+    record["completed_at"] = timestamp
+    record["result_artifacts"] = artifacts
+    records[index] = record
+    queue["jobs"] = records
+    _write_queue(path, queue)
+    return copy.deepcopy(record)
+
+
+def fail_job(
+    path: Path,
+    job_id: str,
+    *,
+    reason: str,
+    failed_at: str,
+) -> JsonObject:
+    timestamp = _string(failed_at)
+    if not timestamp:
+        raise ValueError("diagnostic queue failure timestamp is required")
+
+    queue = load_queue(path)
+    records = [_as_dict(item) for item in _as_list(queue.get("jobs"))]
+    index = _record_index(queue, job_id)
+    record = records[index]
+
+    if _string(record.get("state")) != CLAIMED:
+        raise ValueError("diagnostic queue job can only fail from claimed state")
+
+    record["state"] = FAILED
+    record["failed_at"] = timestamp
+    record["failure_reason"] = _sanitize_failure_reason(reason)
+    records[index] = record
+    queue["jobs"] = records
+    _write_queue(path, queue)
+    return copy.deepcopy(record)

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.diagnostic_job import build_diagnostic_job
+from sdetkit.job_queue import (
+    CLAIMED,
+    COMPLETED,
+    FAILED,
+    PENDING,
+    SCHEMA_VERSION,
+    claim_job,
+    complete_job,
+    enqueue_job,
+    fail_job,
+    load_queue,
+)
+
+
+def _job(*, head_sha: str, created_at: str) -> dict:
+    return build_diagnostic_job(
+        repo="sherif69-sa/DevS69-sdetkit",
+        base_sha="base123",
+        head_sha=head_sha,
+        event_name="pull_request",
+        pr_number=1771,
+        input_artifacts={"check_intelligence": "build/check-intelligence.json"},
+        generated_at=created_at,
+    )
+
+
+def test_enqueue_is_deterministic_file_backed_and_read_only(tmp_path: Path) -> None:
+    first_path = tmp_path / "first" / "queue.json"
+    second_path = tmp_path / "second" / "queue.json"
+    job = _job(head_sha="head123", created_at="2026-06-14T00:00:00Z")
+
+    first_record = enqueue_job(first_path, job)
+    second_record = enqueue_job(second_path, job)
+
+    assert first_record == second_record
+    assert first_path.read_bytes() == second_path.read_bytes()
+
+    queue = load_queue(first_path)
+    assert queue["schema_version"] == SCHEMA_VERSION
+    assert queue["execution_mode"] == "local_read_only"
+    assert queue["jobs"][0]["state"] == PENDING
+    assert queue["jobs"][0]["job"] == job
+    assert queue["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "proof_commands_executed": False,
+    }
+
+
+def test_enqueue_rejects_duplicate_job_id(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    job = _job(head_sha="head123", created_at="2026-06-14T00:00:00Z")
+
+    enqueue_job(path, job)
+
+    with pytest.raises(ValueError, match="duplicate diagnostic queue job"):
+        enqueue_job(path, job)
+
+
+def test_claim_order_is_created_at_then_job_id(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    later = _job(head_sha="later", created_at="2026-06-14T02:00:00Z")
+    earlier_b = _job(head_sha="earlier-b", created_at="2026-06-14T01:00:00Z")
+    earlier_a = _job(head_sha="earlier-a", created_at="2026-06-14T01:00:00Z")
+
+    enqueue_job(path, later)
+    enqueue_job(path, earlier_b)
+    enqueue_job(path, earlier_a)
+
+    expected_first = min(
+        (earlier_a, earlier_b),
+        key=lambda job: str(job["job_id"]),
+    )
+
+    claimed = claim_job(path, claimed_at="2026-06-14T03:00:00Z")
+    assert claimed["job_id"] == expected_first["job_id"]
+    assert claimed["state"] == CLAIMED
+
+    queue = load_queue(path)
+    sort_projection = [(record["job"]["created_at"], record["job_id"]) for record in queue["jobs"]]
+    assert sort_projection == sorted(sort_projection)
+
+
+def test_unknown_and_invalid_state_transitions_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    job = _job(head_sha="head123", created_at="2026-06-14T00:00:00Z")
+    enqueue_job(path, job)
+
+    with pytest.raises(ValueError, match="unknown diagnostic queue job"):
+        claim_job(
+            path,
+            job_id="diagnostic-job-unknown",
+            claimed_at="2026-06-14T01:00:00Z",
+        )
+
+    with pytest.raises(ValueError, match="only complete from claimed state"):
+        complete_job(
+            path,
+            job["job_id"],
+            result_artifacts={"worker_result": "build/result.json"},
+            completed_at="2026-06-14T02:00:00Z",
+        )
+
+    with pytest.raises(ValueError, match="only fail from claimed state"):
+        fail_job(
+            path,
+            job["job_id"],
+            reason="worker failed",
+            failed_at="2026-06-14T02:00:00Z",
+        )
+
+
+def test_completed_job_records_artifacts_and_cannot_be_reclaimed(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    job = _job(head_sha="head123", created_at="2026-06-14T00:00:00Z")
+    enqueue_job(path, job)
+    claim_job(
+        path,
+        job_id=job["job_id"],
+        claimed_at="2026-06-14T01:00:00Z",
+    )
+
+    completed = complete_job(
+        path,
+        job["job_id"],
+        result_artifacts={
+            "worker_result": "build/diagnostic-worker-result.json",
+            "vector": "build/vector/diagnostic-vector.json",
+        },
+        completed_at="2026-06-14T02:00:00Z",
+    )
+
+    assert completed["state"] == COMPLETED
+    assert completed["result_artifacts"] == {
+        "vector": "build/vector/diagnostic-vector.json",
+        "worker_result": "build/diagnostic-worker-result.json",
+    }
+
+    with pytest.raises(ValueError, match="only be claimed from pending state"):
+        claim_job(
+            path,
+            job_id=job["job_id"],
+            claimed_at="2026-06-14T03:00:00Z",
+        )
+
+
+def test_failed_job_sanitizes_reason_and_cannot_be_reclaimed(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    job = _job(head_sha="head123", created_at="2026-06-14T00:00:00Z")
+    enqueue_job(path, job)
+    claim_job(
+        path,
+        job_id=job["job_id"],
+        claimed_at="2026-06-14T01:00:00Z",
+    )
+
+    failed = fail_job(
+        path,
+        job["job_id"],
+        reason="  worker\nfailed\rwithout repository mutation  ",
+        failed_at="2026-06-14T02:00:00Z",
+    )
+
+    assert failed["state"] == FAILED
+    assert failed["failure_reason"] == "worker failed without repository mutation"
+
+    with pytest.raises(ValueError, match="only be claimed from pending state"):
+        claim_job(
+            path,
+            job_id=job["job_id"],
+            claimed_at="2026-06-14T03:00:00Z",
+        )
+
+
+def test_malformed_unsupported_and_authority_expanding_queues_fail_closed(
+    tmp_path: Path,
+) -> None:
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unable to read diagnostic job queue"):
+        load_queue(malformed)
+
+    unsupported = tmp_path / "unsupported.json"
+    unsupported.write_text(
+        json.dumps(
+            {
+                "schema_version": "unsupported",
+                "execution_mode": "local_read_only",
+                "jobs": [],
+                "decision_boundary": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema is not supported"):
+        load_queue(unsupported)
+
+    expanded = tmp_path / "expanded.json"
+    expanded.write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "execution_mode": "local_read_only",
+                "jobs": [],
+                "decision_boundary": {
+                    "automation_allowed": True,
+                    "patch_application_allowed": False,
+                    "merge_authorized": False,
+                    "semantic_equivalence_proven": False,
+                    "proof_commands_executed": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="expands authority"):
+        load_queue(expanded)
+
+
+def test_queue_never_executes_diagnostic_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sdetkit.diagnostic_job as diagnostic_job
+
+    def forbidden_worker(*args: object, **kwargs: object) -> None:
+        raise AssertionError("queue must not execute the diagnostic worker")
+
+    monkeypatch.setattr(diagnostic_job, "run_diagnostic_worker", forbidden_worker)
+
+    path = tmp_path / "queue.json"
+    job = _job(head_sha="head123", created_at="2026-06-14T00:00:00Z")
+    enqueue_job(path, job)
+    claim_job(
+        path,
+        job_id=job["job_id"],
+        claimed_at="2026-06-14T01:00:00Z",
+    )
+    complete_job(
+        path,
+        job["job_id"],
+        result_artifacts={"worker_result": "build/result.json"},
+        completed_at="2026-06-14T02:00:00Z",
+    )
+
+    assert load_queue(path)["jobs"][0]["state"] == COMPLETED


### PR DESCRIPTION
## Summary

Adds the first deterministic local `JobQueue` contract for existing `DiagnosticJob` records.

The queue is deliberately local and single-process. It establishes the job lifecycle and persistence contract before any external queue, cloud service, multi-worker orchestration, or automatic execution is considered.

## What changed

- Added `src/sdetkit/job_queue.py`.
- Added `tests/test_job_queue.py`.
- Added deterministic file-backed queue persistence.
- Added atomic temporary-file replacement.
- Added strict lifecycle transitions:
  - `pending -> claimed`
  - `claimed -> completed`
  - `claimed -> failed`
- Added deterministic claim ordering by job creation time and job ID.
- Added duplicate, unknown-job, malformed-schema, invalid-transition, and authority-expansion rejection.
- Added sanitized failure-reason evidence.
- Preserved the original validated `DiagnosticJob` payload.

## Safety and authority boundary

```text
automation_allowed=false
patch_application_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
proof_commands_executed=false
```

The queue does not:

- execute `DiagnosticWorker`;
- run proof commands;
- apply patches;
- publish a PR decision;
- authorize a merge;
- add a CLI, workflow, Make target, network service, or cloud dependency.

## Proof

```text
python -m ruff check src/sdetkit/job_queue.py tests/test_job_queue.py
python -m ruff format --check src/sdetkit/job_queue.py tests/test_job_queue.py
python -m pytest -q tests/test_job_queue.py tests/test_diagnostic_job.py tests/test_diagnostic_worker_trajectory.py -o addopts=
make proof-after-format
git diff --cached --check
```

Local result before opening this PR:

```text
focused_tests=20 passed
ruff_check=passed
ruff_format=passed
repository_proof=passed
mypy=passed
scope=2 files
```

## Scope and compatibility

```text
public_cli_changed=false
workflow_changed=false
make_target_changed=false
external_service_added=false
existing_contract_changed=false
```

## Known boundary

Concurrent multi-process claiming and external queue backends are intentionally out of scope. This PR proves the local deterministic lifecycle contract first.

## Rollback

Revert this PR. No existing public surface or stored production queue is migrated by this slice.

## Roadmap

Wave G: local deterministic `JobQueue` / worker-orchestration foundation after the existing diagnostic job, worker evidence, verifier, reporter, benchmark, trajectory, and memory contracts.
