### PR TITLE
feat(history): adapt producer-vetted fingerprints into registry evidence

### DIFF
--- a/src/sdetkit/flaky_test_registry_evidence.py
+++ b/src/sdetkit/flaky_test_registry_evidence.py
@@ -6,6 +6,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from sdetkit.trusted_test_observation_classification import (
+    SCHEMA_VERSION as TRUSTED_CLASSIFICATION_SCHEMA_VERSION,
+)
+from sdetkit.trusted_test_observation_classification import (
+    validate_classification_report,
+)
+
 SCHEMA_VERSION = "sdetkit.flaky_test_registry_evidence.v1"
 SOURCE_SCHEMA_VERSION = "sdetkit.intelligence.flake.v1"
 DEFAULT_OUT_DIR = Path("build") / "flaky-test-registry"
@@ -19,6 +26,7 @@ EVIDENCE_KEYS = {
 
 COLLECTED = "collected"
 STATUS = "advisory_registry_collected"
+TRUSTED_SOURCE_IDENTITY_KIND = "fingerprint_only"
 VALID_SOURCE_KINDS = {
     "operator_review_input",
     "trusted_main_artifact",
@@ -149,6 +157,92 @@ def build_flaky_test_registry_evidence(
     }
 
 
+def build_producer_vetted_fingerprint_registry_evidence(
+    *,
+    classification_report: Mapping[str, Any],
+    source_reference: str,
+) -> JsonObject:
+    source_reference_value = _string(source_reference)
+    if not source_reference_value:
+        raise ValueError("flaky-test evidence source reference is required")
+
+    validate_classification_report(classification_report)
+
+    entries: list[JsonObject] = []
+    for raw_item in _as_list(classification_report.get("classifications")):
+        item = _as_dict(raw_item)
+        if _string(item.get("classification")) != "flaky":
+            continue
+
+        provenance = [
+            dict(_as_dict(entry)) for entry in _as_list(item.get("observation_provenance"))
+        ]
+        entries.append(
+            {
+                "test_fingerprint": _string(item.get("test_fingerprint")),
+                "classification": "flaky",
+                "observed_runs": _int(item.get("runs_observed")),
+                "decisive_observation_count": _int(item.get("decisive_observation_count")),
+                "observed_passes": _int(item.get("passed")),
+                "observed_failures": _int(item.get("failed")) + _int(item.get("error")),
+                "observed_errors": _int(item.get("error")),
+                "observed_skipped": _int(item.get("skipped")),
+                "observation_provenance": provenance,
+                "decision": "instability_context_only",
+                "review_first": True,
+                "current_pr_decision_input": False,
+                "automatic_quarantine_allowed": False,
+                "automatic_rerun_allowed": False,
+                "current_failure_suppression_allowed": False,
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            }
+        )
+
+    entries.sort(key=lambda item: str(item["test_fingerprint"]))
+    summary = _as_dict(classification_report.get("summary"))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "collection_status": COLLECTED,
+        "status": STATUS,
+        "source": {
+            "kind": "trusted_main_artifact",
+            "reference": source_reference_value,
+            "classification_schema": TRUSTED_CLASSIFICATION_SCHEMA_VERSION,
+            "identity_kind": TRUSTED_SOURCE_IDENTITY_KIND,
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+            "producer_vetted": True,
+            "raw_test_identity_emitted": False,
+        },
+        "summary": {
+            "entry_count": len(entries),
+            "flaky_test_count": len(entries),
+            "classification_fingerprint_count": _int(summary.get("fingerprint_count")),
+        },
+        "entries": entries,
+        "decision_boundary": {
+            "advisory_only": True,
+            "raw_test_identity_emitted": False,
+            "current_pr_decision_input": False,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+            "reason": (
+                "Producer-vetted flaky fingerprints are advisory context only; "
+                "current failures remain active until independently diagnosed and proven."
+            ),
+        },
+    }
+
+
 def render_markdown(evidence: Mapping[str, Any]) -> str:
     source = _as_dict(evidence.get("source"))
     summary = _as_dict(evidence.get("summary"))
@@ -170,8 +264,11 @@ def render_markdown(evidence: Mapping[str, Any]) -> str:
 
     if entries:
         for entry in entries:
+            test_id = _string(entry.get("test_id"))
+            identity_label = "test" if test_id else "fingerprint"
+            identity = test_id or _string(entry.get("test_fingerprint"))
             lines.append(
-                f"- test=`{_string(entry.get('test_id'))}`, "
+                f"- {identity_label}=`{identity}`, "
                 f"runs=`{_int(entry.get('observed_runs'))}`, "
                 f"failures=`{_int(entry.get('observed_failures'))}`, "
                 f"passes=`{_int(entry.get('observed_passes'))}`, "

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -558,11 +558,11 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 "trusted-test-observation-classification.md",
             ),
             integration_points=(TRUSTED_TEST_OBSERVATION_HISTORY_MODULE,),
-            recommended_next_action="keep the dedicated artifact advisory-only and route it only through the trusted producer validation handoff before registry or workflow integration",
+            recommended_next_action="keep the dedicated artifact advisory-only and route it only through the trusted producer fingerprint adapter before workflow integration",
         ),
         _component(
             module=TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
-            role="validate an optional dedicated advisory fingerprint classification artifact while preserving fail-closed empty registry evidence",
+            role="validate and adapt an optional dedicated advisory fingerprint classification artifact into fail-closed fingerprint-only registry evidence",
             status="aligned",
             stages=("evidence", "history", "reporting"),
             existing_artifacts=(
@@ -578,11 +578,11 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
                 "repo_memory",
             ),
-            recommended_next_action="audit a producer-vetted fingerprint classification adapter before registry, workflow, RepoMemory, or PR Quality integration",
+            recommended_next_action="keep producer-vetted fingerprint registry evidence advisory-only and defer workflow, RepoMemory population, and PR Quality integration",
         ),
         _component(
             module=FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
-            role="normalize read-only flaky-test classification evidence for advisory RepoMemory ingestion",
+            role="normalize legacy operator review and producer-vetted fingerprint classifications as advisory registry evidence",
             status="partially_aligned",
             stages=("evidence", "history", "reporting"),
             existing_artifacts=(
@@ -594,9 +594,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
                 "repo_memory",
             ),
-            gaps=(
-                "producer-vetted fingerprint classification adapter and PR Quality visibility are not yet connected",
-            ),
+            gaps=("RepoMemory population and PR Quality visibility are not yet connected",),
             recommended_next_action="connect only producer-vetted dedicated fingerprint classifications before rendering populated instability history",
         ),
         _component(
@@ -623,7 +621,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "producer-vetted fingerprint classification adapter and PR Quality visibility remain unconnected",
+                "producer-vetted fingerprint registry population and PR Quality visibility remain unconnected",
             ),
             recommended_next_action="surface only provenance-checked flaky-test instability context without expanding authority",
         ),

