### PR TITLE
feat(history): add trusted test observation history

### DIFF
--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -19,6 +19,7 @@ TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE = "_".join(
     ("trusted", "flaky", "test", "registry", "producer")
 )
 TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE = "_".join(("trusted", "test", "observation", "capture"))
+TRUSTED_TEST_OBSERVATION_HISTORY_MODULE = "_".join(("trusted", "test", "observation", "history"))
 SECURITY_FINDING_DIAGNOSIS_MODULE = "_".join(("security", "finding", "diagnosis"))
 SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE = "_".join(
     ("security", "reviewed", "disposition", "history")
@@ -525,6 +526,22 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "quality.sh cov",
             ),
             recommended_next_action="aggregate accepted-main observations across trusted runs before any flaky-test classification",
+        ),
+        _component(
+            module=TRUSTED_TEST_OBSERVATION_HISTORY_MODULE,
+            role="aggregate provenance-checked accepted-main fingerprinted test outcomes into immutable read-only cross-run history without classifying flakiness",
+            status="aligned",
+            stages=("evidence", "history", "reporting"),
+            existing_artifacts=(
+                "trusted-test-observation-history.jsonl",
+                "trusted-test-observation-history-summary.json",
+                "trusted-test-observation-history-summary.md",
+            ),
+            integration_points=(
+                TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
+                "CI Full CI lane",
+            ),
+            recommended_next_action="wire the immutable raw history artifact into trusted-main history collection before any separate classification handoff",
         ),
         _component(
             module=TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,

--- a/src/sdetkit/trusted_test_observation_history.py
+++ b/src/sdetkit/trusted_test_observation_history.py
@@ -1,0 +1,724 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.trusted_test_observation_history.v1"
+RECORD_SCHEMA_VERSION = "sdetkit.trusted_test_observation_history.record.v1"
+SOURCE_SCHEMA_VERSION = "sdetkit.trusted_test_observation_capture.v1"
+SOURCE_STATUS = "trusted_main_observations_captured"
+
+TRUSTED_WORKFLOW = "CI"
+TRUSTED_JOB = "Full CI lane"
+TRUSTED_EVENT = "push"
+TRUSTED_REF = "refs/heads/main"
+
+DEFAULT_OUT_DIR = Path("build") / "trusted-test-observation-history"
+HISTORY_JSONL = "trusted-test-observation-history.jsonl"
+SUMMARY_JSON = "trusted-test-observation-history-summary.json"
+SUMMARY_MD = "trusted-test-observation-history-summary.md"
+
+ALLOWED_OUTCOMES = {
+    "passed",
+    "failed",
+    "error",
+    "skipped",
+}
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _text(value).lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        dict(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "raw_observation_only": True,
+        "flaky_classification_performed": False,
+        "current_pr_decision_input": False,
+        "automatic_quarantine_allowed": False,
+        "automatic_rerun_allowed": False,
+        "current_failure_suppression_allowed": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _assert_boundary(
+    boundary: Mapping[str, Any],
+    *,
+    source: str,
+) -> None:
+    expected = _decision_boundary()
+    for key, expected_value in expected.items():
+        if _bool(boundary.get(key)) is not expected_value:
+            raise ValueError(f"{source} has invalid authority boundary for {key}")
+
+
+def _validate_fingerprint(value: Any) -> str:
+    fingerprint = _text(value).lower()
+    if len(fingerprint) != 64 or any(char not in "0123456789abcdef" for char in fingerprint):
+        raise ValueError(
+            "trusted test observation fingerprint must be a 64-character SHA-256 digest"
+        )
+    return fingerprint
+
+
+def _normalise_observations(
+    value: Any,
+) -> list[JsonObject]:
+    observations: list[JsonObject] = []
+    seen: set[str] = set()
+
+    for raw in _as_list(value):
+        item = _as_dict(raw)
+        fingerprint = _validate_fingerprint(item.get("test_fingerprint"))
+        outcome = _text(item.get("outcome"))
+        if outcome not in ALLOWED_OUTCOMES:
+            raise ValueError("trusted test observation outcome is not supported")
+        if fingerprint in seen:
+            raise ValueError(
+                "trusted test observation history record contains duplicate fingerprints"
+            )
+        if any(
+            key in item
+            for key in (
+                "test_id",
+                "classname",
+                "name",
+                "nodeid",
+            )
+        ):
+            raise ValueError("raw test identity cannot enter trusted observation history")
+
+        seen.add(fingerprint)
+        observations.append(
+            {
+                "test_fingerprint": fingerprint,
+                "outcome": outcome,
+            }
+        )
+
+    if not observations:
+        raise ValueError("trusted test observation report contains no observations")
+
+    observations.sort(
+        key=lambda item: (
+            item["test_fingerprint"],
+            item["outcome"],
+        )
+    )
+    return observations
+
+
+def _outcome_counts(
+    observations: list[Mapping[str, Any]],
+) -> Counter[str]:
+    return Counter(_text(item.get("outcome")) for item in observations)
+
+
+def _validate_counts(
+    *,
+    summary: Mapping[str, Any],
+    observations: list[Mapping[str, Any]],
+    source: str,
+) -> None:
+    counts = _outcome_counts(observations)
+    observation_count = _int(summary.get("observation_count"))
+
+    if observation_count != len(observations):
+        raise ValueError(f"{source} observation count is inconsistent")
+
+    for outcome in sorted(ALLOWED_OUTCOMES):
+        if _int(summary.get(outcome)) != counts[outcome]:
+            raise ValueError(f"{source} {outcome} count is inconsistent")
+
+    if sum(counts.values()) != observation_count:
+        raise ValueError(f"{source} outcome totals are inconsistent")
+
+
+def validate_observation_report(
+    report: Mapping[str, Any],
+) -> None:
+    if _text(report.get("schema_version")) != (SOURCE_SCHEMA_VERSION):
+        raise ValueError("trusted test observation report schema is not supported")
+    if _text(report.get("status")) != SOURCE_STATUS:
+        raise ValueError("trusted test observation report status is not supported")
+
+    source = _as_dict(report.get("source"))
+    expected_source = {
+        "workflow": TRUSTED_WORKFLOW,
+        "job": TRUSTED_JOB,
+        "event_name": TRUSTED_EVENT,
+        "ref_name": TRUSTED_REF,
+    }
+    for key, expected in expected_source.items():
+        if _text(source.get(key)) != expected:
+            raise ValueError(f"trusted test observation source is not supported for {key}")
+
+    if not _text(source.get("run_id")):
+        raise ValueError("trusted test observation source run id is required")
+    if not _text(source.get("head_sha")):
+        raise ValueError("trusted test observation source head sha is required")
+    if source.get("trusted_main") is not True:
+        raise ValueError("trusted test observations require trusted main provenance")
+    if source.get("input_read_only") is not True:
+        raise ValueError("trusted test observation input must be read-only")
+    if source.get("commands_executed_by_reader") is not False:
+        raise ValueError("trusted test observation reader cannot execute commands")
+
+    summary = _as_dict(report.get("summary"))
+    if summary.get("flaky_classification_performed") is not False:
+        raise ValueError("trusted observation history cannot consume classified input")
+    if summary.get("raw_test_identity_emitted") is not False:
+        raise ValueError("trusted observation history cannot consume raw test identities")
+
+    observations = _normalise_observations(report.get("observations"))
+    _validate_counts(
+        summary=summary,
+        observations=observations,
+        source="trusted test observation report",
+    )
+
+    boundary = _as_dict(report.get("decision_boundary"))
+    required_false = (
+        "flaky_classification_performed",
+        "automatic_quarantine_allowed",
+        "automatic_rerun_allowed",
+        "current_failure_suppression_allowed",
+        "automation_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+    )
+    if boundary.get("raw_observation_only") is not True:
+        raise ValueError("trusted test observation report must be raw-observation-only")
+    if any(boundary.get(key) is not False for key in required_false):
+        raise ValueError("trusted test observation report expands authority")
+
+
+def _stable_record_payload(
+    record: Mapping[str, Any],
+) -> JsonObject:
+    return {
+        "source_run_id": _text(record.get("source_run_id")),
+        "source_head_sha": _text(record.get("source_head_sha")),
+        "source_workflow": _text(record.get("source_workflow")),
+        "source_job": _text(record.get("source_job")),
+        "event_name": _text(record.get("event_name")),
+        "ref_name": _text(record.get("ref_name")),
+        "observation_count": _int(record.get("observation_count")),
+        "passed": _int(record.get("passed")),
+        "failed": _int(record.get("failed")),
+        "error": _int(record.get("error")),
+        "skipped": _int(record.get("skipped")),
+        "observations": _normalise_observations(record.get("observations")),
+        "decision_boundary": _decision_boundary(),
+    }
+
+
+def build_observation_history_record(
+    report: Mapping[str, Any],
+    *,
+    source_run_id: str,
+    source_head_sha: str,
+    recorded_at_utc: str | None = None,
+) -> JsonObject:
+    validate_observation_report(report)
+
+    source = _as_dict(report.get("source"))
+    run_id = _text(source_run_id)
+    head_sha = _text(source_head_sha)
+
+    if not run_id:
+        raise ValueError("source_run_id is required")
+    if not head_sha:
+        raise ValueError("source_head_sha is required")
+    if run_id != _text(source.get("run_id")):
+        raise ValueError("source_run_id does not match trusted observation report provenance")
+    if head_sha != _text(source.get("head_sha")):
+        raise ValueError("source_head_sha does not match trusted observation report provenance")
+
+    observations = _normalise_observations(report.get("observations"))
+    summary = _as_dict(report.get("summary"))
+
+    stable = {
+        "source_run_id": run_id,
+        "source_head_sha": head_sha,
+        "source_workflow": TRUSTED_WORKFLOW,
+        "source_job": TRUSTED_JOB,
+        "event_name": TRUSTED_EVENT,
+        "ref_name": TRUSTED_REF,
+        "observation_count": len(observations),
+        "passed": _int(summary.get("passed")),
+        "failed": _int(summary.get("failed")),
+        "error": _int(summary.get("error")),
+        "skipped": _int(summary.get("skipped")),
+        "observations": observations,
+        "decision_boundary": _decision_boundary(),
+    }
+
+    return {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "record_id": _stable_hash(stable),
+        "recorded_at_utc": (_text(recorded_at_utc) or _utc_now()),
+        **stable,
+    }
+
+
+def validate_observation_history_record(
+    record: Mapping[str, Any],
+) -> None:
+    if _text(record.get("schema_version")) != (RECORD_SCHEMA_VERSION):
+        raise ValueError("trusted observation history record schema is not supported")
+    if not _text(record.get("recorded_at_utc")):
+        raise ValueError("trusted observation history recorded_at_utc is required")
+
+    stable = _stable_record_payload(record)
+
+    for key, expected in (
+        ("source_workflow", TRUSTED_WORKFLOW),
+        ("source_job", TRUSTED_JOB),
+        ("event_name", TRUSTED_EVENT),
+        ("ref_name", TRUSTED_REF),
+    ):
+        if stable[key] != expected:
+            raise ValueError(f"trusted observation history provenance is invalid for {key}")
+
+    if not stable["source_run_id"]:
+        raise ValueError("trusted observation history source run id is required")
+    if not stable["source_head_sha"]:
+        raise ValueError("trusted observation history source head sha is required")
+
+    observations = list(stable["observations"])
+    _validate_counts(
+        summary=stable,
+        observations=observations,
+        source="trusted observation history record",
+    )
+    _assert_boundary(
+        _as_dict(record.get("decision_boundary")),
+        source="trusted observation history record",
+    )
+
+    expected_id = _stable_hash(stable)
+    if _text(record.get("record_id")) != expected_id:
+        raise ValueError("trusted observation history record id is inconsistent")
+
+
+def merge_observation_history_records(
+    prior_records: list[Mapping[str, Any]],
+    record: Mapping[str, Any],
+) -> tuple[list[JsonObject], bool]:
+    validate_observation_history_record(record)
+
+    records: list[JsonObject] = []
+    seen_ids: set[str] = set()
+
+    for prior in prior_records:
+        validate_observation_history_record(prior)
+        record_id = _text(prior.get("record_id"))
+        if record_id in seen_ids:
+            raise ValueError("trusted observation history contains duplicate prior record ids")
+        seen_ids.add(record_id)
+        records.append(dict(prior))
+
+    current_id = _text(record.get("record_id"))
+    appended = current_id not in seen_ids
+    if appended:
+        records.append(dict(record))
+
+    return records, appended
+
+
+def _read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _read_jsonl(path: Path) -> list[JsonObject]:
+    if not path.exists():
+        raise ValueError("prior trusted observation history does not exist")
+
+    records: list[JsonObject] = []
+    for line_number, raw in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not raw.strip():
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object on line {line_number} in {path}")
+        records.append(payload)
+
+    return records
+
+
+def build_observation_history_summary(
+    records: list[Mapping[str, Any]],
+    *,
+    appended: bool,
+    history_path: Path,
+    prior_history_collected: bool,
+    prior_record_count: int,
+) -> JsonObject:
+    if prior_record_count < 0:
+        raise ValueError("prior_record_count cannot be negative")
+    if not prior_history_collected and prior_record_count != 0:
+        raise ValueError("uncollected prior history cannot report prior records")
+
+    expected_record_count = prior_record_count + (1 if appended else 0)
+    if len(records) != expected_record_count:
+        raise ValueError("trusted observation history record totals are inconsistent")
+
+    fingerprint_outcomes: dict[str, list[str]] = defaultdict(list)
+    source_run_ids: list[str] = []
+    source_head_shas: list[str] = []
+    totals: Counter[str] = Counter()
+
+    for record in records:
+        validate_observation_history_record(record)
+        source_run_ids.append(_text(record.get("source_run_id")))
+        source_head_shas.append(_text(record.get("source_head_sha")))
+        for observation in _normalise_observations(record.get("observations")):
+            fingerprint = _text(observation.get("test_fingerprint"))
+            outcome = _text(observation.get("outcome"))
+            fingerprint_outcomes[fingerprint].append(outcome)
+            totals[outcome] += 1
+
+    histories = [
+        {
+            "test_fingerprint": fingerprint,
+            "runs_observed": len(outcomes),
+            "outcomes": list(outcomes),
+            "passed": outcomes.count("passed"),
+            "failed": outcomes.count("failed"),
+            "error": outcomes.count("error"),
+            "skipped": outcomes.count("skipped"),
+        }
+        for fingerprint, outcomes in sorted(fingerprint_outcomes.items())
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "history_recorded",
+        "history_path": history_path.as_posix(),
+        "prior_history_collected": (prior_history_collected),
+        "prior_record_count": prior_record_count,
+        "record_count": len(records),
+        "appended": appended,
+        "source_run_ids": source_run_ids,
+        "source_head_shas": source_head_shas,
+        "fingerprint_count": len(histories),
+        "observation_count": sum(totals.values()),
+        "passed": totals["passed"],
+        "failed": totals["failed"],
+        "error": totals["error"],
+        "skipped": totals["skipped"],
+        "fingerprint_histories": histories,
+        "raw_test_identity_emitted": False,
+        "flaky_classification_performed": False,
+        "current_pr_decision_input": False,
+        "decision_boundary": _decision_boundary(),
+        "recommended_next_action": (
+            "Use only provenance-checked raw outcome "
+            "history as input to a separate advisory "
+            "classification handoff."
+        ),
+    }
+
+
+def write_observation_history(
+    records: list[Mapping[str, Any]],
+    *,
+    out_dir: Path,
+) -> Path:
+    for record in records:
+        validate_observation_history_record(record)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    history_path = out_dir / HISTORY_JSONL
+    history_path.write_text(
+        "".join(
+            json.dumps(
+                dict(record),
+                sort_keys=True,
+            )
+            + "\n"
+            for record in records
+        ),
+        encoding="utf-8",
+    )
+    return history_path
+
+
+def render_observation_history_markdown(
+    summary: Mapping[str, Any],
+) -> str:
+    boundary = _as_dict(summary.get("decision_boundary"))
+    histories = [
+        _as_dict(item) for item in _as_list(summary.get("fingerprint_histories")) if _as_dict(item)
+    ]
+
+    lines = [
+        "# Trusted test observation history",
+        "",
+        f"- Schema: `{_text(summary.get('schema_version'))}`",
+        f"- Status: `{_text(summary.get('status'))}`",
+        f"- Records: `{_int(summary.get('record_count'))}`",
+        (
+            "- Prior history collected: "
+            f"`{str(_bool(summary.get('prior_history_collected'))).lower()}`"
+        ),
+        f"- Appended: `{str(_bool(summary.get('appended'))).lower()}`",
+        (f"- Fingerprints: `{_int(summary.get('fingerprint_count'))}`"),
+        (f"- Observations: `{_int(summary.get('observation_count'))}`"),
+        f"- Passed: `{_int(summary.get('passed'))}`",
+        f"- Failed: `{_int(summary.get('failed'))}`",
+        f"- Errors: `{_int(summary.get('error'))}`",
+        f"- Skipped: `{_int(summary.get('skipped'))}`",
+        "",
+        "## Fingerprint histories",
+        "",
+    ]
+
+    if histories:
+        for item in histories:
+            outcomes = ", ".join(_text(value) for value in _as_list(item.get("outcomes")))
+            lines.append(
+                "- fingerprint="
+                f"`{_text(item.get('test_fingerprint'))}`, "
+                f"runs=`{_int(item.get('runs_observed'))}`, "
+                f"outcomes=`{outcomes}`"
+            )
+    else:
+        lines.append("- none observed")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "- Raw observation only: `true`",
+            "- Raw test identity emitted: `false`",
+            "- Flaky classification performed: `false`",
+            "- Current PR decision input: `false`",
+            (
+                "- Automatic quarantine allowed: "
+                f"`{str(_bool(boundary.get('automatic_quarantine_allowed'))).lower()}`"
+            ),
+            (
+                "- Automatic rerun allowed: "
+                f"`{str(_bool(boundary.get('automatic_rerun_allowed'))).lower()}`"
+            ),
+            (
+                "- Current failure suppression allowed: "
+                f"`{str(_bool(boundary.get('current_failure_suppression_allowed'))).lower()}`"
+            ),
+            (f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`"),
+            (
+                "- Patch application allowed: "
+                f"`{str(_bool(boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`"),
+            (
+                "- Semantic equivalence proven: "
+                f"`{str(_bool(boundary.get('semantic_equivalence_proven'))).lower()}`"
+            ),
+            "",
+            (f"- Next: {_text(summary.get('recommended_next_action'))}"),
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def write_observation_history_summary(
+    summary: Mapping[str, Any],
+    *,
+    out_dir: Path,
+) -> dict[str, str]:
+    if _text(summary.get("schema_version")) != (SCHEMA_VERSION):
+        raise ValueError("trusted observation history summary schema is not supported")
+    _assert_boundary(
+        _as_dict(summary.get("decision_boundary")),
+        source="trusted observation history summary",
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / SUMMARY_JSON
+    markdown_path = out_dir / SUMMARY_MD
+
+    json_path.write_text(
+        json.dumps(
+            dict(summary),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(
+        render_observation_history_markdown(summary),
+        encoding="utf-8",
+    )
+
+    return {
+        "summary_json": json_path.as_posix(),
+        "summary_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=("python -m sdetkit.trusted_test_observation_history"))
+    parser.add_argument(
+        "--observation-report",
+        type=Path,
+        required=True,
+    )
+    parser.add_argument(
+        "--source-run-id",
+        required=True,
+    )
+    parser.add_argument(
+        "--source-head-sha",
+        required=True,
+    )
+    parser.add_argument(
+        "--prior-history-jsonl",
+        type=Path,
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        report = _read_json(args.observation_report)
+        prior_records = _read_jsonl(args.prior_history_jsonl) if args.prior_history_jsonl else []
+        prior_collected = args.prior_history_jsonl is not None
+        record = build_observation_history_record(
+            report,
+            source_run_id=args.source_run_id,
+            source_head_sha=args.source_head_sha,
+        )
+        records, appended = merge_observation_history_records(
+            prior_records,
+            record,
+        )
+
+        history_path = args.out_dir / HISTORY_JSONL
+        summary = build_observation_history_summary(
+            records,
+            appended=appended,
+            history_path=history_path,
+            prior_history_collected=prior_collected,
+            prior_record_count=len(prior_records),
+        )
+        written_history = write_observation_history(
+            records,
+            out_dir=args.out_dir,
+        )
+        artifacts = write_observation_history_summary(
+            summary,
+            out_dir=args.out_dir,
+        )
+    except (
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        print(f"error={exc}")
+        return 2
+
+    output = {
+        "status": summary["status"],
+        "record_count": summary["record_count"],
+        "appended": summary["appended"],
+        "fingerprint_count": (summary["fingerprint_count"]),
+        "flaky_classification_performed": False,
+        "current_pr_decision_input": False,
+        "artifacts": {
+            "history_jsonl": (written_history.as_posix()),
+            **artifacts,
+        },
+    }
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                output,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for key, value in output.items():
+            print(f"{key}={value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -14,6 +14,7 @@ from sdetkit.reliability_spine_alignment import (
     TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
     TRUSTED_HISTORY_EVIDENCE_MODULE,
     TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
+    TRUSTED_TEST_OBSERVATION_HISTORY_MODULE,
     build_alignment_components,
     build_alignment_report,
     main,
@@ -48,6 +49,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in modules
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE in modules
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE in modules
+    assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in modules
     assert SECURITY_FINDING_DIAGNOSIS_MODULE in modules
     assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE in modules
 
@@ -93,6 +95,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert TRUSTED_HISTORY_EVIDENCE_MODULE not in gaps_by_module
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE not in gaps_by_module
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE not in gaps_by_module
+    assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
     assert SECURITY_FINDING_DIAGNOSIS_MODULE not in gaps_by_module
     assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE not in gaps_by_module
@@ -145,6 +148,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert f"`{FLAKY_TEST_REGISTRY_EVIDENCE_MODULE}`: `partially_aligned`" in markdown
     assert f"`{TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE}`: `aligned`" in markdown
     assert f"`{TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE}`: `aligned`" in markdown
+    assert f"`{TRUSTED_TEST_OBSERVATION_HISTORY_MODULE}`: `aligned`" in markdown
     assert f"`{SECURITY_FINDING_DIAGNOSIS_MODULE}`: `aligned`" in markdown
     assert f"`{SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE}`: `aligned`" in markdown
 
@@ -227,6 +231,7 @@ def test_alignment_has_no_behavior_mutation_surfaces() -> None:
         FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
         TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
         TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
+        TRUSTED_TEST_OBSERVATION_HISTORY_MODULE,
         SECURITY_FINDING_DIAGNOSIS_MODULE,
         SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE,
     }
@@ -286,4 +291,30 @@ def test_operator_evidence_loop_alignment_is_closed() -> None:
         component.recommended_next_action == "keep producer artifacts optional, "
         "reporting-only, and excluded from "
         "operator classification"
+    )
+
+
+def test_trusted_test_observation_history_alignment_is_closed() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+
+    component = components[TRUSTED_TEST_OBSERVATION_HISTORY_MODULE]
+
+    assert component.status == "aligned"
+    assert component.gaps == ()
+    assert component.stages == (
+        "evidence",
+        "history",
+        "reporting",
+    )
+    assert component.existing_artifacts == (
+        "trusted-test-observation-history.jsonl",
+        "trusted-test-observation-history-summary.json",
+        "trusted-test-observation-history-summary.md",
+    )
+    assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE in component.integration_points
+    assert "CI Full CI lane" in component.integration_points
+    assert (
+        component.recommended_next_action == "wire the immutable raw history artifact "
+        "into trusted-main history collection before "
+        "any separate classification handoff"
     )

--- a/tests/test_trusted_test_observation_history.py
+++ b/tests/test_trusted_test_observation_history.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import trusted_test_observation_history as history
+
+
+def _fingerprint(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _report(
+    *,
+    run_id: str = "run-1",
+    head_sha: str = "a" * 40,
+    outcomes: tuple[
+        tuple[str, str],
+        ...,
+    ] = (
+        ("suite::test_b", "failed"),
+        ("suite::test_a", "passed"),
+    ),
+) -> dict[str, object]:
+    observations = [
+        {
+            "test_fingerprint": _fingerprint(identity),
+            "outcome": outcome,
+        }
+        for identity, outcome in outcomes
+    ]
+    counts = {
+        outcome: sum(1 for item in observations if item["outcome"] == outcome)
+        for outcome in history.ALLOWED_OUTCOMES
+    }
+    return {
+        "schema_version": ("sdetkit.trusted_test_observation_capture.v1"),
+        "status": ("trusted_main_observations_captured"),
+        "source": {
+            "workflow": "CI",
+            "job": "Full CI lane",
+            "run_id": run_id,
+            "head_sha": head_sha,
+            "event_name": "push",
+            "ref_name": "refs/heads/main",
+            "input_kind": "junit_xml",
+            "identity_handling": "sha256_digest",
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+            "trusted_main": True,
+        },
+        "observations": observations,
+        "summary": {
+            "observation_count": len(observations),
+            **counts,
+            "flaky_classification_performed": False,
+            "raw_test_identity_emitted": False,
+        },
+        "decision_boundary": {
+            "raw_observation_only": True,
+            "raw_test_identity_emitted": False,
+            "flaky_classification_performed": False,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def test_build_record_is_sorted_and_timestamp_independent() -> None:
+    report = _report()
+
+    first = history.build_observation_history_record(
+        report,
+        source_run_id="run-1",
+        source_head_sha="a" * 40,
+        recorded_at_utc="2026-06-16T01:00:00Z",
+    )
+    second = history.build_observation_history_record(
+        report,
+        source_run_id="run-1",
+        source_head_sha="a" * 40,
+        recorded_at_utc="2026-06-16T02:00:00Z",
+    )
+
+    assert first["schema_version"] == ("sdetkit.trusted_test_observation_history.record.v1")
+    assert first["record_id"] == second["record_id"]
+    assert first["recorded_at_utc"] != second["recorded_at_utc"]
+    assert first["observations"] == sorted(
+        first["observations"],
+        key=lambda item: (
+            item["test_fingerprint"],
+            item["outcome"],
+        ),
+    )
+    assert first["observation_count"] == 2
+    assert first["passed"] == 1
+    assert first["failed"] == 1
+    assert first["decision_boundary"] == {
+        "raw_observation_only": True,
+        "flaky_classification_performed": False,
+        "current_pr_decision_input": False,
+        "automatic_quarantine_allowed": False,
+        "automatic_rerun_allowed": False,
+        "current_failure_suppression_allowed": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda report: report.update({"schema_version": ("unsupported")}),
+            "schema",
+        ),
+        (
+            lambda report: report["source"].update({"ref_name": "refs/heads/feature"}),
+            "source",
+        ),
+        (
+            lambda report: report["source"].update({"commands_executed_by_reader": True}),
+            "execute commands",
+        ),
+        (
+            lambda report: report["summary"].update({"flaky_classification_performed": True}),
+            "classified input",
+        ),
+        (
+            lambda report: report["observations"][0].update({"test_id": "raw::identity"}),
+            "raw test identity",
+        ),
+        (
+            lambda report: report["summary"].update({"observation_count": 9}),
+            "observation count",
+        ),
+    ],
+)
+def test_validate_report_rejects_contract_drift(
+    mutator,
+    message: str,
+) -> None:
+    report = _report()
+    mutator(report)
+
+    with pytest.raises(
+        ValueError,
+        match=message,
+    ):
+        history.validate_observation_report(report)
+
+
+def test_build_record_rejects_explicit_provenance_mismatch() -> None:
+    report = _report()
+
+    with pytest.raises(
+        ValueError,
+        match="source_run_id does not match",
+    ):
+        history.build_observation_history_record(
+            report,
+            source_run_id="different-run",
+            source_head_sha="a" * 40,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="source_head_sha does not match",
+    ):
+        history.build_observation_history_record(
+            report,
+            source_run_id="run-1",
+            source_head_sha="b" * 40,
+        )
+
+
+def test_validate_record_rejects_id_or_authority_drift() -> None:
+    record = history.build_observation_history_record(
+        _report(),
+        source_run_id="run-1",
+        source_head_sha="a" * 40,
+    )
+
+    bad_id = dict(record)
+    bad_id["record_id"] = "wrong"
+    with pytest.raises(
+        ValueError,
+        match="record id",
+    ):
+        history.validate_observation_history_record(bad_id)
+
+    bad_boundary = json.loads(json.dumps(record))
+    bad_boundary["decision_boundary"]["automation_allowed"] = True
+    with pytest.raises(
+        ValueError,
+        match="authority boundary",
+    ):
+        history.validate_observation_history_record(bad_boundary)
+
+
+def test_merge_preserves_order_and_deduplicates() -> None:
+    first = history.build_observation_history_record(
+        _report(),
+        source_run_id="run-1",
+        source_head_sha="a" * 40,
+        recorded_at_utc="2026-06-16T01:00:00Z",
+    )
+    second = history.build_observation_history_record(
+        _report(
+            run_id="run-2",
+            head_sha="b" * 40,
+            outcomes=(
+                ("suite::test_a", "failed"),
+                ("suite::test_b", "passed"),
+            ),
+        ),
+        source_run_id="run-2",
+        source_head_sha="b" * 40,
+        recorded_at_utc="2026-06-16T02:00:00Z",
+    )
+
+    records, appended = history.merge_observation_history_records(
+        [first],
+        second,
+    )
+
+    assert appended is True
+    assert [record["record_id"] for record in records] == [
+        first["record_id"],
+        second["record_id"],
+    ]
+
+    repeated, repeated_appended = history.merge_observation_history_records(
+        records,
+        second,
+    )
+    assert repeated_appended is False
+    assert repeated == records
+
+
+def test_summary_aggregates_raw_outcomes_without_classification(
+    tmp_path: Path,
+) -> None:
+    first = history.build_observation_history_record(
+        _report(),
+        source_run_id="run-1",
+        source_head_sha="a" * 40,
+    )
+    second = history.build_observation_history_record(
+        _report(
+            run_id="run-2",
+            head_sha="b" * 40,
+            outcomes=(
+                ("suite::test_a", "failed"),
+                ("suite::test_b", "passed"),
+            ),
+        ),
+        source_run_id="run-2",
+        source_head_sha="b" * 40,
+    )
+
+    records, appended = history.merge_observation_history_records(
+        [first],
+        second,
+    )
+    summary = history.build_observation_history_summary(
+        records,
+        appended=appended,
+        history_path=tmp_path / history.HISTORY_JSONL,
+        prior_history_collected=True,
+        prior_record_count=1,
+    )
+
+    assert summary["schema_version"] == ("sdetkit.trusted_test_observation_history.v1")
+    assert summary["record_count"] == 2
+    assert summary["fingerprint_count"] == 2
+    assert summary["observation_count"] == 4
+    assert summary["passed"] == 2
+    assert summary["failed"] == 2
+    assert summary["flaky_classification_performed"] is False
+    assert summary["current_pr_decision_input"] is False
+    assert len(summary["fingerprint_histories"]) == 2
+
+    serialized = json.dumps(summary)
+    assert '"classification"' not in serialized
+    assert '"test_id"' not in serialized
+    assert '"classname"' not in serialized
+    assert '"nodeid"' not in serialized
+
+
+def test_write_history_and_summary_artifacts(
+    tmp_path: Path,
+) -> None:
+    record = history.build_observation_history_record(
+        _report(),
+        source_run_id="run-1",
+        source_head_sha="a" * 40,
+    )
+    history_path = history.write_observation_history(
+        [record],
+        out_dir=tmp_path,
+    )
+    summary = history.build_observation_history_summary(
+        [record],
+        appended=True,
+        history_path=history_path,
+        prior_history_collected=False,
+        prior_record_count=0,
+    )
+    artifacts = history.write_observation_history_summary(
+        summary,
+        out_dir=tmp_path,
+    )
+
+    written = [
+        json.loads(line)
+        for line in history_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert written == [record]
+
+    saved_summary = json.loads(Path(artifacts["summary_json"]).read_text(encoding="utf-8"))
+    markdown = Path(artifacts["summary_markdown"]).read_text(encoding="utf-8")
+
+    assert saved_summary == summary
+    assert "# Trusted test observation history" in markdown
+    assert "Raw test identity emitted: `false`" in markdown
+    assert "Flaky classification performed: `false`" in markdown
+    assert "Automatic quarantine allowed: `false`" in markdown
+    assert "Current failure suppression allowed: `false`" in markdown
+
+
+def test_cli_records_initial_and_prior_history(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    first_report = tmp_path / "first.json"
+    first_report.write_text(
+        json.dumps(_report()) + "\n",
+        encoding="utf-8",
+    )
+    first_out = tmp_path / "first-out"
+
+    first_rc = history.main(
+        [
+            "--observation-report",
+            str(first_report),
+            "--source-run-id",
+            "run-1",
+            "--source-head-sha",
+            "a" * 40,
+            "--out-dir",
+            str(first_out),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert first_rc == 0
+    first_output = json.loads(capsys.readouterr().out)
+    assert first_output["record_count"] == 1
+    assert first_output["appended"] is True
+    assert first_output["flaky_classification_performed"] is False
+
+    second_report = tmp_path / "second.json"
+    second_report.write_text(
+        json.dumps(
+            _report(
+                run_id="run-2",
+                head_sha="b" * 40,
+                outcomes=(
+                    ("suite::test_a", "failed"),
+                    ("suite::test_b", "passed"),
+                ),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    second_out = tmp_path / "second-out"
+
+    second_rc = history.main(
+        [
+            "--observation-report",
+            str(second_report),
+            "--source-run-id",
+            "run-2",
+            "--source-head-sha",
+            "b" * 40,
+            "--prior-history-jsonl",
+            str(first_out / history.HISTORY_JSONL),
+            "--out-dir",
+            str(second_out),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert second_rc == 0
+    second_output = json.loads(capsys.readouterr().out)
+    assert second_output["record_count"] == 2
+    assert second_output["appended"] is True
+
+    history_records = [
+        json.loads(line)
+        for line in (second_out / history.HISTORY_JSONL).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [item["source_run_id"] for item in history_records] == ["run-1", "run-2"]
+
+
+def test_cli_rejects_untrusted_observation_source(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    report = _report()
+    report["source"]["ref_name"] = "refs/heads/feature"
+    report_path = tmp_path / "untrusted.json"
+    report_path.write_text(
+        json.dumps(report) + "\n",
+        encoding="utf-8",
+    )
+
+    rc = history.main(
+        [
+            "--observation-report",
+            str(report_path),
+            "--source-run-id",
+            "run-1",
+            "--source-head-sha",
+            "a" * 40,
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 2
+    assert "error=" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- add immutable, provenance-checked trusted-main test observation history
- retain only SHA-256 test fingerprints and raw outcomes across accepted-main runs
- add deterministic append order, stable record IDs, JSONL deduplication, and bounded summaries
- register the new evidence/history/reporting component in the reliability spine

## Contract

- raw observation only: true
- flaky classification performed: false
- current PR decision input: false
- automatic quarantine allowed: false
- automatic rerun allowed: false
- current failure suppression allowed: false
- automation allowed: false
- patch application allowed: false
- merge authorized: false
- semantic equivalence proven: false

## Explicit exclusions

- no trusted flaky-test registry producer integration
- no populated RepoMemory registry changes
- no PR Quality visibility changes
- no RepoMemory Profile History workflow changes

## Proof

- focused observation-history, capture, RepoMemory history, registry, producer, RepoMemory, and alignment tests: 104 passed
- direct provenance, timestamp-independent stable-ID, append-order, and deduplication proof
- baseline-aware security check: zero new findings
- changed-scope security check: zero new findings
- `make proof-after-format`: passed

## Scope

- `src/sdetkit/trusted_test_observation_history.py`
- `tests/test_trusted_test_observation_history.py`
- `src/sdetkit/reliability_spine_alignment.py`
- `tests/test_reliability_spine_alignment.py`
