### PR TITLE
feat(diagnostic-worker): add bounded local diagnostic queue runner

### DIFF
--- a/src/sdetkit/diagnostic_queue_runner.py
+++ b/src/sdetkit/diagnostic_queue_runner.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.job_queue import (
+    CLAIMED,
+    COMPLETED,
+    FAILED,
+    PENDING,
+    load_queue,
+)
+from sdetkit.queued_diagnostic_worker import run_queued_diagnostic_job
+
+SCHEMA_VERSION = "sdetkit.bounded_diagnostic_queue_runner.v1"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _records(queue: Mapping[str, Any]) -> list[JsonObject]:
+    return [_as_dict(item) for item in _as_list(queue.get("jobs"))]
+
+
+def _pending_job_ids(queue: Mapping[str, Any]) -> list[str]:
+    return [
+        _string(record.get("job_id"))
+        for record in _records(queue)
+        if _string(record.get("state")) == PENDING
+    ]
+
+
+def _record_state(
+    queue: Mapping[str, Any],
+    job_id: str,
+) -> str:
+    for record in _records(queue):
+        if _string(record.get("job_id")) == job_id:
+            return _string(record.get("state"))
+
+    return ""
+
+
+def _state_counts(queue: Mapping[str, Any]) -> dict[str, int]:
+    records = _records(queue)
+
+    return {
+        PENDING: sum(_string(record.get("state")) == PENDING for record in records),
+        CLAIMED: sum(_string(record.get("state")) == CLAIMED for record in records),
+        COMPLETED: sum(_string(record.get("state")) == COMPLETED for record in records),
+        FAILED: sum(_string(record.get("state")) == FAILED for record in records),
+    }
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "proof_commands_executed": False,
+        "automatic_retry": False,
+    }
+
+
+def run_bounded_diagnostic_queue(
+    queue_path: Path,
+    *,
+    max_jobs: int,
+    claimed_at: str,
+    finished_at: str,
+    out_root: Path,
+    input_root: Path = Path("."),
+) -> JsonObject:
+    if isinstance(max_jobs, bool) or not isinstance(max_jobs, int) or max_jobs < 1:
+        raise ValueError("bounded diagnostic queue runner requires a positive integer max_jobs")
+
+    if not _string(claimed_at):
+        raise ValueError("bounded diagnostic queue runner requires claimed_at")
+
+    if not _string(finished_at):
+        raise ValueError("bounded diagnostic queue runner requires finished_at")
+
+    successful_results: list[JsonObject] = []
+    failure: JsonObject = {}
+    jobs_attempted = 0
+    stop_reason = "max_jobs_reached"
+
+    for _ in range(max_jobs):
+        queue_before = load_queue(queue_path)
+        pending_before = _pending_job_ids(queue_before)
+
+        if not pending_before:
+            stop_reason = "no_pending_jobs"
+            break
+
+        jobs_attempted += 1
+
+        try:
+            result = run_queued_diagnostic_job(
+                queue_path,
+                claimed_at=claimed_at,
+                finished_at=finished_at,
+                out_root=out_root,
+                input_root=input_root,
+            )
+        except Exception as exc:
+            queue_after = load_queue(queue_path)
+
+            failed_job_ids = [
+                job_id for job_id in pending_before if _record_state(queue_after, job_id) == FAILED
+            ]
+
+            failure = {
+                "job_id": (failed_job_ids[0] if len(failed_job_ids) == 1 else ""),
+                "exception_type": type(exc).__name__,
+                "message": _string(exc) or type(exc).__name__,
+            }
+            stop_reason = "job_failed"
+            break
+
+        successful_results.append(copy.deepcopy(result))
+
+    final_queue = load_queue(queue_path)
+    jobs_failed = 1 if failure else 0
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "failed" if failure else "completed",
+        "stop_reason": stop_reason,
+        "max_jobs": max_jobs,
+        "jobs_attempted": jobs_attempted,
+        "jobs_completed": len(successful_results),
+        "jobs_failed": jobs_failed,
+        "successful_results": successful_results,
+        "failure": failure,
+        "queue_state_counts": _state_counts(final_queue),
+        "decision_boundary": _decision_boundary(),
+        "execution": {
+            "automatic_retry": False,
+            "proof_commands_executed": False,
+            "patch_attempted": False,
+            "merge_authorized": False,
+        },
+    }

