### PR TITLE
feat(maintenance): add queue rollup dashboard

### DIFF
--- a/src/sdetkit/maintenance_queue_rollup_dashboard.py
+++ b/src/sdetkit/maintenance_queue_rollup_dashboard.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from sdetkit import maintenance_queue_rollup
+from sdetkit.atomicio import atomic_write_text
+
+SCHEMA_VERSION = "sdetkit.maintenance_queue_rollup_dashboard.v1"
+DEFAULT_OUT = Path("build") / "sdetkit" / "maintenance-queue-rollup-dashboard.html"
+
+JsonObject = dict[str, Any]
+
+_SOURCE_AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _integer(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _validate_denied_authority(
+    value: Mapping[str, Any],
+    *,
+    context: str,
+) -> None:
+    expanded = [field for field in _SOURCE_AUTHORITY_FIELDS if value.get(field) is not False]
+    if expanded:
+        fields = ", ".join(expanded)
+        raise ValueError(f"{context} authority boundary must remain denied: {fields}")
+
+
+def _load_rollup(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("expected maintenance queue rollup JSON object")
+
+    schema_version = _string(payload.get("schema_version"))
+    if schema_version != maintenance_queue_rollup.SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported maintenance queue rollup schema: {schema_version or 'missing'}"
+        )
+
+    _validate_denied_authority(
+        payload,
+        context="maintenance queue rollup",
+    )
+    return payload
+
+
+def _queue_item(value: Any) -> JsonObject:
+    item = _as_dict(value)
+    _validate_denied_authority(
+        item,
+        context="maintenance queue item",
+    )
+    return {
+        "issue_number": _integer(item.get("issue_number")),
+        "title": _string(item.get("title")),
+        "lane": _string(item.get("lane")) or "triage",
+        "classification": (_string(item.get("classification")) or "needs_human_review"),
+        "rank_score": _integer(item.get("rank_score")),
+        "review_required": item.get("review_required") is True,
+        "close_candidate": item.get("close_candidate") is True,
+        "security_disposition": _string(item.get("security_disposition")),
+        "automation_health_state": _string(item.get("automation_health_state")),
+        "recommended_action": _string(item.get("recommended_action")),
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _input_artifacts(value: Any) -> JsonObject:
+    artifacts = _as_dict(value)
+    return {
+        "issue_queue_schema_version": _string(artifacts.get("issue_queue_schema_version")),
+        "automation_health_schema_version": _string(
+            artifacts.get("automation_health_schema_version")
+        ),
+        "security_schema": _string(artifacts.get("security_schema")),
+    }
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "current_pr_decision_input": False,
+        "automation_allowed": False,
+        "issue_mutation_allowed": False,
+        "security_dismissal_allowed": False,
+        "proof_commands_executed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _validate_source_counts(
+    rollup: Mapping[str, Any],
+    items: list[JsonObject],
+) -> None:
+    source_count = _integer(rollup.get("queue_item_count"))
+    if source_count != len(items):
+        raise ValueError("queue_item_count does not match queue_items")
+
+    review_required_count = sum(item["review_required"] is True for item in items)
+    if _integer(rollup.get("review_required_count")) != review_required_count:
+        raise ValueError("review_required_count does not match queue_items")
+
+    close_candidate_count = sum(item["close_candidate"] is True for item in items)
+    if _integer(rollup.get("close_candidate_count")) != close_candidate_count:
+        raise ValueError("close_candidate_count does not match queue_items")
+
+    raw_primary = rollup.get("primary_issue")
+    primary_issue = _integer(raw_primary) if raw_primary is not None else None
+    expected_primary = _integer(items[0].get("issue_number")) if items else None
+    if primary_issue != expected_primary:
+        raise ValueError("primary_issue does not match queue ordering")
+
+
+def build_dashboard(
+    rollup_path: Path,
+    *,
+    out_path: Path,
+) -> JsonObject:
+    del out_path
+
+    rollup = _load_rollup(rollup_path)
+    items = [
+        _queue_item(item) for item in _as_list(rollup.get("queue_items")) if isinstance(item, dict)
+    ]
+    _validate_source_counts(rollup, items)
+
+    lane_counts = dict(
+        sorted(Counter(_string(item.get("lane")) or "triage" for item in items).items())
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ready" if items else "empty",
+        "rollup_path": rollup_path.as_posix(),
+        "rollup_exists": rollup_path.is_file(),
+        "source_rollup_schema_version": _string(rollup.get("schema_version")),
+        "source_rollup_status": _string(rollup.get("status")),
+        "source_issue_count": _integer(rollup.get("source_issue_count")),
+        "queue_item_count": len(items),
+        "review_required_count": sum(item["review_required"] is True for item in items),
+        "close_candidate_count": sum(item["close_candidate"] is True for item in items),
+        "primary_issue": (_integer(items[0].get("issue_number")) if items else None),
+        "recommended_next_action": _string(rollup.get("recommended_next_action")),
+        "lane_counts": lane_counts,
+        "input_artifacts": _input_artifacts(rollup.get("input_artifacts")),
+        "queue_items": items,
+        "local_only": True,
+        "read_only": True,
+        "decision_boundary": _decision_boundary(),
+    }
+
+
+def _escape(value: Any) -> str:
+    return html.escape(_string(value))
+
+
+def _queue_card(item: Mapping[str, Any]) -> str:
+    review_required = item.get("review_required") is True
+    close_candidate = item.get("close_candidate") is True
+
+    if review_required:
+        state_class = "review"
+        state_label = "review required"
+    elif close_candidate:
+        state_class = "close"
+        state_label = "close candidate"
+    else:
+        state_class = "ready"
+        state_label = "ready with proof"
+
+    return (
+        f"<article class='card {state_class}'>"
+        f"<h2>Issue #{_integer(item.get('issue_number'))}</h2>"
+        f"<p class='state'>{html.escape(state_label)}</p>"
+        "<dl>"
+        f"<dt>Title</dt><dd>{_escape(item.get('title')) or '—'}</dd>"
+        f"<dt>Lane</dt><dd>{_escape(item.get('lane'))}</dd>"
+        f"<dt>Classification</dt><dd>{_escape(item.get('classification'))}</dd>"
+        f"<dt>Rank score</dt><dd>{_integer(item.get('rank_score'))}</dd>"
+        f"<dt>Security disposition</dt><dd>{_escape(item.get('security_disposition')) or '—'}</dd>"
+        f"<dt>Automation health</dt><dd>{_escape(item.get('automation_health_state')) or '—'}</dd>"
+        "</dl>"
+        f"<p><strong>Recommended action:</strong> "
+        f"{_escape(item.get('recommended_action')) or '—'}</p>"
+        "<p class='muted'>This item is review context only. "
+        "It does not authorize issue mutation, security dismissal, "
+        "patch application, or merge.</p>"
+        "</article>"
+    )
+
+
+def render_html(payload: Mapping[str, Any]) -> str:
+    items = [
+        _as_dict(item) for item in _as_list(payload.get("queue_items")) if isinstance(item, dict)
+    ]
+    cards = "".join(_queue_card(item) for item in items)
+    if not cards:
+        cards = (
+            "<article class='card empty'>"
+            "<h2>No maintenance queue items</h2>"
+            "<p>The source rollup is valid and currently empty.</p>"
+            "</article>"
+        )
+
+    lane_counts = _as_dict(payload.get("lane_counts"))
+    lane_items = "".join(
+        f"<li><strong>{html.escape(key)}</strong>: {_integer(value)}</li>"
+        for key, value in sorted(lane_counts.items())
+    )
+    if not lane_items:
+        lane_items = "<li class='muted'>none</li>"
+
+    boundary = _as_dict(payload.get("decision_boundary"))
+    boundary_items = "".join(
+        f"<li><strong>{html.escape(key)}</strong>: {str(value).lower()}</li>"
+        for key, value in sorted(boundary.items())
+    )
+
+    primary_issue = payload.get("primary_issue")
+    primary_text = str(_integer(primary_issue)) if primary_issue is not None else "none"
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Maintenance queue rollup dashboard</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; color: #172033; background: #f6f7fb; }}
+    header {{ margin-bottom: 1.5rem; }}
+    .summary {{ display: flex; flex-wrap: wrap; gap: .6rem; margin: 1rem 0; }}
+    .pill {{ background: white; border: 1px solid #d7dce8; border-radius: 999px; padding: .45rem .8rem; }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; }}
+    .card {{ background: white; border: 1px solid #d7dce8; border-radius: 14px; padding: 1rem; box-shadow: 0 1px 2px rgb(20 30 50 / 8%); }}
+    .review {{ border-top: 5px solid #b42318; }}
+    .close {{ border-top: 5px solid #b54708; }}
+    .ready {{ border-top: 5px solid #247a3f; }}
+    .empty {{ border-top: 5px solid #667085; }}
+    .state {{ font-weight: 700; text-transform: uppercase; }}
+    .muted {{ color: #667085; }}
+    dl {{ display: grid; grid-template-columns: max-content 1fr; gap: .35rem .75rem; }}
+    dt {{ font-weight: 700; }}
+    dd {{ margin: 0; overflow-wrap: anywhere; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Maintenance queue rollup dashboard</h1>
+    <p>Static, local-only, read-only view of the accepted Python maintenance queue rollup artifact.</p>
+    <div class="summary">
+      <span class="pill">status: {_escape(payload.get("status"))}</span>
+      <span class="pill">source status: {_escape(payload.get("source_rollup_status"))}</span>
+      <span class="pill">queue items: {_integer(payload.get("queue_item_count"))}</span>
+      <span class="pill">review required: {_integer(payload.get("review_required_count"))}</span>
+      <span class="pill">close candidates: {_integer(payload.get("close_candidate_count"))}</span>
+      <span class="pill">primary issue: {html.escape(primary_text)}</span>
+      <span class="pill">local only: {str(payload.get("local_only")).lower()}</span>
+      <span class="pill">read only: {str(payload.get("read_only")).lower()}</span>
+    </div>
+    <p><strong>Rollup:</strong> <code>{_escape(payload.get("rollup_path"))}</code></p>
+    <p><strong>Recommended next action:</strong> {_escape(payload.get("recommended_next_action")) or "—"}</p>
+  </header>
+  <main class="grid">
+    {cards}
+    <article class="card">
+      <h2>Lane counts</h2>
+      <ul>{lane_items}</ul>
+    </article>
+    <article class="card">
+      <h2>Authority boundary</h2>
+      <ul>{boundary_items}</ul>
+      <p>This dashboard is not proof execution, issue mutation, security dismissal, patch approval, a current-PR decision, or merge authorization.</p>
+    </article>
+  </main>
+</body>
+</html>
+"""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=("python -m sdetkit.maintenance_queue_rollup_dashboard"),
+        description=(
+            "Render a deterministic local-only dashboard from an "
+            "existing maintenance queue rollup JSON artifact."
+        ),
+    )
+    parser.add_argument(
+        "--rollup-path",
+        type=Path,
+        required=True,
+    )
+    parser.add_argument(
+        "--format",
+        choices=("html", "json"),
+        default="html",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        payload = build_dashboard(
+            args.rollup_path,
+            out_path=args.out,
+        )
+        rendered = (
+            json.dumps(
+                payload,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+            if args.format == "json"
+            else render_html(payload)
+        )
+        atomic_write_text(args.out, rendered)
+    except (
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        print(
+            f"error={_string(exc) or type(exc).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance_queue_rollup_dashboard.py
+++ b/tests/test_maintenance_queue_rollup_dashboard.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import maintenance_queue_rollup_dashboard
+
+
+def _queue_item(
+    *,
+    issue_number: int,
+    title: str,
+    lane: str,
+    rank_score: int,
+    review_required: bool,
+    close_candidate: bool,
+) -> dict[str, object]:
+    return {
+        "issue_number": issue_number,
+        "title": title,
+        "lane": lane,
+        "classification": ("security_followup" if lane == "security" else "generated_tracker"),
+        "rank_score": rank_score,
+        "review_required": review_required,
+        "close_candidate": close_candidate,
+        "security_disposition": ("needs review" if lane == "security" else ""),
+        "automation_health_state": "",
+        "recommended_action": (
+            "Review the item manually." if review_required else "Keep as context."
+        ),
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _rollup_payload(
+    *,
+    queue_items: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    rows = (
+        queue_items
+        if queue_items is not None
+        else [
+            _queue_item(
+                issue_number=1502,
+                title="Review current security warnings",
+                lane="security",
+                rank_score=700,
+                review_required=True,
+                close_candidate=False,
+            ),
+            _queue_item(
+                issue_number=1500,
+                title="Generated command center",
+                lane="command center",
+                rank_score=0,
+                review_required=False,
+                close_candidate=True,
+            ),
+        ]
+    )
+    review_count = sum(item["review_required"] is True for item in rows)
+    close_count = sum(item["close_candidate"] is True for item in rows)
+    return {
+        "schema_version": ("sdetkit.maintenance.queue.rollup.v1"),
+        "status": (
+            "review required" if review_count else ("ready with proof" if rows else "empty")
+        ),
+        "source_issue_count": len(rows),
+        "queue_item_count": len(rows),
+        "review_required_count": review_count,
+        "close_candidate_count": close_count,
+        "primary_issue": (rows[0]["issue_number"] if rows else None),
+        "recommended_next_action": (rows[0]["recommended_action"] if rows else None),
+        "queue_items": rows,
+        "input_artifacts": {
+            "issue_queue_schema_version": ("sdetkit.issue.queue.classifier.v1"),
+            "automation_health_schema_version": ("sdetkit.automation.health.v1"),
+            "security_schema": ("sdetkit.security.followup.disposition.v1"),
+        },
+        "automation_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _write_rollup(
+    path: Path,
+    *,
+    payload: dict[str, object] | None = None,
+) -> Path:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    path.write_text(
+        json.dumps(
+            payload or _rollup_payload(),
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_dashboard_builds_read_only_queue_summary(
+    tmp_path: Path,
+) -> None:
+    rollup = _write_rollup(tmp_path / "maintenance-queue-rollup.json")
+    before = rollup.read_bytes()
+    out = tmp_path / "dashboard.html"
+
+    payload = maintenance_queue_rollup_dashboard.build_dashboard(
+        rollup,
+        out_path=out,
+    )
+
+    assert payload["schema_version"] == ("sdetkit.maintenance_queue_rollup_dashboard.v1")
+    assert payload["status"] == "ready"
+    assert payload["rollup_exists"] is True
+    assert payload["source_rollup_schema_version"] == ("sdetkit.maintenance.queue.rollup.v1")
+    assert payload["source_rollup_status"] == ("review required")
+    assert payload["queue_item_count"] == 2
+    assert payload["review_required_count"] == 1
+    assert payload["close_candidate_count"] == 1
+    assert payload["primary_issue"] == 1502
+    assert payload["lane_counts"] == {
+        "command center": 1,
+        "security": 1,
+    }
+    assert payload["local_only"] is True
+    assert payload["read_only"] is True
+    assert rollup.read_bytes() == before
+    assert all(value is False for value in payload["decision_boundary"].values())
+
+
+def test_dashboard_renders_static_escaped_html(
+    tmp_path: Path,
+) -> None:
+    item = _queue_item(
+        issue_number=1502,
+        title="<script>alert('x')</script>",
+        lane="security",
+        rank_score=700,
+        review_required=True,
+        close_candidate=False,
+    )
+    item["recommended_action"] = "<img src=x onerror=alert(1)>"
+    rollup = _write_rollup(
+        tmp_path / "maintenance-queue-rollup.json",
+        payload=_rollup_payload(queue_items=[item]),
+    )
+    out = tmp_path / "dashboard.html"
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(rollup),
+            "--format",
+            "html",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "Maintenance queue rollup dashboard" in text
+    assert "Static, local-only, read-only" in text
+    assert "&lt;script&gt;" in text
+    assert "&lt;img src=x onerror=alert(1)&gt;" in text
+    assert "<script>" not in text
+    assert "issue_mutation_allowed</strong>: false" in text
+    assert "security_dismissal_allowed</strong>: false" in text
+    assert "merge_authorized</strong>: false" in text
+
+
+def test_dashboard_writes_deterministic_json(
+    tmp_path: Path,
+) -> None:
+    rollup = _write_rollup(tmp_path / "maintenance-queue-rollup.json")
+    before = rollup.read_bytes()
+    first = tmp_path / "dashboard-1.json"
+    second = tmp_path / "dashboard-2.json"
+
+    for out in (first, second):
+        rc = maintenance_queue_rollup_dashboard.main(
+            [
+                "--rollup-path",
+                str(rollup),
+                "--format",
+                "json",
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 0
+
+    assert first.read_bytes() == second.read_bytes()
+    assert rollup.read_bytes() == before
+
+    payload = json.loads(first.read_text(encoding="utf-8"))
+    assert payload["queue_item_count"] == 2
+    assert payload["decision_boundary"]["automation_allowed"] is False
+    assert payload["decision_boundary"]["issue_mutation_allowed"] is False
+    assert payload["decision_boundary"]["merge_authorized"] is False
+
+
+def test_dashboard_renders_valid_empty_rollup(
+    tmp_path: Path,
+) -> None:
+    rollup = _write_rollup(
+        tmp_path / "maintenance-queue-rollup.json",
+        payload=_rollup_payload(queue_items=[]),
+    )
+    out = tmp_path / "dashboard.html"
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(rollup),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "No maintenance queue items" in text
+
+    payload = maintenance_queue_rollup_dashboard.build_dashboard(
+        rollup,
+        out_path=out,
+    )
+    assert payload["status"] == "empty"
+    assert payload["queue_item_count"] == 0
+    assert payload["primary_issue"] is None
+    assert payload["lane_counts"] == {}
+
+
+def test_dashboard_rejects_missing_or_malformed_rollup(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out = tmp_path / "dashboard.html"
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(tmp_path / "missing.json"),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "error=" in capsys.readouterr().err
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text(
+        "{not-json",
+        encoding="utf-8",
+    )
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(malformed),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "error=" in capsys.readouterr().err
+
+
+def test_dashboard_rejects_unknown_schema_or_count_drift(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out = tmp_path / "dashboard.json"
+
+    unknown = _rollup_payload()
+    unknown["schema_version"] = "sdetkit.maintenance.queue.rollup.v999"
+    unknown_path = _write_rollup(
+        tmp_path / "unknown.json",
+        payload=unknown,
+    )
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(unknown_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "unsupported maintenance queue rollup schema" in capsys.readouterr().err
+
+    inconsistent = _rollup_payload()
+    inconsistent["queue_item_count"] = 99
+    inconsistent_path = _write_rollup(
+        tmp_path / "inconsistent.json",
+        payload=inconsistent,
+    )
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(inconsistent_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "queue_item_count does not match" in capsys.readouterr().err
+
+
+def test_dashboard_rejects_derived_count_or_primary_drift(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out = tmp_path / "dashboard.json"
+
+    review_drift = _rollup_payload()
+    review_drift["review_required_count"] = 0
+    review_path = _write_rollup(
+        tmp_path / "review-drift.json",
+        payload=review_drift,
+    )
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(review_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "review_required_count does not match" in capsys.readouterr().err
+
+    primary_drift = _rollup_payload()
+    primary_drift["primary_issue"] = 1500
+    primary_path = _write_rollup(
+        tmp_path / "primary-drift.json",
+        payload=primary_drift,
+    )
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(primary_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "primary_issue does not match" in capsys.readouterr().err
+
+
+def test_dashboard_rejects_authority_expansion(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out = tmp_path / "dashboard.json"
+
+    expanded = _rollup_payload()
+    expanded["automation_allowed"] = True
+    expanded_path = _write_rollup(
+        tmp_path / "expanded.json",
+        payload=expanded,
+    )
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(expanded_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "authority boundary must remain denied" in capsys.readouterr().err
+
+    item_expanded = _rollup_payload()
+    item = item_expanded["queue_items"][0]
+    assert isinstance(item, dict)
+    item["merge_authorized"] = True
+    item_path = _write_rollup(
+        tmp_path / "item-expanded.json",
+        payload=item_expanded,
+    )
+
+    rc = maintenance_queue_rollup_dashboard.main(
+        [
+            "--rollup-path",
+            str(item_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 2
+    assert not out.exists()
+    assert "maintenance queue item authority boundary" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Adds a thin static dashboard consumer for the accepted maintenance queue rollup JSON artifact.

## Scope

- `src/sdetkit/maintenance_queue_rollup_dashboard.py`
- `tests/test_maintenance_queue_rollup_dashboard.py`

## Dashboard contract

- source schema: `sdetkit.maintenance.queue.rollup.v1`
- dashboard schema: `sdetkit.maintenance_queue_rollup_dashboard.v1`
- default HTML output: `build/sdetkit/maintenance-queue-rollup-dashboard.html`
- optional deterministic JSON output

## Behavior

- reads an existing rollup artifact without mutating it;
- validates source schema and derived counts;
- validates `primary_issue` against queue ordering;
- rejects top-level or item-level authority expansion;
- renders escaped static HTML;
- performs no JavaScript or network access;
- exposes local-only, read-only decision boundaries.

## Proof

- compile, Ruff format, and Ruff check passed;
- dashboard and source-rollup tests passed: 12;
- HTML and deterministic JSON runtime smoke passed;
- source rollup remained unchanged;
- deferred CLI, docs, artifact-index, and workflow guards passed;
- `make proof-after-format` passed before commit;
- exact two-file scope verified;
- `git diff --check` passed.

## Runtime impact

- source_rollup_mutation=false
- local_only=true
- read_only=true
- javascript=false
- network_access=false
- workflow_exposure=false
- cloud_dependency=false

## Deferred surfaces

- public CLI registration;
- dashboard operator documentation;
- dashboard JSON artifact-contract registration.

## Authority boundaries

- current_pr_decision_input=false
- automation_allowed=false
- issue_mutation_allowed=false
- security_dismissal_allowed=false
- proof_commands_executed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No CLI registration, operator-documentation change, artifact-index change, workflow integration, hosted service, issue mutation, security dismissal, patch application, PR decision, or merge authorization.
