### PR TITLE
feat(artifacts): index adoption learning report dashboard JSON

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -678,6 +678,32 @@
       "stability": "advanced"
     },
     {
+      "id": "adoption-learning-report-dashboard-json",
+      "path": "build/sdetkit/adoption-learning-report-dashboard.json",
+      "produced_by": "sdetkit-adoption-learning-report-dashboard --report-path build/sdetkit/adoption-learning-report.json --format json --out build/sdetkit/adoption-learning-report-dashboard.json",
+      "schema_version": "sdetkit.adoption_learning_report_dashboard.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "report_path",
+        "report_exists",
+        "source_report_schema_version",
+        "source_matrix",
+        "source_matrix_schema_version",
+        "source_matrix_status",
+        "source_repo_count",
+        "candidate_count",
+        "top_candidate",
+        "prioritized_upgrade_candidates",
+        "repo_memory_profile",
+        "operator_summary",
+        "local_only",
+        "read_only",
+        "decision_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "doctor-json",
       "path": "build/doctor.json",
       "produced_by": "python -m sdetkit doctor --format json --out build/doctor.json",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from . import (
     adoption_learning_report,
+    adoption_learning_report_dashboard,
     adoption_surface,
     automation_health,
     candidate_collision_checklist,
@@ -56,6 +57,13 @@ def build_index() -> dict[str, Any]:
         "--queue-path build/local-diagnostic-queue/queue.json "
         "--format json "
         "--out build/local-diagnostic-queue/dashboard.json"
+    )
+
+    adoption_learning_report_dashboard_command = (
+        "sdetkit-adoption-learning-report-dashboard "
+        "--report-path build/sdetkit/adoption-learning-report.json "
+        "--format json "
+        "--out build/sdetkit/adoption-learning-report-dashboard.json"
     )
 
     return {
@@ -759,6 +767,34 @@ def build_index() -> dict[str, Any]:
                     "merge_authorized",
                     "semantic_equivalence_proven",
                     "authority_boundary",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "adoption-learning-report-dashboard-json",
+                "path": adoption_learning_report_dashboard.DEFAULT_OUT.with_suffix(
+                    ".json"
+                ).as_posix(),
+                "produced_by": adoption_learning_report_dashboard_command,
+                "schema_version": adoption_learning_report_dashboard.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "report_path",
+                    "report_exists",
+                    "source_report_schema_version",
+                    "source_matrix",
+                    "source_matrix_schema_version",
+                    "source_matrix_status",
+                    "source_repo_count",
+                    "candidate_count",
+                    "top_candidate",
+                    "prioritized_upgrade_candidates",
+                    "repo_memory_profile",
+                    "operator_summary",
+                    "local_only",
+                    "read_only",
+                    "decision_boundary",
                 ],
                 "stability": "advanced",
             },

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from sdetkit import (
     adoption_learning_report,
+    adoption_learning_report_dashboard,
     adoption_surface,
     automation_health,
     candidate_collision_checklist,
@@ -458,6 +459,46 @@ def test_artifact_contract_index_includes_adoption_learning_report_json() -> Non
     )
     assert "--out build/sdetkit/adoption-learning-report.json" in entry["produced_by"]
     assert "--format json" in entry["produced_by"]
+
+
+def test_artifact_contract_index_includes_adoption_learning_report_dashboard_json() -> None:
+    payload = build_index()
+    entries = {item["id"]: item for item in payload["artifacts"]}
+
+    artifact_id = "adoption-learning-report-dashboard-json"
+    assert artifact_id in entries
+
+    entry = entries[artifact_id]
+    assert entry["schema_version"] == adoption_learning_report_dashboard.SCHEMA_VERSION
+    assert entry["path"] == (
+        adoption_learning_report_dashboard.DEFAULT_OUT.with_suffix(".json").as_posix()
+    )
+    assert entry["stability"] == "advanced"
+
+    assert {
+        "schema_version",
+        "status",
+        "report_path",
+        "report_exists",
+        "source_report_schema_version",
+        "source_matrix",
+        "source_matrix_schema_version",
+        "source_matrix_status",
+        "source_repo_count",
+        "candidate_count",
+        "top_candidate",
+        "prioritized_upgrade_candidates",
+        "repo_memory_profile",
+        "operator_summary",
+        "local_only",
+        "read_only",
+        "decision_boundary",
+    }.issubset(set(entry["required_fields"]))
+
+    assert entry["produced_by"].startswith("sdetkit-adoption-learning-report-dashboard ")
+    assert "--report-path build/sdetkit/adoption-learning-report.json" in entry["produced_by"]
+    assert "--format json" in entry["produced_by"]
+    assert "--out build/sdetkit/adoption-learning-report-dashboard.json" in entry["produced_by"]
 
 
 def test_artifact_contract_index_docs_json_matches_generator_payload() -> None:


### PR DESCRIPTION
## Summary

Registers the accepted adoption learning report dashboard JSON projection in the artifact contract index.

## Scope

- `src/sdetkit/artifact_contract_index.py`
- `tests/test_artifact_contract_index.py`
- `docs/artifact-contract-index.json`

## Artifact contract

- id: `adoption-learning-report-dashboard-json`
- path: `build/sdetkit/adoption-learning-report-dashboard.json`
- schema: `sdetkit.adoption_learning_report_dashboard.v1`
- stability: `advanced`

## Producer

```text
sdetkit-adoption-learning-report-dashboard --report-path build/sdetkit/adoption-learning-report.json --format json --out build/sdetkit/adoption-learning-report-dashboard.json
```

## Proof

- artifact contract and generated-index synchronization passed;
- focused artifact-index and dashboard tests passed: 15;
- runtime JSON satisfied every registered required field;
- runtime schema matched the registered schema;
- source adoption learning report remained unchanged;
- `make proof-after-format` passed before commit;
- exact three-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_logic_changed=false
- cli_registration_changed=false
- operator_docs_changed=false
- source_report_mutation=false
- workflow_exposure=false
- cloud_dependency=false

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No dashboard runtime change, CLI change, operator-documentation change, workflow integration, hosted service, target-repository mutation, patch application, PR decision, or merge authorization.