--- a/tests/test_diagnostic_queue_runner.py
+++ b/tests/test_diagnostic_queue_runner.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.diagnostic_job import build_diagnostic_job
+from sdetkit.diagnostic_queue_runner import (
+    SCHEMA_VERSION,
+    run_bounded_diagnostic_queue,
+)
+from sdetkit.job_queue import (
+    COMPLETED,
+    FAILED,
+    PENDING,
+    enqueue_job,
+    load_queue,
+)
+
+
+def _formatting_intelligence() -> dict:
+    return {
+        "failed_checks": [
+            {
+                "name": "PR Quality local quality gate",
+                "surface": "formatting",
+                "command": "python -m pre_commit run -a",
+                "scope": "pr_owned_only",
+                "diagnosis": {
+                    "title": "Pre-commit formatting drift",
+                    "surface": "formatting",
+                },
+                "first_failure": {
+                    "line": ("ruff format..............................Failed"),
+                    "line_number": 30,
+                    "tool": "ruff",
+                    "kind": "format_drift",
+                },
+                "safe_to_auto_fix": True,
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "affected_files": [
+                        "src/sdetkit/example.py",
+                    ],
+                },
+                "affected_files": [
+                    "src/sdetkit/example.py",
+                ],
+            }
+        ]
+    }
+
+
+def _job(
+    *,
+    head_sha: str,
+    created_at: str,
+    input_artifacts: dict[str, str],
+) -> dict:
+    return build_diagnostic_job(
+        repo="sherif69-sa/DevS69-sdetkit",
+        base_sha="base123",
+        head_sha=head_sha,
+        event_name="pull_request",
+        pr_number=1773,
+        input_artifacts=input_artifacts,
+        generated_at=created_at,
+    )
+
+
+def _states(queue_path: Path) -> dict[str, str]:
+    return {record["job_id"]: record["state"] for record in load_queue(queue_path)["jobs"]}
+
+
+@pytest.mark.parametrize(
+    "max_jobs",
+    [
+        0,
+        -1,
+        True,
+    ],
+)
+def test_runner_rejects_invalid_max_jobs(
+    tmp_path: Path,
+    max_jobs: int,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="positive integer max_jobs",
+    ):
+        run_bounded_diagnostic_queue(
+            tmp_path / "queue.json",
+            max_jobs=max_jobs,
+            claimed_at="2026-06-14T01:00:00Z",
+            finished_at="2026-06-14T02:00:00Z",
+            out_root=tmp_path / "worker",
+        )
+
+
+def test_runner_rejects_missing_timestamps(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="requires claimed_at",
+    ):
+        run_bounded_diagnostic_queue(
+            tmp_path / "queue.json",
+            max_jobs=1,
+            claimed_at="",
+            finished_at="2026-06-14T02:00:00Z",
+            out_root=tmp_path / "worker",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="requires finished_at",
+    ):
+        run_bounded_diagnostic_queue(
+            tmp_path / "queue.json",
+            max_jobs=1,
+            claimed_at="2026-06-14T01:00:00Z",
+            finished_at="",
+            out_root=tmp_path / "worker",
+        )
+
+
+def test_empty_queue_stops_cleanly(
+    tmp_path: Path,
+) -> None:
+    result = run_bounded_diagnostic_queue(
+        tmp_path / "queue.json",
+        max_jobs=3,
+        claimed_at="2026-06-14T01:00:00Z",
+        finished_at="2026-06-14T02:00:00Z",
+        out_root=tmp_path / "worker",
+    )
+
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["status"] == "completed"
+    assert result["stop_reason"] == "no_pending_jobs"
+    assert result["jobs_attempted"] == 0
+    assert result["jobs_completed"] == 0
+    assert result["jobs_failed"] == 0
+    assert result["successful_results"] == []
+    assert result["failure"] == {}
+
+    assert result["queue_state_counts"] == {
+        "pending": 0,
+        "claimed": 0,
+        "completed": 0,
+        "failed": 0,
+    }
+
+    assert result["decision_boundary"]["automation_allowed"] is False
+    assert result["decision_boundary"]["patch_application_allowed"] is False
+    assert result["decision_boundary"]["merge_authorized"] is False
+    assert result["execution"]["automatic_retry"] is False
+
+
+def test_runner_processes_no_more_than_max_jobs(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_path = tmp_path / "check-intelligence.json"
+
+    input_path.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    first = _job(
+        head_sha="first",
+        created_at="2026-06-14T01:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+    second = _job(
+        head_sha="second",
+        created_at="2026-06-14T02:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+    third = _job(
+        head_sha="third",
+        created_at="2026-06-14T03:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+
+    enqueue_job(queue_path, third)
+    enqueue_job(queue_path, second)
+    enqueue_job(queue_path, first)
+
+    result = run_bounded_diagnostic_queue(
+        queue_path,
+        max_jobs=2,
+        claimed_at="2026-06-14T04:00:00Z",
+        finished_at="2026-06-14T05:00:00Z",
+        out_root=tmp_path / "worker",
+    )
+
+    assert result["status"] == "completed"
+    assert result["stop_reason"] == "max_jobs_reached"
+    assert result["jobs_attempted"] == 2
+    assert result["jobs_completed"] == 2
+    assert result["jobs_failed"] == 0
+
+    assert [item["job_id"] for item in result["successful_results"]] == [
+        first["job_id"],
+        second["job_id"],
+    ]
+
+    states = _states(queue_path)
+
+    assert states[first["job_id"]] == COMPLETED
+    assert states[second["job_id"]] == COMPLETED
+    assert states[third["job_id"]] == PENDING
+
+    assert result["queue_state_counts"] == {
+        "pending": 1,
+        "claimed": 0,
+        "completed": 2,
+        "failed": 0,
+    }
+
+
+def test_runner_stops_cleanly_after_draining_queue(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_path = tmp_path / "check-intelligence.json"
+
+    input_path.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    job = _job(
+        head_sha="single",
+        created_at="2026-06-14T01:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+
+    enqueue_job(queue_path, job)
+
+    result = run_bounded_diagnostic_queue(
+        queue_path,
+        max_jobs=3,
+        claimed_at="2026-06-14T02:00:00Z",
+        finished_at="2026-06-14T03:00:00Z",
+        out_root=tmp_path / "worker",
+    )
+
+    assert result["status"] == "completed"
+    assert result["stop_reason"] == "no_pending_jobs"
+    assert result["jobs_attempted"] == 1
+    assert result["jobs_completed"] == 1
+    assert result["jobs_failed"] == 0
+
+    assert _states(queue_path)[job["job_id"]] == COMPLETED
+
+
+def test_runner_stops_after_first_failed_job_without_retry(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    valid_input = tmp_path / "valid.json"
+
+    valid_input.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    failing = _job(
+        head_sha="failing",
+        created_at="2026-06-14T01:00:00Z",
+        input_artifacts={
+            "check_intelligence": "missing.json",
+        },
+    )
+    later = _job(
+        head_sha="later",
+        created_at="2026-06-14T02:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(valid_input),
+        },
+    )
+
+    enqueue_job(queue_path, later)
+    enqueue_job(queue_path, failing)
+
+    result = run_bounded_diagnostic_queue(
+        queue_path,
+        max_jobs=5,
+        claimed_at="2026-06-14T03:00:00Z",
+        finished_at="2026-06-14T04:00:00Z",
+        out_root=tmp_path / "worker",
+        input_root=tmp_path,
+    )
+
+    assert result["status"] == "failed"
+    assert result["stop_reason"] == "job_failed"
+    assert result["jobs_attempted"] == 1
+    assert result["jobs_completed"] == 0
+    assert result["jobs_failed"] == 1
+    assert result["successful_results"] == []
+
+    assert result["failure"]["job_id"] == failing["job_id"]
+    assert result["failure"]["exception_type"] == "ValueError"
+    assert "evidence input is missing" in result["failure"]["message"]
+
+    states = _states(queue_path)
+
+    assert states[failing["job_id"]] == FAILED
+    assert states[later["job_id"]] == PENDING
+
+    assert result["queue_state_counts"] == {
+        "pending": 1,
+        "claimed": 0,
+        "completed": 0,
+        "failed": 1,
+    }
+
+    assert result["execution"]["automatic_retry"] is False
+    assert result["execution"]["proof_commands_executed"] is False
+    assert result["execution"]["patch_attempted"] is False
+    assert result["execution"]["merge_authorized"] is False


### PR DESCRIPTION
## Summary

Adds a bounded local diagnostic queue runner that processes no more than a required positive max_jobs limit.

## Behavior

- processes pending jobs in deterministic queue order;
- stops cleanly when no pending jobs remain;
- stops after reaching max_jobs;
- stops after the first failed job;
- performs no automatic retry;
- preserves the existing queue and worker authority boundaries.

## Scope

- src/sdetkit/diagnostic_queue_runner.py
- tests/test_diagnostic_queue_runner.py

## Proof

- 34 focused tests passed
- make proof-after-format passed
- Ruff passed
- Mypy passed
- git diff --check passed

## Boundaries

- automation_allowed=false
- automatic_retry=false
- proof_commands_executed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No CLI, workflow, Make target, cloud queue, concurrent claiming, automatic retry, proof execution, patch application, or merge authorization.