### PR TITLE
feat(artifacts): index local diagnostic queue contracts

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -26,6 +26,83 @@
       "stability": "public"
     },
     {
+      "id": "local-diagnostic-queue-json",
+      "path": "build/local-diagnostic-queue/queue.json",
+      "produced_by": "sdetkit-diagnostic-queue-runner --queue-path build/local-diagnostic-queue/queue.json --out-root build/local-diagnostic-queue/worker --input-root build/local-diagnostic-queue/inputs --max-jobs <count> --claimed-at <timestamp> --finished-at <timestamp>",
+      "schema_version": "sdetkit.local_diagnostic_job_queue.v1",
+      "required_fields": [
+        "schema_version",
+        "execution_mode",
+        "jobs",
+        "decision_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "diagnostic-worker-result-json",
+      "path": "build/local-diagnostic-queue/worker/<job-id>/diagnostic-worker-result.json",
+      "produced_by": "sdetkit-diagnostic-queue-runner --queue-path build/local-diagnostic-queue/queue.json --out-root build/local-diagnostic-queue/worker --input-root build/local-diagnostic-queue/inputs --max-jobs <count> --claimed-at <timestamp> --finished-at <timestamp>",
+      "schema_version": "sdetkit.diagnostic_worker_result.v1",
+      "required_fields": [
+        "schema_version",
+        "job_id",
+        "job_type",
+        "worker",
+        "status",
+        "execution_mode",
+        "summary",
+        "primary_diagnosis",
+        "output_artifacts",
+        "decision_boundary",
+        "execution"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "diagnostic-worker-trajectory-jsonl",
+      "path": "build/local-diagnostic-queue/worker/<job-id>/trajectory/diagnostic-worker-trajectory.jsonl",
+      "produced_by": "sdetkit-diagnostic-queue-runner --queue-path build/local-diagnostic-queue/queue.json --out-root build/local-diagnostic-queue/worker --input-root build/local-diagnostic-queue/inputs --max-jobs <count> --claimed-at <timestamp> --finished-at <timestamp>",
+      "schema_version": "sdetkit.trajectory.v1",
+      "required_fields": [
+        "schema_version",
+        "trajectory_id",
+        "environment",
+        "diagnosis",
+        "decision",
+        "response",
+        "fix",
+        "proof",
+        "final_result",
+        "learned_pattern",
+        "worker_evidence"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "diagnostic-worker-trajectory-summary-json",
+      "path": "build/local-diagnostic-queue/worker/<job-id>/trajectory/diagnostic-worker-trajectory-summary.json",
+      "produced_by": "sdetkit-diagnostic-queue-runner --queue-path build/local-diagnostic-queue/queue.json --out-root build/local-diagnostic-queue/worker --input-root build/local-diagnostic-queue/inputs --max-jobs <count> --claimed-at <timestamp> --finished-at <timestamp>",
+      "schema_version": "sdetkit.diagnostic_worker_trajectory.v1",
+      "required_fields": [
+        "schema_version",
+        "trajectory_schema_version",
+        "status",
+        "record_count",
+        "review_first_count",
+        "observed_safe_fix_candidate_count",
+        "worker_result_status",
+        "trajectory_jsonl",
+        "reporting_only",
+        "current_pr_decision_input",
+        "proof_commands_executed",
+        "patch_application_allowed",
+        "automation_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "diagnostic-signal-snapshot-json",
       "path": "build/pr-quality/diagnostic-signal-snapshot/diagnostic-signal-snapshot.json",
       "produced_by": "python -m sdetkit.diagnostic_signal_snapshot --evidence-narrative <evidence-narrative.json> --evidence-graph <evidence-graph.json> --diagnostic-worker-result <diagnostic-worker-result.json> --runtime-proof-artifacts <runtime-proof-artifacts.json> --security-finding-diagnosis <security-finding-diagnosis.json> --out-dir build/pr-quality/diagnostic-signal-snapshot --format json",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -10,10 +10,13 @@ from . import (
     candidate_evidence_checklist,
     candidate_freeze_readiness,
     check_intelligence,
+    diagnostic_job,
     diagnostic_signal_snapshot,
     diagnostic_signal_snapshot_history,
+    diagnostic_worker_trajectory,
     doctor,
     issue_queue_classifier,
+    job_queue,
     maintenance_queue_rollup,
     pr_quality_runtime_proof_artifacts,
     professional_naming_cleanup_plan,
@@ -36,6 +39,16 @@ INDEX_SCHEMA_VERSION = "sdetkit.artifact-contract-index.v1"
 
 
 def build_index() -> dict[str, Any]:
+    local_diagnostic_queue_command = (
+        "sdetkit-diagnostic-queue-runner "
+        "--queue-path build/local-diagnostic-queue/queue.json "
+        "--out-root build/local-diagnostic-queue/worker "
+        "--input-root build/local-diagnostic-queue/inputs "
+        "--max-jobs <count> "
+        "--claimed-at <timestamp> "
+        "--finished-at <timestamp>"
+    )
+
     return {
         "schema_version": INDEX_SCHEMA_VERSION,
         "artifacts": [
@@ -54,6 +67,93 @@ def build_index() -> dict[str, Any]:
                 "schema_version": None,
                 "required_fields": ["ok", "failed_steps", "profile"],
                 "stability": "public",
+            },
+            {
+                "id": "local-diagnostic-queue-json",
+                "path": "build/local-diagnostic-queue/queue.json",
+                "produced_by": local_diagnostic_queue_command,
+                "schema_version": job_queue.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "execution_mode",
+                    "jobs",
+                    "decision_boundary",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "diagnostic-worker-result-json",
+                "path": (
+                    "build/local-diagnostic-queue/worker/<job-id>/diagnostic-worker-result.json"
+                ),
+                "produced_by": local_diagnostic_queue_command,
+                "schema_version": diagnostic_job.WORKER_RESULT_SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "job_id",
+                    "job_type",
+                    "worker",
+                    "status",
+                    "execution_mode",
+                    "summary",
+                    "primary_diagnosis",
+                    "output_artifacts",
+                    "decision_boundary",
+                    "execution",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "diagnostic-worker-trajectory-jsonl",
+                "path": (
+                    "build/local-diagnostic-queue/worker/"
+                    "<job-id>/trajectory/"
+                    "diagnostic-worker-trajectory.jsonl"
+                ),
+                "produced_by": local_diagnostic_queue_command,
+                "schema_version": trajectory_store.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "trajectory_id",
+                    "environment",
+                    "diagnosis",
+                    "decision",
+                    "response",
+                    "fix",
+                    "proof",
+                    "final_result",
+                    "learned_pattern",
+                    "worker_evidence",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "diagnostic-worker-trajectory-summary-json",
+                "path": (
+                    "build/local-diagnostic-queue/worker/"
+                    "<job-id>/trajectory/"
+                    "diagnostic-worker-trajectory-summary.json"
+                ),
+                "produced_by": local_diagnostic_queue_command,
+                "schema_version": diagnostic_worker_trajectory.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "trajectory_schema_version",
+                    "status",
+                    "record_count",
+                    "review_first_count",
+                    "observed_safe_fix_candidate_count",
+                    "worker_result_status",
+                    "trajectory_jsonl",
+                    "reporting_only",
+                    "current_pr_decision_input",
+                    "proof_commands_executed",
+                    "patch_application_allowed",
+                    "automation_allowed",
+                    "merge_authorized",
+                    "semantic_equivalence_proven",
+                ],
+                "stability": "advanced",
             },
             {
                 "id": "diagnostic-signal-snapshot-json",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -10,10 +10,13 @@ from sdetkit import (
     candidate_evidence_checklist,
     candidate_freeze_readiness,
     check_intelligence,
+    diagnostic_job,
     diagnostic_signal_snapshot,
     diagnostic_signal_snapshot_history,
+    diagnostic_worker_trajectory,
     doctor,
     issue_queue_classifier,
+    job_queue,
     maintenance_queue_rollup,
     pr_quality_runtime_proof_artifacts,
     professional_naming_cleanup_plan,
@@ -295,6 +298,85 @@ def test_artifact_contract_index_includes_canonical_gate_artifacts() -> None:
         assert artifact_id in entries
         required = set(entries[artifact_id]["required_fields"])
         assert {"ok", "failed_steps", "profile"}.issubset(required)
+
+
+def test_artifact_contract_index_includes_local_diagnostic_queue_artifacts() -> None:
+    payload = build_index()
+    entries = {item["id"]: item for item in payload["artifacts"]}
+
+    artifact_ids = {
+        "local-diagnostic-queue-json",
+        "diagnostic-worker-result-json",
+        "diagnostic-worker-trajectory-jsonl",
+        "diagnostic-worker-trajectory-summary-json",
+    }
+
+    assert artifact_ids.issubset(entries)
+
+    queue_entry = entries["local-diagnostic-queue-json"]
+    worker_entry = entries["diagnostic-worker-result-json"]
+    trajectory_entry = entries["diagnostic-worker-trajectory-jsonl"]
+    summary_entry = entries["diagnostic-worker-trajectory-summary-json"]
+
+    assert queue_entry["schema_version"] == job_queue.SCHEMA_VERSION
+    assert worker_entry["schema_version"] == diagnostic_job.WORKER_RESULT_SCHEMA_VERSION
+    assert trajectory_entry["schema_version"] == trajectory_store.SCHEMA_VERSION
+    assert summary_entry["schema_version"] == diagnostic_worker_trajectory.SCHEMA_VERSION
+
+    assert queue_entry["path"] == ("build/local-diagnostic-queue/queue.json")
+    assert worker_entry["path"] == (
+        "build/local-diagnostic-queue/worker/<job-id>/diagnostic-worker-result.json"
+    )
+    assert trajectory_entry["path"] == (
+        "build/local-diagnostic-queue/worker/<job-id>/trajectory/diagnostic-worker-trajectory.jsonl"
+    )
+    assert summary_entry["path"] == (
+        "build/local-diagnostic-queue/worker/"
+        "<job-id>/trajectory/"
+        "diagnostic-worker-trajectory-summary.json"
+    )
+
+    assert {
+        "schema_version",
+        "execution_mode",
+        "jobs",
+        "decision_boundary",
+    }.issubset(queue_entry["required_fields"])
+
+    assert {
+        "schema_version",
+        "job_id",
+        "status",
+        "output_artifacts",
+        "decision_boundary",
+        "execution",
+    }.issubset(worker_entry["required_fields"])
+
+    assert {
+        "schema_version",
+        "trajectory_id",
+        "decision",
+        "proof",
+        "worker_evidence",
+    }.issubset(trajectory_entry["required_fields"])
+
+    assert {
+        "schema_version",
+        "trajectory_schema_version",
+        "reporting_only",
+        "current_pr_decision_input",
+        "automation_allowed",
+        "merge_authorized",
+    }.issubset(summary_entry["required_fields"])
+
+    for artifact_id in artifact_ids:
+        entry = entries[artifact_id]
+
+        assert entry["stability"] == "advanced"
+        assert entry["produced_by"].startswith("sdetkit-diagnostic-queue-runner ")
+        assert "--max-jobs <count>" in entry["produced_by"]
+        assert "--claimed-at <timestamp>" in entry["produced_by"]
+        assert "--finished-at <timestamp>" in entry["produced_by"]
 
 
 def test_artifact_contract_index_docs_json_matches_generator_payload() -> None:


### PR DESCRIPTION
## Summary

Indexes the accepted bounded local diagnostic queue artifacts in the canonical artifact contract index.

## Scope

- src/sdetkit/artifact_contract_index.py
- tests/test_artifact_contract_index.py
- docs/artifact-contract-index.json

## Added artifact contracts

- local-diagnostic-queue-json
- diagnostic-worker-result-json
- diagnostic-worker-trajectory-jsonl
- diagnostic-worker-trajectory-summary-json

## Contract coverage

- canonical artifact paths
- producing local queue command
- synchronized schema versions
- required fields
- advanced stability classification
- generated documentation index synchronization

## Proof

- focused artifact and queue tests passed: 26
- make proof-after-format passed
- Ruff passed
- Mypy passed
- generated index matches build_index()
- exact three-file scope verified
- git diff --check passed

## Runtime impact

This change adds artifact discoverability and contract assertions only. It does not change queue execution, worker behavior, trajectory generation, or CLI behavior.

## Authority boundaries

- product_runtime_behavior_changed=false
- workflow_exposure=false
- cloud_dependency=false
- automation_allowed=false
- automatic_retry=false
- proof_commands_executed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No workflow integration, cloud queue, retries, proof execution, patch application, current-PR decisions, security dismissal, or merge authorization.