### PR TITLE
feat(history): add trusted observation fingerprint classification

### DIFF
--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -20,6 +20,9 @@ TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE = "_".join(
 )
 TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE = "_".join(("trusted", "test", "observation", "capture"))
 TRUSTED_TEST_OBSERVATION_HISTORY_MODULE = "_".join(("trusted", "test", "observation", "history"))
+TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE = "_".join(
+    ("trusted", "test", "observation", "classification")
+)
 SECURITY_FINDING_DIAGNOSIS_MODULE = "_".join(("security", "finding", "diagnosis"))
 SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE = "_".join(
     ("security", "reviewed", "disposition", "history")
@@ -539,10 +542,23 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             integration_points=(
                 TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
+                TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE,
                 "CI Full CI lane",
                 "RepoMemory Profile History workflow",
             ),
-            recommended_next_action="audit a separate provenance-checked classification handoff before any registry or PR Quality visibility",
+            recommended_next_action="keep immutable history as the only input to the dedicated fingerprint classification contract",
+        ),
+        _component(
+            module=TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE,
+            role="classify provenance-bound fingerprint outcome histories into deterministic advisory states without recovering raw test identity",
+            status="aligned",
+            stages=("evidence", "diagnosis", "history", "reporting"),
+            existing_artifacts=(
+                "trusted-test-observation-classification.json",
+                "trusted-test-observation-classification.md",
+            ),
+            integration_points=(TRUSTED_TEST_OBSERVATION_HISTORY_MODULE,),
+            recommended_next_action="audit trusted producer consumption of the dedicated advisory classification artifact before registry, workflow, RepoMemory, or PR Quality integration",
         ),
         _component(
             module=TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
@@ -560,7 +576,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
                 "repo_memory",
             ),
-            recommended_next_action="consume only persisted provenance-checked observation history after a separate advisory classification handoff is proven",
+            recommended_next_action="audit consumption of the dedicated advisory classification artifact before changing the no-observation fail-closed state",
         ),
         _component(
             module=FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
@@ -576,8 +592,10 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
                 "repo_memory",
             ),
-            gaps=("flaky-classification handoff and PR Quality visibility are not yet connected",),
-            recommended_next_action="connect only cross-run provenance-checked classifications before rendering populated instability history",
+            gaps=(
+                "trusted classification producer handoff and PR Quality visibility are not yet connected",
+            ),
+            recommended_next_action="connect only producer-vetted dedicated fingerprint classifications before rendering populated instability history",
         ),
         _component(
             module="repo_memory",
@@ -603,7 +621,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "flaky-classification handoff and PR Quality visibility remain unconnected",
+                "trusted classification producer handoff and PR Quality visibility remain unconnected",
             ),
             recommended_next_action="surface only provenance-checked flaky-test instability context without expanding authority",
         ),

