### PR TITLE
feat(artifacts): index adoption learning report JSON

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -653,6 +653,31 @@
       "stability": "advanced"
     },
     {
+      "id": "adoption-learning-report-json",
+      "path": "build/sdetkit/adoption-learning-report.json",
+      "produced_by": "python -m sdetkit adoption-learning-report --matrix-json build/sdetkit/adoption-real-world-learning/adoption-real-world-matrix.json --out build/sdetkit/adoption-learning-report.json --format json",
+      "schema_version": "sdetkit.adoption_learning_report.v1",
+      "required_fields": [
+        "schema_version",
+        "source_matrix",
+        "source_matrix_schema_version",
+        "source_matrix_status",
+        "source_repo_count",
+        "candidate_count",
+        "top_candidate",
+        "prioritized_upgrade_candidates",
+        "repo_memory_profile",
+        "operator_summary",
+        "rules",
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "authority_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "doctor-json",
       "path": "build/doctor.json",
       "produced_by": "python -m sdetkit doctor --format json --out build/doctor.json",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from . import (
+    adoption_learning_report,
     adoption_surface,
     automation_health,
     candidate_collision_checklist,
@@ -726,6 +727,38 @@ def build_index() -> dict[str, Any]:
                     "automation_allowed",
                     "merge_authorized",
                     "semantic_equivalence_proven",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "adoption-learning-report-json",
+                "path": "build/sdetkit/adoption-learning-report.json",
+                "produced_by": (
+                    "python -m sdetkit adoption-learning-report "
+                    "--matrix-json "
+                    "build/sdetkit/adoption-real-world-learning/"
+                    "adoption-real-world-matrix.json "
+                    "--out build/sdetkit/adoption-learning-report.json "
+                    "--format json"
+                ),
+                "schema_version": adoption_learning_report.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "source_matrix",
+                    "source_matrix_schema_version",
+                    "source_matrix_status",
+                    "source_repo_count",
+                    "candidate_count",
+                    "top_candidate",
+                    "prioritized_upgrade_candidates",
+                    "repo_memory_profile",
+                    "operator_summary",
+                    "rules",
+                    "automation_allowed",
+                    "patch_application_allowed",
+                    "merge_authorized",
+                    "semantic_equivalence_proven",
+                    "authority_boundary",
                 ],
                 "stability": "advanced",
             },

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from sdetkit import (
+    adoption_learning_report,
     adoption_surface,
     automation_health,
     candidate_collision_checklist,
@@ -416,6 +417,47 @@ def test_artifact_contract_index_includes_local_diagnostic_queue_dashboard_json(
     assert "--queue-path build/local-diagnostic-queue/queue.json" in (entry["produced_by"])
     assert "--format json" in entry["produced_by"]
     assert "--out build/local-diagnostic-queue/dashboard.json" in (entry["produced_by"])
+
+
+def test_artifact_contract_index_includes_adoption_learning_report_json() -> None:
+    payload = build_index()
+    entries = {item["id"]: item for item in payload["artifacts"]}
+
+    artifact_id = "adoption-learning-report-json"
+    assert artifact_id in entries
+
+    entry = entries[artifact_id]
+    assert entry["schema_version"] == adoption_learning_report.SCHEMA_VERSION
+    assert entry["path"] == ("build/sdetkit/adoption-learning-report.json")
+    assert entry["stability"] == "advanced"
+
+    assert {
+        "schema_version",
+        "source_matrix",
+        "source_matrix_schema_version",
+        "source_matrix_status",
+        "source_repo_count",
+        "candidate_count",
+        "top_candidate",
+        "prioritized_upgrade_candidates",
+        "repo_memory_profile",
+        "operator_summary",
+        "rules",
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "authority_boundary",
+    }.issubset(set(entry["required_fields"]))
+
+    assert entry["produced_by"].startswith("python -m sdetkit adoption-learning-report ")
+    assert (
+        "--matrix-json "
+        "build/sdetkit/adoption-real-world-learning/"
+        "adoption-real-world-matrix.json" in entry["produced_by"]
+    )
+    assert "--out build/sdetkit/adoption-learning-report.json" in entry["produced_by"]
+    assert "--format json" in entry["produced_by"]
 
 
 def test_artifact_contract_index_docs_json_matches_generator_payload() -> None:


### PR DESCRIPTION
## Summary

Registers the schema-bearing JSON output of the accepted adoption learning report in the generated artifact contract index.

## Scope

- `src/sdetkit/artifact_contract_index.py`
- `tests/test_artifact_contract_index.py`
- `docs/artifact-contract-index.json`

## Artifact contract

- id: `adoption-learning-report-json`
- path: `build/sdetkit/adoption-learning-report.json`
- schema: `sdetkit.adoption_learning_report.v1`
- stability: `advanced`
- producer: `python -m sdetkit adoption-learning-report`

## Required fields

- `schema_version`
- `source_matrix`
- `source_matrix_schema_version`
- `source_matrix_status`
- `source_repo_count`
- `candidate_count`
- `top_candidate`
- `prioritized_upgrade_candidates`
- `repo_memory_profile`
- `operator_summary`
- `rules`
- `automation_allowed`
- `patch_application_allowed`
- `merge_authorized`
- `semantic_equivalence_proven`
- `authority_boundary`

## Proof

- accepted adoption-report source contract verified
- generated artifact index matched `build_index()`
- focused artifact-index, learning-report, and matrix tests passed: 16
- public producer-command smoke passed
- `make proof-after-format` passed
- Ruff passed
- Mypy passed
- exact three-file scope verified
- `git diff --check` passed

## Runtime impact

- runtime_code_changed=false
- target_repos_read=false
- target_repo_mutation=false
- workflow_exposure=false
- cloud_dependency=false

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No adoption-report runtime changes, operator documentation, dashboard/UI consumer, target-repository reads or mutations, workflow integration, cloud dependency, patch application, PR decision, or merge authorization.
