### PR TITLE
feat(verifier): report remediation plan context

### DIFF
--- a/src/sdetkit/protected_verifier.py
+++ b/src/sdetkit/protected_verifier.py
@@ -7,8 +7,33 @@ from pathlib import Path
 from typing import Any
 
 from sdetkit.patch_scorer import PROTECTED_EXACT_PATHS, PROTECTED_PREFIXES
+from sdetkit.remediation_plan_engine import (
+    ALLOWED_STRATEGY,
+    BLOCKED_REASON,
+    CLASSIFICATION,
+    EXACT_FIX_SCOPE,
+    HUMAN_REVIEW_ACTION,
+    REQUIRES_FRESH_LOGS,
+    REQUIRES_RELEASE_VALIDATION,
+    REQUIRES_SECURITY_REVIEW,
+    RISK_LEVEL,
+    SAFE_TO_AUTO_FIX,
+)
 
 SCHEMA_VERSION = "sdetkit.protected_verifier.decision.v1"
+REMEDIATION_PLAN_CONTEXT_SCHEMA_VERSION = ".".join(
+    ("sdetkit", "protected", "verifier", "remediation", "plan", "context", "v1")
+)
+REMEDIATION_PLAN_CONTEXT = "_".join(("remediation", "plan", "context"))
+REMEDIATION_PLAN_SOURCE = "_".join(("remediation", "plan"))
+REMEDIATION_PLAN_SCHEMA_INPUT = "_".join(("remediation", "plan", "schema"))
+REMEDIATION_PLAN_CONTEXT_STATUS_INPUT = "_".join(("remediation", "plan", "context", "status"))
+CURRENT_PR_DECISION_INPUT = "_".join(("current", "pr", "decision", "input"))
+PROTECTED_VERIFIER_EXECUTION_CHANGED = "_".join(("protected", "verifier", "execution", "changed"))
+SELECTED_PLAN_PRESENT = "_".join(("selected", "plan", "present"))
+SELECTED_PLAN = "_".join(("selected", "plan"))
+PLAN_SELECTED = "_".join(("plan", "selected"))
+PLAN_NOT_FOUND = "_".join(("plan", "not", "found"))
 DEFAULT_OUT_DIR = Path("build") / "protected-verifier"
 PROTECTED_VERIFIER_JSON = "protected-verifier-decision.json"
 PROTECTED_VERIFIER_MD = "protected-verifier-decision.md"
@@ -239,6 +264,89 @@ def _read_json(path: Path | None) -> JsonObject:
         msg = f"expected JSON object in {path}"
         raise ValueError(msg)
     return payload
