### PR TITLE
feat(history): validate trusted classification producer handoff

### DIFF
--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -558,25 +558,27 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "trusted-test-observation-classification.md",
             ),
             integration_points=(TRUSTED_TEST_OBSERVATION_HISTORY_MODULE,),
-            recommended_next_action="audit trusted producer consumption of the dedicated advisory classification artifact before registry, workflow, RepoMemory, or PR Quality integration",
+            recommended_next_action="keep the dedicated artifact advisory-only and route it only through the trusted producer validation handoff before registry or workflow integration",
         ),
         _component(
             module=TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
-            role="emit an explicit trusted-main no-observation flaky-test registry artifact until real per-test history exists",
+            role="validate an optional dedicated advisory fingerprint classification artifact while preserving fail-closed empty registry evidence",
             status="aligned",
             stages=("evidence", "history", "reporting"),
             existing_artifacts=(
                 "trusted-flaky-test-registry-producer.json",
                 "trusted-flaky-test-registry-producer.md",
+                "classification_handoff summary",
                 "flaky-test-registry-evidence.json",
                 "flaky-test-registry-evidence.md",
             ),
             integration_points=(
+                TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE,
                 "RepoMemory Profile History workflow",
                 FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
                 "repo_memory",
             ),
-            recommended_next_action="audit consumption of the dedicated advisory classification artifact before changing the no-observation fail-closed state",
+            recommended_next_action="audit a producer-vetted fingerprint classification adapter before registry, workflow, RepoMemory, or PR Quality integration",
         ),
         _component(
             module=FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
@@ -593,7 +595,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "repo_memory",
             ),
             gaps=(
-                "trusted classification producer handoff and PR Quality visibility are not yet connected",
+                "producer-vetted fingerprint classification adapter and PR Quality visibility are not yet connected",
             ),
             recommended_next_action="connect only producer-vetted dedicated fingerprint classifications before rendering populated instability history",
         ),
@@ -621,7 +623,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "trusted classification producer handoff and PR Quality visibility remain unconnected",
+                "producer-vetted fingerprint classification adapter and PR Quality visibility remain unconnected",
             ),
             recommended_next_action="surface only provenance-checked flaky-test instability context without expanding authority",
         ),

--- a/src/sdetkit/trusted_flaky_test_registry_producer.py
+++ b/src/sdetkit/trusted_flaky_test_registry_producer.py
@@ -11,11 +11,21 @@ from sdetkit.flaky_test_registry_evidence import (
     build_flaky_test_registry_evidence,
     write_evidence,
 )
+from sdetkit.trusted_test_observation_classification import (
+    SCHEMA_VERSION as CLASSIFICATION_SCHEMA_VERSION,
+)
+from sdetkit.trusted_test_observation_classification import (
+    validate_classification_report,
+)
 
 SCHEMA_VERSION = "sdetkit.trusted_flaky_test_registry_producer.v1"
 SOURCE_WORKFLOW = "RepoMemory Profile History"
 SOURCE_CONNECTED = "trusted_main_source_connected"
 NO_TEST_OBSERVATIONS = "no_test_observations_available"
+
+CLASSIFICATION_NOT_SUPPLIED = "not_supplied_fail_closed"
+CLASSIFICATION_EMPTY = "validated_empty_not_forwarded"
+CLASSIFICATION_ADVISORY = "validated_advisory_not_forwarded"
 
 DEFAULT_OUT_DIR = Path("build") / "trusted-flaky-test-registry"
 PRODUCER_JSON = "trusted-flaky-test-registry-producer.json"
@@ -28,8 +38,26 @@ def _as_dict(value: Any) -> JsonObject:
     return value if isinstance(value, dict) else {}
 
 
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
 def _string(value: Any) -> str:
     return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
 
 
 def _empty_classification_report() -> JsonObject:
@@ -44,10 +72,72 @@ def _empty_classification_report() -> JsonObject:
     }
 
 
