### PR TITLE
feat(diagnostic-worker): record queued worker trajectory artifacts

### DIFF
--- a/src/sdetkit/queued_diagnostic_worker.py
+++ b/src/sdetkit/queued_diagnostic_worker.py
@@ -9,9 +9,16 @@ from pathlib import Path
 from typing import Any
 
 from sdetkit.diagnostic_job import RESULT_JSON, run_diagnostic_worker
+from sdetkit.diagnostic_worker_trajectory import (
+    build_worker_trajectory_records,
+)
+from sdetkit.diagnostic_worker_trajectory import (
+    write_artifacts as write_worker_trajectory_artifacts,
+)
 from sdetkit.job_queue import claim_job, complete_job, fail_job
 
 SCHEMA_VERSION = "sdetkit.queued_diagnostic_worker.v1"
+TRAJECTORY_DIR = "trajectory"
 SUPPORTED_INPUTS = frozenset(
     {
         "check_intelligence",
@@ -111,10 +118,55 @@ def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
         raise
 
 
+def _diagnostic_vector_path(
+    worker_result: Mapping[str, Any],
+) -> Path:
+    candidates = sorted(
+        {
+            normalized
+            for raw_path in _as_dict(worker_result.get("output_artifacts")).values()
+            if (normalized := _string(raw_path))
+            and Path(normalized).name == "diagnostic-vector.json"
+        }
+    )
+
+    if len(candidates) != 1:
+        raise ValueError("queued diagnostic worker requires exactly one diagnostic vector artifact")
+
+    return Path(candidates[0])
+
+
+def _record_worker_trajectory(
+    *,
+    job: Mapping[str, Any],
+    worker_result: Mapping[str, Any],
+    out_dir: Path,
+) -> JsonObject:
+    diagnostic_vector = _read_json_object(_diagnostic_vector_path(worker_result))
+
+    records = build_worker_trajectory_records(
+        job=job,
+        worker_result=worker_result,
+        diagnostic_vector=diagnostic_vector,
+        repo=(_string(job.get("repo")) or _string(job.get("repository"))),
+        branch=_string(job.get("branch")),
+        commit_sha=(_string(job.get("head_sha")) or _string(job.get("commit_sha"))),
+        pr_number=int(job.get("pr_number") or 0),
+        generated_at=_string(job.get("created_at")),
+    )
+
+    return write_worker_trajectory_artifacts(
+        records,
+        worker_result=worker_result,
+        out_dir=out_dir / TRAJECTORY_DIR,
+    )
+
+
 def _result_artifacts(
     worker_result: Mapping[str, Any],
     *,
     result_path: Path,
+    trajectory_payload: Mapping[str, Any],
 ) -> dict[str, str]:
     artifacts = {
         "worker_result": str(result_path),
@@ -126,6 +178,13 @@ def _result_artifacts(
 
         if normalized_name and normalized_path:
             artifacts[f"worker_{normalized_name}"] = normalized_path
+
+    for name, raw_path in sorted(_as_dict(trajectory_payload.get("artifacts")).items()):
+        normalized_name = _string(name)
+        normalized_path = _string(raw_path)
+
+        if normalized_name and normalized_path:
+            artifacts[normalized_name] = normalized_path
 
     return artifacts
 
@@ -178,12 +237,19 @@ def run_queued_diagnostic_job(
             worker_result,
         )
 
+        trajectory_payload = _record_worker_trajectory(
+            job=job,
+            worker_result=worker_result,
+            out_dir=out_dir,
+        )
+
         completed = complete_job(
             queue_path,
             claimed_job_id,
             result_artifacts=_result_artifacts(
                 worker_result,
                 result_path=result_path,
+                trajectory_payload=trajectory_payload,
             ),
             completed_at=finished_at,
         )
@@ -209,6 +275,7 @@ def run_queued_diagnostic_job(
         "job_id": claimed_job_id,
         "queue_record": copy.deepcopy(completed),
         "worker_result": copy.deepcopy(worker_result),
+        "trajectory": copy.deepcopy(trajectory_payload),
         "decision_boundary": _boundary(),
         "execution": {
             "automatic_retry": False,

--- a/tests/test_queued_diagnostic_worker.py
+++ b/tests/test_queued_diagnostic_worker.py
@@ -121,8 +121,35 @@ def test_queued_worker_claims_runs_and_completes_job(
     result_path = tmp_path / "worker" / job["job_id"] / "diagnostic-worker-result.json"
     vector_path = tmp_path / "worker" / job["job_id"] / "vector" / "diagnostic-vector.json"
 
+    trajectory_jsonl = (
+        tmp_path / "worker" / job["job_id"] / "trajectory" / "diagnostic-worker-trajectory.jsonl"
+    )
+    trajectory_summary = (
+        tmp_path
+        / "worker"
+        / job["job_id"]
+        / "trajectory"
+        / "diagnostic-worker-trajectory-summary.json"
+    )
+    trajectory_markdown = (
+        tmp_path / "worker" / job["job_id"] / "trajectory" / "diagnostic-worker-trajectory.md"
+    )
+
     assert result_path.exists()
     assert vector_path.exists()
+    assert trajectory_jsonl.exists()
+    assert trajectory_summary.exists()
+    assert trajectory_markdown.exists()
+
+    assert result["trajectory"]["summary"]["status"] == "recorded"
+    assert result["trajectory"]["summary"]["reporting_only"] is True
+    assert result["trajectory"]["summary"]["current_pr_decision_input"] is False
+    assert result["trajectory"]["summary"]["automation_allowed"] is False
+    assert result["trajectory"]["summary"]["merge_authorized"] is False
+
+    assert "diagnostic_worker_trajectory_jsonl" in record["result_artifacts"]
+    assert "diagnostic_worker_trajectory_summary_json" in record["result_artifacts"]
+    assert "diagnostic_worker_trajectory_markdown" in record["result_artifacts"]
 
 
 def test_queued_worker_uses_queue_order_when_job_id_is_omitted(
@@ -346,3 +373,54 @@ def test_worker_exception_marks_job_failed_and_is_reraised(
 
     assert record["state"] == FAILED
     assert record["failure_reason"] == "RuntimeError: bounded worker failure"
+
+
+def test_trajectory_recording_failure_marks_job_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_path = tmp_path / "check-intelligence.json"
+
+    input_path.write_text(
+        json.dumps(_formatting_intelligence()),
+        encoding="utf-8",
+    )
+
+    job = _job(
+        head_sha="trajectory-error",
+        created_at="2026-06-14T00:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(input_path),
+        },
+    )
+
+    enqueue_job(queue_path, job)
+
+    def fail_trajectory_writer(
+        *args: object,
+        **kwargs: object,
+    ) -> dict:
+        raise RuntimeError("bounded trajectory recording failure")
+
+    monkeypatch.setattr(
+        queued_worker,
+        "write_worker_trajectory_artifacts",
+        fail_trajectory_writer,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="bounded trajectory recording failure",
+    ):
+        run_queued_diagnostic_job(
+            queue_path,
+            claimed_at="2026-06-14T01:00:00Z",
+            finished_at="2026-06-14T02:00:00Z",
+            out_root=tmp_path / "worker",
+        )
+
+    record = load_queue(queue_path)["jobs"][0]
+
+    assert record["state"] == FAILED
+    assert record["failure_reason"] == ("RuntimeError: bounded trajectory recording failure")


### PR DESCRIPTION
## Summary

Records deterministic reporting-only trajectory artifacts after a queued diagnostic worker completes successfully.

## Scope

- src/sdetkit/queued_diagnostic_worker.py
- tests/test_queued_diagnostic_worker.py

## Behavior

- reuses the existing diagnostic worker trajectory writer
- writes deterministic JSONL, JSON summary, and Markdown artifacts
- registers trajectory paths in the completed queue record
- marks the queue job failed if trajectory recording fails
- keeps trajectory evidence reporting-only
- performs no automatic retry

## Proof

- 44 focused tests passed
- full test suite passed: 4284 passed, 1 skipped, 3 deselected
- make proof-after-format passed
- Ruff passed
- Mypy passed
- exact two-file scope verified

## Authority boundaries

- trajectory_reporting_only=true
- current_pr_decision_input=false
- automation_allowed=false
- automatic_retry=false
- proof_commands_executed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No workflow exposure, RepoMemory ingestion, current-run decision authority, cloud dependency, retries, proof execution, patch application, or merge authorization.