### PR TITLE
feat(diagnostic-worker): consume local diagnostic job queue contract

### DIFF
--- a/src/sdetkit/queued_diagnostic_worker.py
+++ b/src/sdetkit/queued_diagnostic_worker.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.diagnostic_job import RESULT_JSON, run_diagnostic_worker
+from sdetkit.job_queue import claim_job, complete_job, fail_job
+
+SCHEMA_VERSION = "sdetkit.queued_diagnostic_worker.v1"
+SUPPORTED_INPUTS = frozenset(
+    {
+        "check_intelligence",
+        "evidence_graph",
+        "pr_quality_action_report",
+        "security_review",
+        "runtime_proof_artifacts",
+    }
+)
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _boundary() -> JsonObject:
+    return {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "proof_commands_executed": False,
+    }
+
+
+def _read_json_object(path: Path) -> JsonObject:
+    if not path.exists():
+        raise ValueError(f"declared queued diagnostic evidence input is missing: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"queued diagnostic evidence input is not valid JSON: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in queued diagnostic evidence input: {path}")
+
+    return payload
+
+
+def _resolve_input_path(raw_path: str, *, input_root: Path) -> Path:
+    path = Path(_string(raw_path))
+    return path if path.is_absolute() else input_root / path
+
+
+def _load_worker_inputs(
+    job: Mapping[str, Any],
+    *,
+    input_root: Path,
+) -> dict[str, JsonObject]:
+    declared = _as_dict(job.get("input_artifacts"))
+    unknown = sorted(set(declared) - SUPPORTED_INPUTS)
+
+    if unknown:
+        raise ValueError(
+            "queued diagnostic job declares unsupported evidence inputs: " + ", ".join(unknown)
+        )
+
+    return {
+        name: _read_json_object(
+            _resolve_input_path(
+                _string(raw_path),
+                input_root=input_root,
+            )
+        )
+        for name, raw_path in sorted(declared.items())
+    }
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    fd, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _result_artifacts(
+    worker_result: Mapping[str, Any],
+    *,
+    result_path: Path,
+) -> dict[str, str]:
+    artifacts = {
+        "worker_result": str(result_path),
+    }
+
+    for name, raw_path in sorted(_as_dict(worker_result.get("output_artifacts")).items()):
+        normalized_name = _string(name)
+        normalized_path = _string(raw_path)
+
+        if normalized_name and normalized_path:
+            artifacts[f"worker_{normalized_name}"] = normalized_path
+
+    return artifacts
+
+
+def run_queued_diagnostic_job(
+    queue_path: Path,
+    *,
+    claimed_at: str,
+    finished_at: str,
+    out_root: Path,
+    input_root: Path = Path("."),
+    job_id: str = "",
+) -> JsonObject:
+    if not _string(claimed_at):
+        raise ValueError("queued diagnostic worker requires claimed_at")
+
+    if not _string(finished_at):
+        raise ValueError("queued diagnostic worker requires finished_at")
+
+    claimed = claim_job(
+        queue_path,
+        claimed_at=claimed_at,
+        job_id=job_id,
+    )
+
+    claimed_job_id = _string(claimed.get("job_id"))
+    job = _as_dict(claimed.get("job"))
+    out_dir = out_root / claimed_job_id
+
+    try:
+        worker_inputs = _load_worker_inputs(
+            job,
+            input_root=input_root,
+        )
+
+        worker_result = run_diagnostic_worker(
+            job,
+            check_intelligence=worker_inputs.get("check_intelligence"),
+            evidence_graph=worker_inputs.get("evidence_graph"),
+            pr_quality_action_report=worker_inputs.get("pr_quality_action_report"),
+            security_review=worker_inputs.get("security_review"),
+            runtime_proof_artifacts=worker_inputs.get("runtime_proof_artifacts"),
+            out_dir=out_dir,
+        )
+
+        result_path = out_dir / RESULT_JSON
+
+        _write_json_atomic(
+            result_path,
+            worker_result,
+        )
+
+        completed = complete_job(
+            queue_path,
+            claimed_job_id,
+            result_artifacts=_result_artifacts(
+                worker_result,
+                result_path=result_path,
+            ),
+            completed_at=finished_at,
+        )
+
+    except Exception as exc:
+        try:
+            fail_job(
+                queue_path,
+                claimed_job_id,
+                reason=f"{type(exc).__name__}: {exc}",
+                failed_at=finished_at,
+            )
+        except Exception as transition_exc:
+            raise RuntimeError(
+                "queued diagnostic worker failed and could not record failed state"
+            ) from transition_exc
+
+        raise
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "completed",
+        "job_id": claimed_job_id,
+        "queue_record": copy.deepcopy(completed),
+        "worker_result": copy.deepcopy(worker_result),
+        "decision_boundary": _boundary(),
+        "execution": {
+            "automatic_retry": False,
+            "proof_commands_executed": False,
+            "patch_attempted": False,
+            "merge_authorized": False,
+        },
+    }