+def _classification_handoff(
+    classification_report: Mapping[str, Any] | None,
+    *,
+    producer_source_head_sha: str,
+) -> JsonObject:
+    if classification_report is None:
+        return {
+            "schema_version": CLASSIFICATION_SCHEMA_VERSION,
+            "status": CLASSIFICATION_NOT_SUPPLIED,
+            "record_count": 0,
+            "fingerprint_count": 0,
+            "flaky": 0,
+            "stable_failing": 0,
+            "stable_passing": 0,
+            "insufficient_history": 0,
+            "latest_source_run_id": "",
+            "latest_source_head_sha": "",
+            "input_read_only": True,
+            "raw_test_identity_emitted": False,
+            "forwarded_to_registry": False,
+            "current_pr_decision_input": False,
+        }
+
+    validate_classification_report(classification_report)
+
+    source = _as_dict(classification_report.get("source"))
+    summary = _as_dict(classification_report.get("summary"))
+    source_run_ids = [_string(item) for item in _as_list(source.get("source_run_ids"))]
+    source_head_shas = [_string(item) for item in _as_list(source.get("source_head_shas"))]
+    record_count = _int(source.get("record_count"))
+    fingerprint_count = _int(summary.get("fingerprint_count"))
+
+    latest_source_run_id = source_run_ids[-1] if record_count else ""
+    latest_source_head_sha = source_head_shas[-1] if record_count else ""
+    producer_head = _string(producer_source_head_sha)
+
+    if record_count and latest_source_head_sha != producer_head:
+        raise ValueError(
+            "trusted classification latest source head sha must match producer source_head_sha"
+        )
+
+    status = CLASSIFICATION_EMPTY if fingerprint_count == 0 else CLASSIFICATION_ADVISORY
+
+    return {
+        "schema_version": CLASSIFICATION_SCHEMA_VERSION,
+        "status": status,
+        "record_count": record_count,
+        "fingerprint_count": fingerprint_count,
+        "flaky": _int(summary.get("flaky")),
+        "stable_failing": _int(summary.get("stable_failing")),
+        "stable_passing": _int(summary.get("stable_passing")),
+        "insufficient_history": _int(summary.get("insufficient_history")),
+        "latest_source_run_id": latest_source_run_id,
+        "latest_source_head_sha": latest_source_head_sha,
+        "input_read_only": True,
+        "raw_test_identity_emitted": False,
+        "forwarded_to_registry": False,
+        "current_pr_decision_input": False,
+    }
+
+
 def build_trusted_registry_evidence(
     *,
     source_run_id: str,
     source_head_sha: str,
+    classification_report: Mapping[str, Any] | None = None,
 ) -> JsonObject:
     run_id = _string(source_run_id)
     head_sha = _string(source_head_sha)
@@ -56,10 +146,15 @@ def build_trusted_registry_evidence(
     if not head_sha:
         raise ValueError("trusted flaky-test producer source_head_sha is required")
 
+    handoff = _classification_handoff(
+        classification_report,
+        producer_source_head_sha=head_sha,
+    )
+
     evidence = build_flaky_test_registry_evidence(
         classification_report=_empty_classification_report(),
         source_kind="trusted_main_artifact",
-        source_reference=f"{SOURCE_WORKFLOW}:run={run_id}:head={head_sha}",
+        source_reference=(f"{SOURCE_WORKFLOW}:run={run_id}:head={head_sha}"),
     )
 
     source = _as_dict(evidence.get("source"))
@@ -83,16 +178,26 @@ def build_trusted_registry_evidence(
     )
     evidence["summary"] = summary
     evidence["note"] = (
-        "Trusted-main producer is connected, but no per-test observation "
-        "history source is available; no flaky-test entries are claimed."
+        "Trusted-main producer remains fail-closed; dedicated "
+        f"classification handoff status is {handoff['status']}; "
+        "no classification is forwarded to registry entries."
     )
     return evidence
 
 
-def build_producer_report(evidence: Mapping[str, Any]) -> JsonObject:
+def build_producer_report(
+    evidence: Mapping[str, Any],
+    *,
+    classification_report: Mapping[str, Any] | None = None,
+    producer_source_head_sha: str = "",
+) -> JsonObject:
     source = _as_dict(evidence.get("source"))
     summary = _as_dict(evidence.get("summary"))
     boundary = _as_dict(evidence.get("decision_boundary"))
+    handoff = _classification_handoff(
+        classification_report,
+        producer_source_head_sha=producer_source_head_sha,
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "status": SOURCE_CONNECTED,
@@ -101,10 +206,11 @@ def build_producer_report(evidence: Mapping[str, Any]) -> JsonObject:
             "schema_version": _string(evidence.get("schema_version")),
             "collection_status": _string(evidence.get("collection_status")),
             "status": _string(evidence.get("status")),
-            "entry_count": int(summary.get("entry_count", 0)),
+            "entry_count": _int(summary.get("entry_count")),
             "observation_status": _string(summary.get("observation_status")),
-            "observation_count": int(summary.get("observation_count", 0)),
+            "observation_count": _int(summary.get("observation_count")),
         },
+        "classification_handoff": handoff,
         "decision_boundary": dict(boundary),
         "note": _string(evidence.get("note")),
     }
