### PR TITLE
feat(maintenance): register queue rollup dashboard artifact contract

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -492,6 +492,33 @@
       "stability": "advanced"
     },
     {
+      "id": "maintenance-queue-rollup-dashboard-json",
+      "path": "build/sdetkit/maintenance-queue-rollup-dashboard.json",
+      "produced_by": "sdetkit-maintenance-queue-rollup-dashboard --rollup-path build/sdetkit/maintenance-queue-rollup.json --format json --out build/sdetkit/maintenance-queue-rollup-dashboard.json",
+      "schema_version": "sdetkit.maintenance_queue_rollup_dashboard.v1",
+      "required_fields": [
+        "schema_version",
+        "status",
+        "rollup_path",
+        "rollup_exists",
+        "source_rollup_schema_version",
+        "source_rollup_status",
+        "source_issue_count",
+        "queue_item_count",
+        "review_required_count",
+        "close_candidate_count",
+        "primary_issue",
+        "recommended_next_action",
+        "lane_counts",
+        "input_artifacts",
+        "queue_items",
+        "local_only",
+        "read_only",
+        "decision_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "security-review-packet-json",
       "path": "build/sdetkit/security-review-packet.json",
       "produced_by": "python -m sdetkit security-review-packet --inventory-json <security-findings-inventory.json> --matrix-json <security-finding-disposition-matrix.json> --out build/sdetkit/security-review-packet.json --format text",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -21,6 +21,7 @@ from . import (
     job_queue,
     local_diagnostic_queue_dashboard,
     maintenance_queue_rollup,
+    maintenance_queue_rollup_dashboard,
     pr_quality_runtime_proof_artifacts,
     professional_naming_cleanup_plan,
     professional_naming_inventory,
@@ -64,6 +65,13 @@ def build_index() -> dict[str, Any]:
         "--report-path build/sdetkit/adoption-learning-report.json "
         "--format json "
         "--out build/sdetkit/adoption-learning-report-dashboard.json"
+    )
+
+    maintenance_queue_rollup_dashboard_command = (
+        "sdetkit-maintenance-queue-rollup-dashboard "
+        "--rollup-path build/sdetkit/maintenance-queue-rollup.json "
+        "--format json "
+        "--out build/sdetkit/maintenance-queue-rollup-dashboard.json"
     )
 
     return {
@@ -574,6 +582,35 @@ def build_index() -> dict[str, Any]:
                     "automation_allowed",
                     "merge_authorized",
                     "semantic_equivalence_proven",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "maintenance-queue-rollup-dashboard-json",
+                "path": maintenance_queue_rollup_dashboard.DEFAULT_OUT.with_suffix(
+                    ".json"
+                ).as_posix(),
+                "produced_by": maintenance_queue_rollup_dashboard_command,
+                "schema_version": maintenance_queue_rollup_dashboard.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "status",
+                    "rollup_path",
+                    "rollup_exists",
+                    "source_rollup_schema_version",
+                    "source_rollup_status",
+                    "source_issue_count",
+                    "queue_item_count",
+                    "review_required_count",
+                    "close_candidate_count",
+                    "primary_issue",
+                    "recommended_next_action",
+                    "lane_counts",
+                    "input_artifacts",
+                    "queue_items",
+                    "local_only",
+                    "read_only",
+                    "decision_boundary",
                 ],
                 "stability": "advanced",
             },

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -21,6 +21,7 @@ from sdetkit import (
     job_queue,
     local_diagnostic_queue_dashboard,
     maintenance_queue_rollup,
+    maintenance_queue_rollup_dashboard,
     pr_quality_runtime_proof_artifacts,
     professional_naming_cleanup_plan,
     professional_naming_inventory,
@@ -499,6 +500,47 @@ def test_artifact_contract_index_includes_adoption_learning_report_dashboard_jso
     assert "--report-path build/sdetkit/adoption-learning-report.json" in entry["produced_by"]
     assert "--format json" in entry["produced_by"]
     assert "--out build/sdetkit/adoption-learning-report-dashboard.json" in entry["produced_by"]
+
+
+def test_artifact_contract_index_includes_maintenance_queue_rollup_dashboard_json() -> None:
+    payload = build_index()
+    entries = {item["id"]: item for item in payload["artifacts"]}
+
+    artifact_id = "maintenance-queue-rollup-dashboard-json"
+    assert artifact_id in entries
+
+    entry = entries[artifact_id]
+    assert entry["schema_version"] == maintenance_queue_rollup_dashboard.SCHEMA_VERSION
+    assert entry["path"] == (
+        maintenance_queue_rollup_dashboard.DEFAULT_OUT.with_suffix(".json").as_posix()
+    )
+    assert entry["stability"] == "advanced"
+
+    assert {
+        "schema_version",
+        "status",
+        "rollup_path",
+        "rollup_exists",
+        "source_rollup_schema_version",
+        "source_rollup_status",
+        "source_issue_count",
+        "queue_item_count",
+        "review_required_count",
+        "close_candidate_count",
+        "primary_issue",
+        "recommended_next_action",
+        "lane_counts",
+        "input_artifacts",
+        "queue_items",
+        "local_only",
+        "read_only",
+        "decision_boundary",
+    }.issubset(set(entry["required_fields"]))
+
+    assert entry["produced_by"].startswith("sdetkit-maintenance-queue-rollup-dashboard ")
+    assert "--rollup-path build/sdetkit/maintenance-queue-rollup.json" in entry["produced_by"]
+    assert "--format json" in entry["produced_by"]
+    assert "--out build/sdetkit/maintenance-queue-rollup-dashboard.json" in entry["produced_by"]
 
 
 def test_artifact_contract_index_docs_json_matches_generator_payload() -> None:


### PR DESCRIPTION
## Summary

Registers the accepted maintenance queue rollup dashboard JSON projection in the artifact contract index.

## Scope

- `src/sdetkit/artifact_contract_index.py`
- `tests/test_artifact_contract_index.py`
- `docs/artifact-contract-index.json`

## Artifact contract

- id: `maintenance-queue-rollup-dashboard-json`
- path: `build/sdetkit/maintenance-queue-rollup-dashboard.json`
- schema: `sdetkit.maintenance_queue_rollup_dashboard.v1`
- stability: `advanced`

## Producer

```text
sdetkit-maintenance-queue-rollup-dashboard --rollup-path build/sdetkit/maintenance-queue-rollup.json --format json --out build/sdetkit/maintenance-queue-rollup-dashboard.json
```

## Contract proof

- dashboard module import added to the index generator;
- generator entry contains the accepted path, schema, producer, stability, and 18 required fields;
- generated `docs/artifact-contract-index.json` exactly matches `build_index()`;
- focused artifact-index, dashboard, and rollup tests passed: 22;
- wheel-installed dashboard command generated a runtime JSON artifact;
- runtime artifact satisfied every registered required field;
- runtime schema matched the registered schema;
- source rollup remained unchanged;
- deferred runtime, CLI, operator-doc, and workflow guards passed;
- `make proof-after-format` passed before commit;
- exact three-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_logic_changed=false
- cli_registration_changed=false
- operator_docs_changed=false
- source_rollup_mutation=false
- workflow_exposure=false
- cloud_dependency=false

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No dashboard runtime change, CLI change, operator-documentation change, workflow integration, hosted service, issue mutation, security dismissal, patch application, PR decision, or merge authorization.
