### PR TITLE
feat(cli): register maintenance queue rollup dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ sdetkit-test-bootstrap-validate = "sdetkit.test_bootstrap_validate:main"
 sdetkit-diagnostic-queue-runner = "sdetkit.diagnostic_queue_runner_cli:main"
 sdetkit-local-diagnostic-queue-dashboard = "sdetkit.local_diagnostic_queue_dashboard:main"
 sdetkit-adoption-learning-report-dashboard = "sdetkit.adoption_learning_report_dashboard:main"
+sdetkit-maintenance-queue-rollup-dashboard = "sdetkit.maintenance_queue_rollup_dashboard:main"
 
 [project.entry-points."sdetkit.notify_adapters"]
 stdout = "sdetkit.notify_plugins:stdout_adapter"

--- a/tests/test_maintenance_queue_rollup_dashboard.py
+++ b/tests/test_maintenance_queue_rollup_dashboard.py
@@ -431,3 +431,14 @@ def test_dashboard_rejects_authority_expansion(
     assert rc == 2
     assert not out.exists()
     assert "maintenance queue item authority boundary" in capsys.readouterr().err
+
+
+def test_project_registers_maintenance_queue_rollup_dashboard_script() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    registration = (
+        "sdetkit-maintenance-queue-rollup-dashboard = "
+        '"sdetkit.maintenance_queue_rollup_dashboard:main"'
+    )
+
+    assert pyproject.count(registration) == 1


### PR DESCRIPTION
## Summary

Registers the accepted maintenance queue rollup dashboard as an installable console command.

## Scope

- `pyproject.toml`
- `tests/test_maintenance_queue_rollup_dashboard.py`

## Public command

```text
sdetkit-maintenance-queue-rollup-dashboard
```

## Entry point

```text
sdetkit.maintenance_queue_rollup_dashboard:main
```

## Module fallback

```text
python -m sdetkit.maintenance_queue_rollup_dashboard
```

## Proof

- project metadata contains exactly one registration;
- focused dashboard and rollup tests passed: 13;
- wheel metadata contains the expected console-script entry point;
- wheel installed successfully into an isolated virtual environment;
- installed console command generated HTML and JSON;
- source rollup remained unchanged;
- deferred docs, artifact-index, and workflow guards passed;
- `make proof-after-format` passed before commit;
- exact two-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_logic_changed=false
- source_rollup_mutation=false
- network_access=false
- javascript=false
- workflow_exposure=false
- cloud_dependency=false

## Deferred surfaces

- dashboard operator documentation;
- dashboard JSON artifact-contract registration.

## Authority boundaries

- automation_allowed=false
- issue_mutation_allowed=false
- security_dismissal_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No dashboard runtime change, operator-documentation change, artifact-index change, workflow integration, hosted service, issue mutation, security dismissal, patch application, PR decision, or merge authorization.
