### PR TITLE
feat(queue): carry review evidence through local jobs

### DIFF
--- a/src/sdetkit/diagnostic_job.py
+++ b/src/sdetkit/diagnostic_job.py
@@ -22,6 +22,7 @@ from sdetkit.diagnostic_vector_engine import (
 
 SCHEMA_VERSION = "sdetkit.diagnostic_job.v1"
 WORKER_RESULT_SCHEMA_VERSION = "sdetkit.diagnostic_worker_result.v1"
+REVIEW_HANDOFF_SCHEMA_VERSION = "sdetkit.queue_review_handoff.v1"
 JOB_TYPE = "diagnostic_vector"
 WORKER_NAME = "diagnostic_worker"
 EXECUTION_MODE = "local_read_only"

--- a/src/sdetkit/diagnostic_worker_trajectory.py
+++ b/src/sdetkit/diagnostic_worker_trajectory.py
@@ -10,6 +10,7 @@ from typing import Any
 from sdetkit.diagnostic_job import (
     EXECUTION_MODE,
     JOB_TYPE,
+    REVIEW_HANDOFF_SCHEMA_VERSION,
     WORKER_NAME,
     WORKER_RESULT_SCHEMA_VERSION,
     validate_job,
@@ -98,6 +99,51 @@ def _summary_projection(payload: Mapping[str, Any]) -> JsonObject:
     }
 
 
+def _review_handoff_projection(
+    worker_result: Mapping[str, Any],
+) -> JsonObject:
+    handoff = _as_dict(worker_result.get("review_handoff"))
+    if not handoff:
+        return {}
+
+    if _string(handoff.get("schema_version")) != REVIEW_HANDOFF_SCHEMA_VERSION:
+        raise ValueError("diagnostic worker review handoff schema is not supported")
+    if not _bool(handoff.get("reporting_only")):
+        raise ValueError("diagnostic worker review handoff must be reporting-only")
+    if _bool(handoff.get("current_pr_decision_input")):
+        raise ValueError("diagnostic worker review handoff cannot decide the current PR")
+
+    _assert_false_fields(
+        _as_dict(handoff.get("decision_boundary")),
+        source="diagnostic worker review handoff",
+    )
+
+    safety = _as_dict(handoff.get("safety_gate_decision"))
+    patch = _as_dict(handoff.get("patch_score"))
+
+    for source, payload in (
+        ("diagnostic worker safety-gate projection", safety),
+        ("diagnostic worker patch-score projection", patch),
+    ):
+        if payload and (
+            _bool(payload.get("automation_allowed"))
+            or not _bool(payload.get("reporting_only"))
+            or not _bool(payload.get("authority_boundary_preserved"))
+        ):
+            raise ValueError(f"{source} does not preserve the authority boundary")
+
+    return {
+        "schema_version": REVIEW_HANDOFF_SCHEMA_VERSION,
+        "status": _string(handoff.get("status")) or "unknown",
+        "sources": copy.deepcopy(_as_dict(handoff.get("sources"))),
+        "safety_gate_decision": copy.deepcopy(safety),
+        "patch_score": copy.deepcopy(patch),
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "decision_boundary": copy.deepcopy(_as_dict(handoff.get("decision_boundary"))),
+    }
+
+
 def validate_worker_handoff(
     *,
     job: Mapping[str, Any],
@@ -131,6 +177,8 @@ def validate_worker_handoff(
         raise ValueError(
             "diagnostic worker execution expands authority: " + ", ".join(execution_expanded)
         )
+
+    _review_handoff_projection(worker_result)
 
     result_summary = _summary_projection(_as_dict(worker_result.get("summary")))
     vector_summary = _summary_projection(_as_dict(diagnostic_vector.get("summary")))
@@ -175,6 +223,7 @@ def build_worker_trajectory_records(
         generated_at=generated_at,
     )
 
+    review_handoff = _review_handoff_projection(worker_result)
     records: list[JsonObject] = []
     for base_record in base_records:
         record = copy.deepcopy(base_record)
@@ -221,6 +270,7 @@ def build_worker_trajectory_records(
             "automation_allowed": False,
             "merge_authorized": False,
             "semantic_equivalence_proven": False,
+            "review_handoff": copy.deepcopy(review_handoff),
         }
         records.append(record)
     return records
@@ -246,6 +296,29 @@ def build_summary(
             if _as_dict(row.get("worker_evidence")).get("observed_safe_fix_candidate") is True
         ),
         "worker_result_status": _string(worker_result.get("status")),
+        "review_handoff_count": sum(
+            1
+            for row in records
+            if _as_dict(_as_dict(row.get("worker_evidence")).get("review_handoff"))
+        ),
+        "safety_gate_decision_observed_count": sum(
+            1
+            for row in records
+            if _as_dict(
+                _as_dict(_as_dict(row.get("worker_evidence")).get("review_handoff")).get(
+                    "safety_gate_decision"
+                )
+            )
+        ),
+        "patch_score_observed_count": sum(
+            1
+            for row in records
+            if _as_dict(
+                _as_dict(_as_dict(row.get("worker_evidence")).get("review_handoff")).get(
+                    "patch_score"
+                )
+            )
+        ),
         "trajectory_jsonl": trajectory_jsonl,
         "reporting_only": True,
         "current_pr_decision_input": False,
@@ -269,6 +342,12 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
             "- Observed safe-fix candidates retained as advisory only: "
             f"`{_int(summary.get('observed_safe_fix_candidate_count'))}`"
         ),
+        f"- Review handoffs retained: `{_int(summary.get('review_handoff_count'))}`",
+        (
+            "- SafetyGate decisions retained: "
+            f"`{_int(summary.get('safety_gate_decision_observed_count'))}`"
+        ),
+        f"- Patch scores retained: `{_int(summary.get('patch_score_observed_count'))}`",
         f"- Reporting only: `{str(_bool(summary.get('reporting_only'))).lower()}`",
         (
             "- Current PR decision input: "

--- a/src/sdetkit/queued_diagnostic_worker.py
+++ b/src/sdetkit/queued_diagnostic_worker.py
@@ -8,7 +8,11 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from sdetkit.diagnostic_job import RESULT_JSON, run_diagnostic_worker
+from sdetkit.diagnostic_job import (
+    RESULT_JSON,
+    REVIEW_HANDOFF_SCHEMA_VERSION,
+    run_diagnostic_worker,
+)
 from sdetkit.diagnostic_worker_trajectory import (
     build_worker_trajectory_records,
 )
@@ -16,6 +20,8 @@ from sdetkit.diagnostic_worker_trajectory import (
     write_artifacts as write_worker_trajectory_artifacts,
 )
 from sdetkit.job_queue import claim_job, complete_job, fail_job
+from sdetkit.patch_scorer import SCHEMA_VERSION as PATCH_SCORE_SCHEMA_VERSION
+from sdetkit.safety_gate import SCHEMA_VERSION as SAFETY_GATE_SCHEMA_VERSION
 
 SCHEMA_VERSION = "sdetkit.queued_diagnostic_worker.v1"
 TRAJECTORY_DIR = "trajectory"
@@ -26,6 +32,8 @@ SUPPORTED_INPUTS = frozenset(
         "pr_quality_action_report",
         "security_review",
         "runtime_proof_artifacts",
+        "patch_score",
+        "safety_gate_decision",
     }
 )
 
@@ -38,6 +46,12 @@ def _as_dict(value: Any) -> JsonObject:
 
 def _string(value: Any) -> str:
     return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
 
 
 def _boundary() -> JsonObject:
@@ -91,6 +105,102 @@ def _load_worker_inputs(
             )
         )
         for name, raw_path in sorted(declared.items())
+    }
+
+
+def _assert_review_authority_boundary(
+    payload: Mapping[str, Any],
+    *,
+    source: str,
+) -> None:
+    denied = (
+        "automation_allowed",
+        "patch_application_allowed",
+        "security_dismissal_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "semantic_equivalence_claim",
+    )
+    expanded = [key for key in denied if _bool(payload.get(key))]
+    if expanded:
+        raise ValueError(f"{source} expands authority: " + ", ".join(expanded))
+
+
+def _build_review_handoff(
+    worker_inputs: Mapping[str, Mapping[str, Any]],
+) -> JsonObject:
+    safety = _as_dict(worker_inputs.get("safety_gate_decision"))
+    patch = _as_dict(worker_inputs.get("patch_score"))
+
+    safety_projection: JsonObject = {}
+    patch_projection: JsonObject = {}
+
+    if safety:
+        if _string(safety.get("schema_version")) != SAFETY_GATE_SCHEMA_VERSION:
+            raise ValueError("queued safety-gate decision schema is not supported")
+        if not _bool(safety.get("reporting_only")):
+            raise ValueError("queued safety-gate decision must be reporting-only")
+        _assert_review_authority_boundary(
+            safety,
+            source="queued safety-gate decision",
+        )
+        safety_projection = {
+            "schema_version": SAFETY_GATE_SCHEMA_VERSION,
+            "failure_class": _string(safety.get("failure_class")) or "unknown",
+            "risk": _string(safety.get("risk")) or "unknown",
+            "review_first": _bool(safety.get("review_first")),
+            "safe_fix_allowed": _bool(safety.get("safe_fix_allowed")),
+            "reason": _string(safety.get("reason")),
+            "reporting_only": True,
+            "authority_boundary_preserved": True,
+        }
+
+    if patch:
+        if _string(patch.get("schema_version")) != PATCH_SCORE_SCHEMA_VERSION:
+            raise ValueError("queued patch-score schema is not supported")
+        _assert_review_authority_boundary(
+            patch,
+            source="queued patch-score",
+        )
+        decision = _as_dict(patch.get("decision"))
+        _assert_review_authority_boundary(
+            decision,
+            source="queued patch-score decision",
+        )
+        patch_projection = {
+            "schema_version": PATCH_SCORE_SCHEMA_VERSION,
+            "patch_id": _string(patch.get("patch_id")) or "unknown",
+            "diagnosis_id": _string(patch.get("diagnosis_id")) or "unknown",
+            "score": int(patch.get("score", 0) or 0),
+            "minimum_score": int(patch.get("minimum_score", 0) or 0),
+            "decision_status": _string(decision.get("status")) or "unknown",
+            "candidate_for_protected_verification": _bool(
+                decision.get("candidate_for_protected_verification")
+            ),
+            "risk_flag_count": len(patch.get("risk_flags") or []),
+            "automation_allowed": False,
+            "reporting_only": True,
+            "authority_boundary_preserved": True,
+        }
+
+    observed = bool(safety_projection or patch_projection)
+
+    return {
+        "schema_version": REVIEW_HANDOFF_SCHEMA_VERSION,
+        "status": "observed" if observed else "not_provided",
+        "sources": {
+            "pr_quality_action_report": bool(
+                _as_dict(worker_inputs.get("pr_quality_action_report"))
+            ),
+            "runtime_proof_artifacts": bool(_as_dict(worker_inputs.get("runtime_proof_artifacts"))),
+            "safety_gate_decision": bool(safety_projection),
+            "patch_score": bool(patch_projection),
+        },
+        "safety_gate_decision": safety_projection,
+        "patch_score": patch_projection,
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "decision_boundary": _boundary(),
     }
 
 