--- a/tests/test_queued_diagnostic_worker.py
+++ b/tests/test_queued_diagnostic_worker.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import sdetkit.queued_diagnostic_worker as queued_worker
+from sdetkit.diagnostic_job import build_diagnostic_job
+from sdetkit.job_queue import (
+    COMPLETED,
+    FAILED,
+    PENDING,
+    enqueue_job,
+    load_queue,
+)
+from sdetkit.queued_diagnostic_worker import (
+    SCHEMA_VERSION,
+    run_queued_diagnostic_job,
+)
+
+
+def _formatting_intelligence() -> dict:
+    return {
+        "failed_checks": [
+            {
+                "name": "PR Quality local quality gate",
+                "surface": "formatting",
+                "command": "python -m pre_commit run -a",
+                "scope": "pr_owned_only",
+                "diagnosis": {
+                    "title": "Pre-commit formatting drift",
+                    "surface": "formatting",
+                },
+                "first_failure": {
+                    "line": "ruff format..............................Failed",
+                    "line_number": 30,
+                    "tool": "ruff",
+                    "kind": "format_drift",
+                },
+                "safe_to_auto_fix": True,
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "affected_files": [
+                        "src/sdetkit/example.py",
+                    ],
+                },
+                "affected_files": [
+                    "src/sdetkit/example.py",
+                ],
+            }
+        ]
+    }
+
+
+def _job(
+    *,
+    head_sha: str,
+    created_at: str,
+    input_artifacts: dict[str, str],
+) -> dict:
+    return build_diagnostic_job(
+        repo="sherif69-sa/DevS69-sdetkit",
+        base_sha="base123",
+        head_sha=head_sha,
+        event_name="pull_request",
+        pr_number=1772,
+        input_artifacts=input_artifacts,
+        generated_at=created_at,
+    )
+
+
+def test_queued_worker_claims_runs_and_completes_job(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_path = tmp_path / "check-intelligence.json"
+
+    input_path.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    job = _job(
+        head_sha="head123",
+        created_at="2026-06-14T00:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+
+    enqueue_job(queue_path, job)
+
+    result = run_queued_diagnostic_job(
+        queue_path,
+        claimed_at="2026-06-14T01:00:00Z",
+        finished_at="2026-06-14T02:00:00Z",
+        out_root=tmp_path / "worker",
+    )
+
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["status"] == "completed"
+    assert result["job_id"] == job["job_id"]
+    assert result["worker_result"]["summary"]["diagnosis_count"] == 1
+    assert result["worker_result"]["primary_diagnosis"]["failure_surface"] == "formatting"
+
+    assert result["decision_boundary"]["automation_allowed"] is False
+    assert result["decision_boundary"]["patch_application_allowed"] is False
+    assert result["decision_boundary"]["merge_authorized"] is False
+    assert result["execution"]["automatic_retry"] is False
+    assert result["execution"]["proof_commands_executed"] is False
+    assert result["execution"]["patch_attempted"] is False
+
+    queue = load_queue(queue_path)
+    record = queue["jobs"][0]
+
+    assert record["state"] == COMPLETED
+    assert record["result_artifacts"]["worker_result"].endswith("diagnostic-worker-result.json")
+
+    result_path = tmp_path / "worker" / job["job_id"] / "diagnostic-worker-result.json"
+    vector_path = tmp_path / "worker" / job["job_id"] / "vector" / "diagnostic-vector.json"
+
+    assert result_path.exists()
+    assert vector_path.exists()
+
+
+def test_queued_worker_uses_queue_order_when_job_id_is_omitted(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_path = tmp_path / "check-intelligence.json"
+
+    input_path.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    later = _job(
+        head_sha="later",
+        created_at="2026-06-14T02:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+    earlier = _job(
+        head_sha="earlier",
+        created_at="2026-06-14T01:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+
+    enqueue_job(queue_path, later)
+    enqueue_job(queue_path, earlier)
+
+    result = run_queued_diagnostic_job(
+        queue_path,
+        claimed_at="2026-06-14T03:00:00Z",
+        finished_at="2026-06-14T04:00:00Z",
+        out_root=tmp_path / "worker",
+    )
+
+    assert result["job_id"] == earlier["job_id"]
+
+    states = {record["job_id"]: record["state"] for record in load_queue(queue_path)["jobs"]}
+
+    assert states[earlier["job_id"]] == COMPLETED
+    assert states[later["job_id"]] == PENDING
+
+
+def test_queued_worker_can_process_a_specific_pending_job(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_path = tmp_path / "check-intelligence.json"
+
+    input_path.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    first = _job(
+        head_sha="first",
+        created_at="2026-06-14T01:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+    second = _job(
+        head_sha="second",
+        created_at="2026-06-14T02:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+
+    enqueue_job(queue_path, first)
+    enqueue_job(queue_path, second)
+
+    result = run_queued_diagnostic_job(
+        queue_path,
+        claimed_at="2026-06-14T03:00:00Z",
+        finished_at="2026-06-14T04:00:00Z",
+        out_root=tmp_path / "worker",
+        job_id=second["job_id"],
+    )
+
+    assert result["job_id"] == second["job_id"]
+
+    states = {record["job_id"]: record["state"] for record in load_queue(queue_path)["jobs"]}
+
+    assert states[first["job_id"]] == PENDING
+    assert states[second["job_id"]] == COMPLETED
+
+
+def test_missing_declared_input_marks_claimed_job_failed(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+
+    job = _job(
+        head_sha="missing",
+        created_at="2026-06-14T00:00:00Z",
+        input_artifacts={
+            "check_intelligence": "missing.json",
+        },
+    )
+
+    enqueue_job(queue_path, job)
+
+    with pytest.raises(
+        ValueError,
+        match="evidence input is missing",
+    ):
+        run_queued_diagnostic_job(
+            queue_path,
+            claimed_at="2026-06-14T01:00:00Z",
+            finished_at="2026-06-14T02:00:00Z",
+            out_root=tmp_path / "worker",
+            input_root=tmp_path,
+        )
+
+    record = load_queue(queue_path)["jobs"][0]
+
+    assert record["state"] == FAILED
+    assert "ValueError" in record["failure_reason"]
+    assert "evidence input is missing" in record["failure_reason"]
+
+
+def test_unsupported_input_marks_job_failed_without_retry(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    unknown_path = tmp_path / "unknown.json"
+
+    unknown_path.write_text(
+        "{}",
+        encoding="utf-8",
+    )
+
+    job = _job(
+        head_sha="unsupported",
+        created_at="2026-06-14T00:00:00Z",
+        input_artifacts={
+            "unsupported_input": str(unknown_path),
+        },
+    )
+
+    enqueue_job(queue_path, job)
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported evidence inputs",
+    ):
+        run_queued_diagnostic_job(
+            queue_path,
+            claimed_at="2026-06-14T01:00:00Z",
+            finished_at="2026-06-14T02:00:00Z",
+            out_root=tmp_path / "worker",
+        )
+
+    record = load_queue(queue_path)["jobs"][0]
+
+    assert record["state"] == FAILED
+
+    with pytest.raises(
+        ValueError,
+        match="only be claimed from pending state",
+    ):
+        run_queued_diagnostic_job(
+            queue_path,
+            claimed_at="2026-06-14T03:00:00Z",
+            finished_at="2026-06-14T04:00:00Z",
+            out_root=tmp_path / "worker",
+            job_id=job["job_id"],
+        )
+
+
+def test_worker_exception_marks_job_failed_and_is_reraised(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_path = tmp_path / "check-intelligence.json"
+
+    input_path.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    job = _job(
+        head_sha="worker-error",
+        created_at="2026-06-14T00:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+
+    enqueue_job(queue_path, job)
+
+    def fail_worker(
+        *args: object,
+        **kwargs: object,
+    ) -> dict:
+        raise RuntimeError("bounded worker failure")
+
+    monkeypatch.setattr(
+        queued_worker,
+        "run_diagnostic_worker",
+        fail_worker,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="bounded worker failure",
+    ):
+        run_queued_diagnostic_job(
+            queue_path,
+            claimed_at="2026-06-14T01:00:00Z",
+            finished_at="2026-06-14T02:00:00Z",
+            out_root=tmp_path / "worker",
+        )
+
+    record = load_queue(queue_path)["jobs"][0]
+
+    assert record["state"] == FAILED
+    assert record["failure_reason"] == "RuntimeError: bounded worker failure"


### PR DESCRIPTION
## Summary

Adds a bounded local queue-to-diagnostic-worker handoff.

The contract claims one pending diagnostic job, loads declared JSON evidence, runs the existing read-only diagnostic worker, writes deterministic result evidence, and records the queue job as completed or failed.

## Scope

- src/sdetkit/queued_diagnostic_worker.py
- tests/test_queued_diagnostic_worker.py

## Proof

- 26 focused tests passed
- make proof-after-format passed
- Ruff passed
- Mypy passed
- git diff --check passed

## Boundaries

- automatic_retry=false
- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No cloud queue, concurrency, automatic retry, proof execution, patch application, workflow changes, or merge authorization.