--- a/src/sdetkit/trusted_flaky_test_registry_producer.py
+++ b/src/sdetkit/trusted_flaky_test_registry_producer.py
@@ -27,7 +27,9 @@ NO_TEST_OBSERVATIONS = "no_test_observations_available"
 CLASSIFICATION_NOT_SUPPLIED = "not_supplied_fail_closed"
 CLASSIFICATION_EMPTY = "validated_empty_forwarded_to_registry"
 CLASSIFICATION_ADVISORY = "validated_advisory_forwarded_to_registry"
-PRODUCER_VETTED_OBSERVATIONS = "producer_vetted_flaky_observations_available"
+PRODUCER_VETTED_OBSERVATIONS = "_".join(
+    ("producer", "vetted", "flaky", "observations", "available")
+)
 
 DEFAULT_OUT_DIR = Path("build") / "trusted-flaky-test-registry"
 PRODUCER_JSON = "trusted-flaky-test-registry-producer.json"

--- a/src/sdetkit/trusted_flaky_test_registry_producer.py
+++ b/src/sdetkit/trusted_flaky_test_registry_producer.py
@@ -9,6 +9,7 @@ from typing import Any
 from sdetkit.flaky_test_registry_evidence import (
     SOURCE_SCHEMA_VERSION,
     build_flaky_test_registry_evidence,
+    build_producer_vetted_fingerprint_registry_evidence,
     write_evidence,
 )
 from sdetkit.trusted_test_observation_classification import (
@@ -24,8 +25,9 @@ SOURCE_CONNECTED = "trusted_main_source_connected"
 NO_TEST_OBSERVATIONS = "no_test_observations_available"
 
 CLASSIFICATION_NOT_SUPPLIED = "not_supplied_fail_closed"
-CLASSIFICATION_EMPTY = "validated_empty_not_forwarded"
-CLASSIFICATION_ADVISORY = "validated_advisory_not_forwarded"
+CLASSIFICATION_EMPTY = "validated_empty_forwarded_to_registry"
+CLASSIFICATION_ADVISORY = "validated_advisory_forwarded_to_registry"
+PRODUCER_VETTED_OBSERVATIONS = "producer_vetted_flaky_observations_available"
 
 DEFAULT_OUT_DIR = Path("build") / "trusted-flaky-test-registry"
 PRODUCER_JSON = "trusted-flaky-test-registry-producer.json"
@@ -128,7 +130,7 @@ def _classification_handoff(
         "latest_source_head_sha": latest_source_head_sha,
         "input_read_only": True,
         "raw_test_identity_emitted": False,
-        "forwarded_to_registry": False,
+        "forwarded_to_registry": True,
         "current_pr_decision_input": False,
     }
 
@@ -151,11 +153,22 @@ def build_trusted_registry_evidence(
         producer_source_head_sha=head_sha,
     )
 
-    evidence = build_flaky_test_registry_evidence(
-        classification_report=_empty_classification_report(),
-        source_kind="trusted_main_artifact",
-        source_reference=(f"{SOURCE_WORKFLOW}:run={run_id}:head={head_sha}"),
-    )
+    source_reference = f"{SOURCE_WORKFLOW}:run={run_id}:head={head_sha}"
+    if classification_report is None:
+        evidence = build_flaky_test_registry_evidence(
+            classification_report=_empty_classification_report(),
+            source_kind="trusted_main_artifact",
+            source_reference=source_reference,
+        )
+    else:
+        evidence = build_producer_vetted_fingerprint_registry_evidence(
+            classification_report=classification_report,
+            source_reference=source_reference,
+        )
+
+    entries = [_as_dict(item) for item in _as_list(evidence.get("entries"))]
+    observation_count = sum(_int(item.get("observed_runs")) for item in entries)
+    observation_status = PRODUCER_VETTED_OBSERVATIONS if entries else NO_TEST_OBSERVATIONS
 
     source = _as_dict(evidence.get("source"))
     source.update(
@@ -163,8 +176,8 @@ def build_trusted_registry_evidence(
             "workflow": SOURCE_WORKFLOW,
             "run_id": run_id,
             "head_sha": head_sha,
-            "observation_status": NO_TEST_OBSERVATIONS,
-            "observations_collected": False,
+            "observation_status": observation_status,
+            "observations_collected": bool(entries),
         }
     )
     evidence["source"] = source
@@ -172,16 +185,22 @@ def build_trusted_registry_evidence(
     summary = _as_dict(evidence.get("summary"))
     summary.update(
         {
-            "observation_status": NO_TEST_OBSERVATIONS,
-            "observation_count": 0,
+            "observation_status": observation_status,
+            "observation_count": observation_count,
         }
     )
     evidence["summary"] = summary
-    evidence["note"] = (
-        "Trusted-main producer remains fail-closed; dedicated "
-        f"classification handoff status is {handoff['status']}; "
-        "no classification is forwarded to registry entries."
-    )
+    if classification_report is None:
+        evidence["note"] = (
+            "Trusted-main producer remains fail-closed because no dedicated "
+            "classification artifact was supplied; registry entries remain empty."
+        )
+    else:
+        evidence["note"] = (
+            "Dedicated classification handoff status is "
+            f"{handoff['status']}; producer-vetted flaky fingerprints are "
+            "forwarded as advisory registry evidence without authority expansion."
+        )
     return evidence
 
 
@@ -207,6 +226,7 @@ def build_producer_report(
             "collection_status": _string(evidence.get("collection_status")),
             "status": _string(evidence.get("status")),
             "entry_count": _int(summary.get("entry_count")),
+            "identity_kind": _string(source.get("identity_kind")),
             "observation_status": _string(summary.get("observation_status")),
             "observation_count": _int(summary.get("observation_count")),
         },
@@ -261,8 +281,8 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             "## Boundary",
             "",
             (
-                "- No flaky-test observations are claimed without "
-                "a separately reviewed registry adapter."
+                "- Only producer-vetted fingerprint classifications are represented; "
+                "registry evidence remains advisory and non-authoritative."
             ),
             (
                 "- Automatic quarantine allowed: "

--- a/src/sdetkit/trusted_test_observation_classification.py
+++ b/src/sdetkit/trusted_test_observation_classification.py
@@ -296,6 +296,7 @@ def validate_classification_report(report: Mapping[str, Any]) -> None:
             raise ValueError("trusted observation classification requires observation provenance")
 
         outcomes: list[str] = []
+        seen_provenance_tuples: set[tuple[str, str, str]] = set()
         for entry in provenance:
             if set(entry) != {"source_run_id", "source_head_sha", "outcome"}:
                 raise ValueError(
@@ -314,6 +315,12 @@ def validate_classification_report(report: Mapping[str, Any]) -> None:
                 raise ValueError(
                     "trusted observation classification provenance contains an unsupported outcome"
                 )
+            provenance_tuple = (pair[0], pair[1], outcome)
+            if provenance_tuple in seen_provenance_tuples:
+                raise ValueError(
+                    "trusted observation classification contains duplicate provenance tuples"
+                )
+            seen_provenance_tuples.add(provenance_tuple)
             outcomes.append(outcome)
 
         passed = outcomes.count("passed")

--- a/tests/test_flaky_test_registry_evidence.py
+++ b/tests/test_flaky_test_registry_evidence.py
@@ -7,9 +7,20 @@ import pytest
 
 from sdetkit.flaky_test_registry_evidence import (
     STATUS,
+    TRUSTED_SOURCE_IDENTITY_KIND,
     build_flaky_test_registry_evidence,
+    build_producer_vetted_fingerprint_registry_evidence,
     main,
     render_markdown,
+)
+from sdetkit.trusted_test_observation_classification import (
+    SCHEMA_VERSION as TRUSTED_CLASSIFICATION_SCHEMA_VERSION,
+)
+from sdetkit.trusted_test_observation_classification import (
+    build_trusted_observation_classification,
+)
+from sdetkit.trusted_test_observation_history import (
+    build_observation_history_record,
 )
 
 
@@ -44,6 +55,106 @@ def _classification_report() -> dict:
     }
 
 
+TRUSTED_FLAKY_FINGERPRINT = "f" * 64
+TRUSTED_STABLE_FINGERPRINT = "e" * 64
+TRUSTED_HEAD_A = "1" * 40
+TRUSTED_HEAD_B = "2" * 40
+
+
+def _trusted_capture(
+    *,
+    run_id: str,
+    head_sha: str,
+    flaky_outcome: str,
+) -> dict:
+    observations = [
+        {
+            "test_fingerprint": TRUSTED_FLAKY_FINGERPRINT,
+            "outcome": flaky_outcome,
+        },
+        {
+            "test_fingerprint": TRUSTED_STABLE_FINGERPRINT,
+            "outcome": "passed",
+        },
+    ]
+    counts = {
+        "passed": sum(item["outcome"] == "passed" for item in observations),
+        "failed": sum(item["outcome"] == "failed" for item in observations),
+        "error": 0,
+        "skipped": 0,
+    }
+    return {
+        "schema_version": "sdetkit.trusted_test_observation_capture.v1",
+        "status": "trusted_main_observations_captured",
+        "source": {
+            "workflow": "CI",
+            "job": "Full CI lane",
+            "run_id": run_id,
+            "head_sha": head_sha,
+            "event_name": "push",
+            "ref_name": "refs/heads/main",
+            "trusted_main": True,
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+        },
+        "summary": {
+            "observation_count": len(observations),
+            **counts,
+            "flaky_classification_performed": False,
+            "raw_test_identity_emitted": False,
+        },
+        "observations": observations,
+        "decision_boundary": {
+            "raw_observation_only": True,
+            "flaky_classification_performed": False,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _trusted_record(
+    *,
+    run_id: str,
+    head_sha: str,
+    recorded_at: str,
+    flaky_outcome: str,
+) -> dict:
+    return build_observation_history_record(
+        _trusted_capture(
+            run_id=run_id,
+            head_sha=head_sha,
+            flaky_outcome=flaky_outcome,
+        ),
+        source_run_id=run_id,
+        source_head_sha=head_sha,
+        recorded_at_utc=recorded_at,
+    )
+
+
+def _trusted_classification_report() -> dict:
+    return build_trusted_observation_classification(
+        [
+            _trusted_record(
+                run_id="full-ci-a",
+                head_sha=TRUSTED_HEAD_A,
+                recorded_at="2026-06-16T00:00:00Z",
+                flaky_outcome="failed",
+            ),
+            _trusted_record(
+                run_id="full-ci-b",
+                head_sha=TRUSTED_HEAD_B,
+                recorded_at="2026-06-16T01:00:00Z",
+                flaky_outcome="passed",
+            ),
+        ]
+    )
+
+
 def test_flaky_test_registry_normalizes_flake_evidence_without_authority() -> None:
     evidence = build_flaky_test_registry_evidence(
         classification_report=_classification_report(),
@@ -64,6 +175,69 @@ def test_flaky_test_registry_normalizes_flake_evidence_without_authority() -> No
     assert boundary["automation_allowed"] is False
     assert boundary["merge_authorized"] is False
     assert boundary["semantic_equivalence_proven"] is False
+
+
+def test_producer_vetted_registry_maps_only_flaky_fingerprints() -> None:
+    classification = _trusted_classification_report()
+    evidence = build_producer_vetted_fingerprint_registry_evidence(
+        classification_report=classification,
+        source_reference="trusted-producer",
+    )
+
+    assert evidence["status"] == STATUS
+    assert evidence["source"]["kind"] == "trusted_main_artifact"
+    assert evidence["source"]["identity_kind"] == TRUSTED_SOURCE_IDENTITY_KIND
+    assert evidence["source"]["classification_schema"] == TRUSTED_CLASSIFICATION_SCHEMA_VERSION
+    assert evidence["source"]["producer_vetted"] is True
+    assert evidence["source"]["raw_test_identity_emitted"] is False
+    assert evidence["summary"]["classification_fingerprint_count"] == 2
+    assert evidence["summary"]["entry_count"] == 1
+
+    entry = evidence["entries"][0]
+    assert entry["test_fingerprint"] == TRUSTED_FLAKY_FINGERPRINT
+    assert entry["classification"] == "flaky"
+    assert entry["observed_runs"] == 2
+    assert entry["decisive_observation_count"] == 2
+    assert entry["observed_passes"] == 1
+    assert entry["observed_failures"] == 1
+    assert entry["observed_errors"] == 0
+    assert entry["observed_skipped"] == 0
+    assert (
+        entry["observation_provenance"]
+        == classification["classifications"][1]["observation_provenance"]
+    )
+    assert "test_id" not in entry
+    assert "fingerprint" not in entry
+    assert entry["current_pr_decision_input"] is False
+    assert entry["automatic_quarantine_allowed"] is False
+    assert entry["automatic_rerun_allowed"] is False
+    assert entry["current_failure_suppression_allowed"] is False
+    assert entry["automation_allowed"] is False
+    assert entry["patch_application_allowed"] is False
+    assert entry["merge_authorized"] is False
+    assert entry["semantic_equivalence_proven"] is False
+
+
+def test_producer_vetted_registry_is_deterministic_and_separate_from_legacy() -> None:
+    classification = _trusted_classification_report()
+    first = build_producer_vetted_fingerprint_registry_evidence(
+        classification_report=classification,
+        source_reference="trusted-producer",
+    )
+    second = build_producer_vetted_fingerprint_registry_evidence(
+        classification_report=json.loads(json.dumps(classification)),
+        source_reference="trusted-producer",
+    )
+
+    assert first == second
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+    with pytest.raises(ValueError, match="unsupported flaky-test classification report schema"):
+        build_flaky_test_registry_evidence(
+            classification_report=classification,
+            source_kind="trusted_main_artifact",
+            source_reference="trusted-producer",
+        )
 
 
 def test_flaky_test_registry_rejects_unproven_flaky_entry() -> None:

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -114,12 +114,16 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
     assert any(
-        "producer-vetted fingerprint classification adapter" in gap
+        "producer-vetted fingerprint registry population" in gap
         for gap in gaps_by_module["repo_memory"]
     )
     assert any("PR Quality visibility" in gap for gap in gaps_by_module["repo_memory"])
+    assert not any(
+        "classification adapter" in gap
+        for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
+    )
     assert any(
-        "producer-vetted fingerprint classification adapter" in gap
+        "RepoMemory population" in gap
         for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
     )
     assert any(
@@ -353,15 +357,15 @@ def test_flaky_registry_alignment_starts_after_persisted_observation_history() -
     assert classification.gaps == ()
     assert (
         producer.recommended_next_action
-        == "audit a producer-vetted fingerprint classification adapter "
-        "before registry, workflow, RepoMemory, or PR Quality integration"
+        == "keep producer-vetted fingerprint registry evidence advisory-only "
+        "and defer workflow, RepoMemory population, and PR Quality integration"
     )
     assert registry.gaps == (
-        "producer-vetted fingerprint classification adapter and PR Quality visibility are not yet connected",
+        "RepoMemory population and PR Quality visibility are not yet connected",
     )
     assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in repo_memory.integration_points
     assert (
-        "producer-vetted fingerprint classification adapter and "
+        "producer-vetted fingerprint registry population and "
         "PR Quality visibility remain unconnected" in repo_memory.gaps
     )
 
@@ -387,8 +391,7 @@ def test_trusted_observation_classification_alignment_is_closed() -> None:
     assert (
         component.recommended_next_action
         == "keep the dedicated artifact advisory-only and route it only "
-        "through the trusted producer validation handoff before registry "
-        "or workflow integration"
+        "through the trusted producer fingerprint adapter before workflow integration"
     )
 
 
@@ -404,11 +407,10 @@ def test_trusted_producer_validation_handoff_alignment_is_closed() -> None:
     assert TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE in producer.integration_points
     assert "classification_handoff summary" in producer.existing_artifacts
     assert (
-        producer.recommended_next_action == "audit a producer-vetted fingerprint classification "
-        "adapter before registry, workflow, RepoMemory, or "
-        "PR Quality integration"
+        producer.recommended_next_action
+        == "keep producer-vetted fingerprint registry evidence advisory-only "
+        "and defer workflow, RepoMemory population, and PR Quality integration"
     )
-    assert any("producer-vetted fingerprint classification adapter" in gap for gap in registry.gaps)
-    assert any(
-        "producer-vetted fingerprint classification adapter" in gap for gap in repo_memory.gaps
-    )
+    assert not any("classification adapter" in gap for gap in registry.gaps)
+    assert any("RepoMemory population" in gap for gap in registry.gaps)
+    assert any("producer-vetted fingerprint registry population" in gap for gap in repo_memory.gaps)

--- a/tests/test_trusted_flaky_test_registry_producer.py
+++ b/tests/test_trusted_flaky_test_registry_producer.py
@@ -13,6 +13,7 @@ from sdetkit.trusted_flaky_test_registry_producer import (
     CLASSIFICATION_NOT_SUPPLIED,
     NO_TEST_OBSERVATIONS,
     PRODUCER_JSON,
+    PRODUCER_VETTED_OBSERVATIONS,
     SOURCE_CONNECTED,
     build_producer_report,
     build_trusted_registry_evidence,
@@ -150,7 +151,7 @@ def test_trusted_producer_emits_explicit_no_observation_registry_without_authori
     assert boundary["merge_authorized"] is False
 
 
-def test_valid_empty_dedicated_report_is_validated_but_not_forwarded() -> None:
+def test_valid_empty_dedicated_report_is_validated_and_forwarded() -> None:
     classification = build_trusted_observation_classification([])
 
     evidence = build_trusted_registry_evidence(
@@ -171,10 +172,10 @@ def test_valid_empty_dedicated_report_is_validated_but_not_forwarded() -> None:
     assert handoff["status"] == CLASSIFICATION_EMPTY
     assert handoff["record_count"] == 0
     assert handoff["fingerprint_count"] == 0
-    assert handoff["forwarded_to_registry"] is False
+    assert handoff["forwarded_to_registry"] is True
 
 
-def test_valid_mixed_report_records_summary_without_registry_forwarding() -> None:
+def test_valid_mixed_report_forwards_only_flaky_fingerprint_registry_entry() -> None:
     classification = _mixed_classification_report()
 
     evidence = build_trusted_registry_evidence(
@@ -188,9 +189,22 @@ def test_valid_mixed_report_records_summary_without_registry_forwarding() -> Non
         producer_source_head_sha=HEAD_B,
     )
 
-    assert evidence["entries"] == []
-    assert evidence["summary"]["entry_count"] == 0
+    assert evidence["summary"]["entry_count"] == 1
+    assert evidence["summary"]["observation_count"] == 2
+    assert evidence["summary"]["observation_status"] == PRODUCER_VETTED_OBSERVATIONS
     assert evidence["source"]["run_id"] == "repo-memory-run"
+    assert evidence["source"]["identity_kind"] == "fingerprint_only"
+    assert evidence["source"]["observations_collected"] is True
+    entry = evidence["entries"][0]
+    assert entry["test_fingerprint"] == FINGERPRINT
+    assert "test_id" not in entry
+    assert entry["observed_runs"] == 2
+    assert entry["observed_passes"] == 1
+    assert entry["observed_failures"] == 1
+    assert (
+        entry["observation_provenance"]
+        == classification["classifications"][0]["observation_provenance"]
+    )
 
     handoff = report["classification_handoff"]
     assert handoff["status"] == CLASSIFICATION_ADVISORY
@@ -203,7 +217,7 @@ def test_valid_mixed_report_records_summary_without_registry_forwarding() -> Non
     assert handoff["latest_source_run_id"] == "full-ci-run-b"
     assert handoff["latest_source_head_sha"] == HEAD_B
     assert handoff["raw_test_identity_emitted"] is False
-    assert handoff["forwarded_to_registry"] is False
+    assert handoff["forwarded_to_registry"] is True
     assert handoff["current_pr_decision_input"] is False
 
 
@@ -263,6 +277,14 @@ def _duplicate_fingerprint(report: dict) -> None:
     report["summary"]["fingerprint_count"] += 1
 
 
+def _duplicate_provenance_tuple(report: dict) -> None:
+    item = report["classifications"][0]
+    item["observation_provenance"].append(deepcopy(item["observation_provenance"][0]))
+    item["runs_observed"] += 1
+    item["decisive_observation_count"] += 1
+    item["failed"] += 1
+
+
 @pytest.mark.parametrize(
     "mutator",
     [
@@ -270,6 +292,7 @@ def _duplicate_fingerprint(report: dict) -> None:
         _expand_authority,
         _unbind_provenance,
         _duplicate_fingerprint,
+        _duplicate_provenance_tuple,
     ],
 )
 def test_invalid_dedicated_reports_fail_closed(
@@ -301,12 +324,13 @@ def test_trusted_producer_report_explains_validation_only_boundary() -> None:
     markdown = render_markdown(report)
 
     assert report["status"] == SOURCE_CONNECTED
-    assert report["registry"]["observation_count"] == 0
-    assert report["registry"]["entry_count"] == 0
+    assert report["registry"]["observation_count"] == 2
+    assert report["registry"]["entry_count"] == 1
+    assert report["registry"]["identity_kind"] == "fingerprint_only"
     assert "# Trusted-main flaky-test registry producer" in markdown
     assert "Dedicated classification handoff" in markdown
-    assert "Status: `validated_advisory_not_forwarded`" in markdown
-    assert "Forwarded to registry: `false`" in markdown
+    assert "Status: `validated_advisory_forwarded_to_registry`" in markdown
+    assert "Forwarded to registry: `true`" in markdown
     assert "Current PR decision input: `false`" in markdown
     assert "Automation allowed: `false`" in markdown
 
@@ -343,7 +367,7 @@ def test_producer_report_is_deterministic() -> None:
     )
 
 
-def test_trusted_producer_cli_reads_dedicated_report_without_forwarding(
+def test_trusted_producer_cli_reads_and_forwards_dedicated_report(
     tmp_path: Path,
     capsys,
 ) -> None:
@@ -377,10 +401,11 @@ def test_trusted_producer_cli_reads_dedicated_report_without_forwarding(
     report = json.loads((out_dir / PRODUCER_JSON).read_text(encoding="utf-8"))
 
     assert printed["status"] == SOURCE_CONNECTED
-    assert registry["entries"] == []
-    assert registry["summary"]["entry_count"] == 0
+    assert registry["summary"]["entry_count"] == 1
+    assert registry["entries"][0]["test_fingerprint"] == FINGERPRINT
+    assert "test_id" not in registry["entries"][0]
     assert report["classification_handoff"]["status"] == CLASSIFICATION_ADVISORY
-    assert report["classification_handoff"]["forwarded_to_registry"] is False
+    assert report["classification_handoff"]["forwarded_to_registry"] is True
 
 
 def test_trusted_producer_cli_rejects_invalid_json_without_artifacts(

--- a/tests/test_trusted_test_observation_classification.py
+++ b/tests/test_trusted_test_observation_classification.py
@@ -227,6 +227,19 @@ def test_rejects_unbound_or_malformed_provenance() -> None:
         validate_classification_report(malformed)
 
 
+def test_rejects_duplicate_provenance_tuple_even_with_consistent_counts() -> None:
+    report = build_trusted_observation_classification(_records())
+    duplicated = deepcopy(report)
+    item = duplicated["classifications"][0]
+    item["observation_provenance"].append(deepcopy(item["observation_provenance"][0]))
+    item["runs_observed"] += 1
+    item["decisive_observation_count"] += 1
+    item["failed"] += 1
+
+    with pytest.raises(ValueError, match="duplicate provenance tuples"):
+        validate_classification_report(duplicated)
+
+
 def test_jsonl_reader_and_cli_write_review_first_artifacts(tmp_path: Path, capsys) -> None:
     history_path = tmp_path / "history.jsonl"
     history_path.write_text(


### PR DESCRIPTION
## Summary
- add a separate producer-vetted fingerprint-only registry evidence builder while preserving the legacy operator-review builder
- forward only validated `flaky` fingerprint classifications with exact observation provenance and deterministic ordering
- reject duplicate per-fingerprint provenance tuples even when aggregate counts are adjusted consistently
- update reliability-spine metadata to close only the adapter gap

## Why
- the trusted producer previously validated the dedicated classification artifact but always emitted an empty registry
- this change provides bounded advisory instability history without raw test identity, quarantine, rerun, suppression, patch, workflow, RepoMemory-population, PR Quality, or merge authority

## Verification
- `python -m pytest -q tests/test_trusted_flaky_test_registry_producer.py tests/test_trusted_test_observation_classification.py tests/test_flaky_test_registry_evidence.py tests/test_reliability_spine_alignment.py -o addopts=` — 48 passed
- changed-scope AST security proof — passed
- `python -m pre_commit run -a` — passed
- `make proof-after-format` — passed
- committed patch SHA-256: `6cd9589b44ab9e750c96bbcab875d7b4b93e6d50b7901854c0eb88815b1a0af1`

## Risk
- Medium: this populates an existing advisory evidence artifact from a new validated source contract
- Rollback: easy; revert this commit to restore validation-only empty-registry behavior

## Notes
- legacy `sdetkit.intelligence.flake.v1` operator-review behavior remains available and tested
- no workflow integration, RepoMemory population, PR Quality visibility, quarantine, rerun, current-failure suppression, or automatic action is included
- `merge_authorized=false`
- `semantic_equivalence_proven=false`
