### PR TITLE
feat(cli): register adoption learning report dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ sdetkit-test-bootstrap-contract = "sdetkit.test_bootstrap_contract:main"
 sdetkit-test-bootstrap-validate = "sdetkit.test_bootstrap_validate:main"
 sdetkit-diagnostic-queue-runner = "sdetkit.diagnostic_queue_runner_cli:main"
 sdetkit-local-diagnostic-queue-dashboard = "sdetkit.local_diagnostic_queue_dashboard:main"
+sdetkit-adoption-learning-report-dashboard = "sdetkit.adoption_learning_report_dashboard:main"
 
 [project.entry-points."sdetkit.notify_adapters"]
 stdout = "sdetkit.notify_plugins:stdout_adapter"

--- a/tests/test_adoption_learning_report_dashboard.py
+++ b/tests/test_adoption_learning_report_dashboard.py
@@ -338,3 +338,12 @@ def test_dashboard_rejects_unknown_schema_or_inconsistent_count(
     assert rc == 2
     assert not out.exists()
     assert "candidate_count does not match" in capsys.readouterr().err
+
+
+def test_project_registers_adoption_learning_report_dashboard_script() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert (
+        "sdetkit-adoption-learning-report-dashboard = "
+        '"sdetkit.adoption_learning_report_dashboard:main"' in pyproject
+    )


### PR DESCRIPTION
## Summary

Registers the accepted adoption learning report dashboard as an installable console command.

## Scope

- `pyproject.toml`
- `tests/test_adoption_learning_report_dashboard.py`

## Public command

```text
sdetkit-adoption-learning-report-dashboard
```

The command delegates directly to:

```text
sdetkit.adoption_learning_report_dashboard:main
```

## Compatibility

The existing module command remains available:

```text
python -m sdetkit.adoption_learning_report_dashboard
```

## Proof

- focused dashboard and report tests passed: 12;
- wheel metadata contains the expected console-script entry point;
- project metadata registration is unique;
- registration test contract passed;
- `make proof-after-format` passed before commit;
- exact two-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_logic_changed=false
- source_report_mutation=false
- network_access=false
- javascript=false
- workflow_exposure=false
- cloud_dependency=false

## Deferred surfaces

- operator documentation update is deferred;
- dashboard artifact-contract registration is deferred.

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No dashboard runtime changes, documentation update, artifact-index change, workflow integration, hosted service, target-repository mutation, patch application, PR decision, or merge authorization.