@@ -113,22 +219,51 @@ def build_producer_report(evidence: Mapping[str, Any]) -> JsonObject:
 def render_markdown(report: Mapping[str, Any]) -> str:
     source = _as_dict(report.get("source"))
     registry = _as_dict(report.get("registry"))
+    handoff = _as_dict(report.get("classification_handoff"))
     boundary = _as_dict(report.get("decision_boundary"))
     return "\n".join(
         [
             "# Trusted-main flaky-test registry producer",
             "",
             f"- Status: `{_string(report.get('status'))}`",
-            f"- Source workflow: `{_string(source.get('workflow'))}`",
-            f"- Source run id: `{_string(source.get('run_id'))}`",
-            f"- Source head sha: `{_string(source.get('head_sha'))}`",
-            f"- Observation status: `{_string(registry.get('observation_status'))}`",
-            f"- Observation count: `{int(registry.get('observation_count', 0))}`",
-            f"- Registry entries: `{int(registry.get('entry_count', 0))}`",
+            (f"- Source workflow: `{_string(source.get('workflow'))}`"),
+            (f"- Source run id: `{_string(source.get('run_id'))}`"),
+            (f"- Source head sha: `{_string(source.get('head_sha'))}`"),
+            (f"- Observation status: `{_string(registry.get('observation_status'))}`"),
+            (f"- Observation count: `{_int(registry.get('observation_count'))}`"),
+            (f"- Registry entries: `{_int(registry.get('entry_count'))}`"),
+            "",
+            "## Dedicated classification handoff",
+            "",
+            (f"- Schema: `{_string(handoff.get('schema_version'))}`"),
+            (f"- Status: `{_string(handoff.get('status'))}`"),
+            (f"- Source records: `{_int(handoff.get('record_count'))}`"),
+            (f"- Fingerprints: `{_int(handoff.get('fingerprint_count'))}`"),
+            f"- Flaky: `{_int(handoff.get('flaky'))}`",
+            (f"- Stable failing: `{_int(handoff.get('stable_failing'))}`"),
+            (f"- Stable passing: `{_int(handoff.get('stable_passing'))}`"),
+            (f"- Insufficient history: `{_int(handoff.get('insufficient_history'))}`"),
+            (f"- Latest source run id: `{_string(handoff.get('latest_source_run_id'))}`"),
+            (f"- Latest source head sha: `{_string(handoff.get('latest_source_head_sha'))}`"),
+            (
+                "- Raw test identity emitted: "
+                f"`{str(bool(handoff.get('raw_test_identity_emitted'))).lower()}`"
+            ),
+            (
+                "- Forwarded to registry: "
+                f"`{str(bool(handoff.get('forwarded_to_registry'))).lower()}`"
+            ),
+            (
+                "- Current PR decision input: "
+                f"`{str(bool(handoff.get('current_pr_decision_input'))).lower()}`"
+            ),
             "",
             "## Boundary",
             "",
-            "- No flaky-test observations are claimed without a trusted observation source.",
+            (
+                "- No flaky-test observations are claimed without "
+                "a separately reviewed registry adapter."
+            ),
             (
                 "- Automatic quarantine allowed: "
                 f"`{str(bool(boundary.get('automatic_quarantine_allowed'))).lower()}`"
@@ -161,18 +296,35 @@ def write_artifacts(
         json.dumps(dict(report), indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    producer_markdown.write_text(render_markdown(report), encoding="utf-8")
+    producer_markdown.write_text(
+        render_markdown(report),
+        encoding="utf-8",
+    )
     artifacts["producer_json"] = producer_json.as_posix()
     artifacts["producer_markdown"] = producer_markdown.as_posix()
     return artifacts
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="python -m sdetkit.trusted_flaky_test_registry_producer")
+    parser = argparse.ArgumentParser(
+        prog=("python -m sdetkit.trusted_flaky_test_registry_producer")
+    )
     parser.add_argument("--source-run-id", required=True)
     parser.add_argument("--source-head-sha", required=True)
-    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
-    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument(
+        "--classification-report",
+        type=Path,
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+    )
     return parser
 
 
@@ -180,21 +332,35 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
+        classification_report = (
+            _read_json(args.classification_report)
+            if args.classification_report is not None
+            else None
+        )
         evidence = build_trusted_registry_evidence(
             source_run_id=args.source_run_id,
             source_head_sha=args.source_head_sha,
+            classification_report=classification_report,
         )
-        report = build_producer_report(evidence)
-        artifacts = write_artifacts(evidence, report, out_dir=args.out_dir)
-    except (OSError, ValueError) as exc:
-        print(f"error={exc}")
+        report = build_producer_report(
+            evidence,
+            classification_report=classification_report,
+            producer_source_head_sha=args.source_head_sha,
+        )
+        artifacts = write_artifacts(
+            evidence,
+            report,
+            out_dir=args.out_dir,
+        )
+    except (OSError, ValueError):
+        print("error=trusted classification producer input rejected")
         return 2
 
     if args.format == "json":
         print(
             json.dumps(
                 {
-                    "status": report["status"],
+                    "status": SOURCE_CONNECTED,
                     "artifacts": artifacts,
                 },
                 indent=2,
@@ -202,7 +368,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
-        print(f"status={report['status']}")
+        print(f"status={SOURCE_CONNECTED}")
         for key, value in artifacts.items():
             print(f"{key}={value}")
 

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -114,11 +114,12 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
     assert any(
-        "trusted classification producer handoff" in gap for gap in gaps_by_module["repo_memory"]
+        "producer-vetted fingerprint classification adapter" in gap
+        for gap in gaps_by_module["repo_memory"]
     )
     assert any("PR Quality visibility" in gap for gap in gaps_by_module["repo_memory"])
     assert any(
-        "trusted classification producer handoff" in gap
+        "producer-vetted fingerprint classification adapter" in gap
         for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
     )
     assert any(
@@ -352,16 +353,16 @@ def test_flaky_registry_alignment_starts_after_persisted_observation_history() -
     assert classification.gaps == ()
     assert (
         producer.recommended_next_action
-        == "audit consumption of the dedicated advisory classification "
-        "artifact before changing the no-observation fail-closed state"
+        == "audit a producer-vetted fingerprint classification adapter "
+        "before registry, workflow, RepoMemory, or PR Quality integration"
     )
     assert registry.gaps == (
-        "trusted classification producer handoff and PR Quality visibility are not yet connected",
+        "producer-vetted fingerprint classification adapter and PR Quality visibility are not yet connected",
     )
     assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in repo_memory.integration_points
     assert (
-        "trusted classification producer handoff and PR Quality "
-        "visibility remain unconnected" in repo_memory.gaps
+        "producer-vetted fingerprint classification adapter and "
+        "PR Quality visibility remain unconnected" in repo_memory.gaps
     )
 
 
@@ -384,7 +385,30 @@ def test_trusted_observation_classification_alignment_is_closed() -> None:
     )
     assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in component.integration_points
     assert (
-        component.recommended_next_action == "audit trusted producer consumption of the dedicated "
-        "advisory classification artifact before registry, workflow, "
-        "RepoMemory, or PR Quality integration"
+        component.recommended_next_action
+        == "keep the dedicated artifact advisory-only and route it only "
+        "through the trusted producer validation handoff before registry "
+        "or workflow integration"
+    )
+
+
+def test_trusted_producer_validation_handoff_alignment_is_closed() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+
+    producer = components[TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE]
+    registry = components[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
+    repo_memory = components["repo_memory"]
+
+    assert producer.status == "aligned"
+    assert producer.gaps == ()
+    assert TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE in producer.integration_points
+    assert "classification_handoff summary" in producer.existing_artifacts
+    assert (
+        producer.recommended_next_action == "audit a producer-vetted fingerprint classification "
+        "adapter before registry, workflow, RepoMemory, or "
+        "PR Quality integration"
+    )
+    assert any("producer-vetted fingerprint classification adapter" in gap for gap in registry.gaps)
+    assert any(
+        "producer-vetted fingerprint classification adapter" in gap for gap in repo_memory.gaps
     )

--- a/tests/test_trusted_flaky_test_registry_producer.py
+++ b/tests/test_trusted_flaky_test_registry_producer.py
@@ -1,25 +1,131 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
 from sdetkit.trusted_flaky_test_registry_producer import (
+    CLASSIFICATION_ADVISORY,
+    CLASSIFICATION_EMPTY,
+    CLASSIFICATION_NOT_SUPPLIED,
     NO_TEST_OBSERVATIONS,
+    PRODUCER_JSON,
     SOURCE_CONNECTED,
     build_producer_report,
     build_trusted_registry_evidence,
     main,
     render_markdown,
 )
+from sdetkit.trusted_test_observation_classification import (
+    SCHEMA_VERSION as CLASSIFICATION_SCHEMA_VERSION,
+)
+from sdetkit.trusted_test_observation_classification import (
+    build_trusted_observation_classification,
+)
+from sdetkit.trusted_test_observation_history import (
+    build_observation_history_record,
+)
+
+FINGERPRINT = "a" * 64
+HEAD_A = "1" * 40
+HEAD_B = "2" * 40
+
+
+def _capture(
+    *,
+    run_id: str,
+    head_sha: str,
+    outcome: str,
+) -> dict:
+    return {
+        "schema_version": "sdetkit.trusted_test_observation_capture.v1",
+        "status": "trusted_main_observations_captured",
+        "source": {
+            "workflow": "CI",
+            "job": "Full CI lane",
+            "run_id": run_id,
+            "head_sha": head_sha,
+            "event_name": "push",
+            "ref_name": "refs/heads/main",
+            "trusted_main": True,
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+        },
+        "summary": {
+            "observation_count": 1,
+            "passed": int(outcome == "passed"),
+            "failed": int(outcome == "failed"),
+            "error": int(outcome == "error"),
+            "skipped": int(outcome == "skipped"),
+            "flaky_classification_performed": False,
+            "raw_test_identity_emitted": False,
+        },
+        "observations": [
+            {
+                "test_fingerprint": FINGERPRINT,
+                "outcome": outcome,
+            }
+        ],
+        "decision_boundary": {
+            "raw_observation_only": True,
+            "flaky_classification_performed": False,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _record(
+    *,
+    run_id: str,
+    head_sha: str,
+    recorded_at: str,
+    outcome: str,
+) -> dict:
+    return build_observation_history_record(
+        _capture(
+            run_id=run_id,
+            head_sha=head_sha,
+            outcome=outcome,
+        ),
+        source_run_id=run_id,
+        source_head_sha=head_sha,
+        recorded_at_utc=recorded_at,
+    )
+
+
+def _mixed_classification_report() -> dict:
+    return build_trusted_observation_classification(
+        [
+            _record(
+                run_id="full-ci-run-a",
+                head_sha=HEAD_A,
+                recorded_at="2026-06-16T00:00:00Z",
+                outcome="failed",
+            ),
+            _record(
+                run_id="full-ci-run-b",
+                head_sha=HEAD_B,
+                recorded_at="2026-06-16T01:00:00Z",
+                outcome="passed",
+            ),
+        ]
+    )
 
 
 def test_trusted_producer_emits_explicit_no_observation_registry_without_authority() -> None:
     evidence = build_trusted_registry_evidence(
-        source_run_id="run-1417",
-        source_head_sha="a5545fa1",
+        source_run_id="producer-run",
+        source_head_sha=HEAD_B,
     )
+    report = build_producer_report(evidence)
 
     assert evidence["collection_status"] == "collected"
     assert evidence["status"] == "advisory_registry_collected"
@@ -29,7 +135,12 @@ def test_trusted_producer_emits_explicit_no_observation_registry_without_authori
     assert evidence["source"]["kind"] == "trusted_main_artifact"
     assert evidence["source"]["workflow"] == "RepoMemory Profile History"
     assert evidence["source"]["observations_collected"] is False
-    assert evidence["source"]["observation_status"] == NO_TEST_OBSERVATIONS
+
+    handoff = report["classification_handoff"]
+    assert handoff["status"] == CLASSIFICATION_NOT_SUPPLIED
+    assert handoff["fingerprint_count"] == 0
+    assert handoff["forwarded_to_registry"] is False
+    assert handoff["current_pr_decision_input"] is False
 
     boundary = evidence["decision_boundary"]
     assert boundary["automatic_quarantine_allowed"] is False
@@ -39,43 +150,218 @@ def test_trusted_producer_emits_explicit_no_observation_registry_without_authori
     assert boundary["merge_authorized"] is False
 
 
-def test_trusted_producer_rejects_missing_workflow_provenance() -> None:
+def test_valid_empty_dedicated_report_is_validated_but_not_forwarded() -> None:
+    classification = build_trusted_observation_classification([])
+
+    evidence = build_trusted_registry_evidence(
+        source_run_id="producer-run",
+        source_head_sha=HEAD_B,
+        classification_report=classification,
+    )
+    report = build_producer_report(
+        evidence,
+        classification_report=classification,
+        producer_source_head_sha=HEAD_B,
+    )
+
+    assert evidence["entries"] == []
+    assert evidence["summary"]["entry_count"] == 0
+    handoff = report["classification_handoff"]
+    assert handoff["schema_version"] == CLASSIFICATION_SCHEMA_VERSION
+    assert handoff["status"] == CLASSIFICATION_EMPTY
+    assert handoff["record_count"] == 0
+    assert handoff["fingerprint_count"] == 0
+    assert handoff["forwarded_to_registry"] is False
+
+
+def test_valid_mixed_report_records_summary_without_registry_forwarding() -> None:
+    classification = _mixed_classification_report()
+
+    evidence = build_trusted_registry_evidence(
+        source_run_id="repo-memory-run",
+        source_head_sha=HEAD_B,
+        classification_report=classification,
+    )
+    report = build_producer_report(
+        evidence,
+        classification_report=classification,
+        producer_source_head_sha=HEAD_B,
+    )
+
+    assert evidence["entries"] == []
+    assert evidence["summary"]["entry_count"] == 0
+    assert evidence["source"]["run_id"] == "repo-memory-run"
+
+    handoff = report["classification_handoff"]
+    assert handoff["status"] == CLASSIFICATION_ADVISORY
+    assert handoff["record_count"] == 2
+    assert handoff["fingerprint_count"] == 1
+    assert handoff["flaky"] == 1
+    assert handoff["stable_failing"] == 0
+    assert handoff["stable_passing"] == 0
+    assert handoff["insufficient_history"] == 0
+    assert handoff["latest_source_run_id"] == "full-ci-run-b"
+    assert handoff["latest_source_head_sha"] == HEAD_B
+    assert handoff["raw_test_identity_emitted"] is False
+    assert handoff["forwarded_to_registry"] is False
+    assert handoff["current_pr_decision_input"] is False
+
+
+def test_full_ci_run_id_may_differ_from_producer_workflow_run_id() -> None:
+    classification = _mixed_classification_report()
+
+    evidence = build_trusted_registry_evidence(
+        source_run_id="distinct-repo-memory-run",
+        source_head_sha=HEAD_B,
+        classification_report=classification,
+    )
+    report = build_producer_report(
+        evidence,
+        classification_report=classification,
+        producer_source_head_sha=HEAD_B,
+    )
+
+    assert evidence["source"]["run_id"] == "distinct-repo-memory-run"
+    assert report["classification_handoff"]["latest_source_run_id"] == "full-ci-run-b"
+
+
+def test_trusted_producer_rejects_missing_or_mismatched_provenance() -> None:
     with pytest.raises(ValueError, match="source_run_id is required"):
-        build_trusted_registry_evidence(source_run_id="", source_head_sha="a5545fa1")
+        build_trusted_registry_evidence(
+            source_run_id="",
+            source_head_sha=HEAD_B,
+        )
 
     with pytest.raises(ValueError, match="source_head_sha is required"):
-        build_trusted_registry_evidence(source_run_id="run-1417", source_head_sha="")
-
-
-def test_trusted_producer_report_explains_no_claim_boundary() -> None:
-    report = build_producer_report(
         build_trusted_registry_evidence(
-            source_run_id="run-1417",
-            source_head_sha="a5545fa1",
+            source_run_id="producer-run",
+            source_head_sha="",
         )
+
+    with pytest.raises(ValueError, match="must match producer"):
+        build_trusted_registry_evidence(
+            source_run_id="producer-run",
+            source_head_sha="3" * 40,
+            classification_report=_mixed_classification_report(),
+        )
+
+
+def _unsupported_schema(report: dict) -> None:
+    report["schema_version"] = "unsupported"
+
+
+def _expand_authority(report: dict) -> None:
+    report["decision_boundary"]["automatic_rerun_allowed"] = True
+
+
+def _unbind_provenance(report: dict) -> None:
+    report["classifications"][0]["observation_provenance"][0]["source_run_id"] = "unbound"
+
+
+def _duplicate_fingerprint(report: dict) -> None:
+    report["classifications"].append(deepcopy(report["classifications"][0]))
+    report["summary"]["fingerprint_count"] += 1
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        _unsupported_schema,
+        _expand_authority,
+        _unbind_provenance,
+        _duplicate_fingerprint,
+    ],
+)
+def test_invalid_dedicated_reports_fail_closed(
+    mutator: Callable[[dict], None],
+) -> None:
+    report = _mixed_classification_report()
+    mutator(report)
+
+    with pytest.raises(ValueError):
+        build_trusted_registry_evidence(
+            source_run_id="producer-run",
+            source_head_sha=HEAD_B,
+            classification_report=report,
+        )
+
+
+def test_trusted_producer_report_explains_validation_only_boundary() -> None:
+    classification = _mixed_classification_report()
+    evidence = build_trusted_registry_evidence(
+        source_run_id="producer-run",
+        source_head_sha=HEAD_B,
+        classification_report=classification,
+    )
+    report = build_producer_report(
+        evidence,
+        classification_report=classification,
+        producer_source_head_sha=HEAD_B,
     )
     markdown = render_markdown(report)
 
     assert report["status"] == SOURCE_CONNECTED
     assert report["registry"]["observation_count"] == 0
+    assert report["registry"]["entry_count"] == 0
     assert "# Trusted-main flaky-test registry producer" in markdown
-    assert "Observation status: `no_test_observations_available`" in markdown
-    assert "No flaky-test observations are claimed" in markdown
+    assert "Dedicated classification handoff" in markdown
+    assert "Status: `validated_advisory_not_forwarded`" in markdown
+    assert "Forwarded to registry: `false`" in markdown
+    assert "Current PR decision input: `false`" in markdown
     assert "Automation allowed: `false`" in markdown
 
 
-def test_trusted_producer_cli_writes_registry_and_producer_artifacts(
+def test_producer_report_is_deterministic() -> None:
+    classification = _mixed_classification_report()
+
+    first_evidence = build_trusted_registry_evidence(
+        source_run_id="producer-run",
+        source_head_sha=HEAD_B,
+        classification_report=classification,
+    )
+    first = build_producer_report(
+        first_evidence,
+        classification_report=classification,
+        producer_source_head_sha=HEAD_B,
+    )
+
+    second_evidence = build_trusted_registry_evidence(
+        source_run_id="producer-run",
+        source_head_sha=HEAD_B,
+        classification_report=deepcopy(classification),
+    )
+    second = build_producer_report(
+        second_evidence,
+        classification_report=deepcopy(classification),
+        producer_source_head_sha=HEAD_B,
+    )
+
+    assert first == second
+    assert json.dumps(first, sort_keys=True) == json.dumps(
+        second,
+        sort_keys=True,
+    )
+
+
+def test_trusted_producer_cli_reads_dedicated_report_without_forwarding(
     tmp_path: Path,
     capsys,
 ) -> None:
+    classification_path = tmp_path / "classification.json"
+    classification_path.write_text(
+        json.dumps(_mixed_classification_report(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     out_dir = tmp_path / "trusted-registry"
 
     rc = main(
         [
             "--source-run-id",
-            "run-1417",
+            "repo-memory-run",
             "--source-head-sha",
-            "a5545fa1",
+            HEAD_B,
+            "--classification-report",
+            str(classification_path),
             "--out-dir",
             str(out_dir),
             "--format",
@@ -88,13 +374,39 @@ def test_trusted_producer_cli_writes_registry_and_producer_artifacts(
     registry = json.loads(
         (out_dir / "flaky-test-registry-evidence.json").read_text(encoding="utf-8")
     )
-    report = json.loads(
-        (out_dir / "trusted-flaky-test-registry-producer.json").read_text(encoding="utf-8")
-    )
-    markdown = (out_dir / "trusted-flaky-test-registry-producer.md").read_text(encoding="utf-8")
+    report = json.loads((out_dir / PRODUCER_JSON).read_text(encoding="utf-8"))
 
     assert printed["status"] == SOURCE_CONNECTED
-    assert registry["source"]["observation_status"] == NO_TEST_OBSERVATIONS
     assert registry["entries"] == []
-    assert report["registry"]["entry_count"] == 0
-    assert "Current failure suppression allowed: `false`" in markdown
+    assert registry["summary"]["entry_count"] == 0
+    assert report["classification_handoff"]["status"] == CLASSIFICATION_ADVISORY
+    assert report["classification_handoff"]["forwarded_to_registry"] is False
+
+
+def test_trusted_producer_cli_rejects_invalid_json_without_artifacts(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    classification_path = tmp_path / "classification.json"
+    classification_path.write_text(
+        "{not-json}\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "trusted-registry"
+
+    rc = main(
+        [
+            "--source-run-id",
+            "repo-memory-run",
+            "--source-head-sha",
+            HEAD_B,
+            "--classification-report",
+            str(classification_path),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 2
+    assert "error=" in capsys.readouterr().out
+    assert not (out_dir / PRODUCER_JSON).exists()


### PR DESCRIPTION
## Summary
- accept an optional dedicated trusted-observation classification report in the trusted flaky-test registry producer
- validate schema, provenance, authority boundaries, and latest accepted-main head binding
- record a deterministic `classification_handoff` summary while keeping registry entries empty
- update reliability-spine alignment to show the producer validation handoff as closed and later integrations as pending

## Why
- closes the reviewed classification-to-producer validation boundary without prematurely connecting registry, workflow, RepoMemory, or PR Quality consumers
- preserves the current no-observation fail-closed behavior when no classification report is supplied

## Verification
- `python -m pytest -q tests/test_trusted_flaky_test_registry_producer.py tests/test_trusted_test_observation_classification.py tests/test_flaky_test_registry_evidence.py tests/test_reliability_spine_alignment.py -o addopts=` — 44 passed
- direct validation-only handoff proof — passed
- `python -m sdetkit security check --root . --format json` — 0 new findings
- `python -m pre_commit run -a` — passed
- `make proof-after-format` — passed

## Risk
- Medium
- Compatibility: preserved; `--classification-report` is optional
- Rollback: easy; revert this commit

## Notes
- exact changed-file scope: 4 files
- no registry forwarding
- no workflow integration
- no RepoMemory population
- no PR Quality visibility
- no raw test identity projection
- no automatic quarantine, rerun, suppression, patch, or merge authority

```text
pr_card:
  title=feat(history): validate trusted classification producer handoff
  branch=feat/trusted-classification-producer-validation-handoff
  change_type=feature
  problem=the dedicated trusted-observation classification artifact had no validated producer handoff
  user_value=operators gain a provenance-checked validation boundary before later registry and workflow integration
  risk=medium
  public_surface=yes
  compatibility=preserved
  files_expected=src/sdetkit/trusted_flaky_test_registry_producer.py,tests/test_trusted_flaky_test_registry_producer.py,src/sdetkit/reliability_spine_alignment.py,tests/test_reliability_spine_alignment.py
  proof_plan=focused pytest, direct handoff proof, security check, pre-commit, proof-after-format
  rollback=easy
  split_needed=no
  verdict=fix_now
```