--- a/src/sdetkit/trusted_test_observation_classification.py
+++ b/src/sdetkit/trusted_test_observation_classification.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.trusted_test_observation_history import (
+    ALLOWED_OUTCOMES,
+    RECORD_SCHEMA_VERSION,
+    validate_observation_history_record,
+)
+
+SCHEMA_VERSION = "sdetkit.trusted_test_observation_classification.v1"
+STATUS = "advisory_classification_recorded"
+DEFAULT_OUT_DIR = Path("build") / "trusted-test-observation-classification"
+CLASSIFICATION_JSON = "trusted-test-observation-classification.json"
+CLASSIFICATION_MD = "trusted-test-observation-classification.md"
+
+MINIMUM_DECISIVE_OBSERVATIONS = 2
+DECISIVE_PASS_OUTCOMES = {"passed"}
+DECISIVE_FAILURE_OUTCOMES = {"failed", "error"}
+NON_DECISIVE_OUTCOMES = {"skipped"}
+ALLOWED_CLASSIFICATIONS = {
+    "flaky",
+    "stable-failing",
+    "stable-passing",
+    "insufficient-history",
+}
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _validate_fingerprint(value: Any) -> str:
+    fingerprint = _text(value).lower()
+    if len(fingerprint) != 64 or any(char not in "0123456789abcdef" for char in fingerprint):
+        raise ValueError(
+            "trusted observation classification requires a 64-character SHA-256 test fingerprint"
+        )
+    return fingerprint
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "advisory_only": True,
+        "raw_test_identity_emitted": False,
+        "current_pr_decision_input": False,
+        "automatic_quarantine_allowed": False,
+        "automatic_rerun_allowed": False,
+        "current_failure_suppression_allowed": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _classification_policy() -> JsonObject:
+    return {
+        "minimum_decisive_observations": MINIMUM_DECISIVE_OBSERVATIONS,
+        "decisive_pass_outcomes": sorted(DECISIVE_PASS_OUTCOMES),
+        "decisive_failure_outcomes": sorted(DECISIVE_FAILURE_OUTCOMES),
+        "non_decisive_outcomes": sorted(NON_DECISIVE_OUTCOMES),
+        "flaky": "at least one decisive pass and at least one decisive failure",
+        "stable_passing": "at least two decisive passes and no decisive failures",
+        "stable_failing": "at least two decisive failures and no decisive passes",
+        "insufficient_history": "fewer than two decisive observations",
+    }
+
+
+def _classification_for(*, passes: int, failures: int) -> str:
+    decisive = passes + failures
+    if decisive >= MINIMUM_DECISIVE_OBSERVATIONS and passes and failures:
+        return "flaky"
+    if decisive >= MINIMUM_DECISIVE_OBSERVATIONS and passes >= 2 and failures == 0:
+        return "stable-passing"
+    if decisive >= MINIMUM_DECISIVE_OBSERVATIONS and failures >= 2 and passes == 0:
+        return "stable-failing"
+    return "insufficient-history"
+
+
+def read_observation_history_records(path: Path) -> list[JsonObject]:
+    if not path.exists():
+        raise ValueError("trusted observation history JSONL does not exist")
+
+    records: list[JsonObject] = []
+    seen_record_ids: set[str] = set()
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw.strip():
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError(
+                f"trusted observation history JSONL must contain objects; line={line_number}"
+            )
+        validate_observation_history_record(payload)
+        record_id = _text(payload.get("record_id"))
+        if record_id in seen_record_ids:
+            raise ValueError("trusted observation history contains duplicate record ids")
+        seen_record_ids.add(record_id)
+        records.append(dict(payload))
+    return records
+
+
+def build_trusted_observation_classification(
+    records: list[Mapping[str, Any]],
+) -> JsonObject:
+    seen_record_ids: set[str] = set()
+    record_ids: list[str] = []
+    source_run_ids: list[str] = []
+    source_head_shas: list[str] = []
+    provenance_by_fingerprint: dict[str, list[JsonObject]] = defaultdict(list)
+
+    for raw_record in records:
+        validate_observation_history_record(raw_record)
+        record = dict(raw_record)
+        record_id = _text(record.get("record_id"))
+        if record_id in seen_record_ids:
+            raise ValueError(
+                "trusted observation classification input contains duplicate record ids"
+            )
+        seen_record_ids.add(record_id)
+        record_ids.append(record_id)
+
+        source_run_id = _text(record.get("source_run_id"))
+        source_head_sha = _text(record.get("source_head_sha"))
+        source_run_ids.append(source_run_id)
+        source_head_shas.append(source_head_sha)
+
+        for raw_observation in _as_list(record.get("observations")):
+            observation = _as_dict(raw_observation)
+            fingerprint = _validate_fingerprint(observation.get("test_fingerprint"))
+            outcome = _text(observation.get("outcome"))
+            if outcome not in ALLOWED_OUTCOMES:
+                raise ValueError(
+                    "trusted observation classification input contains an unsupported outcome"
+                )
+            provenance_by_fingerprint[fingerprint].append(
+                {
+                    "source_run_id": source_run_id,
+                    "source_head_sha": source_head_sha,
+                    "outcome": outcome,
+                }
+            )
+
+    classifications: list[JsonObject] = []
+    summary_counts: Counter[str] = Counter()
+    for fingerprint in sorted(provenance_by_fingerprint):
+        provenance = provenance_by_fingerprint[fingerprint]
+        outcomes = [_text(item.get("outcome")) for item in provenance]
+        passed = outcomes.count("passed")
+        failed = outcomes.count("failed")
+        error = outcomes.count("error")
+        skipped = outcomes.count("skipped")
+        decisive_failures = failed + error
+        decisive_count = passed + decisive_failures
+        classification = _classification_for(passes=passed, failures=decisive_failures)
+        summary_counts[classification] += 1
+        classifications.append(
+            {
+                "test_fingerprint": fingerprint,
+                "classification": classification,
+                "decision": (
+                    "instability_context_only"
+                    if classification == "flaky"
+                    else "advisory_context_only"
+                ),
+                "review_first": True,
+                "runs_observed": len(provenance),
+                "decisive_observation_count": decisive_count,
+                "passed": passed,
+                "failed": failed,
+                "error": error,
+                "skipped": skipped,
+                "observation_provenance": provenance,
+                "automatic_quarantine_allowed": False,
+                "automatic_rerun_allowed": False,
+                "current_failure_suppression_allowed": False,
+                "automation_allowed": False,
+            }
+        )
+
+    report: JsonObject = {
+        "schema_version": SCHEMA_VERSION,
+        "status": STATUS,
+        "source": {
+            "history_record_schema": RECORD_SCHEMA_VERSION,
+            "record_count": len(records),
+            "record_ids": record_ids,
+            "source_run_ids": source_run_ids,
+            "source_head_shas": source_head_shas,
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+            "per_observation_provenance_bound": True,
+        },
+        "policy": _classification_policy(),
+        "summary": {
+            "fingerprint_count": len(classifications),
+            "flaky": summary_counts["flaky"],
+            "stable_failing": summary_counts["stable-failing"],
+            "stable_passing": summary_counts["stable-passing"],
+            "insufficient_history": summary_counts["insufficient-history"],
+            "classification_performed": True,
+            "raw_test_identity_emitted": False,
+            "current_pr_decision_input": False,
+        },
+        "classifications": classifications,
+        "decision_boundary": _decision_boundary(),
+        "recommended_next_action": (
+            "Use this provenance-bound advisory artifact only through a "
+            "separately audited producer handoff."
+        ),
+    }
+    validate_classification_report(report)
+    return report
+
+
+def validate_classification_report(report: Mapping[str, Any]) -> None:
+    if _text(report.get("schema_version")) != SCHEMA_VERSION:
+        raise ValueError("trusted observation classification schema is not supported")
+    if _text(report.get("status")) != STATUS:
+        raise ValueError("trusted observation classification status is not supported")
+
+    source = _as_dict(report.get("source"))
+    if _text(source.get("history_record_schema")) != RECORD_SCHEMA_VERSION:
+        raise ValueError("trusted observation classification source schema is not supported")
+    if source.get("input_read_only") is not True:
+        raise ValueError("trusted observation classification input must be read-only")
+    if source.get("commands_executed_by_reader") is not False:
+        raise ValueError("trusted observation classification reader cannot execute commands")
+    if source.get("per_observation_provenance_bound") is not True:
+        raise ValueError("trusted observation classification requires per-observation provenance")
+
+    record_ids = [_text(item) for item in _as_list(source.get("record_ids"))]
+    source_run_ids = [_text(item) for item in _as_list(source.get("source_run_ids"))]
+    source_head_shas = [_text(item) for item in _as_list(source.get("source_head_shas"))]
+    record_count = _int(source.get("record_count"))
+    if not (record_count == len(record_ids) == len(source_run_ids) == len(source_head_shas)):
+        raise ValueError(
+            "trusted observation classification source provenance totals are inconsistent"
+        )
+    if len(set(record_ids)) != len(record_ids):
+        raise ValueError("trusted observation classification contains duplicate source record ids")
+    if any(not value for value in (*record_ids, *source_run_ids, *source_head_shas)):
+        raise ValueError("trusted observation classification source provenance is incomplete")
+    if _as_dict(report.get("policy")) != _classification_policy():
+        raise ValueError("trusted observation classification policy is inconsistent")
+
+    classifications = [_as_dict(item) for item in _as_list(report.get("classifications"))]
+    if any(not item for item in classifications):
+        raise ValueError("trusted observation classification contains a non-object entry")
+
+    fingerprints: list[str] = []
+    classification_counts: Counter[str] = Counter()
+    allowed_source_pairs = set(zip(source_run_ids, source_head_shas, strict=True))
+
+    for item in classifications:
+        for forbidden_key in ("test_id", "classname", "name", "nodeid"):
+            if forbidden_key in item:
+                raise ValueError(
+                    "raw test identity cannot enter trusted observation classification"
+                )
+
+        fingerprint = _validate_fingerprint(item.get("test_fingerprint"))
+        fingerprints.append(fingerprint)
+        classification = _text(item.get("classification"))
+        if classification not in ALLOWED_CLASSIFICATIONS:
+            raise ValueError(
+                "trusted observation classification contains an unsupported classification"
+            )
+        classification_counts[classification] += 1
+
+        provenance = [_as_dict(entry) for entry in _as_list(item.get("observation_provenance"))]
+        if not provenance or any(not entry for entry in provenance):
+            raise ValueError("trusted observation classification requires observation provenance")
+
+        outcomes: list[str] = []
+        for entry in provenance:
+            if set(entry) != {"source_run_id", "source_head_sha", "outcome"}:
+                raise ValueError(
+                    "trusted observation classification provenance fields are inconsistent"
+                )
+            pair = (
+                _text(entry.get("source_run_id")),
+                _text(entry.get("source_head_sha")),
+            )
+            if pair not in allowed_source_pairs:
+                raise ValueError(
+                    "trusted observation classification provenance is not bound to source history"
+                )
+            outcome = _text(entry.get("outcome"))
+            if outcome not in ALLOWED_OUTCOMES:
+                raise ValueError(
+                    "trusted observation classification provenance contains an unsupported outcome"
+                )
+            outcomes.append(outcome)
+
+        passed = outcomes.count("passed")
+        failed = outcomes.count("failed")
+        error = outcomes.count("error")
+        skipped = outcomes.count("skipped")
+        decisive_failures = failed + error
+        expected_classification = _classification_for(passes=passed, failures=decisive_failures)
+        if classification != expected_classification:
+            raise ValueError("trusted observation classification does not match its observations")
+        if _int(item.get("runs_observed")) != len(provenance):
+            raise ValueError("trusted observation classification run count is inconsistent")
+        if _int(item.get("decisive_observation_count")) != (passed + decisive_failures):
+            raise ValueError("trusted observation classification decisive count is inconsistent")
+        for key, expected in (
+            ("passed", passed),
+            ("failed", failed),
+            ("error", error),
+            ("skipped", skipped),
+        ):
+            if _int(item.get(key)) != expected:
+                raise ValueError(f"trusted observation classification {key} count is inconsistent")
+        for key in (
+            "automatic_quarantine_allowed",
+            "automatic_rerun_allowed",
+            "current_failure_suppression_allowed",
+            "automation_allowed",
+        ):
+            if item.get(key) is not False:
+                raise ValueError("trusted observation classification entry expands authority")
+        if item.get("review_first") is not True:
+            raise ValueError("trusted observation classification entry must remain review-first")
+
+    if fingerprints != sorted(fingerprints):
+        raise ValueError("trusted observation classification ordering is not deterministic")
+    if len(set(fingerprints)) != len(fingerprints):
+        raise ValueError("trusted observation classification contains duplicate fingerprints")
+
+    summary = _as_dict(report.get("summary"))
+    if _int(summary.get("fingerprint_count")) != len(classifications):
+        raise ValueError("trusted observation classification summary count is inconsistent")
+    for key, classification in (
+        ("flaky", "flaky"),
+        ("stable_failing", "stable-failing"),
+        ("stable_passing", "stable-passing"),
+        ("insufficient_history", "insufficient-history"),
+    ):
+        if _int(summary.get(key)) != classification_counts[classification]:
+            raise ValueError(f"trusted observation classification summary {key} is inconsistent")
+    if summary.get("classification_performed") is not True:
+        raise ValueError("trusted observation classification summary must record classification")
+    if summary.get("raw_test_identity_emitted") is not False:
+        raise ValueError("trusted observation classification cannot emit raw test identity")
+    if summary.get("current_pr_decision_input") is not False:
+        raise ValueError(
+            "trusted observation classification cannot influence the current PR decision"
+        )
+    if _as_dict(report.get("decision_boundary")) != _decision_boundary():
+        raise ValueError("trusted observation classification authority boundary is inconsistent")
+
+
+def render_classification_markdown(report: Mapping[str, Any]) -> str:
+    validate_classification_report(report)
+    source = _as_dict(report.get("source"))
+    summary = _as_dict(report.get("summary"))
+    boundary = _as_dict(report.get("decision_boundary"))
+    classifications = [_as_dict(item) for item in _as_list(report.get("classifications"))]
+
+    lines = [
+        "# Trusted test observation classification",
+        "",
+        f"- Schema: `{_text(report.get('schema_version'))}`",
+        f"- Status: `{_text(report.get('status'))}`",
+        f"- Source records: `{_int(source.get('record_count'))}`",
+        f"- Fingerprints: `{_int(summary.get('fingerprint_count'))}`",
+        f"- Flaky: `{_int(summary.get('flaky'))}`",
+        f"- Stable failing: `{_int(summary.get('stable_failing'))}`",
+        f"- Stable passing: `{_int(summary.get('stable_passing'))}`",
+        f"- Insufficient history: `{_int(summary.get('insufficient_history'))}`",
+        "",
+        "## Advisory classifications",
+        "",
+    ]
+    if classifications:
+        for item in classifications:
+            lines.append(
+                "- fingerprint="
+                f"`{_text(item.get('test_fingerprint'))}`, "
+                "classification="
+                f"`{_text(item.get('classification'))}`, "
+                "decisive_observations="
+                f"`{_int(item.get('decisive_observation_count'))}`, "
+                f"decision=`{_text(item.get('decision'))}`"
+            )
+    else:
+        lines.append("- none observed")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            f"- Advisory only: `{str(bool(boundary.get('advisory_only'))).lower()}`",
+            "- Raw test identity emitted: "
+            f"`{str(bool(boundary.get('raw_test_identity_emitted'))).lower()}`",
+            "- Current PR decision input: "
+            f"`{str(bool(boundary.get('current_pr_decision_input'))).lower()}`",
+            "- Automatic quarantine allowed: "
+            f"`{str(bool(boundary.get('automatic_quarantine_allowed'))).lower()}`",
+            "- Automatic rerun allowed: "
+            f"`{str(bool(boundary.get('automatic_rerun_allowed'))).lower()}`",
+            "- Current failure suppression allowed: "
+            f"`{str(bool(boundary.get('current_failure_suppression_allowed'))).lower()}`",
+            f"- Automation allowed: `{str(bool(boundary.get('automation_allowed'))).lower()}`",
+            "- Patch application allowed: "
+            f"`{str(bool(boundary.get('patch_application_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(bool(boundary.get('merge_authorized'))).lower()}`",
+            "- Semantic equivalence proven: "
+            f"`{str(bool(boundary.get('semantic_equivalence_proven'))).lower()}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_classification_artifacts(report: Mapping[str, Any], *, out_dir: Path) -> dict[str, str]:
+    validate_classification_report(report)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / CLASSIFICATION_JSON
+    markdown_path = out_dir / CLASSIFICATION_MD
+    json_path.write_text(
+        json.dumps(dict(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_classification_markdown(report), encoding="utf-8")
+    return {
+        "classification_json": json_path.as_posix(),
+        "classification_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.trusted_test_observation_classification"
+    )
+    parser.add_argument("--history-jsonl", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        records = read_observation_history_records(args.history_jsonl)
+        report = build_trusted_observation_classification(records)
+        artifacts = write_classification_artifacts(report, out_dir=args.out_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {"status": report["status"], "artifacts": artifacts},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"status={report['status']}")
+        for key, value in artifacts.items():
+            print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/trusted_test_observation_classification.py
+++ b/src/sdetkit/trusted_test_observation_classification.py
@@ -478,13 +478,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.format == "json":
         print(
             json.dumps(
-                {"status": report["status"], "artifacts": artifacts},
+                {"status": STATUS, "artifacts": artifacts},
                 indent=2,
                 sort_keys=True,
             )
         )
     else:
-        print(f"status={report['status']}")
+        print(f"status={STATUS}")
         for key, value in artifacts.items():
             print(f"{key}={value}")
     return 0

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -14,6 +14,7 @@ from sdetkit.reliability_spine_alignment import (
     TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
     TRUSTED_HISTORY_EVIDENCE_MODULE,
     TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE,
+    TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE,
     TRUSTED_TEST_OBSERVATION_HISTORY_MODULE,
     build_alignment_components,
     build_alignment_report,
@@ -50,6 +51,7 @@ def test_alignment_components_cover_current_reliability_spine() -> None:
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE in modules
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE in modules
     assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in modules
+    assert TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE in modules
     assert SECURITY_FINDING_DIAGNOSIS_MODULE in modules
     assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE in modules
 
@@ -96,6 +98,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE not in gaps_by_module
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE not in gaps_by_module
     assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE not in gaps_by_module
+    assert TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE not in gaps_by_module
     assert FLAKY_TEST_REGISTRY_EVIDENCE_MODULE in gaps_by_module
     assert SECURITY_FINDING_DIAGNOSIS_MODULE not in gaps_by_module
     assert SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE not in gaps_by_module
@@ -110,10 +113,12 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert any("containment" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
-    assert any("flaky-classification handoff" in gap for gap in gaps_by_module["repo_memory"])
+    assert any(
+        "trusted classification producer handoff" in gap for gap in gaps_by_module["repo_memory"]
+    )
     assert any("PR Quality visibility" in gap for gap in gaps_by_module["repo_memory"])
     assert any(
-        "flaky-classification handoff" in gap
+        "trusted classification producer handoff" in gap
         for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
     )
     assert any(
@@ -319,10 +324,11 @@ def test_trusted_test_observation_history_alignment_is_closed() -> None:
     assert TRUSTED_TEST_OBSERVATION_CAPTURE_MODULE in component.integration_points
     assert "CI Full CI lane" in component.integration_points
     assert "RepoMemory Profile History workflow" in component.integration_points
+    assert TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE in component.integration_points
     assert (
         component.recommended_next_action
-        == "audit a separate provenance-checked classification handoff "
-        "before any registry or PR Quality visibility"
+        == "keep immutable history as the only input to the dedicated "
+        "fingerprint classification contract"
     )
 
 
@@ -341,16 +347,44 @@ def test_flaky_registry_alignment_starts_after_persisted_observation_history() -
         "flaky-test classification"
     )
     assert "RepoMemory Profile History workflow" in history.integration_points
+    classification = components[TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE]
+    assert classification.status == "aligned"
+    assert classification.gaps == ()
     assert (
-        producer.recommended_next_action == "consume only persisted provenance-checked "
-        "observation history after a separate advisory "
-        "classification handoff is proven"
+        producer.recommended_next_action
+        == "audit consumption of the dedicated advisory classification "
+        "artifact before changing the no-observation fail-closed state"
     )
     assert registry.gaps == (
-        "flaky-classification handoff and PR Quality visibility are not yet connected",
+        "trusted classification producer handoff and PR Quality visibility are not yet connected",
     )
     assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in repo_memory.integration_points
     assert (
-        "flaky-classification handoff and PR Quality visibility "
-        "remain unconnected" in repo_memory.gaps
+        "trusted classification producer handoff and PR Quality "
+        "visibility remain unconnected" in repo_memory.gaps
+    )
+
+
+def test_trusted_observation_classification_alignment_is_closed() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+
+    component = components[TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE]
+
+    assert component.status == "aligned"
+    assert component.gaps == ()
+    assert component.stages == (
+        "evidence",
+        "diagnosis",
+        "history",
+        "reporting",
+    )
+    assert component.existing_artifacts == (
+        "trusted-test-observation-classification.json",
+        "trusted-test-observation-classification.md",
+    )
+    assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in component.integration_points
+    assert (
+        component.recommended_next_action == "audit trusted producer consumption of the dedicated "
+        "advisory classification artifact before registry, workflow, "
+        "RepoMemory, or PR Quality integration"
     )

--- a/tests/test_trusted_test_observation_classification.py
+++ b/tests/test_trusted_test_observation_classification.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from sdetkit.trusted_test_observation_classification import (
+    CLASSIFICATION_JSON,
+    CLASSIFICATION_MD,
+    SCHEMA_VERSION,
+    STATUS,
+    build_trusted_observation_classification,
+    main,
+    read_observation_history_records,
+    render_classification_markdown,
+    validate_classification_report,
+)
+from sdetkit.trusted_test_observation_history import (
+    build_observation_history_record,
+)
+
+FINGERPRINT_A = "a" * 64
+FINGERPRINT_B = "b" * 64
+FINGERPRINT_C = "c" * 64
+FINGERPRINT_D = "d" * 64
+HEAD_A = "1" * 40
+HEAD_B = "2" * 40
+
+
+def _report(
+    *,
+    run_id: str,
+    head_sha: str,
+    observations: list[dict[str, str]],
+) -> dict:
+    counts = {
+        "passed": 0,
+        "failed": 0,
+        "error": 0,
+        "skipped": 0,
+    }
+    for observation in observations:
+        counts[observation["outcome"]] += 1
+    return {
+        "schema_version": "sdetkit.trusted_test_observation_capture.v1",
+        "status": "trusted_main_observations_captured",
+        "source": {
+            "workflow": "CI",
+            "job": "Full CI lane",
+            "run_id": run_id,
+            "head_sha": head_sha,
+            "event_name": "push",
+            "ref_name": "refs/heads/main",
+            "trusted_main": True,
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+        },
+        "summary": {
+            "observation_count": len(observations),
+            **counts,
+            "flaky_classification_performed": False,
+            "raw_test_identity_emitted": False,
+        },
+        "observations": observations,
+        "decision_boundary": {
+            "raw_observation_only": True,
+            "flaky_classification_performed": False,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _record(
+    *,
+    run_id: str,
+    head_sha: str,
+    recorded_at: str,
+    observations: list[dict[str, str]],
+) -> dict:
+    return build_observation_history_record(
+        _report(
+            run_id=run_id,
+            head_sha=head_sha,
+            observations=observations,
+        ),
+        source_run_id=run_id,
+        source_head_sha=head_sha,
+        recorded_at_utc=recorded_at,
+    )
+
+
+def _records() -> list[dict]:
+    return [
+        _record(
+            run_id="run-a",
+            head_sha=HEAD_A,
+            recorded_at="2026-06-16T00:00:00Z",
+            observations=[
+                {"test_fingerprint": FINGERPRINT_A, "outcome": "failed"},
+                {"test_fingerprint": FINGERPRINT_B, "outcome": "passed"},
+                {"test_fingerprint": FINGERPRINT_C, "outcome": "error"},
+                {"test_fingerprint": FINGERPRINT_D, "outcome": "skipped"},
+            ],
+        ),
+        _record(
+            run_id="run-b",
+            head_sha=HEAD_B,
+            recorded_at="2026-06-16T01:00:00Z",
+            observations=[
+                {"test_fingerprint": FINGERPRINT_A, "outcome": "passed"},
+                {"test_fingerprint": FINGERPRINT_B, "outcome": "passed"},
+                {"test_fingerprint": FINGERPRINT_C, "outcome": "failed"},
+                {"test_fingerprint": FINGERPRINT_D, "outcome": "skipped"},
+            ],
+        ),
+    ]
+
+
+def test_classifies_fingerprints_with_bound_provenance_without_identity_projection() -> None:
+    report = build_trusted_observation_classification(_records())
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["status"] == STATUS
+    assert report["source"]["record_count"] == 2
+    assert report["source"]["source_run_ids"] == ["run-a", "run-b"]
+    assert report["source"]["source_head_shas"] == [HEAD_A, HEAD_B]
+    assert report["source"]["per_observation_provenance_bound"] is True
+
+    classifications = {item["test_fingerprint"]: item for item in report["classifications"]}
+    flaky = classifications[FINGERPRINT_A]
+    assert flaky["classification"] == "flaky"
+    assert flaky["passed"] == 1
+    assert flaky["failed"] == 1
+    assert flaky["decision"] == "instability_context_only"
+    assert flaky["observation_provenance"] == [
+        {
+            "source_run_id": "run-a",
+            "source_head_sha": HEAD_A,
+            "outcome": "failed",
+        },
+        {
+            "source_run_id": "run-b",
+            "source_head_sha": HEAD_B,
+            "outcome": "passed",
+        },
+    ]
+    assert classifications[FINGERPRINT_B]["classification"] == "stable-passing"
+    assert classifications[FINGERPRINT_C]["classification"] == "stable-failing"
+    assert classifications[FINGERPRINT_D]["classification"] == "insufficient-history"
+
+    serialized = json.dumps(report, sort_keys=True)
+    assert '"test_id"' not in serialized
+    assert '"classname"' not in serialized
+    assert '"nodeid"' not in serialized
+    assert FINGERPRINT_A in serialized
+
+
+def test_policy_treats_skipped_as_non_decisive() -> None:
+    records = [
+        _record(
+            run_id="run-a",
+            head_sha=HEAD_A,
+            recorded_at="2026-06-16T00:00:00Z",
+            observations=[{"test_fingerprint": FINGERPRINT_A, "outcome": "passed"}],
+        ),
+        _record(
+            run_id="run-b",
+            head_sha=HEAD_B,
+            recorded_at="2026-06-16T01:00:00Z",
+            observations=[{"test_fingerprint": FINGERPRINT_A, "outcome": "skipped"}],
+        ),
+    ]
+    item = build_trusted_observation_classification(records)["classifications"][0]
+    assert item["classification"] == "insufficient-history"
+    assert item["decisive_observation_count"] == 1
+    assert item["passed"] == 1
+    assert item["skipped"] == 1
+
+
+def test_empty_history_is_valid_fail_closed_advisory_output() -> None:
+    report = build_trusted_observation_classification([])
+    assert report["classifications"] == []
+    assert report["summary"]["fingerprint_count"] == 0
+    assert report["summary"]["flaky"] == 0
+    assert report["decision_boundary"]["advisory_only"] is True
+    assert report["decision_boundary"]["current_pr_decision_input"] is False
+
+
+def test_classification_is_deterministic() -> None:
+    records = _records()
+    first = build_trusted_observation_classification(records)
+    second = build_trusted_observation_classification(deepcopy(records))
+    assert first == second
+    fingerprints = [item["test_fingerprint"] for item in first["classifications"]]
+    assert fingerprints == sorted(fingerprints)
+
+
+def test_rejects_duplicate_record_ids_and_authority_expansion() -> None:
+    records = _records()
+    with pytest.raises(ValueError, match="duplicate record ids"):
+        build_trusted_observation_classification([records[0], deepcopy(records[0])])
+
+    report = build_trusted_observation_classification(records)
+    expanded = deepcopy(report)
+    expanded["decision_boundary"]["automatic_rerun_allowed"] = True
+    with pytest.raises(ValueError, match="authority boundary"):
+        validate_classification_report(expanded)
+
+
+def test_rejects_unbound_or_malformed_provenance() -> None:
+    report = build_trusted_observation_classification(_records())
+    unbound = deepcopy(report)
+    unbound["classifications"][0]["observation_provenance"][0]["source_run_id"] = "unknown-run"
+    with pytest.raises(ValueError, match="not bound to source history"):
+        validate_classification_report(unbound)
+
+    malformed = deepcopy(report)
+    malformed["classifications"][0]["observation_provenance"][0]["test_id"] = "raw-name"
+    with pytest.raises(ValueError, match="provenance fields"):
+        validate_classification_report(malformed)
+
+
+def test_jsonl_reader_and_cli_write_review_first_artifacts(tmp_path: Path, capsys) -> None:
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in _records()),
+        encoding="utf-8",
+    )
+    assert len(read_observation_history_records(history_path)) == 2
+
+    out_dir = tmp_path / "classification"
+    rc = main(
+        [
+            "--history-jsonl",
+            str(history_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["status"] == STATUS
+
+    saved = json.loads((out_dir / CLASSIFICATION_JSON).read_text(encoding="utf-8"))
+    markdown = (out_dir / CLASSIFICATION_MD).read_text(encoding="utf-8")
+    assert saved["summary"]["flaky"] == 1
+    assert saved["summary"]["current_pr_decision_input"] is False
+    assert "# Trusted test observation classification" in markdown
+    assert "Automatic quarantine allowed: `false`" in markdown
+    assert "Automatic rerun allowed: `false`" in markdown
+    assert "Current PR decision input: `false`" in markdown
+
+
+def test_cli_rejects_invalid_history_jsonl(tmp_path: Path, capsys) -> None:
+    history_path = tmp_path / "bad-history.jsonl"
+    history_path.write_text('{"not":"a history record"}\n', encoding="utf-8")
+    rc = main(
+        [
+            "--history-jsonl",
+            str(history_path),
+            "--out-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+    assert rc == 2
+    assert "error=" in capsys.readouterr().out
+
+
+def test_markdown_and_report_keep_every_authority_denied() -> None:
+    report = build_trusted_observation_classification(_records())
+    markdown = render_classification_markdown(report)
+    boundary = report["decision_boundary"]
+    assert boundary["advisory_only"] is True
+    assert boundary["raw_test_identity_emitted"] is False
+    assert boundary["current_pr_decision_input"] is False
+    assert boundary["automatic_quarantine_allowed"] is False
+    assert boundary["automatic_rerun_allowed"] is False
+    assert boundary["current_failure_suppression_allowed"] is False
+    assert boundary["automation_allowed"] is False
+    assert boundary["patch_application_allowed"] is False
+    assert boundary["merge_authorized"] is False
+    assert boundary["semantic_equivalence_proven"] is False
+    assert "Advisory only: `true`" in markdown
+    assert "Raw test identity emitted: `false`" in markdown
+    assert "Automation allowed: `false`" in markdown
+    assert "Merge authorized: `false`" in markdown


### PR DESCRIPTION
## Summary

- add a dedicated trusted observation fingerprint classifier
- preserve 64-character test fingerprints without recovering raw test identity
- bind every classified outcome to its source run ID and accepted-main head SHA
- emit deterministic advisory classifications with an explicit denied-authority boundary
- register the new classification contract in the reliability spine

## Classification policy

- minimum decisive observations: 2
- decisive pass outcome: `passed`
- decisive failure outcomes: `failed`, `error`
- non-decisive outcome: `skipped`
- `flaky`: at least one decisive pass and one decisive failure
- `stable-passing`: at least two decisive passes and no decisive failures
- `stable-failing`: at least two decisive failures and no decisive passes
- `insufficient-history`: fewer than two decisive observations

## Contract

- schema: `sdetkit.trusted_test_observation_classification.v1`
- identity field: `test_fingerprint`
- fingerprint preserved: true
- per-observation provenance bound: true
- raw test identity emitted: false
- advisory only: true
- current PR decision input: false
- automatic quarantine allowed: false
- automatic rerun allowed: false
- current failure suppression allowed: false
- automation allowed: false
- patch application allowed: false
- merge authorized: false
- semantic equivalence proven: false

## Explicit exclusions

- no legacy classifier modification
- no trusted flaky-test producer integration
- no registry integration
- no workflow integration
- no RepoMemory population
- no PR Quality visibility
- no rerun, quarantine, or failure suppression action

## Proof

- focused classification/history/producer/registry/intelligence/alignment suite: passed
- direct fingerprint and per-observation provenance proof: passed
- Ruff format and check: passed
- baseline-aware security: zero new findings
- changed-scope security: zero new findings
- `make proof-after-format`: passed

## Scope

- `src/sdetkit/trusted_test_observation_classification.py`
- `tests/test_trusted_test_observation_classification.py`
- `src/sdetkit/reliability_spine_alignment.py`
- `tests/test_reliability_spine_alignment.py`
