### PR TITLE
feat(reporting): link same-head trajectory history

### DIFF
--- a/src/sdetkit/current_head_failure_bundle.py
+++ b/src/sdetkit/current_head_failure_bundle.py
@@ -8,6 +8,7 @@ JsonObject = dict[str, Any]
 
 
 SCHEMA_VERSION = "sdetkit.current_head_failure_bundle.v1"
+TRAJECTORY_LINK_SCHEMA_VERSION = "sdetkit.current_head_trajectory_link.v1"
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
 JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
 ARTIFACT_EVIDENCE_KEY = "_".join(("artifact", "evidence"))
@@ -40,6 +41,95 @@ def _stable_json(payload: JsonObject) -> str:
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
 
 
+def _trajectory_link_summary(
+    trajectory_records: list[JsonObject] | None,
+    *,
+    head_sha: str,
+    trajectory_jsonl_path: str,
+) -> JsonObject:
+    normalized_head = _string(head_sha)
+    linked: list[JsonObject] = []
+    expanded_authority_fields: set[str] = set()
+
+    denied = (
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "automatic_security_fix_allowed",
+        "automatic_dismissal_allowed",
+    )
+
+    for raw in _as_list(trajectory_records):
+        record = _as_dict(raw)
+        if not record:
+            continue
+        if not normalized_head:
+            continue
+        if _string(record.get("commit_sha")) != normalized_head:
+            continue
+
+        boundary = _as_dict(record.get("authority_boundary"))
+        expanded = [key for key in denied if _bool(boundary.get(key))]
+        expanded_authority_fields.update(expanded)
+
+        decision = _as_dict(record.get("decision"))
+        linked.append(
+            {
+                "trajectory_id": _string(record.get("trajectory_id")),
+                "diagnostic_id": _string(record.get("diagnostic_id")),
+                "generated_at": _string(record.get("generated_at")),
+                "action": _string(record.get("action")),
+                "final_result": _string(record.get("final_result")),
+                "review_first": _bool(decision.get("review_first")),
+                "auto_fix_allowed": _bool(decision.get("auto_fix_allowed")),
+                "source_reporting_only": _bool(boundary.get("reporting_only")),
+                "source_authority_expanded_fields": expanded,
+            }
+        )
+
+    linked.sort(
+        key=lambda item: (
+            _string(item.get("generated_at")),
+            _string(item.get("trajectory_id")),
+        )
+    )
+
+    if expanded_authority_fields:
+        status = "linked_review_required"
+    elif linked:
+        status = "linked"
+    else:
+        status = "not_found"
+
+    return {
+        "schema_version": TRAJECTORY_LINK_SCHEMA_VERSION,
+        "status": status,
+        "head_sha": normalized_head,
+        "source_path": _string(trajectory_jsonl_path),
+        "record_count": len(linked),
+        "review_first_count": sum(_bool(item.get("review_first")) for item in linked),
+        "auto_fix_allowed_count": sum(_bool(item.get("auto_fix_allowed")) for item in linked),
+        "reporting_only_count": sum(_bool(item.get("source_reporting_only")) for item in linked),
+        "expanded_authority_fields": sorted(expanded_authority_fields),
+        "trajectory_ids": [
+            _string(item.get("trajectory_id"))
+            for item in linked
+            if _string(item.get("trajectory_id"))
+        ],
+        "records": linked,
+        "reporting_only": True,
+        "current_pr_decision_input": False,
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "proof_commands_executed": False,
+        },
+    }
+
+
 def build_current_head_failure_bundle(
     *,
     pr_number: int,
@@ -51,6 +141,8 @@ def build_current_head_failure_bundle(
     remediation_plans: JsonObject | None = None,
     safe_fix_outcome: JsonObject | None = None,
     refresh_summary: JsonObject | None = None,
+    trajectory_records: list[JsonObject] | None = None,
+    trajectory_jsonl_path: str = "",
     created_at: str = "",
 ) -> JsonObject:
     check_payload = _as_dict(check_intelligence)
@@ -59,6 +151,11 @@ def build_current_head_failure_bundle(
     plans_payload = _as_dict(remediation_plans)
     safe_fix_payload = _as_dict(safe_fix_outcome)
     refresh_payload = _as_dict(refresh_summary)
+    trajectory_history = _trajectory_link_summary(
+        trajectory_records,
+        head_sha=head_sha,
+        trajectory_jsonl_path=trajectory_jsonl_path,
+    )
 
     failed_checks = [_as_dict(item) for item in _as_list(check_payload.get("failed_checks"))]
     queued_checks = [_as_dict(item) for item in _as_list(check_payload.get("queued_checks"))]
@@ -115,6 +212,11 @@ def build_current_head_failure_bundle(
         "missing_required_contexts": len(missing_required),
         "review_first": review_first,
         "safe_fix_allowed": safe_fix_allowed,
+        "trajectory_linked": _int(trajectory_history.get("record_count")) > 0,
+        "trajectory_record_count": _int(trajectory_history.get("record_count")),
+        "trajectory_review_first_count": _int(trajectory_history.get("review_first_count")),
+        "trajectory_auto_fix_allowed_count": _int(trajectory_history.get("auto_fix_allowed_count")),
+        "trajectory_source_path": _string(trajectory_history.get("source_path")),
         "bundle_files": [
             "manifest.json",
             "failure-bundle.json",
@@ -131,6 +233,7 @@ def build_current_head_failure_bundle(
         "remediation_plans": plans_payload,
         "safe_fix_outcome": safe_fix_payload,
         "refresh_summary": refresh_payload,
+        "trajectory_history": trajectory_history,
         "owner_files": owner_files,
     }
 
@@ -139,6 +242,10 @@ def render_current_head_failure_bundle_markdown(bundle: JsonObject) -> str:
     manifest = _as_dict(bundle.get("manifest"))
     first_failures = [_as_dict(item) for item in _as_list(bundle.get("first_failures"))]
     owner_files = [_string(item) for item in _as_list(bundle.get("owner_files")) if _string(item)]
+    trajectory_history = _as_dict(bundle.get("trajectory_history"))
+    trajectory_records = [
+        _as_dict(item) for item in _as_list(trajectory_history.get("records")) if _as_dict(item)
+    ]
 
     lines = [
         "# Current-head failure evidence bundle",
@@ -211,6 +318,36 @@ def render_current_head_failure_bundle_markdown(bundle: JsonObject) -> str:
         lines.extend(f"- `{path}`" for path in owner_files)
     else:
         lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Current-head trajectory history",
+            f"- Status: `{_string(trajectory_history.get('status') or 'not_found')}`",
+            f"- Source: `{_string(trajectory_history.get('source_path') or 'none')}`",
+            f"- Matching records: `{_int(trajectory_history.get('record_count'))}`",
+            f"- Review-first records: `{_int(trajectory_history.get('review_first_count'))}`",
+            (
+                "- Auto-fix candidates observed: "
+                f"`{_int(trajectory_history.get('auto_fix_allowed_count'))}`"
+            ),
+            "- Reporting only: `true`",
+            "- Current PR decision input: `false`",
+            "- Patch application allowed: `false`",
+            "- Automation allowed: `false`",
+            "- Merge authorized: `false`",
+        ]
+    )
+    if trajectory_records:
+        lines.extend(["", "### Linked trajectory records"])
+        for item in trajectory_records:
+            lines.append(
+                f"- `{_string(item.get('trajectory_id') or 'unknown')}`: "
+                f"`{_string(item.get('action') or 'none')}` / "
+                f"`{_string(item.get('final_result') or 'unknown')}`"
+            )
+    else:
+        lines.extend(["", "- none"])
 
     lines.append("")
     return "\n".join(lines)

--- a/src/sdetkit/current_head_failure_bundle.py
+++ b/src/sdetkit/current_head_failure_bundle.py
@@ -12,6 +12,7 @@ TRAJECTORY_LINK_SCHEMA_VERSION = "sdetkit.current_head_trajectory_link.v1"
 FAILED_STEP_EVIDENCE_KEY = "_".join(("failed", "step", "evidence"))
 JOB_STEP_CONFIRMATION_KEY = "_".join(("job", "step", "confirmation"))
 ARTIFACT_EVIDENCE_KEY = "_".join(("artifact", "evidence"))
+SOURCE_AUTHORITY_EXPANDED_FIELDS_KEY = "_".join(("source", "authority", "expanded", "fields"))
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -84,7 +85,7 @@ def _trajectory_link_summary(
                 "review_first": _bool(decision.get("review_first")),
                 "auto_fix_allowed": _bool(decision.get("auto_fix_allowed")),
                 "source_reporting_only": _bool(boundary.get("reporting_only")),
-                "source_authority_expanded_fields": expanded,
+                SOURCE_AUTHORITY_EXPANDED_FIELDS_KEY: sorted(expanded),
             }
         )
 

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -3967,6 +3967,10 @@ def write_comment_body(
                 check_intelligence.get("remediation_refresh")
                 or action_report.get("remediation_refresh")
             ),
+            trajectory_records=trajectory_records,
+            trajectory_jsonl_path=(
+                trajectory_jsonl_path.as_posix() if trajectory_jsonl_path is not None else ""
+            ),
         )
         written_bundle_paths = write_current_head_failure_bundle(
             bundle,

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -271,13 +271,16 @@ def build_alignment_components() -> list[AlignmentComponent]:
         ),
         _component(
             module="current_head_failure_bundle",
-            role="capture current-head failure evidence for operator inspection",
-            status="partially_aligned",
-            stages=("evidence", "reporting"),
-            existing_artifacts=("current-head failure bundle",),
-            integration_points=("pr_quality_action_report",),
-            gaps=("should include or link trajectory records for the same head SHA",),
-            recommended_next_action="connect bundle summaries to trajectory/history reports",
+            role="capture current-head failure evidence with same-head trajectory links for operator inspection",
+            status="aligned",
+            stages=("evidence", "trajectory", "reporting", "history"),
+            existing_artifacts=("current-head failure bundle", "same-head trajectory summary"),
+            integration_points=(
+                "pr_quality_action_report",
+                "trajectory_store",
+                "trajectory_history_report",
+            ),
+            recommended_next_action="keep same-head trajectory links reporting-only and authority-denied",
         ),
         _component(
             module="operator_evidence_loop",

--- a/tests/test_current_head_failure_bundle.py
+++ b/tests/test_current_head_failure_bundle.py
@@ -9,6 +9,8 @@ from sdetkit.current_head_failure_bundle import (
     write_current_head_failure_bundle,
 )
 
+TEST_SOURCE_AUTHORITY_EXPANDED_FIELDS_KEY = "_".join(("source", "authority", "expanded", "fields"))
+
 
 def test_current_head_failure_bundle_persists_replayable_manifest(tmp_path):
     bundle = build_current_head_failure_bundle(
@@ -168,6 +170,7 @@ def test_current_head_failure_bundle_links_only_matching_head_trajectory() -> No
     assert history["trajectory_ids"] == ["matching-trajectory"]
     assert history["records"][0]["trajectory_id"] == "matching-trajectory"
     assert history["records"][0]["review_first"] is True
+    assert history["records"][0][TEST_SOURCE_AUTHORITY_EXPANDED_FIELDS_KEY] == []
     assert history["reporting_only"] is True
     assert history["current_pr_decision_input"] is False
     assert history["expanded_authority_fields"] == []
@@ -209,6 +212,12 @@ def test_current_head_failure_bundle_surfaces_trajectory_authority_expansion() -
     history = bundle["trajectory_history"]
 
     assert history["status"] == "linked_review_required"
+    assert history["records"][0][TEST_SOURCE_AUTHORITY_EXPANDED_FIELDS_KEY] == [
+        "automation_allowed",
+        "merge_authorized",
+        "patch_application_allowed",
+        "semantic_equivalence_proven",
+    ]
     assert history["expanded_authority_fields"] == [
         "automation_allowed",
         "merge_authorized",

--- a/tests/test_current_head_failure_bundle.py
+++ b/tests/test_current_head_failure_bundle.py
@@ -94,3 +94,127 @@ def test_current_head_failure_bundle_rendering_is_deterministic():
     assert first == second
     assert "- Failed checks: `0`" in first
     assert "- none" in first
+
+
+def test_current_head_failure_bundle_links_only_matching_head_trajectory() -> None:
+    bundle = build_current_head_failure_bundle(
+        pr_number=1803,
+        head_sha="current-head",
+        base_sha="base-head",
+        check_intelligence={
+            "checks_seen": 1,
+            "failed_checks": [],
+        },
+        trajectory_jsonl_path="build/sdetkit/trajectory.jsonl",
+        trajectory_records=[
+            {
+                "schema_version": "sdetkit.trajectory.v1",
+                "trajectory_id": "matching-trajectory",
+                "diagnostic_id": "diagnosis-1",
+                "commit_sha": "current-head",
+                "generated_at": "2026-06-16T01:00:00Z",
+                "action": "review_test_failure",
+                "final_result": "review_required",
+                "decision": {
+                    "review_first": True,
+                    "auto_fix_allowed": False,
+                },
+                "authority_boundary": {
+                    "reporting_only": True,
+                    "automation_allowed": False,
+                    "patch_application_allowed": False,
+                    "merge_authorized": False,
+                    "semantic_equivalence_proven": False,
+                    "automatic_security_fix_allowed": False,
+                    "automatic_dismissal_allowed": False,
+                },
+            },
+            {
+                "schema_version": "sdetkit.trajectory.v1",
+                "trajectory_id": "other-head-trajectory",
+                "diagnostic_id": "diagnosis-2",
+                "commit_sha": "other-head",
+                "generated_at": "2026-06-16T02:00:00Z",
+                "action": "review_other_failure",
+                "final_result": "review_required",
+                "decision": {
+                    "review_first": True,
+                    "auto_fix_allowed": False,
+                },
+                "authority_boundary": {
+                    "reporting_only": True,
+                    "automation_allowed": False,
+                    "patch_application_allowed": False,
+                    "merge_authorized": False,
+                    "semantic_equivalence_proven": False,
+                },
+            },
+        ],
+    )
+
+    manifest = bundle["manifest"]
+    history = bundle["trajectory_history"]
+
+    assert manifest["trajectory_linked"] is True
+    assert manifest["trajectory_record_count"] == 1
+    assert manifest["trajectory_review_first_count"] == 1
+    assert manifest["trajectory_auto_fix_allowed_count"] == 0
+    assert manifest["trajectory_source_path"] == "build/sdetkit/trajectory.jsonl"
+
+    assert history["schema_version"] == "sdetkit.current_head_trajectory_link.v1"
+    assert history["status"] == "linked"
+    assert history["head_sha"] == "current-head"
+    assert history["record_count"] == 1
+    assert history["trajectory_ids"] == ["matching-trajectory"]
+    assert history["records"][0]["trajectory_id"] == "matching-trajectory"
+    assert history["records"][0]["review_first"] is True
+    assert history["reporting_only"] is True
+    assert history["current_pr_decision_input"] is False
+    assert history["expanded_authority_fields"] == []
+    assert all(value is False for value in history["decision_boundary"].values())
+
+    markdown = render_current_head_failure_bundle_markdown(bundle)
+    assert "## Current-head trajectory history" in markdown
+    assert "Matching records: `1`" in markdown
+    assert "`matching-trajectory`" in markdown
+    assert "other-head-trajectory" not in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Merge authorized: `false`" in markdown
+
+
+def test_current_head_failure_bundle_surfaces_trajectory_authority_expansion() -> None:
+    bundle = build_current_head_failure_bundle(
+        pr_number=1803,
+        head_sha="current-head",
+        base_sha="base-head",
+        trajectory_records=[
+            {
+                "trajectory_id": "unsafe-source-record",
+                "commit_sha": "current-head",
+                "decision": {
+                    "review_first": False,
+                    "auto_fix_allowed": True,
+                },
+                "authority_boundary": {
+                    "reporting_only": False,
+                    "automation_allowed": True,
+                    "patch_application_allowed": True,
+                    "merge_authorized": True,
+                    "semantic_equivalence_proven": True,
+                },
+            }
+        ],
+    )
+
+    history = bundle["trajectory_history"]
+
+    assert history["status"] == "linked_review_required"
+    assert history["expanded_authority_fields"] == [
+        "automation_allowed",
+        "merge_authorized",
+        "patch_application_allowed",
+        "semantic_equivalence_proven",
+    ]
+    assert history["reporting_only"] is True
+    assert history["current_pr_decision_input"] is False
+    assert all(value is False for value in history["decision_boundary"].values())

--- a/tests/test_pr_quality_current_head_failure_bundle.py
+++ b/tests/test_pr_quality_current_head_failure_bundle.py
@@ -260,3 +260,124 @@ def test_current_head_failure_bundle_carries_artifact_evidence() -> None:
     assert "Artifact evidence: `present`" in markdown
     assert "Expected artifacts: `pip-audit-report.json`" in markdown
     assert "Artifact automation allowed: `false`" in markdown
+
+
+def test_pr_quality_failure_bundle_links_same_head_trajectory_records(
+    tmp_path: Path,
+) -> None:
+    action_report_path = _write_json(
+        tmp_path / "action-report.json",
+        {
+            "status": "review_required",
+            "review_first": True,
+            "safe_fix_available": False,
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": "review-first failure",
+            },
+            "recommended_actions": ["Review the current failure."],
+            "proof_commands": ["make proof-after-format"],
+        },
+    )
+    check_intelligence_path = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "checks_seen": 1,
+            "head_sha": "current-head",
+            "base_sha": "base-head",
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+    )
+    trajectory_path = tmp_path / "trajectory.jsonl"
+    trajectory_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "schema_version": "sdetkit.trajectory.v1",
+                        "trajectory_id": "current-head-record",
+                        "diagnostic_id": "diagnosis-current",
+                        "commit_sha": "current-head",
+                        "generated_at": "2026-06-16T00:00:00Z",
+                        "action": "review_current_failure",
+                        "final_result": "review_required",
+                        "decision": {
+                            "review_first": True,
+                            "auto_fix_allowed": False,
+                        },
+                        "authority_boundary": {
+                            "reporting_only": True,
+                            "automation_allowed": False,
+                            "patch_application_allowed": False,
+                            "merge_authorized": False,
+                            "semantic_equivalence_proven": False,
+                        },
+                    },
+                    sort_keys=True,
+                ),
+                json.dumps(
+                    {
+                        "schema_version": "sdetkit.trajectory.v1",
+                        "trajectory_id": "stale-head-record",
+                        "diagnostic_id": "diagnosis-stale",
+                        "commit_sha": "stale-head",
+                        "generated_at": "2026-06-15T00:00:00Z",
+                        "action": "review_stale_failure",
+                        "final_result": "review_required",
+                        "decision": {
+                            "review_first": True,
+                            "auto_fix_allowed": False,
+                        },
+                        "authority_boundary": {
+                            "reporting_only": True,
+                            "automation_allowed": False,
+                            "patch_application_allowed": False,
+                            "merge_authorized": False,
+                            "semantic_equivalence_proven": False,
+                        },
+                    },
+                    sort_keys=True,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "comment.md"
+    bundle_dir = tmp_path / "failure-bundle"
+
+    result = write_comment_body(
+        action_report_path=action_report_path,
+        check_intelligence_path=check_intelligence_path,
+        trajectory_jsonl_path=trajectory_path,
+        out=out,
+        failure_bundle_out_dir=bundle_dir,
+        pr_number=1803,
+        head_sha="current-head",
+        base_sha="base-head",
+    )
+
+    assert result["failure_bundle"]["out_dir"] == bundle_dir.as_posix()
+
+    bundle = json.loads((bundle_dir / "failure-bundle.json").read_text(encoding="utf-8"))
+    manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    markdown = (bundle_dir / "failure-bundle.md").read_text(encoding="utf-8")
+
+    assert manifest["trajectory_linked"] is True
+    assert manifest["trajectory_record_count"] == 1
+    assert manifest["trajectory_source_path"] == trajectory_path.as_posix()
+
+    history = bundle["trajectory_history"]
+    assert history["status"] == "linked"
+    assert history["record_count"] == 1
+    assert history["trajectory_ids"] == ["current-head-record"]
+    assert history["source_path"] == trajectory_path.as_posix()
+    assert history["reporting_only"] is True
+    assert history["current_pr_decision_input"] is False
+    assert "current-head-record" in markdown
+    assert "stale-head-record" not in markdown

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -85,6 +85,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "network_boundary" in gaps_by_module
     assert "proof_runtime_guard" in gaps_by_module
     assert "pr_quality_runtime_proof_artifacts" not in gaps_by_module
+    assert "current_head_failure_bundle" not in gaps_by_module
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE not in gaps_by_module
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE not in gaps_by_module
     assert TRUSTED_HISTORY_EVIDENCE_MODULE not in gaps_by_module
@@ -124,6 +125,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`check_intelligence`: `aligned`" in markdown
     assert "`maintenance_autopilot`: `partially_aligned`" in markdown
     assert "`trajectory_pattern_insights`: `aligned`" in markdown
+    assert "`current_head_failure_bundle`: `aligned`" in markdown
     assert "`patch_scorer`: `partially_aligned`" in markdown
     assert "`protected_verifier`: `partially_aligned`" in markdown
     assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
@@ -227,3 +229,20 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
 
     assert "maintenance_autopilot" not in report_modules
     assert all(component.module for component in components)
+
+
+def test_current_head_failure_bundle_alignment_is_closed() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+
+    component = components["current_head_failure_bundle"]
+
+    assert component.status == "aligned"
+    assert component.gaps == ()
+    assert "trajectory" in component.stages
+    assert "history" in component.stages
+    assert "trajectory_store" in component.integration_points
+    assert "trajectory_history_report" in component.integration_points
+    assert (
+        component.recommended_next_action
+        == "keep same-head trajectory links reporting-only and authority-denied"
+    )


### PR DESCRIPTION
## Summary

Links the current-head failure bundle to trajectory records for the same head SHA.

## Scope

- `src/sdetkit/current_head_failure_bundle.py`
- `src/sdetkit/pr_quality_action_report.py`
- `src/sdetkit/reliability_spine_alignment.py`
- `tests/test_current_head_failure_bundle.py`
- `tests/test_pr_quality_current_head_failure_bundle.py`
- `tests/test_reliability_spine_alignment.py`

## Contract

- schema: `sdetkit.current_head_trajectory_link.v1`
- filters trajectory records strictly by current `head_sha`
- links the source trajectory JSONL path
- adds trajectory counts to `manifest.json`
- stores reviewer-facing trajectory projections in `failure-bundle.json`
- surfaces authority-expanding source evidence as review-required
- remains reporting-only
- does not use trajectory history to decide the current PR

## Proof

- focused bundle, PR Quality, trajectory, history, and alignment tests passed: 116;
- runtime PR Quality bundle smoke passed;
- same-head filtering passed;
- stale-head trajectory exclusion passed;
- source trajectory path linking passed;
- authority boundary remained denied;
- reliability-spine gap changed from partially aligned to aligned;
- `make proof-after-format` passed before commit;
- exact six-file scope verified;
- `git diff --check` passed.

## Runtime impact

- runtime_logic_scope=reporting_only_history_link
- trajectory_store_changed=false
- current_pr_decision_input=false
- workflow_exposure=false
- cloud_dependency=false

## Authority boundaries

- automation_allowed=false
- patch_application_allowed=false
- merge_authorized=false
- semantic_equivalence_proven=false

## Out of scope

No trajectory mutation, proof execution, patch execution, automatic retry, current-PR decision, workflow change, cloud service, issue mutation, security dismissal, or merge authorization.
