### PR TITLE
feat(cli): register local diagnostic queue dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ apigetcli = "sdetkit._entrypoints:apigetcli"
 sdetkit-test-bootstrap-contract = "sdetkit.test_bootstrap_contract:main"
 sdetkit-test-bootstrap-validate = "sdetkit.test_bootstrap_validate:main"
 sdetkit-diagnostic-queue-runner = "sdetkit.diagnostic_queue_runner_cli:main"
+sdetkit-local-diagnostic-queue-dashboard = "sdetkit.local_diagnostic_queue_dashboard:main"
 
 [project.entry-points."sdetkit.notify_adapters"]
 stdout = "sdetkit.notify_plugins:stdout_adapter"

--- a/tests/test_local_diagnostic_queue_dashboard.py
+++ b/tests/test_local_diagnostic_queue_dashboard.py
@@ -213,3 +213,12 @@ def test_missing_queue_renders_valid_empty_dashboard(tmp_path: Path) -> None:
     assert "No queued jobs" in text
     assert "status: empty" in text
     assert "read only: true" in text
+
+
+def test_project_registers_local_diagnostic_queue_dashboard_script() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert (
+        "sdetkit-local-diagnostic-queue-dashboard = "
+        '"sdetkit.local_diagnostic_queue_dashboard:main"' in pyproject
+    )


### PR DESCRIPTION
## Summary

Registers the accepted local diagnostic queue dashboard as an installable console command.

## Scope

- pyproject.toml
- tests/test_local_diagnostic_queue_dashboard.py

## Public command

```text
sdetkit-local-diagnostic-queue-dashboard
```

The command delegates directly to:

```text
sdetkit.local_diagnostic_queue_dashboard:main
```

## Compatibility

The existing Python module command remains available:

```text
python -m sdetkit.local_diagnostic_queue_dashboard
```

## Proof

- focused dashboard and queue-runner CLI tests passed: 14
- module CLI smoke proof passed
- make proof-after-format passed
- Ruff passed
- Mypy passed
- exact two-file scope verified
- git diff --check passed

## Runtime impact

- runtime_logic_changed=false
- queue_mutation=false
- network_access=false
- javascript=false
- workflow_exposure=false
- cloud_dependency=false
- automatic_retry=false

## Authority boundaries

- automation_allowed=false
- proof_commands_executed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No dashboard runtime changes, hosted service, workflow integration, cloud queue, queue mutation, retries, proof execution, patch application, PR decision, security dismissal, or merge authorization.