### PR TITLE
feat(operator): project read-only evidence

### DIFF
--- a/src/sdetkit/operator_evidence_loop.py
+++ b/src/sdetkit/operator_evidence_loop.py
@@ -16,6 +16,15 @@ from sdetkit import (
 )
 
 SCHEMA_VERSION = "sdetkit.operator.evidence_loop.v1"
+REPORTING_PROJECTIONS_SCHEMA_VERSION = ".".join(
+    ("sdetkit", "operator", "evidence", "loop", "reporting", "projections", "v1")
+)
+REPORTING_PROJECTIONS = "_".join(("reporting", "projections"))
+TRAJECTORY_HISTORY_PROJECTION = "_".join(("trajectory", "history", "projection"))
+PATCH_SCORE_PROJECTION = "_".join(("patch", "score", "projection"))
+PROTECTED_VERIFIER_PROJECTION = "_".join(("protected", "verifier", "projection"))
+CURRENT_PR_DECISION_INPUT = "_".join(("current", "pr", "decision", "input"))
+PRODUCER_EXECUTION_CHANGED = "_".join(("producer", "execution", "changed"))
 DEFAULT_OUTPUT_DIR = Path("build/sdetkit/operator-loop")
 
 JsonObject = dict[str, Any]
@@ -55,6 +64,17 @@ def _int(value: Any, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _string_list(value: Any, *, limit: int = 20) -> list[str]:
+    values = [_string(item) for item in _as_list(value) if _string(item)]
+    return values[: max(limit, 0)]
 
 
 def _artifact_key(*parts: str) -> str:
@@ -173,6 +193,163 @@ def _write_safe_fix_outcome_rollup(
     }
 
 
+def _projection_boundary() -> JsonObject:
+    return {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+
+
+def _not_collected_projection(source: str) -> JsonObject:
+    return {
+        "collection_status": "not_collected",
+        "source": source,
+        "source_schema": "not_collected",
+        "reporting_only": True,
+        CURRENT_PR_DECISION_INPUT: False,
+        PRODUCER_EXECUTION_CHANGED: False,
+        "decision_boundary": _projection_boundary(),
+    }
+
+
+def _trajectory_history_projection(
+    payload: JsonObject,
+) -> JsonObject:
+    if not payload:
+        return _not_collected_projection("trajectory_history_report")
+
+    recent = [
+        {
+            "diagnostic_id": _string(_as_dict(item).get("diagnostic_id")),
+            "action": _string(_as_dict(item).get("action")),
+            "failure_class": _string(_as_dict(item).get("failure_class")),
+            "risk_surface": _string(_as_dict(item).get("risk_surface")),
+            "review_first": _bool(_as_dict(item).get("review_first")),
+            "auto_fix_allowed": _bool(_as_dict(item).get("auto_fix_allowed")),
+            "final_result": _string(_as_dict(item).get("final_result")),
+        }
+        for item in _as_list(payload.get("recent_decisions"))[:5]
+        if _as_dict(item)
+    ]
+
+    return {
+        "collection_status": "collected",
+        "source": "trajectory_history_report",
+        "source_schema": (_string(payload.get("schema_version")) or "unknown"),
+        "record_count": _int(payload.get("record_count")),
+        "review_first_count": _int(payload.get("review_first_count")),
+        "auto_fix_allowed_count": _int(payload.get("auto_fix_allowed_count")),
+        "by_final_result": _as_dict(payload.get("by_final_result")),
+        "by_risk_surface": _as_dict(payload.get("by_risk_surface")),
+        "by_failure_class": _as_dict(payload.get("by_failure_class")),
+        "by_action": _as_dict(payload.get("by_action")),
+        "recent_decisions": recent,
+        "reporting_only": True,
+        CURRENT_PR_DECISION_INPUT: False,
+        PRODUCER_EXECUTION_CHANGED: False,
+        "decision_boundary": _projection_boundary(),
+    }
+
+
+def _patch_score_projection(
+    payload: JsonObject,
+) -> JsonObject:
+    if not payload:
+        return _not_collected_projection("patch_scorer")
+
+    decision = _as_dict(payload.get("decision"))
+    flags = [_as_dict(item) for item in _as_list(payload.get("risk_flags")) if _as_dict(item)]
+
+    return {
+        "collection_status": "collected",
+        "source": "patch_scorer",
+        "source_schema": (_string(payload.get("schema_version")) or "unknown"),
+        "patch_id": _string(payload.get("patch_id")),
+        "diagnosis_id": _string(payload.get("diagnosis_id")),
+        "failure_surface": _string(payload.get("failure_surface")),
+        "classification": _string(payload.get("classification")),
+        "risk_level": _string(payload.get("risk_level")),
+        "strategy": _string(payload.get("strategy")),
+        "score": _int(payload.get("score")),
+        "minimum_score": _int(payload.get("minimum_score")),
+        "changed_files": _string_list(payload.get("changed_files")),
+        "risk_flag_count": len(flags),
+        "blocking_risk_flag_count": sum(1 for flag in flags if _bool(flag.get("blocking"))),
+        "risk_flag_codes": sorted(
+            {_string(flag.get("code")) for flag in flags if _string(flag.get("code"))}
+        ),
+        "source_decision_status": _string(decision.get("status")),
+        "source_candidate_for_protected_verification": (
+            _bool(decision.get("candidate_for_protected_verification"))
+        ),
+        "source_automation_allowed": _bool(decision.get("automation_allowed")),
+        "reporting_only": True,
+        CURRENT_PR_DECISION_INPUT: False,
+        PRODUCER_EXECUTION_CHANGED: False,
+        "decision_boundary": _projection_boundary(),
+    }
+
+
+def _protected_verifier_projection(
+    payload: JsonObject,
+) -> JsonObject:
+    if not payload:
+        return _not_collected_projection("protected_verifier")
+
+    decision = _as_dict(payload.get("decision"))
+    findings = [_as_dict(item) for item in _as_list(payload.get("findings")) if _as_dict(item)]
+    risk_flags = [_as_dict(item) for item in _as_list(payload.get("risk_flags")) if _as_dict(item)]
+
+    return {
+        "collection_status": "collected",
+        "source": "protected_verifier",
+        "source_schema": (_string(payload.get("schema_version")) or "unknown"),
+        "patch_id": _string(payload.get("patch_id")),
+        "diagnosis_id": _string(payload.get("diagnosis_id")),
+        "patch_score": _int(payload.get("patch_score")),
+        "source_decision_status": _string(decision.get("status")),
+        "source_review_first": _bool(decision.get("review_first")),
+        "source_structural_verification_passed": (
+            _bool(decision.get("structural_verification_passed"))
+            or _bool(decision.get("protected_verification_passed"))
+        ),
+        "source_semantic_equivalence_proven": (_bool(decision.get("semantic_equivalence_proven"))),
+        "source_automation_allowed": _bool(decision.get("automation_allowed")),
+        "source_merge_authorized": _bool(decision.get("merge_authorized")),
+        "finding_count": len(findings),
+        "risk_flag_count": len(risk_flags),
+        "blocking_finding_count": sum(1 for finding in findings if _bool(finding.get("blocking"))),
+        "reporting_only": True,
+        CURRENT_PR_DECISION_INPUT: False,
+        PRODUCER_EXECUTION_CHANGED: False,
+        "decision_boundary": _projection_boundary(),
+    }
+
+
+def _reporting_projections(
+    *,
+    trajectory_history: JsonObject,
+    patch_score: JsonObject,
+    protected_verifier_decision: JsonObject,
+) -> JsonObject:
+    return {
+        "schema_version": (REPORTING_PROJECTIONS_SCHEMA_VERSION),
+        TRAJECTORY_HISTORY_PROJECTION: (_trajectory_history_projection(trajectory_history)),
+        PATCH_SCORE_PROJECTION: (_patch_score_projection(patch_score)),
+        PROTECTED_VERIFIER_PROJECTION: (
+            _protected_verifier_projection(protected_verifier_decision)
+        ),
+        "reporting_only": True,
+        CURRENT_PR_DECISION_INPUT: False,
+        PRODUCER_EXECUTION_CHANGED: False,
+        "decision_boundary": _projection_boundary(),
+    }
+
+
 def _classification(
     *,
     evidence_narrative: JsonObject,
@@ -231,6 +408,26 @@ def _verify_operator_loop_payload(payload: JsonObject) -> JsonObject:
         ]
     )
 
+    reporting = _as_dict(payload.get(REPORTING_PROJECTIONS))
+    reporting_boundary = _as_dict(reporting.get("decision_boundary"))
+    reporting_projection_ok = (
+        reporting.get("schema_version") == REPORTING_PROJECTIONS_SCHEMA_VERSION
+        and reporting.get("reporting_only") is True
+        and reporting.get(CURRENT_PR_DECISION_INPUT) is False
+        and reporting.get(PRODUCER_EXECUTION_CHANGED) is False
+        and all(
+            reporting_boundary.get(key) is False
+            for key in [
+                "automation_allowed",
+                "patch_application_allowed",
+                "merge_authorized",
+                "semantic_equivalence_proven",
+                "automatic_security_fix_allowed",
+                "automatic_dismissal_allowed",
+            ]
+        )
+    )
+
     comment_key = _artifact_key("pr", "quality", "comment", "markdown")
     comment_path = Path(str(artifacts.get(comment_key, "")))
     comment_ok = comment_path.exists() and "SDETKit Review Result" in comment_path.read_text(
@@ -247,6 +444,7 @@ def _verify_operator_loop_payload(payload: JsonObject) -> JsonObject:
     checks = {
         "required_artifacts": not missing,
         "advisory_boundary": advisory_ok,
+        "reporting_projection_boundary": (reporting_projection_ok),
         "comment": comment_ok,
         "mission": mission_ok,
         "patch_plan": patch_plan_ok,
@@ -297,6 +495,12 @@ def _render_markdown(payload: JsonObject) -> str:
     mission_control_summary = _as_dict(payload.get("mission_control"))
     patch_plan = _as_dict(payload.get("patch_plan"))
     safe_fix_rollup = _as_dict(payload.get("safe_fix_outcome_rollup"))
+
+    reporting = _as_dict(payload.get(REPORTING_PROJECTIONS))
+    reporting_boundary = _as_dict(reporting.get("decision_boundary"))
+    trajectory_projection = _as_dict(reporting.get(TRAJECTORY_HISTORY_PROJECTION))
+    patch_score_projection = _as_dict(reporting.get(PATCH_SCORE_PROJECTION))
+    verifier_projection = _as_dict(reporting.get(PROTECTED_VERIFIER_PROJECTION))
 
     lines = [
         "# Operator evidence loop",
@@ -349,6 +553,88 @@ def _render_markdown(payload: JsonObject) -> str:
         ]
     )
 
+    lines.extend(
+        [
+            "",
+            "## Read-only reporting projections",
+            "",
+            (f"- Schema: `{_string(reporting.get('schema_version'), 'unknown')}`"),
+            (f"- Reporting only: `{str(_bool(reporting.get('reporting_only'))).lower()}`"),
+            (
+                "- Current PR decision input: "
+                f"`{str(_bool(reporting.get(CURRENT_PR_DECISION_INPUT))).lower()}`"
+            ),
+            (
+                "- Producer execution changed: "
+                f"`{str(_bool(reporting.get(PRODUCER_EXECUTION_CHANGED))).lower()}`"
+            ),
+            (
+                "- Patch application allowed: "
+                f"`{str(_bool(reporting_boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Automation allowed: "
+                f"`{str(_bool(reporting_boundary.get('automation_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized: "
+                f"`{str(_bool(reporting_boundary.get('merge_authorized'))).lower()}`"
+            ),
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(_bool(reporting_boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            "",
+            "### Trajectory history",
+            "",
+            (
+                "- Collection status: "
+                f"`{_string(trajectory_projection.get('collection_status'), 'unknown')}`"
+            ),
+            (f"- Records: `{_int(trajectory_projection.get('record_count'))}`"),
+            (
+                "- Review-first decisions: "
+                f"`{_int(trajectory_projection.get('review_first_count'))}`"
+            ),
+            (
+                "- Auto-fix-allowed decisions: "
+                f"`{_int(trajectory_projection.get('auto_fix_allowed_count'))}`"
+            ),
+            "",
+            "### PatchScorer",
+            "",
+            (
+                "- Collection status: "
+                f"`{_string(patch_score_projection.get('collection_status'), 'unknown')}`"
+            ),
+            (
+                "- Decision status: "
+                f"`{_string(patch_score_projection.get('source_decision_status'), 'unknown')}`"
+            ),
+            (f"- Score: `{_int(patch_score_projection.get('score'))}`"),
+            (
+                "- Blocking risk flags: "
+                f"`{_int(patch_score_projection.get('blocking_risk_flag_count'))}`"
+            ),
+            "",
+            "### ProtectedVerifier",
+            "",
+            (
+                "- Collection status: "
+                f"`{_string(verifier_projection.get('collection_status'), 'unknown')}`"
+            ),
+            (
+                "- Decision status: "
+                f"`{_string(verifier_projection.get('source_decision_status'), 'unknown')}`"
+            ),
+            (
+                "- Structural verification passed: "
+                f"`{str(_bool(verifier_projection.get('source_structural_verification_passed'))).lower()}`"
+            ),
+            (f"- Blocking findings: `{_int(verifier_projection.get('blocking_finding_count'))}`"),
+        ]
+    )
+
     lines.extend(["", "## Artifacts", ""])
     for key in sorted(artifacts):
         lines.append(f"- {key}: `{artifacts[key]}`")
@@ -368,6 +654,9 @@ def build_operator_evidence_loop(
     changed_files: Path | None = None,
     action_report: Path | None = None,
     check_intelligence: Path | None = None,
+    trajectory_history: Path | None = None,
+    patch_score: Path | None = None,
+    protected_verifier_decision: Path | None = None,
 ) -> JsonObject:
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -404,6 +693,14 @@ def build_operator_evidence_loop(
 
     action_payload = _read_json(action_report) or _default_action_report(evidence_narrative)
     check_payload = _read_json(check_intelligence) or _default_check_intelligence()
+    trajectory_payload = _read_optional_json(trajectory_history)
+    patch_score_payload = _read_optional_json(patch_score)
+    protected_verifier_payload = _read_optional_json(protected_verifier_decision)
+    reporting_projections = _reporting_projections(
+        trajectory_history=trajectory_payload,
+        patch_score=patch_score_payload,
+        protected_verifier_decision=(protected_verifier_payload),
+    )
     comment_body = pr_quality_action_report.render_comment_body(
         action_report=action_payload,
         check_intelligence=check_payload,
@@ -419,6 +716,23 @@ def build_operator_evidence_loop(
         _artifact_key("pr", "quality", "narrative", "markdown"): narrative_markdown.as_posix(),
         _artifact_key("pr", "quality", "comment", "markdown"): comment_path.as_posix(),
     }
+
+    for source_path, artifact_parts in (
+        (
+            trajectory_history,
+            ("trajectory", "history", "json"),
+        ),
+        (
+            patch_score,
+            ("patch", "score", "json"),
+        ),
+        (
+            protected_verifier_decision,
+            ("protected", "verifier", "json"),
+        ),
+    ):
+        if source_path is not None and source_path.exists():
+            artifacts[_artifact_key(*artifact_parts)] = source_path.as_posix()
 
     evidence_graph_markdown = graph_path.parent / "evidence-graph.md"
     if evidence_graph_markdown.exists():
@@ -450,6 +764,7 @@ def build_operator_evidence_loop(
             "evidence_graph": mission_bundle.get("evidence_graph", {}),
         },
         "patch_plan": mission_bundle.get("patch_plan", {}),
+        REPORTING_PROJECTIONS: reporting_projections,
         "pr_quality": {
             "primary_signal": evidence_narrative.get("primary_signal", {}),
             "quality": evidence_narrative.get("quality", {}),
@@ -495,6 +810,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--changed-files", type=Path, default=None)
     parser.add_argument("--action-report", type=Path, default=None)
     parser.add_argument("--check-intelligence", type=Path, default=None)
+    parser.add_argument("--trajectory-history", type=Path, default=None)
+    parser.add_argument("--patch-score", type=Path, default=None)
+    parser.add_argument("--protected-verifier", type=Path, default=None)
     parser.add_argument("--format", choices=["json", "markdown"], default="json")
     parser.add_argument(
         "--verify",
@@ -517,6 +835,9 @@ def main(argv: list[str] | None = None) -> int:
         changed_files=args.changed_files,
         action_report=args.action_report,
         check_intelligence=args.check_intelligence,
+        trajectory_history=args.trajectory_history,
+        patch_score=args.patch_score,
+        protected_verifier_decision=(args.protected_verifier),
     )
 
     if args.format == "markdown":

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -289,15 +289,29 @@ def build_alignment_components() -> list[AlignmentComponent]:
         ),
         _component(
             module="operator_evidence_loop",
-            role="assemble verified operator evidence loop outputs",
-            status="partially_aligned",
-            stages=("evidence", "diagnosis", "decision", "reporting"),
-            integration_points=("evidence_graph", "pr_quality_action_report"),
-            gaps=(
-                "should consume trajectory history",
-                "should later include PatchScorer and ProtectedVerifier results",
+            role="assemble verified operator evidence loop outputs with optional read-only trajectory, PatchScorer, and ProtectedVerifier projections",
+            status="aligned",
+            stages=(
+                "evidence",
+                "diagnosis",
+                "decision",
+                "history",
+                "proof",
+                "reporting",
             ),
-            recommended_next_action="make it the local orchestration report after PatchScorer exists",
+            existing_artifacts=(
+                "operator-loop.json",
+                "operator-loop.md",
+                "read-only reporting projections",
+            ),
+            integration_points=(
+                "evidence_graph",
+                "pr_quality_action_report",
+                "trajectory_history_report",
+                "patch_scorer",
+                "protected_verifier",
+            ),
+            recommended_next_action="keep producer artifacts optional, reporting-only, and excluded from operator classification",
         ),
         _component(
             module="security_review_evidence",

--- a/tests/test_operator_evidence_loop.py
+++ b/tests/test_operator_evidence_loop.py
@@ -188,6 +188,7 @@ def test_operator_evidence_loop_verification_marks_complete_bundle(tmp_path: Pat
     assert verification["missing_artifacts"] == []
     assert verification["checks"] == {
         "advisory_boundary": True,
+        "reporting_projection_boundary": True,
         "comment": True,
         "mission": True,
         "patch_plan": True,
@@ -302,3 +303,337 @@ def test_operator_evidence_loop_surfaces_safe_fix_outcome_rollup(tmp_path: Path)
     assert "## Safe-fix outcome rollup" in markdown
     assert "Recommendation: `rerun_proof`" in markdown
     assert "`tests/test_example.py`" in markdown
+
+
+def _projection_inputs(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path]:
+    trajectory_path = _write_json(
+        tmp_path / "trajectory-history.json",
+        {
+            "schema_version": ("sdetkit.trajectory_history_report.v1"),
+            "record_count": 3,
+            "review_first_count": 2,
+            "auto_fix_allowed_count": 1,
+            "by_final_result": {
+                "passed": 2,
+                "review_required": 1,
+            },
+            "by_risk_surface": {
+                "formatting": 1,
+                "security": 2,
+            },
+            "by_failure_class": {
+                "formatting_only": 1,
+                "security_review": 2,
+            },
+            "by_action": {
+                "review": 2,
+                "verify": 1,
+            },
+            "recent_decisions": [
+                {
+                    "diagnostic_id": "diag-3",
+                    "action": "review",
+                    "failure_class": ("security_review"),
+                    "risk_surface": "security",
+                    "review_first": True,
+                    "auto_fix_allowed": False,
+                    "final_result": ("review_required"),
+                }
+            ],
+        },
+    )
+    patch_score_path = _write_json(
+        tmp_path / "patch-score.json",
+        {
+            "schema_version": "sdetkit.patch_score.v1",
+            "patch_id": "patch-1",
+            "diagnosis_id": "diag-3",
+            "failure_surface": "formatting",
+            "classification": "formatting_only",
+            "risk_level": "low",
+            "strategy": "run_pre_commit",
+            "score": 90,
+            "minimum_score": 80,
+            "changed_files": ["src/example.py"],
+            "risk_flags": [
+                {
+                    "code": ("SAFE_PATTERN_NOT_REPEATED"),
+                    "blocking": False,
+                }
+            ],
+            "decision": {
+                "status": ("candidate_for_protected_verification"),
+                "candidate_for_protected_verification": (True),
+                "automation_allowed": False,
+            },
+        },
+    )
+    verifier_path = _write_json(
+        tmp_path / "protected-verifier.json",
+        {
+            "schema_version": ("sdetkit.protected_verifier.decision.v1"),
+            "patch_id": "patch-1",
+            "diagnosis_id": "diag-3",
+            "patch_score": 90,
+            "findings": [
+                {
+                    "code": ("SEMANTIC_EQUIVALENCE_NOT_PROVEN"),
+                    "blocking": False,
+                }
+            ],
+            "risk_flags": [],
+            "decision": {
+                "status": ("structurally_verified_candidate"),
+                "structural_verification_passed": (True),
+                "semantic_equivalence_proven": False,
+                "automation_allowed": False,
+                "merge_authorized": False,
+            },
+        },
+    )
+    return (
+        trajectory_path,
+        patch_score_path,
+        verifier_path,
+    )
+
+
+def test_operator_loop_projects_existing_reports_without_changing_decision(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    graph_path = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [],
+            "source_summary": [],
+        },
+    )
+    (
+        trajectory_path,
+        patch_score_path,
+        verifier_path,
+    ) = _projection_inputs(tmp_path)
+
+    original_inputs = {
+        path: path.read_text(encoding="utf-8")
+        for path in (
+            trajectory_path,
+            patch_score_path,
+            verifier_path,
+        )
+    }
+
+    baseline = loop.build_operator_evidence_loop(
+        repo=repo,
+        out_dir=tmp_path / "baseline",
+        evidence_graph_path=graph_path,
+        quality_outcome="success",
+    )
+    projected = loop.build_operator_evidence_loop(
+        repo=repo,
+        out_dir=tmp_path / "projected",
+        evidence_graph_path=graph_path,
+        quality_outcome="success",
+        trajectory_history=trajectory_path,
+        patch_score=patch_score_path,
+        protected_verifier_decision=verifier_path,
+    )
+
+    reporting_key = _artifact_key(
+        "reporting",
+        "projections",
+    )
+    trajectory_key = _artifact_key(
+        "trajectory",
+        "history",
+        "projection",
+    )
+    patch_key = _artifact_key(
+        "patch",
+        "score",
+        "projection",
+    )
+    verifier_key = _artifact_key(
+        "protected",
+        "verifier",
+        "projection",
+    )
+    current_input_key = _artifact_key(
+        "current",
+        "pr",
+        "decision",
+        "input",
+    )
+    producer_changed_key = _artifact_key(
+        "producer",
+        "execution",
+        "changed",
+    )
+
+    reporting = projected[reporting_key]
+
+    assert reporting["schema_version"] == ".".join(
+        (
+            "sdetkit",
+            "operator",
+            "evidence",
+            "loop",
+            "reporting",
+            "projections",
+            "v1",
+        )
+    )
+    assert reporting["reporting_only"] is True
+    assert reporting[current_input_key] is False
+    assert reporting[producer_changed_key] is False
+    assert reporting["decision_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "automatic_security_fix_allowed": False,
+        "automatic_dismissal_allowed": False,
+    }
+
+    trajectory = reporting[trajectory_key]
+    assert trajectory["collection_status"] == "collected"
+    assert trajectory["record_count"] == 3
+    assert trajectory["review_first_count"] == 2
+    assert len(trajectory["recent_decisions"]) == 1
+
+    patch_score = reporting[patch_key]
+    assert patch_score["collection_status"] == "collected"
+    assert patch_score["score"] == 90
+    assert patch_score["source_candidate_for_protected_verification"] is True
+    assert patch_score["source_automation_allowed"] is False
+
+    verifier = reporting[verifier_key]
+    assert verifier["collection_status"] == "collected"
+    assert verifier["source_structural_verification_passed"] is True
+    assert verifier["source_semantic_equivalence_proven"] is False
+
+    assert projected["classification"] == baseline["classification"]
+    projected_patch_plan = {
+        key: value
+        for key, value in projected["patch_plan"].items()
+        if key not in {"path", "artifacts"}
+    }
+    baseline_patch_plan = {
+        key: value
+        for key, value in baseline["patch_plan"].items()
+        if key not in {"path", "artifacts"}
+    }
+    assert projected_patch_plan == baseline_patch_plan
+    assert projected["automation_boundary"] == baseline["automation_boundary"]
+    assert projected["verification"]["ok"] is True
+
+    artifacts = projected["artifacts"]
+    assert (
+        artifacts[
+            _artifact_key(
+                "trajectory",
+                "history",
+                "json",
+            )
+        ]
+        == trajectory_path.as_posix()
+    )
+    assert artifacts[_artifact_key("patch", "score", "json")] == patch_score_path.as_posix()
+    assert (
+        artifacts[
+            _artifact_key(
+                "protected",
+                "verifier",
+                "json",
+            )
+        ]
+        == verifier_path.as_posix()
+    )
+
+    markdown = (tmp_path / "projected" / "operator-loop.md").read_text(encoding="utf-8")
+    assert "## Read-only reporting projections" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Producer execution changed: `false`" in markdown
+    assert "### Trajectory history" in markdown
+    assert "### PatchScorer" in markdown
+    assert "### ProtectedVerifier" in markdown
+
+    for path, original in original_inputs.items():
+        assert path.read_text(encoding="utf-8") == original
+
+
+def test_operator_loop_cli_accepts_optional_projection_artifacts(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    graph_path = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [],
+            "source_summary": [],
+        },
+    )
+    (
+        trajectory_path,
+        patch_score_path,
+        verifier_path,
+    ) = _projection_inputs(tmp_path)
+    out_dir = tmp_path / "operator-loop"
+
+    rc = loop.main(
+        [
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--evidence-graph",
+            str(graph_path),
+            "--quality-outcome",
+            "success",
+            "--trajectory-history",
+            str(trajectory_path),
+            "--patch-score",
+            str(patch_score_path),
+            "--protected-verifier",
+            str(verifier_path),
+            "--format",
+            "json",
+            "--verify",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    reporting = payload[_artifact_key("reporting", "projections")]
+
+    assert reporting["reporting_only"] is True
+    assert (
+        reporting[
+            _artifact_key(
+                "current",
+                "pr",
+                "decision",
+                "input",
+            )
+        ]
+        is False
+    )
+    assert (
+        reporting[
+            _artifact_key(
+                "producer",
+                "execution",
+                "changed",
+            )
+        ]
+        is False
+    )
+    assert payload["verification"]["ok"] is True

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -57,7 +57,7 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 12
-    assert status_counts["partially_aligned"] >= 12
+    assert status_counts["partially_aligned"] >= 11
     assert status_counts.get("planned", 0) == 0
     assert report["next_recommended_pr"] == NEXT_RECOMMENDED_PR
 
@@ -87,6 +87,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "pr_quality_runtime_proof_artifacts" not in gaps_by_module
     assert "current_head_failure_bundle" not in gaps_by_module
     assert "remediation_plan_engine" not in gaps_by_module
+    assert "operator_evidence_loop" not in gaps_by_module
     assert PR_QUALITY_LIVE_WORKSPACE_MODULE not in gaps_by_module
     assert REPO_MEMORY_PROFILE_HISTORY_MODULE not in gaps_by_module
     assert TRUSTED_HISTORY_EVIDENCE_MODULE not in gaps_by_module
@@ -128,6 +129,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`trajectory_pattern_insights`: `aligned`" in markdown
     assert "`current_head_failure_bundle`: `aligned`" in markdown
     assert "`remediation_plan_engine`: `aligned`" in markdown
+    assert "`operator_evidence_loop`: `aligned`" in markdown
     assert "`patch_scorer`: `partially_aligned`" in markdown
     assert "`protected_verifier`: `partially_aligned`" in markdown
     assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
@@ -264,4 +266,24 @@ def test_remediation_plan_engine_alignment_is_closed() -> None:
     assert (
         component.recommended_next_action == "keep remediation-plan context reporting-only "
         "until structural and semantic proof mature"
+    )
+
+
+def test_operator_evidence_loop_alignment_is_closed() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+
+    component = components["operator_evidence_loop"]
+
+    assert component.status == "aligned"
+    assert component.gaps == ()
+    assert "history" in component.stages
+    assert "proof" in component.stages
+    assert "trajectory_history_report" in component.integration_points
+    assert "patch_scorer" in component.integration_points
+    assert "protected_verifier" in component.integration_points
+    assert "read-only reporting projections" in component.existing_artifacts
+    assert (
+        component.recommended_next_action == "keep producer artifacts optional, "
+        "reporting-only, and excluded from "
+        "operator classification"
     )


### PR DESCRIPTION
## Summary

- add optional read-only trajectory-history, PatchScorer, and ProtectedVerifier projections to the operator evidence loop
- render bounded producer summaries in operator-loop JSON and Markdown
- preserve the existing operator classification, patch-plan semantics, and automation boundary
- close the operator-evidence-loop alignment gap

## Contract

- reporting-only: true
- producer execution changed: false
- operator classification input changed: false
- current PR decision input: false
- patch application allowed: false
- automation allowed: false
- merge authorized: false
- semantic equivalence proven: false

## Proof

- focused operator-loop, onboarding, trajectory-history, PatchScorer, ProtectedVerifier, PR Quality, and alignment tests
- direct classification and semantic patch-plan invariance proof
- source producer artifacts remain byte-for-byte unchanged
- baseline-aware security check with zero new findings
- `make proof-after-format`

## Scope

- `src/sdetkit/operator_evidence_loop.py`
- `tests/test_operator_evidence_loop.py`
- `src/sdetkit/reliability_spine_alignment.py`
- `tests/test_reliability_spine_alignment.py`