+
+
+def _remediation_plan_context(
+    remediation_plan: Mapping[str, Any],
+    *,
+    diagnosis_id: str,
+) -> JsonObject:
+    denied = {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+    payload = _as_dict(remediation_plan)
+    plans = [_as_dict(item) for item in _as_list(payload.get("plans")) if _as_dict(item)]
+
+    if not payload:
+        return {
+            "schema_version": REMEDIATION_PLAN_CONTEXT_SCHEMA_VERSION,
+            "collection_status": "not_collected",
+            "status": "not_collected",
+            "source": REMEDIATION_PLAN_SOURCE,
+            "source_schema": "not_collected",
+            "diagnosis_id": diagnosis_id,
+            "plan_count": 0,
+            SELECTED_PLAN_PRESENT: False,
+            SELECTED_PLAN: {},
+            "reporting_only": True,
+            CURRENT_PR_DECISION_INPUT: False,
+            PROTECTED_VERIFIER_EXECUTION_CHANGED: False,
+            "decision_boundary": denied,
+        }
+
+    selected: JsonObject = {}
+    if diagnosis_id:
+        selected = next(
+            (plan for plan in plans if _string(plan.get("diagnosis_id")) == diagnosis_id),
+            {},
+        )
+    elif plans:
+        selected = plans[0]
+
+    exact_scope = _as_dict(selected.get(EXACT_FIX_SCOPE))
+    selected_projection: JsonObject = {}
+    if selected:
+        selected_projection = {
+            "diagnosis_id": _string(selected.get("diagnosis_id")),
+            "failure_surface": _string(selected.get("failure_surface")),
+            CLASSIFICATION: _string(selected.get(CLASSIFICATION)),
+            SAFE_TO_AUTO_FIX: _bool(selected.get(SAFE_TO_AUTO_FIX)),
+            ALLOWED_STRATEGY: _string(selected.get(ALLOWED_STRATEGY)),
+            BLOCKED_REASON: _string(selected.get(BLOCKED_REASON)),
+            RISK_LEVEL: _string(selected.get(RISK_LEVEL)),
+            "affected_files": _string_list(selected.get("affected_files")),
+            EXACT_FIX_SCOPE: {
+                "allowed_files": _string_list(exact_scope.get("allowed_files")),
+                ALLOWED_STRATEGY: _string(exact_scope.get(ALLOWED_STRATEGY)),
+                "scope": _string(exact_scope.get("scope")),
+            },
+            "proof_commands": _string_list(selected.get("proof_commands")),
+            HUMAN_REVIEW_ACTION: _string(selected.get(HUMAN_REVIEW_ACTION)),
+            REQUIRES_FRESH_LOGS: _bool(selected.get(REQUIRES_FRESH_LOGS)),
+            REQUIRES_SECURITY_REVIEW: _bool(selected.get(REQUIRES_SECURITY_REVIEW)),
+            REQUIRES_RELEASE_VALIDATION: _bool(selected.get(REQUIRES_RELEASE_VALIDATION)),
+        }
+
+    return {
+        "schema_version": REMEDIATION_PLAN_CONTEXT_SCHEMA_VERSION,
+        "collection_status": "collected",
+        "status": (PLAN_SELECTED if selected_projection else PLAN_NOT_FOUND),
+        "source": REMEDIATION_PLAN_SOURCE,
+        "source_schema": (_string(payload.get("schema_version")) or "unknown"),
+        "diagnosis_id": diagnosis_id,
+        "plan_count": len(plans),
+        SELECTED_PLAN_PRESENT: bool(selected_projection),
+        SELECTED_PLAN: selected_projection,
+        "reporting_only": True,
+        CURRENT_PR_DECISION_INPUT: False,
+        PROTECTED_VERIFIER_EXECUTION_CHANGED: False,
+        "decision_boundary": denied,
+    }
 
 
 def _boundary_payloads(
@@ -561,10 +669,12 @@ def _risk_flag(code: str, message: str, *, blocking: bool) -> JsonObject:
 def verify_patch(
     *,
     patch_score: Mapping[str, Any],
+    remediation_plan: Mapping[str, Any] | None = None,
     failure_bundle: Mapping[str, Any] | None = None,
     runtime_proof: Mapping[str, Any] | None = None,
     repo_memory_profile: Mapping[str, Any] | None = None,
 ) -> JsonObject:
+    remediation = _as_dict(remediation_plan)
     bundle = _as_dict(failure_bundle)
     runtime = _as_dict(runtime_proof)
     repo_memory = _as_dict(repo_memory_profile)
@@ -578,6 +688,10 @@ def verify_patch(
 
     patch_id = _string(patch_score.get("patch_id")) or "unknown"
     diagnosis_id = _string(patch_score.get("diagnosis_id")) or "unknown"
+    remediation_plan_context = _remediation_plan_context(
+        remediation,
+        diagnosis_id=diagnosis_id,
+    )
     patch_score_status = _string(patch_decision.get("status")) or "unknown"
     candidate = _bool(patch_decision.get(CANDIDATE_FOR_PROTECTED_VERIFICATION))
     score = _int(patch_score.get("score"))
@@ -706,11 +820,16 @@ def verify_patch(
         "inputs": {
             "patch_score_schema": _string(patch_score.get("schema_version")) or "unknown",
             "patch_score_status": patch_score_status,
+            REMEDIATION_PLAN_SCHEMA_INPUT: (
+                _string(remediation.get("schema_version")) or "not_collected"
+            ),
+            REMEDIATION_PLAN_CONTEXT_STATUS_INPUT: _string(remediation_plan_context.get("status")),
             "failure_bundle_status": _string(bundle.get("status")) or "not_collected",
             "runtime_proof_status": _string(runtime.get("status")) or "not_collected",
             "repo_memory_profile_status": _string(repo_memory.get("profile_status"))
             or "not_collected",
         },
+        REMEDIATION_PLAN_CONTEXT: remediation_plan_context,
         "runtime_proof_evidence": {
             "protected_verifier_contract_evidence": runtime_proof_contract_evidence,
             "benchmark_contract_replay_evidence": benchmark_contract_replay_evidence,
@@ -1004,6 +1123,9 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
     decision = _as_dict(payload.get("decision"))
     evidence = _as_dict(payload.get("verification_evidence"))
     boundary = _as_dict(payload.get("decision_boundary"))
+    remediation_context = _as_dict(payload.get(REMEDIATION_PLAN_CONTEXT))
+    remediation_selected = _as_dict(remediation_context.get(SELECTED_PLAN))
+    remediation_boundary = _as_dict(remediation_context.get("decision_boundary"))
     runtime_proof = _as_dict(payload.get("runtime_proof_evidence"))
     runtime_contract = _as_dict(runtime_proof.get("protected_verifier_contract_evidence"))
     runtime_boundary = _as_dict(runtime_contract.get("decision_boundary"))
@@ -1052,6 +1174,63 @@ def render_markdown(payload: Mapping[str, Any]) -> str:
     lines.extend(
         f"- `{command}`" for command in proof_requirements
     ) if proof_requirements else lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Remediation plan context",
+            "",
+            (f"- Collection status: `{_string(remediation_context.get('collection_status'))}`"),
+            (f"- Status: `{_string(remediation_context.get('status'))}`"),
+            (f"- Source schema: `{_string(remediation_context.get('source_schema'))}`"),
+            (f"- Plan count: `{_int(remediation_context.get('plan_count'))}`"),
+            (
+                "- Selected plan present: "
+                f"`{str(_bool(remediation_context.get(SELECTED_PLAN_PRESENT))).lower()}`"
+            ),
+            (
+                "- Failure surface: "
+                f"`{_string(remediation_selected.get('failure_surface')) or 'none'}`"
+            ),
+            (f"- Classification: `{_string(remediation_selected.get(CLASSIFICATION)) or 'none'}`"),
+            (
+                "- Allowed strategy: "
+                f"`{_string(remediation_selected.get(ALLOWED_STRATEGY)) or 'none'}`"
+            ),
+            (
+                "- Source safe-to-auto-fix claim: "
+                f"`{str(_bool(remediation_selected.get(SAFE_TO_AUTO_FIX))).lower()}`"
+            ),
+            (
+                "- Reporting only: "
+                f"`{str(_bool(remediation_context.get('reporting_only'))).lower()}`"
+            ),
+            (
+                "- Current PR decision input: "
+                f"`{str(_bool(remediation_context.get(CURRENT_PR_DECISION_INPUT))).lower()}`"
+            ),
+            (
+                "- ProtectedVerifier execution changed: "
+                f"`{str(_bool(remediation_context.get(PROTECTED_VERIFIER_EXECUTION_CHANGED))).lower()}`"
+            ),
+            (
+                "- Patch application allowed by remediation-plan context: "
+                f"`{str(_bool(remediation_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Automation allowed by remediation-plan context: "
+                f"`{str(_bool(remediation_boundary.get('automation_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized by remediation-plan context: "
+                f"`{str(_bool(remediation_boundary.get('merge_authorized'))).lower()}`"
+            ),
+            (
+                "- Semantic equivalence proven by remediation-plan context: "
+                f"`{str(_bool(remediation_boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+        ]
+    )
 
     lines.extend(
         [
@@ -1324,6 +1503,7 @@ def write_protected_verifier_decision(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.protected_verifier")
     parser.add_argument("--patch-score", type=Path, required=True)
+    parser.add_argument("--remediation-plan", type=Path)
     parser.add_argument("--verification-evidence", type=Path)
     parser.add_argument("--failure-bundle", type=Path)
     parser.add_argument("--runtime-proof", type=Path)
@@ -1347,6 +1527,7 @@ def main(argv: list[str] | None = None) -> int:
         else:
             payload = verify_patch(
                 patch_score=patch_score_payload,
+                remediation_plan=_read_json(args.remediation_plan),
                 failure_bundle=_read_json(args.failure_bundle),
                 runtime_proof=_read_json(args.runtime_proof),
                 repo_memory_profile=_read_json(args.repo_memory_profile),

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -132,15 +132,20 @@ def build_alignment_components() -> list[AlignmentComponent]:
         ),
         _component(
             module="remediation_plan_engine",
-            role="plan review-first and safe-fix remediation routes",
-            status="partially_aligned",
-            stages=("decision", "remediation_eligibility", "proof"),
-            existing_artifacts=("remediation plans",),
-            integration_points=("diagnostic_vector_engine", "trajectory_store", "patch_scorer"),
-            gaps=(
-                "needs structural verifier results and later semantic proof before broader mutation use",
+            role="plan review-first and safe-fix remediation routes with PatchScorer and ProtectedVerifier reporting",
+            status="aligned",
+            stages=("decision", "remediation_eligibility", "proof", "reporting"),
+            existing_artifacts=(
+                "remediation plans",
+                "ProtectedVerifier remediation-plan context",
             ),
-            recommended_next_action="feed plans through PatchScorer and protected_verifier reporting",
+            integration_points=(
+                "diagnostic_vector_engine",
+                "trajectory_store",
+                "patch_scorer",
+                "protected_verifier",
+            ),
+            recommended_next_action="keep remediation-plan context reporting-only until structural and semantic proof mature",
         ),
         _component(
             module="safe_remediation_eligibility",

--- a/tests/test_protected_verifier.py
+++ b/tests/test_protected_verifier.py
@@ -13,6 +13,11 @@ BLOCKED_REVIEW_FIRST = _key(("blocked", "review", "first"))
 HUMAN_REVIEW_REQUIRED_BEFORE_PATCH_APPLICATION = _key(
     ("human", "review", "required", "before", "patch", "application")
 )
+REMEDIATION_PLAN_CONTEXT = _key(("remediation", "plan", "context"))
+CURRENT_PR_DECISION_INPUT = _key(("current", "pr", "decision", "input"))
+PROTECTED_VERIFIER_EXECUTION_CHANGED = _key(("protected", "verifier", "execution", "changed"))
+SELECTED_PLAN = _key(("selected", "plan"))
+SELECTED_PLAN_PRESENT = _key(("selected", "plan", "present"))
 
 
 def _safe_plan() -> dict:
@@ -628,3 +633,110 @@ def test_protected_verifier_blocks_authority_expanding_runtime_proof_pr_quality_
     markdown = render_markdown(payload)
     assert "Expanded authority fields: `merge_authorized`" in markdown
     assert PR_QUALITY_BENCHMARK_REPLAY_MERGE_FALSE_LINE in markdown
+
+
+def test_protected_verifier_reports_remediation_plan_context_without_decision_authority() -> None:
+    remediation_plan = _safe_plan()
+    remediation_plan["schema_version"] = ".".join(("sdetkit", "remediation", "plan", "v1"))
+
+    baseline = verify_patch(
+        patch_score=_candidate_patch_score(),
+    )
+    payload = verify_patch(
+        patch_score=_candidate_patch_score(),
+        remediation_plan=remediation_plan,
+    )
+
+    context = payload[REMEDIATION_PLAN_CONTEXT]
+    selected = context[SELECTED_PLAN]
+
+    assert context["schema_version"] == ".".join(
+        (
+            "sdetkit",
+            "protected",
+            "verifier",
+            "remediation",
+            "plan",
+            "context",
+            "v1",
+        )
+    )
+    assert context["collection_status"] == "collected"
+    assert context["status"] == "plan_selected"
+    assert context["source_schema"] == ".".join(("sdetkit", "remediation", "plan", "v1"))
+    assert context["plan_count"] == 1
+    assert context[SELECTED_PLAN_PRESENT] is True
+    assert selected["diagnosis_id"] == "formatting-autopilot"
+    assert selected["failure_surface"] == "formatting"
+    assert selected["classification"] == "formatting_only"
+    assert selected["safe_to_auto_fix"] is True
+    assert selected["allowed_strategy"] == "run_pre_commit"
+    assert selected["affected_files"] == ["src/sdetkit/example.py"]
+    assert context["reporting_only"] is True
+    assert context[CURRENT_PR_DECISION_INPUT] is False
+    assert context[PROTECTED_VERIFIER_EXECUTION_CHANGED] is False
+    assert context["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+
+    assert payload["decision"] == baseline["decision"]
+    assert payload["risk_flags"] == baseline["risk_flags"] == []
+
+    markdown = render_markdown(payload)
+    assert "## Remediation plan context" in markdown
+    assert "Status: `plan_selected`" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "ProtectedVerifier execution changed: `false`" in markdown
+    assert "Patch application allowed by remediation-plan context: `false`" in markdown
+
+
+def test_protected_verifier_cli_accepts_optional_remediation_plan_context(
+    tmp_path: Path,
+) -> None:
+    patch_score_path = tmp_path / "patch-score.json"
+    remediation_plan_path = tmp_path / "remediation-plan.json"
+    out_dir = tmp_path / "protected-verifier"
+
+    remediation_plan = _safe_plan()
+    remediation_plan["schema_version"] = ".".join(("sdetkit", "remediation", "plan", "v1"))
+
+    patch_score_path.write_text(
+        json.dumps(_candidate_patch_score()),
+        encoding="utf-8",
+    )
+    remediation_plan_path.write_text(
+        json.dumps(remediation_plan),
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--patch-score",
+            str(patch_score_path),
+            "--remediation-plan",
+            str(remediation_plan_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+
+    payload = json.loads((out_dir / "protected-verifier-decision.json").read_text(encoding="utf-8"))
+    context = payload[REMEDIATION_PLAN_CONTEXT]
+
+    assert context["status"] == "plan_selected"
+    assert context[SELECTED_PLAN_PRESENT] is True
+    assert context["reporting_only"] is True
+    assert context[CURRENT_PR_DECISION_INPUT] is False
+    assert context[PROTECTED_VERIFIER_EXECUTION_CHANGED] is False
+    assert payload["decision"]["patch_application_allowed"] is False
+    assert payload["decision"]["merge_authorized"] is False
+    assert payload["decision"]["semantic_equivalence_proven"] is False

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -86,6 +86,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "proof_runtime_guard" in gaps_by_module
     assert "pr_quality_runtime_proof_artifacts" not in gaps_by_module
     assert "current_head_failure_bundle" not in gaps_by_module
+    assert "remediation_plan_engine" not in gaps_by_module
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE not in gaps_by_module
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE not in gaps_by_module
     assert TRUSTED_HISTORY_EVIDENCE_MODULE not in gaps_by_module
@@ -126,6 +127,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`maintenance_autopilot`: `partially_aligned`" in markdown
     assert "`trajectory_pattern_insights`: `aligned`" in markdown
     assert "`current_head_failure_bundle`: `aligned`" in markdown
+    assert "`remediation_plan_engine`: `aligned`" in markdown
     assert "`patch_scorer`: `partially_aligned`" in markdown
     assert "`protected_verifier`: `partially_aligned`" in markdown
     assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
@@ -245,4 +247,21 @@ def test_current_head_failure_bundle_alignment_is_closed() -> None:
     assert (
         component.recommended_next_action
         == "keep same-head trajectory links reporting-only and authority-denied"
+    )
+
+
+def test_remediation_plan_engine_alignment_is_closed() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+
+    component = components["remediation_plan_engine"]
+
+    assert component.status == "aligned"
+    assert component.gaps == ()
+    assert "reporting" in component.stages
+    assert "patch_scorer" in component.integration_points
+    assert "protected_verifier" in component.integration_points
+    assert "ProtectedVerifier remediation-plan context" in component.existing_artifacts
+    assert (
+        component.recommended_next_action == "keep remediation-plan context reporting-only "
+        "until structural and semantic proof mature"
     )


### PR DESCRIPTION
## Summary

- add optional remediation-plan context to ProtectedVerifier JSON and Markdown
- select the plan matching the PatchScorer diagnosis ID
- preserve the existing verifier decision and risk flags
- close the remediation-plan reporting alignment gap

## Contract

- reporting-only context
- current PR decision input: false
- ProtectedVerifier execution changed: false
- patch application allowed: false
- automation allowed: false
- merge authorized: false
- semantic equivalence proven: false

## Proof

- focused remediation-plan, PatchScorer, ProtectedVerifier, alignment, and end-to-end tests
- direct decision-invariance proof
- baseline-aware security check with zero new findings
- `make proof-after-format`

## Scope

- `src/sdetkit/protected_verifier.py`
- `tests/test_protected_verifier.py`
- `src/sdetkit/reliability_spine_alignment.py`
- `tests/test_reliability_spine_alignment.py`
