### PR TITLE
docs(adoption): document learning report operator contract

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -119,3 +119,59 @@ patch_application_allowed=false
 merge_authorized=false
 semantic_equivalence_proven=false
 ```
+
+## Review real-world adoption learning
+
+Maintainers can aggregate read-only observations from a verified matrix of external repository roots, then convert the resulting matrix artifact into a review-first learning report.
+
+First, generate the real-world learning matrix from repository roots whose licenses and local paths have already been verified:
+
+```bash
+python -m sdetkit adoption-real-world-learning-matrix \
+  --matrix-json <verified-repo-matrix.json> \
+  --artifact-root build/sdetkit/adoption-real-world-learning \
+  --out build/sdetkit/adoption-real-world-learning/adoption-real-world-matrix.json \
+  --markdown-out build/sdetkit/adoption-real-world-learning/adoption-real-world-matrix.md \
+  --minimum-repos 10 \
+  --format json
+```
+
+The matrix lane inspects repository surfaces without installing dependencies, running target tests, changing target repositories, or opening target issues or pull requests. A fully passed matrix returns exit code `0`; a matrix that requires human review returns exit code `2` while still writing its evidence artifacts.
+
+Then generate the prioritized adoption learning report:
+
+```bash
+python -m sdetkit adoption-learning-report \
+  --matrix-json build/sdetkit/adoption-real-world-learning/adoption-real-world-matrix.json \
+  --out build/sdetkit/adoption-learning-report.json \
+  --markdown-out build/sdetkit/adoption-learning-report.md \
+  --format json
+```
+
+The report command reads the matrix artifact and, when explicitly provided, an optional RepoMemory profile. It does not revisit the target repositories, execute proof commands, apply patches, or make a current-PR decision.
+
+Read these JSON fields first:
+
+- `source_matrix_schema_version`
+- `source_matrix_status`
+- `source_repo_count`
+- `candidate_count`
+- `top_candidate`
+- `prioritized_upgrade_candidates`
+- `repo_memory_profile`
+- `operator_summary`
+- `rules`
+- `authority_boundary`
+
+Each candidate remains review-first. `safe_to_patch=false` means the report is evidence for a human-scoped follow-up, not approval to edit another repository.
+
+The report preserves these boundaries:
+
+```text
+automation_allowed=false
+patch_application_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+```
+
+The generated JSON artifact is registered as `adoption-learning-report-json` at `build/sdetkit/adoption-learning-report.json`. The Markdown file is an operator-readable companion, not a separate machine schema.


### PR DESCRIPTION
## Summary

Documents the accepted read-only real-world adoption learning matrix and adoption learning report operator contract in the canonical adoption guide.

## Scope

- `docs/adoption.md`

## Documented workflow

- generate a verified real-world adoption learning matrix;
- generate the schema-bearing adoption learning report JSON;
- read the matrix/report status and prioritized candidates;
- preserve review-first and no-patch authority boundaries.

## Accepted artifacts

- matrix JSON: `build/sdetkit/adoption-real-world-learning/adoption-real-world-matrix.json`
- report JSON: `build/sdetkit/adoption-learning-report.json`
- artifact contract id: `adoption-learning-report-json`
- report schema: `sdetkit.adoption_learning_report.v1`

## Proof

- documented contract assertions passed;
- MkDocs strict build passed;
- docs QA and navigation tests passed: 39;
- primary docs map validation passed;
- `make proof-after-format` passed;
- exact one-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_code_changed=false
- artifact_contract_changed=false
- new_primary_doc=false
- navigation_change=false
- target_repos_read=false
- target_repo_mutation=false
- workflow_exposure=false
- cloud_dependency=false

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No runtime implementation, artifact schema changes, dashboard/UI consumer, navigation change, workflow integration, target-repository mutation, patch application, PR decision, or merge authorization.
