### PR TITLE
feat(diagnostic-worker): add local diagnostic queue runner CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ kvcli = "sdetkit._entrypoints:kvcli"
 apigetcli = "sdetkit._entrypoints:apigetcli"
 sdetkit-test-bootstrap-contract = "sdetkit.test_bootstrap_contract:main"
 sdetkit-test-bootstrap-validate = "sdetkit.test_bootstrap_validate:main"
+sdetkit-diagnostic-queue-runner = "sdetkit.diagnostic_queue_runner_cli:main"
 
 [project.entry-points."sdetkit.notify_adapters"]
 stdout = "sdetkit.notify_plugins:stdout_adapter"

--- a/src/sdetkit/diagnostic_queue_runner_cli.py
+++ b/src/sdetkit/diagnostic_queue_runner_cli.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from sdetkit.diagnostic_queue_runner import (
+    run_bounded_diagnostic_queue,
+)
+
+SCHEMA_VERSION = "sdetkit.diagnostic_queue_runner_cli.v1"
+
+JsonObject = dict[str, Any]
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("max-jobs must be a positive integer") from exc
+
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("max-jobs must be a positive integer")
+
+    return parsed
+
+
+def parse_args(
+    argv: Sequence[str] | None = None,
+) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a bounded local diagnostic job queue and emit a deterministic JSON summary."
+        )
+    )
+
+    parser.add_argument(
+        "--queue-path",
+        required=True,
+        help="Path to the local diagnostic queue JSON file.",
+    )
+    parser.add_argument(
+        "--out-root",
+        required=True,
+        help="Directory for diagnostic worker output artifacts.",
+    )
+    parser.add_argument(
+        "--input-root",
+        required=True,
+        help="Root directory for relative evidence input paths.",
+    )
+    parser.add_argument(
+        "--max-jobs",
+        required=True,
+        type=_positive_integer,
+        help="Maximum number of pending jobs to attempt.",
+    )
+    parser.add_argument(
+        "--claimed-at",
+        required=True,
+        help="Explicit deterministic queue claim timestamp.",
+    )
+    parser.add_argument(
+        "--finished-at",
+        required=True,
+        help="Explicit deterministic queue completion timestamp.",
+    )
+
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "automation_allowed": False,
+        "automatic_retry": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _error_summary(exc: Exception) -> JsonObject:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "error",
+        "error": {
+            "exception_type": type(exc).__name__,
+            "message": _string(exc) or type(exc).__name__,
+        },
+        "decision_boundary": _decision_boundary(),
+        "execution": {
+            "automatic_retry": False,
+            "proof_commands_executed": False,
+            "patch_attempted": False,
+            "merge_authorized": False,
+        },
+    }
+
+
+def main(
+    argv: Sequence[str] | None = None,
+) -> int:
+    args = parse_args(argv)
+
+    try:
+        result = run_bounded_diagnostic_queue(
+            Path(args.queue_path),
+            max_jobs=args.max_jobs,
+            claimed_at=args.claimed_at,
+            finished_at=args.finished_at,
+            out_root=Path(args.out_root),
+            input_root=Path(args.input_root),
+        )
+    except Exception as exc:
+        print(
+            json.dumps(
+                _error_summary(exc),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 1
+
+    print(
+        json.dumps(
+            result,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    return 0 if result.get("status") == "completed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_diagnostic_queue_runner_cli.py
+++ b/tests/test_diagnostic_queue_runner_cli.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import sdetkit.diagnostic_queue_runner_cli as cli
+from sdetkit.diagnostic_queue_runner_cli import main
+
+
+def _arguments(tmp_path: Path) -> list[str]:
+    return [
+        "--queue-path",
+        str(tmp_path / "queue.json"),
+        "--out-root",
+        str(tmp_path / "worker"),
+        "--input-root",
+        str(tmp_path / "inputs"),
+        "--max-jobs",
+        "2",
+        "--claimed-at",
+        "2026-06-15T01:00:00Z",
+        "--finished-at",
+        "2026-06-15T02:00:00Z",
+    ]
+
+
+def test_cli_requires_explicit_arguments() -> None:
+    with pytest.raises(SystemExit) as exc:
+        main([])
+
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "0",
+        "-1",
+        "not-an-integer",
+    ],
+)
+def test_cli_rejects_invalid_max_jobs(
+    tmp_path: Path,
+    value: str,
+) -> None:
+    args = _arguments(tmp_path)
+    index = args.index("--max-jobs") + 1
+    args[index] = value
+
+    with pytest.raises(SystemExit) as exc:
+        main(args)
+
+    assert exc.value.code == 2
+
+
+def test_cli_runs_empty_queue_and_emits_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = main(_arguments(tmp_path))
+
+    assert result == 0
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["status"] == "completed"
+    assert payload["stop_reason"] == "no_pending_jobs"
+    assert payload["max_jobs"] == 2
+    assert payload["jobs_attempted"] == 0
+    assert payload["jobs_completed"] == 0
+    assert payload["jobs_failed"] == 0
+
+    assert payload["decision_boundary"]["automation_allowed"] is False
+    assert payload["decision_boundary"]["merge_authorized"] is False
+    assert payload["execution"]["automatic_retry"] is False
+
+
+def test_cli_passes_explicit_arguments_to_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_runner(
+        queue_path: Path,
+        *,
+        max_jobs: int,
+        claimed_at: str,
+        finished_at: str,
+        out_root: Path,
+        input_root: Path,
+    ) -> dict[str, Any]:
+        captured.update(
+            {
+                "queue_path": queue_path,
+                "max_jobs": max_jobs,
+                "claimed_at": claimed_at,
+                "finished_at": finished_at,
+                "out_root": out_root,
+                "input_root": input_root,
+            }
+        )
+
+        return {
+            "schema_version": "runner.v1",
+            "status": "completed",
+            "stop_reason": "max_jobs_reached",
+        }
+
+    monkeypatch.setattr(
+        cli,
+        "run_bounded_diagnostic_queue",
+        fake_runner,
+    )
+
+    result = main(_arguments(tmp_path))
+
+    assert result == 0
+    assert captured == {
+        "queue_path": tmp_path / "queue.json",
+        "max_jobs": 2,
+        "claimed_at": "2026-06-15T01:00:00Z",
+        "finished_at": "2026-06-15T02:00:00Z",
+        "out_root": tmp_path / "worker",
+        "input_root": tmp_path / "inputs",
+    }
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["status"] == "completed"
+
+
+def test_cli_returns_one_for_runner_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_runner(
+        *args: object,
+        **kwargs: object,
+    ) -> dict[str, Any]:
+        return {
+            "schema_version": "runner.v1",
+            "status": "failed",
+            "stop_reason": "job_failed",
+            "jobs_attempted": 1,
+            "jobs_completed": 0,
+            "jobs_failed": 1,
+        }
+
+    monkeypatch.setattr(
+        cli,
+        "run_bounded_diagnostic_queue",
+        fake_runner,
+    )
+
+    result = main(_arguments(tmp_path))
+
+    assert result == 1
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["status"] == "failed"
+    assert payload["stop_reason"] == "job_failed"
+
+
+def test_cli_emits_deterministic_error_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_runner(
+        *args: object,
+        **kwargs: object,
+    ) -> dict[str, Any]:
+        raise ValueError("malformed local queue")
+
+    monkeypatch.setattr(
+        cli,
+        "run_bounded_diagnostic_queue",
+        fail_runner,
+    )
+
+    result = main(_arguments(tmp_path))
+
+    assert result == 1
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == {
+        "schema_version": ("sdetkit.diagnostic_queue_runner_cli.v1"),
+        "status": "error",
+        "error": {
+            "exception_type": "ValueError",
+            "message": "malformed local queue",
+        },
+        "decision_boundary": {
+            "automation_allowed": False,
+            "automatic_retry": False,
+            "proof_commands_executed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+        "execution": {
+            "automatic_retry": False,
+            "proof_commands_executed": False,
+            "patch_attempted": False,
+            "merge_authorized": False,
+        },
+    }
+
+
+def test_project_registers_queue_runner_script() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert (
+        'sdetkit-diagnostic-queue-runner = "sdetkit.diagnostic_queue_runner_cli:main"' in pyproject
+    )


### PR DESCRIPTION
## Summary

Adds an explicit local CLI for the bounded diagnostic queue runner.

The CLI requires all queue paths, deterministic timestamps, and the positive max-jobs bound to be provided explicitly. It emits a deterministic JSON summary and exposes no workflow or cloud integration.

## Scope

- pyproject.toml
- src/sdetkit/diagnostic_queue_runner_cli.py
- tests/test_diagnostic_queue_runner_cli.py

## CLI contract

- command: sdetkit-diagnostic-queue-runner
- required queue path
- required output root
- required input root
- required positive max-jobs
- required claimed-at timestamp
- required finished-at timestamp
- deterministic JSON stdout
- success exit code: 0
- runner failure exit code: 1
- usage error exit code: 2

## Proof

- 43 focused tests passed
- direct empty-queue CLI execution passed
- make proof-after-format passed
- Ruff passed
- Mypy passed
- git diff --check passed

## Authority boundaries

- automation_allowed=false
- automatic_retry=false
- proof_commands_executed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No workflow exposure, cloud queue, concurrent claiming, automatic retry, proof execution, patch application, PR decision, or merge authorization.