@@ -219,6 +329,7 @@ def run_queued_diagnostic_job(
             job,
             input_root=input_root,
         )
+        review_handoff = _build_review_handoff(worker_inputs)
 
         worker_result = run_diagnostic_worker(
             job,
@@ -229,6 +340,7 @@ def run_queued_diagnostic_job(
             runtime_proof_artifacts=worker_inputs.get("runtime_proof_artifacts"),
             out_dir=out_dir,
         )
+        worker_result["review_handoff"] = review_handoff
 
         result_path = out_dir / RESULT_JSON
 

--- a/tests/test_diagnostic_queue_runner_e2e.py
+++ b/tests/test_diagnostic_queue_runner_e2e.py
@@ -311,3 +311,114 @@ def test_module_cli_stops_after_real_failed_job_without_retry(
     assert states[later["job_id"]] == PENDING
 
     assert not (out_root / later["job_id"]).exists()
+
+
+def test_module_cli_carries_review_evidence_through_bounded_queue(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    input_root = tmp_path / "inputs"
+    out_root = tmp_path / "worker"
+    input_root.mkdir()
+
+    check_path = input_root / "check-intelligence.json"
+    safety_path = input_root / "safety-gate.json"
+    patch_path = input_root / "patch-score.json"
+
+    check_path.write_text(
+        json.dumps(_formatting_intelligence(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    safety_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.safety_gate.v1",
+                "failure_class": "formatter_only",
+                "risk": "low",
+                "scope": "pr_owned_only",
+                "failure_kind": "formatter_only",
+                "affected_surface": "source",
+                "ownership_area": "src/sdetkit/example.py",
+                "retryability": "not_retryable_without_change",
+                "security_relevance": False,
+                "recommended_next_human_action": "review candidate",
+                "reporting_only": True,
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "security_dismissal_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_claim": False,
+                "safe_fix_allowed": True,
+                "review_first": False,
+                "reason": "protected verification required",
+                "allowed_files": ["src/sdetkit/example.py"],
+                "blocked_actions": [],
+                "proof_commands": ["make proof-after-format"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    patch_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.patch_score.v1",
+                "patch_id": "patch-e2e",
+                "diagnosis_id": "diagnosis-e2e",
+                "score": 90,
+                "minimum_score": 80,
+                "risk_flags": [],
+                "decision": {
+                    "status": "candidate_for_protected_verification",
+                    "candidate_for_protected_verification": True,
+                    "automation_allowed": False,
+                    "reason": "protected verification required",
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    job = _job(
+        head_sha="e2e-review-handoff",
+        created_at="2026-06-16T00:00:00Z",
+        input_artifacts={
+            "check_intelligence": check_path.name,
+            "safety_gate_decision": safety_path.name,
+            "patch_score": patch_path.name,
+        },
+    )
+    enqueue_job(queue_path, job)
+
+    completed = _run_cli(
+        queue_path=queue_path,
+        out_root=out_root,
+        input_root=input_root,
+        max_jobs=1,
+    )
+
+    assert completed.returncode == 0
+    payload = _json_stdout(completed)
+    result = payload["successful_results"][0]
+    handoff = result["worker_result"]["review_handoff"]
+
+    assert handoff["status"] == "observed"
+    assert handoff["reporting_only"] is True
+    assert handoff["current_pr_decision_input"] is False
+    assert handoff["patch_score"]["score"] == 90
+    assert handoff["safety_gate_decision"]["safe_fix_allowed"] is True
+
+    trajectory = result["trajectory"]["summary"]
+    assert trajectory["review_handoff_count"] == 1
+    assert trajectory["safety_gate_decision_observed_count"] == 1
+    assert trajectory["patch_score_observed_count"] == 1
+    assert trajectory["automation_allowed"] is False
+    assert trajectory["merge_authorized"] is False
+
+    queue = load_queue(queue_path)
+    assert queue["jobs"][0]["state"] == COMPLETED

--- a/tests/test_queued_diagnostic_worker.py
+++ b/tests/test_queued_diagnostic_worker.py
@@ -424,3 +424,153 @@ def test_trajectory_recording_failure_marks_job_failed(
 
     assert record["state"] == FAILED
     assert record["failure_reason"] == ("RuntimeError: bounded trajectory recording failure")
+
+
+def _safety_gate_decision() -> dict:
+    return {
+        "schema_version": "sdetkit.safety_gate.v1",
+        "failure_class": "formatter_only",
+        "risk": "low",
+        "scope": "pr_owned_only",
+        "failure_kind": "formatter_only",
+        "affected_surface": "source",
+        "ownership_area": "src/sdetkit/example.py",
+        "retryability": "not_retryable_without_change",
+        "security_relevance": False,
+        "recommended_next_human_action": "review formatter-only candidate",
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_claim": False,
+        "safe_fix_allowed": True,
+        "review_first": False,
+        "reason": "eligible for protected verification only",
+        "allowed_files": ["src/sdetkit/example.py"],
+        "blocked_actions": [],
+        "proof_commands": ["python -m pre_commit run -a", "make proof-after-format"],
+    }
+
+
+def _patch_score() -> dict:
+    return {
+        "schema_version": "sdetkit.patch_score.v1",
+        "patch_id": "patch-1",
+        "diagnosis_id": "diagnosis-1",
+        "failure_surface": "formatting",
+        "classification": "formatter_only",
+        "risk_level": "low",
+        "strategy": "run_pre_commit",
+        "changed_files": ["src/sdetkit/example.py"],
+        "allowed_files": ["src/sdetkit/example.py"],
+        "score": 90,
+        "minimum_score": 80,
+        "risk_flags": [],
+        "decision": {
+            "status": "candidate_for_protected_verification",
+            "candidate_for_protected_verification": True,
+            "automation_allowed": False,
+            "reason": "candidate for protected verification only",
+        },
+        "proof_requirements": [
+            "python -m pre_commit run -a",
+            "make proof-after-format",
+        ],
+    }
+
+
+def test_queued_worker_carries_safety_and_patch_score_as_reporting_only_evidence(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    check_path = tmp_path / "check-intelligence.json"
+    safety_path = tmp_path / "safety-gate.json"
+    patch_path = tmp_path / "patch-score.json"
+
+    check_path.write_text(json.dumps(_formatting_intelligence()), encoding="utf-8")
+    safety_path.write_text(json.dumps(_safety_gate_decision()), encoding="utf-8")
+    patch_path.write_text(json.dumps(_patch_score()), encoding="utf-8")
+
+    job = _job(
+        head_sha="review-handoff",
+        created_at="2026-06-16T00:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(check_path),
+            "safety_gate_decision": str(safety_path),
+            "patch_score": str(patch_path),
+        },
+    )
+    enqueue_job(queue_path, job)
+
+    result = run_queued_diagnostic_job(
+        queue_path,
+        claimed_at="2026-06-16T01:00:00Z",
+        finished_at="2026-06-16T02:00:00Z",
+        out_root=tmp_path / "worker",
+    )
+
+    handoff = result["worker_result"]["review_handoff"]
+    assert handoff["schema_version"] == "sdetkit.queue_review_handoff.v1"
+    assert handoff["status"] == "observed"
+    assert handoff["reporting_only"] is True
+    assert handoff["current_pr_decision_input"] is False
+    assert handoff["sources"]["safety_gate_decision"] is True
+    assert handoff["sources"]["patch_score"] is True
+    assert handoff["safety_gate_decision"]["authority_boundary_preserved"] is True
+    assert handoff["patch_score"]["authority_boundary_preserved"] is True
+    assert handoff["patch_score"]["candidate_for_protected_verification"] is True
+    assert all(value is False for value in handoff["decision_boundary"].values())
+
+    trajectory = result["trajectory"]["summary"]
+    assert trajectory["review_handoff_count"] == 1
+    assert trajectory["safety_gate_decision_observed_count"] == 1
+    assert trajectory["patch_score_observed_count"] == 1
+    assert trajectory["reporting_only"] is True
+    assert trajectory["current_pr_decision_input"] is False
+
+    trajectory_jsonl = Path(
+        result["queue_record"]["result_artifacts"]["diagnostic_worker_trajectory_jsonl"]
+    )
+    record = json.loads(trajectory_jsonl.read_text(encoding="utf-8").splitlines()[0])
+    retained = record["worker_evidence"]["review_handoff"]
+    assert retained["patch_score"]["score"] == 90
+    assert retained["safety_gate_decision"]["safe_fix_allowed"] is True
+    assert record["decision"]["review_first"] is True
+    assert record["decision"]["auto_fix_allowed"] is False
+    assert record["proof"]["commands"] == []
+
+
+def test_queued_worker_rejects_review_evidence_authority_expansion(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "queue.json"
+    check_path = tmp_path / "check-intelligence.json"
+    safety_path = tmp_path / "safety-gate.json"
+
+    check_path.write_text(json.dumps(_formatting_intelligence()), encoding="utf-8")
+    unsafe = _safety_gate_decision()
+    unsafe["automation_allowed"] = True
+    safety_path.write_text(json.dumps(unsafe), encoding="utf-8")
+
+    job = _job(
+        head_sha="unsafe-review-handoff",
+        created_at="2026-06-16T00:00:00Z",
+        input_artifacts={
+            "check_intelligence": str(check_path),
+            "safety_gate_decision": str(safety_path),
+        },
+    )
+    enqueue_job(queue_path, job)
+
+    with pytest.raises(ValueError, match="expands authority"):
+        run_queued_diagnostic_job(
+            queue_path,
+            claimed_at="2026-06-16T01:00:00Z",
+            finished_at="2026-06-16T02:00:00Z",
+            out_root=tmp_path / "worker",
+        )
+
+    record = load_queue(queue_path)["jobs"][0]
+    assert record["state"] == FAILED
+    assert "expands authority" in record["failure_reason"]


### PR DESCRIPTION
## Summary

Carries accepted SafetyGate and PatchScorer evidence through the local diagnostic job queue as reporting-only review evidence.

## Scope

- `src/sdetkit/diagnostic_job.py`
- `src/sdetkit/queued_diagnostic_worker.py`
- `src/sdetkit/diagnostic_worker_trajectory.py`
- `tests/test_queued_diagnostic_worker.py`
- `tests/test_diagnostic_queue_runner_e2e.py`

## Contract

- schema: `sdetkit.queue_review_handoff.v1`
- accepts optional `safety_gate_decision`
- accepts optional `patch_score`
- validates the accepted source schemas
- rejects authority-expanding payloads
- projects only reviewer-relevant evidence
- retains the handoff in worker trajectory artifacts
- does not use the handoff to decide the current PR

## Proof

- focused queue/worker/runner/SafetyGate/PatchScorer tests passed: 48;
- real bounded-queue runtime handoff passed;
- SafetyGate evidence reached the worker result and trajectory;
- PatchScorer evidence reached the worker result and trajectory;
- authority expansion caused a failed queue record;
- queue state machine was not changed;
- bounded runner loop was not changed;
- `make proof-after-format` passed before commit;
- exact five-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_logic_scope=read_only_evidence_transport
- job_queue_state_machine_changed=false
- runner_loop_changed=false
- current_pr_decision_input=false
- proof_commands_executed=false
- workflow_exposure=false
- cloud_dependency=false

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No patch execution, proof execution, retry automation, current-PR decision, workflow integration, hosted queue, issue mutation, security dismissal, or merge authorization.
