### PR TITLE
feat(artifacts): index local diagnostic queue dashboard JSON

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -39,6 +39,30 @@
       "stability": "advanced"
     },
     {
+      "id": "local-diagnostic-queue-dashboard-json",
+      "path": "build/local-diagnostic-queue/dashboard.json",
+      "produced_by": "sdetkit-local-diagnostic-queue-dashboard --queue-path build/local-diagnostic-queue/queue.json --format json --out build/local-diagnostic-queue/dashboard.json",
+      "schema_version": "sdetkit.local_diagnostic_queue_dashboard.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "queue_path",
+        "queue_exists",
+        "source_queue_schema_version",
+        "execution_mode",
+        "local_only",
+        "read_only",
+        "job_count",
+        "state_counts",
+        "artifact_count",
+        "present_artifact_count",
+        "missing_artifact_count",
+        "jobs",
+        "decision_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "diagnostic-worker-result-json",
       "path": "build/local-diagnostic-queue/worker/<job-id>/diagnostic-worker-result.json",
       "produced_by": "sdetkit-diagnostic-queue-runner --queue-path build/local-diagnostic-queue/queue.json --out-root build/local-diagnostic-queue/worker --input-root build/local-diagnostic-queue/inputs --max-jobs <count> --claimed-at <timestamp> --finished-at <timestamp>",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -17,6 +17,7 @@ from . import (
     doctor,
     issue_queue_classifier,
     job_queue,
+    local_diagnostic_queue_dashboard,
     maintenance_queue_rollup,
     pr_quality_runtime_proof_artifacts,
     professional_naming_cleanup_plan,
@@ -49,6 +50,13 @@ def build_index() -> dict[str, Any]:
         "--finished-at <timestamp>"
     )
 
+    local_diagnostic_queue_dashboard_command = (
+        "sdetkit-local-diagnostic-queue-dashboard "
+        "--queue-path build/local-diagnostic-queue/queue.json "
+        "--format json "
+        "--out build/local-diagnostic-queue/dashboard.json"
+    )
+
     return {
         "schema_version": INDEX_SCHEMA_VERSION,
         "artifacts": [
@@ -76,6 +84,32 @@ def build_index() -> dict[str, Any]:
                 "required_fields": [
                     "schema_version",
                     "execution_mode",
+                    "jobs",
+                    "decision_boundary",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "local-diagnostic-queue-dashboard-json",
+                "path": local_diagnostic_queue_dashboard.DEFAULT_OUT.with_suffix(
+                    ".json"
+                ).as_posix(),
+                "produced_by": local_diagnostic_queue_dashboard_command,
+                "schema_version": local_diagnostic_queue_dashboard.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "queue_path",
+                    "queue_exists",
+                    "source_queue_schema_version",
+                    "execution_mode",
+                    "local_only",
+                    "read_only",
+                    "job_count",
+                    "state_counts",
+                    "artifact_count",
+                    "present_artifact_count",
+                    "missing_artifact_count",
                     "jobs",
                     "decision_boundary",
                 ],

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -17,6 +17,7 @@ from sdetkit import (
     doctor,
     issue_queue_classifier,
     job_queue,
+    local_diagnostic_queue_dashboard,
     maintenance_queue_rollup,
     pr_quality_runtime_proof_artifacts,
     professional_naming_cleanup_plan,
@@ -377,6 +378,44 @@ def test_artifact_contract_index_includes_local_diagnostic_queue_artifacts() -> 
         assert "--max-jobs <count>" in entry["produced_by"]
         assert "--claimed-at <timestamp>" in entry["produced_by"]
         assert "--finished-at <timestamp>" in entry["produced_by"]
+
+
+def test_artifact_contract_index_includes_local_diagnostic_queue_dashboard_json() -> None:
+    payload = build_index()
+    entries = {item["id"]: item for item in payload["artifacts"]}
+
+    artifact_id = "local-diagnostic-queue-dashboard-json"
+    assert artifact_id in entries
+
+    entry = entries[artifact_id]
+    assert entry["schema_version"] == local_diagnostic_queue_dashboard.SCHEMA_VERSION
+    assert entry["path"] == (
+        local_diagnostic_queue_dashboard.DEFAULT_OUT.with_suffix(".json").as_posix()
+    )
+    assert entry["stability"] == "advanced"
+
+    assert {
+        "schema_version",
+        "status",
+        "queue_path",
+        "queue_exists",
+        "source_queue_schema_version",
+        "execution_mode",
+        "local_only",
+        "read_only",
+        "job_count",
+        "state_counts",
+        "artifact_count",
+        "present_artifact_count",
+        "missing_artifact_count",
+        "jobs",
+        "decision_boundary",
+    }.issubset(set(entry["required_fields"]))
+
+    assert entry["produced_by"].startswith("sdetkit-local-diagnostic-queue-dashboard ")
+    assert "--queue-path build/local-diagnostic-queue/queue.json" in (entry["produced_by"])
+    assert "--format json" in entry["produced_by"]
+    assert "--out build/local-diagnostic-queue/dashboard.json" in (entry["produced_by"])
 
 
 def test_artifact_contract_index_docs_json_matches_generator_payload() -> None:


### PR DESCRIPTION
## Summary

Registers the deterministic JSON output of the accepted local diagnostic queue dashboard in the generated artifact contract index.

## Scope

- `src/sdetkit/artifact_contract_index.py`
- `tests/test_artifact_contract_index.py`
- `docs/artifact-contract-index.json`

## Artifact contract

- id: `local-diagnostic-queue-dashboard-json`
- path: `build/local-diagnostic-queue/dashboard.json`
- schema: `sdetkit.local_diagnostic_queue_dashboard.v1`
- stability: `advanced`
- producer: `sdetkit-local-diagnostic-queue-dashboard`

## Required fields

- `schema_version`
- `status`
- `queue_path`
- `queue_exists`
- `source_queue_schema_version`
- `execution_mode`
- `local_only`
- `read_only`
- `job_count`
- `state_counts`
- `artifact_count`
- `present_artifact_count`
- `missing_artifact_count`
- `jobs`
- `decision_boundary`

## Contract boundary

Only the schema-bearing JSON dashboard output is indexed. The static HTML presentation output remains intentionally deferred because it is not a machine-readable schema contract.

## Proof

- dashboard contract grounding passed
- generated artifact index matched `build_index()`
- focused artifact-index, dashboard, and queue tests passed: 19
- dashboard runtime contract smoke passed
- `make proof-after-format` passed
- Ruff passed
- Mypy passed
- exact three-file scope verified
- `git diff --check` passed

## Runtime impact

- runtime_code_changed=false
- queue_mutation=false
- network_access=false
- javascript=false
- workflow_exposure=false
- cloud_dependency=false
- automatic_retry=false

## Authority boundaries

- current_pr_decision_input=false
- automation_allowed=false
- proof_commands_executed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No dashboard runtime changes, HTML artifact contract, hosted service, workflow integration, cloud queue, queue mutation, worker execution, retries, proof execution, patch application, PR decision, security dismissal, or merge authorization.