### PR TITLE
feat(adoption): add learning report dashboard

### DIFF
--- a/src/sdetkit/adoption_learning_report_dashboard.py
+++ b/src/sdetkit/adoption_learning_report_dashboard.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from sdetkit import adoption_learning_report
+from sdetkit.atomicio import atomic_write_text
+
+SCHEMA_VERSION = "sdetkit.adoption_learning_report_dashboard.v1"
+DEFAULT_OUT = Path("build") / "sdetkit" / "adoption-learning-report-dashboard.html"
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _strings(value: Any) -> list[str]:
+    return [_string(item) for item in _as_list(value) if _string(item)]
+
+
+def _integer(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _candidate_row(value: Any) -> JsonObject:
+    candidate = _as_dict(value)
+    return {
+        "rank": _integer(candidate.get("rank")),
+        "classification": _string(candidate.get("classification")) or "unknown",
+        "priority": _string(candidate.get("priority")) or "unknown",
+        "ranking_score": _integer(candidate.get("ranking_score")),
+        "next_pr_title": _string(candidate.get("next_pr_title")),
+        "observed_in_repos": _strings(candidate.get("observed_in_repos")),
+        "frequency_across_matrix": _integer(candidate.get("frequency_across_matrix")),
+        "owner_files": _strings(candidate.get("owner_files")),
+        "reason_from_real_repo": _string(candidate.get("reason_from_real_repo")),
+        "proof_needed": _strings(candidate.get("proof_needed")),
+        "review_first": candidate.get("review_first") is True,
+        "safe_to_patch": candidate.get("safe_to_patch") is True,
+        "recommended_next_action": _string(candidate.get("recommended_next_action")),
+    }
+
+
+def _repo_memory_summary(value: Any) -> JsonObject:
+    memory = _as_dict(value)
+    authority = _as_dict(memory.get("authority_boundary"))
+    return {
+        "connected": memory.get("connected") is True,
+        "path": _string(memory.get("path")),
+        "schema_version": _string(memory.get("schema_version")),
+        "profile_status": _string(memory.get("profile_status")) or "not_provided",
+        "memory_mode": _string(memory.get("memory_mode")),
+        "review_first": memory.get("review_first") is True,
+        "authoritative_for_adoption_report": (
+            memory.get("authoritative_for_adoption_report") is True
+        ),
+        "authority_boundary": {
+            "automation_allowed": authority.get("automation_allowed") is True,
+            "patch_application_allowed": authority.get("patch_application_allowed") is True,
+            "merge_authorized": authority.get("merge_authorized") is True,
+            "semantic_equivalence_proven": (authority.get("semantic_equivalence_proven") is True),
+        },
+    }
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "current_pr_decision_input": False,
+        "automation_allowed": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _load_report(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("expected adoption learning report JSON object")
+    schema_version = _string(payload.get("schema_version"))
+    if schema_version != adoption_learning_report.SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported adoption learning report schema: {schema_version or 'missing'}"
+        )
+    return payload
+
+
+def build_dashboard(report_path: Path, *, out_path: Path) -> JsonObject:
+    report = _load_report(report_path)
+    candidates = [
+        _candidate_row(candidate)
+        for candidate in _as_list(report.get("prioritized_upgrade_candidates"))
+        if isinstance(candidate, dict)
+    ]
+    top_candidate_raw = report.get("top_candidate")
+    top_candidate = (
+        _candidate_row(top_candidate_raw) if isinstance(top_candidate_raw, dict) else None
+    )
+    source_count = _integer(report.get("candidate_count"))
+    if source_count != len(candidates):
+        raise ValueError("candidate_count does not match prioritized_upgrade_candidates")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ready" if candidates else "empty",
+        "report_path": report_path.as_posix(),
+        "report_exists": report_path.is_file(),
+        "source_report_schema_version": _string(report.get("schema_version")),
+        "source_matrix": _string(report.get("source_matrix")),
+        "source_matrix_schema_version": _string(report.get("source_matrix_schema_version")),
+        "source_matrix_status": _string(report.get("source_matrix_status")),
+        "source_repo_count": _integer(report.get("source_repo_count")),
+        "candidate_count": len(candidates),
+        "top_candidate": top_candidate,
+        "prioritized_upgrade_candidates": candidates,
+        "repo_memory_profile": _repo_memory_summary(report.get("repo_memory_profile")),
+        "operator_summary": _as_dict(report.get("operator_summary")),
+        "local_only": True,
+        "read_only": True,
+        "decision_boundary": _decision_boundary(),
+    }
+
+
+def _escape(value: Any) -> str:
+    return html.escape(_string(value))
+
+
+def _string_list(values: Any, *, empty: str = "none") -> str:
+    items = _strings(values)
+    if not items:
+        return f"<span class='muted'>{html.escape(empty)}</span>"
+    return "<ul>" + "".join(f"<li>{html.escape(item)}</li>" for item in items) + "</ul>"
+
+
+def _candidate_card(candidate: Mapping[str, Any]) -> str:
+    safe_to_patch = candidate.get("safe_to_patch") is True
+    review_first = candidate.get("review_first") is True
+    state_class = "unsafe" if safe_to_patch else "review"
+    title = _escape(candidate.get("next_pr_title")) or "Untitled candidate"
+    return (
+        f"<article class='card {state_class}'>"
+        f"<h2>#{_integer(candidate.get('rank'))} {title}</h2>"
+        "<dl>"
+        f"<dt>Classification</dt><dd>{_escape(candidate.get('classification'))}</dd>"
+        f"<dt>Priority</dt><dd>{_escape(candidate.get('priority'))}</dd>"
+        f"<dt>Ranking score</dt><dd>{_integer(candidate.get('ranking_score'))}</dd>"
+        f"<dt>Frequency</dt><dd>{_integer(candidate.get('frequency_across_matrix'))}</dd>"
+        f"<dt>Review first</dt><dd>{str(review_first).lower()}</dd>"
+        f"<dt>Safe to patch</dt><dd>{str(safe_to_patch).lower()}</dd>"
+        "</dl>"
+        f"<p><strong>Reason:</strong> {_escape(candidate.get('reason_from_real_repo')) or '—'}</p>"
+        "<h3>Observed in repositories</h3>"
+        f"{_string_list(candidate.get('observed_in_repos'))}"
+        "<h3>Owner files</h3>"
+        f"{_string_list(candidate.get('owner_files'))}"
+        "<h3>Proof needed</h3>"
+        f"{_string_list(candidate.get('proof_needed'))}"
+        f"<p><strong>Recommended next action:</strong> "
+        f"{_escape(candidate.get('recommended_next_action')) or '—'}</p>"
+        "</article>"
+    )
+
+
+def render_html(payload: Mapping[str, Any]) -> str:
+    candidates = [
+        _as_dict(candidate)
+        for candidate in _as_list(payload.get("prioritized_upgrade_candidates"))
+        if isinstance(candidate, dict)
+    ]
+    cards = "".join(_candidate_card(candidate) for candidate in candidates)
+    if not cards:
+        cards = (
+            "<article class='card empty'>"
+            "<h2>No upgrade candidates</h2>"
+            "<p>The source report is valid and contains no prioritized candidates.</p>"
+            "</article>"
+        )
+
+    top = _as_dict(payload.get("top_candidate"))
+    top_title = _escape(top.get("next_pr_title")) if top else "none"
+    memory = _as_dict(payload.get("repo_memory_profile"))
+    boundary = _as_dict(payload.get("decision_boundary"))
+
+    boundary_items = "".join(
+        f"<li><strong>{html.escape(key)}</strong>: {str(value).lower()}</li>"
+        for key, value in sorted(boundary.items())
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Adoption learning report dashboard</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; color: #172033; background: #f6f7fb; }}
+    header {{ margin-bottom: 1.5rem; }}
+    .summary {{ display: flex; flex-wrap: wrap; gap: .6rem; margin: 1rem 0; }}
+    .pill {{ background: white; border: 1px solid #d7dce8; border-radius: 999px; padding: .45rem .8rem; }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; }}
+    .card {{ background: white; border: 1px solid #d7dce8; border-radius: 14px; padding: 1rem; box-shadow: 0 1px 2px rgb(20 30 50 / 8%); }}
+    .review {{ border-top: 5px solid #175cd3; }}
+    .unsafe {{ border-top: 5px solid #b42318; }}
+    .empty {{ border-top: 5px solid #667085; }}
+    .muted {{ color: #667085; }}
+    dl {{ display: grid; grid-template-columns: max-content 1fr; gap: .35rem .75rem; }}
+    dt {{ font-weight: 700; }}
+    dd {{ margin: 0; overflow-wrap: anywhere; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Adoption learning report dashboard</h1>
+    <p>Static, local-only, read-only view of the accepted Python adoption learning report artifact.</p>
+    <div class="summary">
+      <span class="pill">status: {_escape(payload.get("status"))}</span>
+      <span class="pill">matrix status: {_escape(payload.get("source_matrix_status"))}</span>
+      <span class="pill">repositories: {_integer(payload.get("source_repo_count"))}</span>
+      <span class="pill">candidates: {_integer(payload.get("candidate_count"))}</span>
+      <span class="pill">local only: {str(payload.get("local_only")).lower()}</span>
+      <span class="pill">read only: {str(payload.get("read_only")).lower()}</span>
+    </div>
+    <p><strong>Report:</strong> <code>{_escape(payload.get("report_path"))}</code></p>
+    <p><strong>Top candidate:</strong> {top_title}</p>
+    <p><strong>RepoMemory connected:</strong> {str(memory.get("connected") is True).lower()}</p>
+  </header>
+  <main class="grid">
+    {cards}
+    <article class="card">
+      <h2>Authority boundary</h2>
+      <ul>{boundary_items}</ul>
+      <p>This dashboard is not proof execution, patch approval, a current-PR decision, or merge authorization.</p>
+    </article>
+  </main>
+</body>
+</html>
+"""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.adoption_learning_report_dashboard",
+        description=(
+            "Render a deterministic local-only dashboard from an existing "
+            "adoption learning report JSON artifact."
+        ),
+    )
+    parser.add_argument("--report-path", type=Path, required=True)
+    parser.add_argument("--format", choices=("html", "json"), default="html")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        payload = build_dashboard(args.report_path, out_path=args.out)
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else render_html(payload)
+        )
+        atomic_write_text(args.out, rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={_string(exc) or type(exc).__name__}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adoption_learning_report_dashboard.py
+++ b/tests/test_adoption_learning_report_dashboard.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adoption_learning_report_dashboard
+
+
+def _report_payload(
+    *,
+    candidates: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    rows = (
+        candidates
+        if candidates is not None
+        else [
+            {
+                "rank": 1,
+                "classification": "weak_proof_command_mapping",
+                "priority": "P1",
+                "ranking_score": 130,
+                "next_pr_title": (
+                    "feat(adoption): strengthen proof-command mapping "
+                    "from real-world matrix evidence"
+                ),
+                "observed_in_repos": ["repo-a", "repo-b", "repo-c"],
+                "frequency_across_matrix": 3,
+                "owner_files": ["src/sdetkit/adoption_proof_recommendations.py"],
+                "reason_from_real_repo": ("weak_proof_command_mapping appeared in 3 repos."),
+                "proof_needed": ["python -m pytest -q tests/test_adoption_surface.py -o addopts="],
+                "review_first": True,
+                "safe_to_patch": False,
+                "recommended_next_action": ("Open one focused PR after human review."),
+            },
+            {
+                "rank": 2,
+                "classification": "artifact_path_gap",
+                "priority": "P2",
+                "ranking_score": 50,
+                "next_pr_title": ("feat(adoption): improve artifact path detection"),
+                "observed_in_repos": ["repo-d"],
+                "frequency_across_matrix": 1,
+                "owner_files": ["src/sdetkit/adoption_repo_topology.py"],
+                "reason_from_real_repo": "artifact_path_gap appeared in 1 repo.",
+                "proof_needed": [],
+                "review_first": True,
+                "safe_to_patch": False,
+                "recommended_next_action": ("Open one focused PR after human review."),
+            },
+        ]
+    )
+    return {
+        "schema_version": "sdetkit.adoption_learning_report.v1",
+        "source_matrix": "/tmp/adoption-real-world-matrix.json",
+        "source_matrix_schema_version": ("sdetkit.adoption_real_world_learning_matrix.v1"),
+        "source_matrix_status": "review_required",
+        "source_repo_count": 4,
+        "candidate_count": len(rows),
+        "top_candidate": rows[0] if rows else None,
+        "prioritized_upgrade_candidates": rows,
+        "repo_memory_profile": {
+            "connected": False,
+            "path": "",
+            "schema_version": "",
+            "profile_status": "not_provided",
+            "memory_mode": "",
+            "review_first": True,
+            "authoritative_for_adoption_report": False,
+            "authority_boundary": {
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        },
+        "operator_summary": {
+            "status": "review_first_learning_report_generated",
+            "next_action": (
+                rows[0]["next_pr_title"]
+                if rows
+                else "No upgrade candidates found in the source matrix."
+            ),
+        },
+        "rules": {
+            "source_matrix_only": True,
+            "repo_memory_profile_read": False,
+            "repo_memory_profile_authoritative": False,
+            "target_repos_read": False,
+            "install_dependencies": False,
+            "target_tests_executed": False,
+            "target_repo_mutation": False,
+            "target_pr_or_issue_opened": False,
+            "endorsement_claim": False,
+            "review_first": True,
+        },
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "authority_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _write_report(
+    path: Path,
+    *,
+    payload: dict[str, object] | None = None,
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload or _report_payload(), indent=2),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_dashboard_builds_read_only_candidate_summary(
+    tmp_path: Path,
+) -> None:
+    report = _write_report(tmp_path / "adoption-learning-report.json")
+    before = report.read_bytes()
+    out = tmp_path / "dashboard.html"
+
+    payload = adoption_learning_report_dashboard.build_dashboard(
+        report,
+        out_path=out,
+    )
+
+    assert payload["schema_version"] == ("sdetkit.adoption_learning_report_dashboard.v1")
+    assert payload["status"] == "ready"
+    assert payload["report_exists"] is True
+    assert payload["source_report_schema_version"] == ("sdetkit.adoption_learning_report.v1")
+    assert payload["source_repo_count"] == 4
+    assert payload["candidate_count"] == 2
+    assert payload["top_candidate"]["classification"] == ("weak_proof_command_mapping")
+    assert payload["local_only"] is True
+    assert payload["read_only"] is True
+    assert report.read_bytes() == before
+
+    boundary = payload["decision_boundary"]
+    assert all(value is False for value in boundary.values())
+
+
+def test_dashboard_renders_static_escaped_html(
+    tmp_path: Path,
+) -> None:
+    candidate = {
+        "rank": 1,
+        "classification": "review_first_unknown",
+        "priority": "P2",
+        "ranking_score": 10,
+        "next_pr_title": "<script>alert('x')</script>",
+        "observed_in_repos": ["repo-<one>"],
+        "frequency_across_matrix": 1,
+        "owner_files": ["src/<unsafe>.py"],
+        "reason_from_real_repo": "<img src=x onerror=alert(1)>",
+        "proof_needed": ["pytest <unsafe>"],
+        "review_first": True,
+        "safe_to_patch": False,
+        "recommended_next_action": "Review <manually>.",
+    }
+    report = _write_report(
+        tmp_path / "adoption-learning-report.json",
+        payload=_report_payload(candidates=[candidate]),
+    )
+    out = tmp_path / "dashboard.html"
+
+    rc = adoption_learning_report_dashboard.main(
+        [
+            "--report-path",
+            str(report),
+            "--format",
+            "html",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "Adoption learning report dashboard" in text
+    assert "Static, local-only, read-only" in text
+    assert "&lt;script&gt;" in text
+    assert "&lt;img src=x onerror=alert(1)&gt;" in text
+    assert "<script>" not in text
+    assert "safe to patch</dt><dd>false" in text.lower()
+    assert "merge_authorized</strong>: false" in text
+
+
+def test_dashboard_writes_deterministic_json(
+    tmp_path: Path,
+) -> None:
+    report = _write_report(tmp_path / "adoption-learning-report.json")
+    before = report.read_bytes()
+    first = tmp_path / "dashboard-1.json"
+    second = tmp_path / "dashboard-2.json"
+
+    for out in (first, second):
+        rc = adoption_learning_report_dashboard.main(
+            [
+                "--report-path",
+                str(report),
+                "--format",
+                "json",
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 0
+
+    assert first.read_bytes() == second.read_bytes()
+    assert report.read_bytes() == before
+
+    payload = json.loads(first.read_text(encoding="utf-8"))
+    assert payload["candidate_count"] == 2
+    assert payload["decision_boundary"]["automation_allowed"] is False
+    assert payload["decision_boundary"]["merge_authorized"] is False
+
+
+def test_dashboard_renders_valid_empty_report(
+    tmp_path: Path,
+) -> None:
+    report = _write_report(
+        tmp_path / "adoption-learning-report.json",
+        payload=_report_payload(candidates=[]),
+    )
+    out = tmp_path / "dashboard.html"
+
+    rc = adoption_learning_report_dashboard.main(
+        [
+            "--report-path",
+            str(report),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "No upgrade candidates" in text
+
+    payload = adoption_learning_report_dashboard.build_dashboard(
+        report,
+        out_path=out,
+    )
+    assert payload["status"] == "empty"
+    assert payload["candidate_count"] == 0
+    assert payload["top_candidate"] is None
+
+
+def test_dashboard_rejects_missing_or_malformed_report(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out = tmp_path / "dashboard.html"
+
+    rc = adoption_learning_report_dashboard.main(
+        [
+            "--report-path",
+            str(tmp_path / "missing.json"),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "error=" in capsys.readouterr().err
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not-json", encoding="utf-8")
+
+    rc = adoption_learning_report_dashboard.main(
+        [
+            "--report-path",
+            str(malformed),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "error=" in capsys.readouterr().err
+
+
+def test_dashboard_rejects_unknown_schema_or_inconsistent_count(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out = tmp_path / "dashboard.json"
+
+    unknown = _report_payload()
+    unknown["schema_version"] = "sdetkit.adoption_learning_report.v999"
+    unknown_path = _write_report(
+        tmp_path / "unknown.json",
+        payload=unknown,
+    )
+
+    rc = adoption_learning_report_dashboard.main(
+        [
+            "--report-path",
+            str(unknown_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "unsupported adoption learning report schema" in (capsys.readouterr().err)
+
+    inconsistent = _report_payload()
+    inconsistent["candidate_count"] = 99
+    inconsistent_path = _write_report(
+        tmp_path / "inconsistent.json",
+        payload=inconsistent,
+    )
+
+    rc = adoption_learning_report_dashboard.main(
+        [
+            "--report-path",
+            str(inconsistent_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "candidate_count does not match" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Adds a deterministic static local-only dashboard consumer for the accepted adoption learning report JSON artifact.

## Scope

- `src/sdetkit/adoption_learning_report_dashboard.py`
- `tests/test_adoption_learning_report_dashboard.py`

## Dashboard contract

- schema: `sdetkit.adoption_learning_report_dashboard.v1`
- default output: `build/sdetkit/adoption-learning-report-dashboard.html`
- source schema: `sdetkit.adoption_learning_report.v1`
- formats: static HTML and deterministic JSON

## Behavior

- reads one existing adoption learning report JSON artifact;
- validates the accepted source schema;
- validates `candidate_count` consistency;
- summarizes prioritized candidates and RepoMemory context;
- escapes untrusted values before HTML rendering;
- does not mutate the source report;
- returns exit code `2` for missing, malformed, unsupported, or inconsistent input.

## Proof

- focused dashboard/report tests passed: 11;
- runtime HTML and JSON smoke passed;
- deterministic JSON verified;
- source report hash remained unchanged;
- HTML escaping and no-script contract verified;
- `make proof-after-format` passed;
- Ruff and Mypy passed;
- exact two-file scope verified;
- `git diff --check` passed.

## Runtime boundaries

- static_html=true
- local_only=true
- read_only=true
- javascript=false
- network_access=false
- source_report_mutation=false
- workflow_exposure=false
- cloud_dependency=false

## Deferred surfaces

- CLI registration is deferred;
- operator documentation update is deferred;
- dashboard artifact-contract registration is deferred.

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No public CLI registration, documentation change, artifact-index change, workflow integration, hosted service, JavaScript application, target-repository mutation, patch application, PR decision, or merge authorization.
