### PR TITLE
feat(ci): register failure extractor artifact contract

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -470,6 +470,19 @@
       "stability": "advanced"
     },
     {
+      "id": "ci-failure-extractor-json",
+      "path": "build/sdetkit/failed-check-logs.json",
+      "produced_by": "python -m sdetkit.ci_failure_extractor --log <raw-ci.log> --out build/sdetkit/failed-check-logs.json --format text",
+      "schema_version": "sdetkit.ci_failure_extractor.v1",
+      "required_fields": [
+        "schema_version",
+        "failed_check_count",
+        "failed_checks",
+        "summary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "maintenance-queue-rollup-json",
       "path": "build/sdetkit/maintenance-queue-rollup.json",
       "produced_by": "python -m sdetkit maintenance-queue-rollup --issue-queue-json <issue-queue.json> --automation-health-json <automation-health.json> --security-followup-json <security-followup-disposition.json> --out build/sdetkit/maintenance-queue-rollup.json --format text",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -12,6 +12,7 @@ from . import (
     candidate_evidence_checklist,
     candidate_freeze_readiness,
     check_intelligence,
+    ci_failure_extractor,
     diagnostic_job,
     diagnostic_signal_snapshot,
     diagnostic_signal_snapshot_history,
@@ -560,6 +561,24 @@ def build_index() -> dict[str, Any]:
                     "automation_allowed",
                     "merge_authorized",
                     "semantic_equivalence_proven",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "ci-failure-extractor-json",
+                "path": ci_failure_extractor.DEFAULT_OUT,
+                "produced_by": (
+                    "python -m sdetkit.ci_failure_extractor "
+                    "--log <raw-ci.log> "
+                    "--out build/sdetkit/failed-check-logs.json "
+                    "--format text"
+                ),
+                "schema_version": ci_failure_extractor.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "failed_check_count",
+                    "failed_checks",
+                    "summary",
                 ],
                 "stability": "advanced",
             },

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -12,6 +12,7 @@ from sdetkit import (
     candidate_evidence_checklist,
     candidate_freeze_readiness,
     check_intelligence,
+    ci_failure_extractor,
     diagnostic_job,
     diagnostic_signal_snapshot,
     diagnostic_signal_snapshot_history,
@@ -541,6 +542,31 @@ def test_artifact_contract_index_includes_maintenance_queue_rollup_dashboard_jso
     assert "--rollup-path build/sdetkit/maintenance-queue-rollup.json" in entry["produced_by"]
     assert "--format json" in entry["produced_by"]
     assert "--out build/sdetkit/maintenance-queue-rollup-dashboard.json" in entry["produced_by"]
+
+
+def test_artifact_contract_index_includes_ci_failure_extractor_json() -> None:
+    payload = build_index()
+    entries = {item["id"]: item for item in payload["artifacts"]}
+
+    artifact_id = "ci-failure-extractor-json"
+    assert artifact_id in entries
+
+    entry = entries[artifact_id]
+    assert entry["schema_version"] == ci_failure_extractor.SCHEMA_VERSION
+    assert entry["path"] == ci_failure_extractor.DEFAULT_OUT
+    assert entry["stability"] == "advanced"
+
+    assert {
+        "schema_version",
+        "failed_check_count",
+        "failed_checks",
+        "summary",
+    }.issubset(set(entry["required_fields"]))
+
+    assert entry["produced_by"].startswith("python -m sdetkit.ci_failure_extractor ")
+    assert "--log <raw-ci.log>" in entry["produced_by"]
+    assert "--out build/sdetkit/failed-check-logs.json" in entry["produced_by"]
+    assert "--format text" in entry["produced_by"]
 
 
 def test_artifact_contract_index_docs_json_matches_generator_payload() -> None:


### PR DESCRIPTION
## Summary

Registers the accepted CI failure extractor JSON output in the artifact contract index.

## Scope

- `src/sdetkit/artifact_contract_index.py`
- `tests/test_artifact_contract_index.py`
- `docs/artifact-contract-index.json`

## Artifact contract

- id: `ci-failure-extractor-json`
- path: `build/sdetkit/failed-check-logs.json`
- schema: `sdetkit.ci_failure_extractor.v1`
- stability: `advanced`

## Producer

```text
python -m sdetkit.ci_failure_extractor --log <raw-ci.log> --out build/sdetkit/failed-check-logs.json --format text
```

## Required fields

- `schema_version`
- `failed_check_count`
- `failed_checks`
- `summary`

## Contract proof

- extractor module import added to the index generator;
- generator entry contains the accepted path, schema, producer, stability, and four required top-level fields;
- generated `docs/artifact-contract-index.json` exactly matches `build_index()`;
- focused artifact-index and extractor tests passed: 17;
- wheel-installed module generated a runtime JSON artifact;
- runtime artifact satisfied every registered required field;
- runtime schema matched the registered schema;
- raw CI log remained unchanged;
- deferred runtime, CLI-registration, operator-doc, and workflow guards passed;
- `make proof-after-format` passed before commit;
- exact three-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_logic_changed=false
- cli_registration_changed=false
- operator_docs_changed=false
- source_log_mutation=false
- workflow_exposure=false
- cloud_dependency=false

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No extractor runtime change, public CLI registration, operator-documentation change, workflow integration, hosted service, issue mutation, security dismissal, patch application, PR decision, or merge authorization.
