### PR TITLE
feat(memory): ingest producer-vetted fingerprint registry evidence

### DIFF
--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -578,7 +578,7 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
                 "repo_memory",
             ),
-            recommended_next_action="keep producer-vetted fingerprint registry evidence advisory-only and defer workflow, RepoMemory population, and PR Quality integration",
+            recommended_next_action="keep producer-vetted fingerprint registry evidence advisory-only and defer trusted-main workflow population and PR Quality integration",
         ),
         _component(
             module=FLAKY_TEST_REGISTRY_EVIDENCE_MODULE,
@@ -594,12 +594,14 @@ def build_alignment_components() -> list[AlignmentComponent]:
                 TRUSTED_FLAKY_TEST_REGISTRY_PRODUCER_MODULE,
                 "repo_memory",
             ),
-            gaps=("RepoMemory population and PR Quality visibility are not yet connected",),
-            recommended_next_action="connect only producer-vetted dedicated fingerprint classifications before rendering populated instability history",
+            gaps=(
+                "trusted-main workflow population and PR Quality visibility are not yet connected",
+            ),
+            recommended_next_action="wire producer-vetted fingerprint registry evidence through the trusted-main workflow before PR Quality visibility",
         ),
         _component(
             module="repo_memory",
-            role="produce local repo-specific memory profiles from trajectory and benchmark evidence",
+            role="produce local repo-specific memory profiles from trajectory, benchmark, and advisory fingerprint-only registry evidence",
             status="partially_aligned",
             stages=("history", "decision", "reporting"),
             existing_artifacts=(
@@ -621,9 +623,9 @@ def build_alignment_components() -> list[AlignmentComponent]:
             ),
             gaps=(
                 "successful network-isolation proof is unavailable until a backend is verified",
-                "producer-vetted fingerprint registry population and PR Quality visibility remain unconnected",
+                "trusted-main workflow population and PR Quality visibility remain unconnected",
             ),
-            recommended_next_action="surface only provenance-checked flaky-test instability context without expanding authority",
+            recommended_next_action="keep provenance-checked flaky-test instability context advisory-only while deferring workflow and PR Quality integration",
         ),
         _component(
             module=REPO_MEMORY_PROFILE_HISTORY_MODULE,

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -1479,19 +1479,11 @@ def main(argv: list[str] | None = None) -> int:
         print(
             json.dumps(
                 {
-                    "profile_status": profile["profile_status"],
                     "artifacts": {
                         "repo_memory_profile_json": PROFILE_JSON,
                         "repo_memory_profile_markdown": PROFILE_MD,
                     },
-                    "known_safe_candidate_count": profile["known_safe_candidate_count"],
-                    "live_safe_candidate_count": profile["live_safe_candidate_count"],
-                    "controlled_candidate_validation_status": profile[
-                        "controlled_candidate_validation"
-                    ]["status"],
-                    "safety_gate_evidence_record_count": profile["safety_gate_evidence"][
-                        "record_count"
-                    ],
+                    "status": "repo_memory_profile_written",
                 },
                 indent=2,
                 sort_keys=True,

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -1464,7 +1464,7 @@ def main(argv: list[str] | None = None) -> int:
                 else None
             ),
         )
-        artifacts = write_profile(profile, out_dir=args.out_dir)
+        write_profile(profile, out_dir=args.out_dir)
     except json.JSONDecodeError:
         print("error=invalid_json")
         return 2
@@ -1480,7 +1480,10 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(
                 {
                     "profile_status": profile["profile_status"],
-                    "artifacts": artifacts,
+                    "artifacts": {
+                        "repo_memory_profile_json": PROFILE_JSON,
+                        "repo_memory_profile_markdown": PROFILE_MD,
+                    },
                     "known_safe_candidate_count": profile["known_safe_candidate_count"],
                     "live_safe_candidate_count": profile["live_safe_candidate_count"],
                     "controlled_candidate_validation_status": profile[
@@ -1495,8 +1498,8 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
-        for key, value in artifacts.items():
-            print(f"{key}: {value}")
+        print(f"repo_memory_profile_json: {PROFILE_JSON}")
+        print(f"repo_memory_profile_markdown: {PROFILE_MD}")
 
     return 0
 

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -1465,8 +1465,14 @@ def main(argv: list[str] | None = None) -> int:
             ),
         )
         artifacts = write_profile(profile, out_dir=args.out_dir)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        print(f"error={exc}")
+    except json.JSONDecodeError:
+        print("error=invalid_json")
+        return 2
+    except OSError:
+        print("error=input_io_failure")
+        return 2
+    except ValueError:
+        print("error=input_validation_failed")
         return 2
 
     if args.format == "json":

--- a/src/sdetkit/repo_memory.py
+++ b/src/sdetkit/repo_memory.py
@@ -17,6 +17,10 @@ from sdetkit.replayable_benchmark_harness import (
     UNCLAIMED_WRITE_FAIL,
     VERIFICATION_EVIDENCE_SOURCE,
 )
+from sdetkit.trusted_test_observation_classification import (
+    SCHEMA_VERSION as TRUSTED_TEST_OBSERVATION_CLASSIFICATION_SCHEMA,
+)
+from sdetkit.trusted_test_observation_history import ALLOWED_OUTCOMES
 
 SCHEMA_VERSION = "sdetkit.repo_memory.v6"
 DEFAULT_OUT_DIR = Path("build") / "repo-memory"
@@ -30,6 +34,12 @@ GIT_INVENTORY_VERIFIED = "_".join(("git", "inventory", "verified"))
 EXPECTED_FAILED_EVIDENCE_COUNT = "_".join(("expected", "failed", "evidence", "count"))
 CONTROLLED_VALIDATION_SCHEMA = "sdetkit.pr_quality.candidate_validation.v1"
 CONTROLLED_VALIDATION_STATUS = "_".join(("controlled", "validation", "passed"))
+LEGACY_FLAKY_CLASSIFICATION_SCHEMA = "sdetkit.intelligence.flake.v1"
+TRUSTED_FLAKY_IDENTITY_KIND = "fingerprint_only"
+NO_TEST_OBSERVATIONS = "_".join(("no", "test", "observations", "available"))
+PRODUCER_VETTED_OBSERVATIONS = "_".join(
+    ("producer", "vetted", "flaky", "observations", "available")
+)
 
 JsonObject = dict[str, Any]
 
@@ -548,8 +558,8 @@ def _live_benchmark_rejections(
     return records
 
 
-def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
-    denied = {
+def _registry_denied(*, trusted_fingerprint: bool = False) -> JsonObject:
+    denied: JsonObject = {
         "automatic_quarantine_allowed": False,
         "automatic_rerun_allowed": False,
         "current_failure_suppression_allowed": False,
@@ -557,8 +567,210 @@ def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
         "merge_authorized": False,
         "semantic_equivalence_proven": False,
     }
+    if trusted_fingerprint:
+        denied.update(
+            {
+                "current_pr_decision_input": False,
+                "patch_application_allowed": False,
+            }
+        )
+    return denied
+
+
+def _assert_registry_authority(
+    value: Mapping[str, Any],
+    *,
+    denied: Mapping[str, Any],
+    source: str,
+    explicit: bool,
+) -> None:
+    expanded = [key for key in denied if _bool(value.get(key))]
+    if expanded:
+        raise ValueError(f"{source} expands authority: " + ", ".join(expanded))
+    if explicit:
+        omitted = [key for key in denied if value.get(key) is not False]
+        if omitted:
+            raise ValueError(f"{source} must explicitly deny authority: " + ", ".join(omitted))
+
+
+def _lower_hex(value: Any, *, length: int, source: str) -> str:
+    rendered = _string(value)
+    if (
+        len(rendered) != length
+        or rendered != rendered.lower()
+        or any(char not in "0123456789abcdef" for char in rendered)
+    ):
+        raise ValueError(f"{source} must be {length}-character lower-case hexadecimal")
+    return rendered
+
+
+def _trusted_registry_provenance(value: Any) -> list[JsonObject]:
+    if not isinstance(value, list):
+        raise ValueError(
+            "producer-vetted flaky-test registry entry requires observation provenance"
+        )
+
+    normalized: list[JsonObject] = []
+    seen: set[tuple[str, str, str]] = set()
+    for raw_item in value:
+        if not isinstance(raw_item, dict):
+            raise ValueError("producer-vetted flaky-test registry provenance contains a non-object")
+        if set(raw_item) != {"source_run_id", "source_head_sha", "outcome"}:
+            raise ValueError(
+                "producer-vetted flaky-test registry provenance fields are not supported"
+            )
+
+        source_run_id = _string(raw_item.get("source_run_id"))
+        source_head_sha = _string(raw_item.get("source_head_sha"))
+        outcome = _string(raw_item.get("outcome"))
+        if not source_run_id or not source_head_sha:
+            raise ValueError("producer-vetted flaky-test registry provenance is incomplete")
+        if outcome not in ALLOWED_OUTCOMES:
+            raise ValueError(
+                "producer-vetted flaky-test registry provenance outcome is not supported"
+            )
+
+        provenance_tuple = (source_run_id, source_head_sha, outcome)
+        if provenance_tuple in seen:
+            raise ValueError(
+                "producer-vetted flaky-test registry contains duplicate provenance tuples"
+            )
+        seen.add(provenance_tuple)
+        normalized.append(
+            {
+                "source_run_id": source_run_id,
+                "source_head_sha": source_head_sha,
+                "outcome": outcome,
+            }
+        )
+
+    if not normalized:
+        raise ValueError(
+            "producer-vetted flaky-test registry entry requires observation provenance"
+        )
+    return normalized
+
+
+def _legacy_registry_entry(
+    raw_item: Mapping[str, Any],
+    *,
+    denied: Mapping[str, Any],
+) -> JsonObject:
+    _assert_registry_authority(
+        raw_item,
+        denied=denied,
+        source="flaky-test registry entry",
+        explicit=False,
+    )
+
+    test_id = _string(raw_item.get("test_id"))
+    fingerprint = _string(raw_item.get("fingerprint"))
+    runs = _int(raw_item.get("observed_runs"))
+    failures = _int(raw_item.get("observed_failures"))
+    passes = _int(raw_item.get("observed_passes"))
+
+    if _string(raw_item.get("classification")) != "flaky":
+        raise ValueError("flaky-test registry entry must classify a flaky test")
+    if not test_id or not fingerprint:
+        raise ValueError("flaky-test registry entry requires test_id and fingerprint")
+    if runs < 2 or failures < 1 or passes < 1:
+        raise ValueError("flaky-test registry entry lacks mixed pass/fail observations")
+    if _string(raw_item.get("decision")) != "instability_context_only":
+        raise ValueError("flaky-test registry entry decision is not supported")
+    if not _bool(raw_item.get("review_first")):
+        raise ValueError("flaky-test registry entry must remain review-first")
+
+    return {
+        "test_id": test_id,
+        "fingerprint": fingerprint,
+        "classification": "flaky",
+        "observed_runs": runs,
+        "observed_failures": failures,
+        "observed_passes": passes,
+        "decision": "instability_context_only",
+        "review_first": True,
+        **denied,
+    }
+
+
+def _trusted_registry_entry(
+    raw_item: Mapping[str, Any],
+    *,
+    denied: Mapping[str, Any],
+    seen_fingerprints: set[str],
+) -> JsonObject:
+    _assert_registry_authority(
+        raw_item,
+        denied=denied,
+        source="producer-vetted flaky-test registry entry",
+        explicit=True,
+    )
+
+    forbidden_identity_fields = {
+        "test_id",
+        "classname",
+        "name",
+        "nodeid",
+        "fingerprint",
+    }
+    present_forbidden = sorted(forbidden_identity_fields.intersection(raw_item))
+    if present_forbidden:
+        raise ValueError(
+            "raw test identity cannot enter producer-vetted RepoMemory registry: "
+            + ", ".join(present_forbidden)
+        )
+
+    fingerprint = _lower_hex(
+        raw_item.get("test_fingerprint"),
+        length=64,
+        source="producer-vetted test fingerprint",
+    )
+    if fingerprint in seen_fingerprints:
+        raise ValueError("producer-vetted flaky-test registry contains duplicate fingerprints")
+    seen_fingerprints.add(fingerprint)
+
+    if _string(raw_item.get("classification")) != "flaky":
+        raise ValueError("producer-vetted flaky-test registry entry must classify a flaky test")
+    if _string(raw_item.get("decision")) != "instability_context_only":
+        raise ValueError("producer-vetted flaky-test registry entry decision is not supported")
+    if raw_item.get("review_first") is not True:
+        raise ValueError("producer-vetted flaky-test registry entry must remain review-first")
+
+    provenance = _trusted_registry_provenance(raw_item.get("observation_provenance"))
+    outcomes = [_string(item.get("outcome")) for item in provenance]
+    expected = {
+        "observed_runs": len(provenance),
+        "decisive_observation_count": (
+            outcomes.count("passed") + outcomes.count("failed") + outcomes.count("error")
+        ),
+        "observed_passes": outcomes.count("passed"),
+        "observed_failures": outcomes.count("failed") + outcomes.count("error"),
+        "observed_errors": outcomes.count("error"),
+        "observed_skipped": outcomes.count("skipped"),
+    }
+    declared = {key: _int(raw_item.get(key)) for key in expected}
+    if declared != expected:
+        raise ValueError("producer-vetted flaky-test registry entry counts are inconsistent")
+    if expected["observed_passes"] < 1 or expected["observed_failures"] < 1:
+        raise ValueError(
+            "producer-vetted flaky-test registry entry lacks mixed pass/fail observations"
+        )
+
+    return {
+        "test_fingerprint": fingerprint,
+        "classification": "flaky",
+        **declared,
+        "observation_provenance": provenance,
+        "decision": "instability_context_only",
+        "review_first": True,
+        **denied,
+    }
+
+
+def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
     payload = _as_dict(evidence)
     if not payload:
+        denied = _registry_denied()
         return {
             "collection_status": "not_collected",
             "status": "not_collected",
@@ -578,92 +790,132 @@ def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
     source = _as_dict(payload.get("source"))
     source_kind = _string(source.get("kind"))
     source_reference = _string(source.get("reference"))
+    classification_schema = _string(source.get("classification_schema"))
     if source_kind not in {"operator_review_input", "trusted_main_artifact"}:
         raise ValueError("flaky-test registry evidence source kind is not supported")
     if not source_reference:
         raise ValueError("flaky-test registry evidence source reference is required")
-    if _string(source.get("classification_schema")) != "sdetkit.intelligence.flake.v1":
+
+    trusted_fingerprint = (
+        source_kind == "trusted_main_artifact"
+        and classification_schema == TRUSTED_TEST_OBSERVATION_CLASSIFICATION_SCHEMA
+    )
+    legacy_classification = classification_schema == LEGACY_FLAKY_CLASSIFICATION_SCHEMA
+    if not trusted_fingerprint and not legacy_classification:
         raise ValueError("flaky-test registry classification schema is not supported")
-    if not _bool(source.get("input_read_only")):
-        raise ValueError("flaky-test registry evidence input must be read-only")
-    if _bool(source.get("commands_executed_by_reader")):
-        raise ValueError("flaky-test registry evidence reader cannot execute commands")
+    if source_kind == "operator_review_input" and not legacy_classification:
+        raise ValueError("producer-vetted flaky-test registry requires trusted-main provenance")
 
-    observation_status = _string(source.get("observation_status"))
-    if source_kind == "trusted_main_artifact":
-        if _string(source.get("workflow")) != "RepoMemory Profile History":
-            raise ValueError("trusted-main flaky-test registry workflow is not supported")
-        if not _string(source.get("run_id")) or not _string(source.get("head_sha")):
-            raise ValueError("trusted-main flaky-test registry provenance is incomplete")
-        if observation_status != "no_test_observations_available":
-            raise ValueError("trusted-main flaky-test registry observation status is not supported")
-        if _bool(source.get("observations_collected")):
-            raise ValueError("trusted-main no-observation registry cannot claim observations")
-
-    boundary = _as_dict(payload.get("decision_boundary"))
-    expanded = [key for key in denied if _bool(boundary.get(key))]
-    if expanded:
-        raise ValueError("flaky-test registry evidence expands authority: " + ", ".join(expanded))
+    if trusted_fingerprint:
+        if source.get("input_read_only") is not True:
+            raise ValueError("flaky-test registry evidence input must be read-only")
+        if source.get("commands_executed_by_reader") is not False:
+            raise ValueError("flaky-test registry evidence reader cannot execute commands")
+    else:
+        if not _bool(source.get("input_read_only")):
+            raise ValueError("flaky-test registry evidence input must be read-only")
+        if _bool(source.get("commands_executed_by_reader")):
+            raise ValueError("flaky-test registry evidence reader cannot execute commands")
 
     raw_entries = payload.get("entries")
     if not isinstance(raw_entries, list):
         raise ValueError("flaky-test registry evidence must contain an entries array")
 
+    observation_status = _string(source.get("observation_status"))
+    if source_kind == "trusted_main_artifact":
+        if _string(source.get("workflow")) != "RepoMemory Profile History":
+            raise ValueError("trusted-main flaky-test registry workflow is not supported")
+        run_id = _string(source.get("run_id"))
+        head_sha = _string(source.get("head_sha"))
+        if not run_id or not head_sha:
+            raise ValueError("trusted-main flaky-test registry provenance is incomplete")
+
+        if trusted_fingerprint:
+            _lower_hex(
+                head_sha,
+                length=40,
+                source="producer-vetted registry source head SHA",
+            )
+            if _string(source.get("identity_kind")) != TRUSTED_FLAKY_IDENTITY_KIND:
+                raise ValueError(
+                    "producer-vetted flaky-test registry identity kind is not supported"
+                )
+            if source.get("producer_vetted") is not True:
+                raise ValueError("producer-vetted flaky-test registry must be producer-vetted")
+            if source.get("raw_test_identity_emitted") is not False:
+                raise ValueError(
+                    "producer-vetted flaky-test registry cannot emit raw test identity"
+                )
+            if observation_status not in {
+                NO_TEST_OBSERVATIONS,
+                PRODUCER_VETTED_OBSERVATIONS,
+            }:
+                raise ValueError(
+                    "producer-vetted flaky-test registry observation status is not supported"
+                )
+            observations_collected = source.get("observations_collected")
+            if observation_status == NO_TEST_OBSERVATIONS:
+                if raw_entries or observations_collected is not False:
+                    raise ValueError(
+                        "producer-vetted no-observation registry cannot contain entries"
+                    )
+            elif not raw_entries or observations_collected is not True:
+                raise ValueError("producer-vetted populated registry must claim observations")
+        else:
+            if observation_status != NO_TEST_OBSERVATIONS:
+                raise ValueError(
+                    "trusted-main flaky-test registry observation status is not supported"
+                )
+            if _bool(source.get("observations_collected")):
+                raise ValueError("trusted-main no-observation registry cannot claim observations")
+
+    denied = _registry_denied(trusted_fingerprint=trusted_fingerprint)
+    boundary = _as_dict(payload.get("decision_boundary"))
+    _assert_registry_authority(
+        boundary,
+        denied=denied,
+        source="flaky-test registry evidence",
+        explicit=trusted_fingerprint,
+    )
+
     entries: list[JsonObject] = []
+    seen_fingerprints: set[str] = set()
     for raw_item in raw_entries:
         if not isinstance(raw_item, dict):
             raise ValueError("flaky-test registry evidence contains a non-object entry")
-
-        item_expanded = [key for key in denied if _bool(raw_item.get(key))]
-        if item_expanded:
-            raise ValueError(
-                "flaky-test registry entry expands authority: " + ", ".join(item_expanded)
+        if trusted_fingerprint:
+            entries.append(
+                _trusted_registry_entry(
+                    raw_item,
+                    denied=denied,
+                    seen_fingerprints=seen_fingerprints,
+                )
+            )
+        else:
+            entries.append(
+                _legacy_registry_entry(
+                    raw_item,
+                    denied=denied,
+                )
             )
 
-        test_id = _string(raw_item.get("test_id"))
-        fingerprint = _string(raw_item.get("fingerprint"))
-        runs = _int(raw_item.get("observed_runs"))
-        failures = _int(raw_item.get("observed_failures"))
-        passes = _int(raw_item.get("observed_passes"))
+    if trusted_fingerprint:
+        entries.sort(key=lambda item: str(item["test_fingerprint"]))
+    else:
+        entries.sort(key=lambda item: (item["test_id"], item["fingerprint"]))
 
-        if _string(raw_item.get("classification")) != "flaky":
-            raise ValueError("flaky-test registry entry must classify a flaky test")
-        if not test_id or not fingerprint:
-            raise ValueError("flaky-test registry entry requires test_id and fingerprint")
-        if runs < 2 or failures < 1 or passes < 1:
-            raise ValueError("flaky-test registry entry lacks mixed pass/fail observations")
-        if _string(raw_item.get("decision")) != "instability_context_only":
-            raise ValueError("flaky-test registry entry decision is not supported")
-        if not _bool(raw_item.get("review_first")):
-            raise ValueError("flaky-test registry entry must remain review-first")
-
-        entries.append(
-            {
-                "test_id": test_id,
-                "fingerprint": fingerprint,
-                "classification": "flaky",
-                "observed_runs": runs,
-                "observed_failures": failures,
-                "observed_passes": passes,
-                "decision": "instability_context_only",
-                "review_first": True,
-                **denied,
-            }
-        )
-
-    entries.sort(key=lambda item: (item["test_id"], item["fingerprint"]))
     summary = _as_dict(payload.get("summary"))
     if _int(summary.get("entry_count")) != len(entries):
         raise ValueError("flaky-test registry evidence summary entry count is inconsistent")
     if _int(summary.get("flaky_test_count")) != len(entries):
         raise ValueError("flaky-test registry evidence summary flaky count is inconsistent")
-    if source_kind == "trusted_main_artifact" and entries:
+    if source_kind == "trusted_main_artifact" and not trusted_fingerprint and entries:
         raise ValueError("trusted-main no-observation registry cannot contain entries")
 
     normalized_source: JsonObject = {
         "kind": source_kind,
         "reference": source_reference,
-        "classification_schema": _string(source.get("classification_schema")),
+        "classification_schema": classification_schema,
         "input_read_only": True,
         "commands_executed_by_reader": False,
     }
@@ -674,7 +926,15 @@ def _flaky_test_registry(evidence: Mapping[str, Any]) -> JsonObject:
                 "run_id": _string(source.get("run_id")),
                 "head_sha": _string(source.get("head_sha")),
                 "observation_status": observation_status,
-                "observations_collected": False,
+                "observations_collected": bool(source.get("observations_collected")),
+            }
+        )
+    if trusted_fingerprint:
+        normalized_source.update(
+            {
+                "identity_kind": TRUSTED_FLAKY_IDENTITY_KIND,
+                "producer_vetted": True,
+                "raw_test_identity_emitted": False,
             }
         )
 
@@ -861,8 +1121,9 @@ def build_repo_memory_profile(
             ),
         },
         "recommended_next_action": (
-            "Establish trusted accepted-main observation history and classification "
-            "handoff before surfacing populated flaky-test history in PR Quality."
+            "Keep trusted accepted-main observation history advisory-only and wire "
+            "producer-vetted fingerprint registry population through the trusted-main "
+            "workflow before PR Quality visibility."
         ),
     }
 

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -113,17 +113,22 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert any("containment" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert any("network-isolation" in gap for gap in gaps_by_module["repo_memory"])
-    assert any(
+    assert not any(
         "producer-vetted fingerprint registry population" in gap
         for gap in gaps_by_module["repo_memory"]
     )
+    assert any("trusted-main workflow population" in gap for gap in gaps_by_module["repo_memory"])
     assert any("PR Quality visibility" in gap for gap in gaps_by_module["repo_memory"])
     assert not any(
         "classification adapter" in gap
         for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
     )
-    assert any(
+    assert not any(
         "RepoMemory population" in gap
+        for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
+    )
+    assert any(
+        "trusted-main workflow population" in gap
         for gap in gaps_by_module[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
     )
     assert any(
@@ -133,6 +138,21 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert not any("persistent profile" in gap for gap in gaps_by_module["repo_memory"])
     assert any("verified" in gap for gap in gaps_by_module["network_boundary"])
     assert any("external filesystem" in gap for gap in gaps_by_module["proof_runtime_guard"])
+
+
+def test_alignment_closes_repomemory_ingestion_before_workflow_wiring() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+    registry = components[FLAKY_TEST_REGISTRY_EVIDENCE_MODULE]
+    memory = components["repo_memory"]
+
+    assert "producer-vetted fingerprint classifications" in registry.role
+    assert "advisory fingerprint-only registry evidence" in memory.role
+    assert not any("RepoMemory population" in gap for gap in registry.gaps)
+    assert not any("producer-vetted fingerprint registry population" in gap for gap in memory.gaps)
+    assert any("trusted-main workflow population" in gap for gap in registry.gaps)
+    assert any("trusted-main workflow population" in gap for gap in memory.gaps)
+    assert any("PR Quality visibility" in gap for gap in registry.gaps)
+    assert any("PR Quality visibility" in gap for gap in memory.gaps)
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -347,27 +367,30 @@ def test_flaky_registry_alignment_starts_after_persisted_observation_history() -
     repo_memory = components["repo_memory"]
 
     assert (
-        capture.recommended_next_action == "preserve capture as raw input and route it only "
-        "through trusted observation history before any "
-        "flaky-test classification"
+        capture.recommended_next_action
+        == "preserve capture as raw input and route it only through trusted "
+        "observation history before any flaky-test classification"
     )
     assert "RepoMemory Profile History workflow" in history.integration_points
+
     classification = components[TRUSTED_TEST_OBSERVATION_CLASSIFICATION_MODULE]
     assert classification.status == "aligned"
     assert classification.gaps == ()
+
     assert (
         producer.recommended_next_action
         == "keep producer-vetted fingerprint registry evidence advisory-only "
-        "and defer workflow, RepoMemory population, and PR Quality integration"
+        "and defer trusted-main workflow population and PR Quality integration"
     )
     assert registry.gaps == (
-        "RepoMemory population and PR Quality visibility are not yet connected",
+        "trusted-main workflow population and PR Quality visibility are not yet connected",
     )
     assert TRUSTED_TEST_OBSERVATION_HISTORY_MODULE in repo_memory.integration_points
-    assert (
-        "producer-vetted fingerprint registry population and "
-        "PR Quality visibility remain unconnected" in repo_memory.gaps
+    assert not any(
+        "producer-vetted fingerprint registry population" in gap for gap in repo_memory.gaps
     )
+    assert any("trusted-main workflow population" in gap for gap in repo_memory.gaps)
+    assert any("PR Quality visibility" in gap for gap in repo_memory.gaps)
 
 
 def test_trusted_observation_classification_alignment_is_closed() -> None:
@@ -409,8 +432,16 @@ def test_trusted_producer_validation_handoff_alignment_is_closed() -> None:
     assert (
         producer.recommended_next_action
         == "keep producer-vetted fingerprint registry evidence advisory-only "
-        "and defer workflow, RepoMemory population, and PR Quality integration"
+        "and defer trusted-main workflow population and PR Quality integration"
     )
+
     assert not any("classification adapter" in gap for gap in registry.gaps)
-    assert any("RepoMemory population" in gap for gap in registry.gaps)
-    assert any("producer-vetted fingerprint registry population" in gap for gap in repo_memory.gaps)
+    assert not any("RepoMemory population" in gap for gap in registry.gaps)
+    assert any("trusted-main workflow population" in gap for gap in registry.gaps)
+    assert any("PR Quality visibility" in gap for gap in registry.gaps)
+
+    assert not any(
+        "producer-vetted fingerprint registry population" in gap for gap in repo_memory.gaps
+    )
+    assert any("trusted-main workflow population" in gap for gap in repo_memory.gaps)
+    assert any("PR Quality visibility" in gap for gap in repo_memory.gaps)

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -453,8 +453,13 @@ def test_repo_memory_cli_writes_profile_artifacts(tmp_path: Path, capsys) -> Non
     saved = json.loads((out_dir / "repo-memory-profile.json").read_text(encoding="utf-8"))
     markdown = (out_dir / "repo-memory-profile.md").read_text(encoding="utf-8")
 
-    assert printed["profile_status"] == "benchmark_supported_memory"
-    assert printed["known_safe_candidate_count"] == 1
+    assert printed == {
+        "artifacts": {
+            "repo_memory_profile_json": "repo-memory-profile.json",
+            "repo_memory_profile_markdown": "repo-memory-profile.md",
+        },
+        "status": "repo_memory_profile_written",
+    }
     assert saved["decision_boundary"]["automation_allowed"] is False
     assert "# RepoMemory profile" in markdown
 
@@ -552,8 +557,13 @@ def test_repo_memory_cli_accepts_live_benchmark_report(tmp_path: Path, capsys) -
     saved = json.loads((out_dir / "repo-memory-profile.json").read_text(encoding="utf-8"))
     markdown = (out_dir / "repo-memory-profile.md").read_text(encoding="utf-8")
 
-    assert printed["profile_status"] == LIVE_PROFILE_STATUS
-    assert printed["live_safe_candidate_count"] == 1
+    assert printed == {
+        "artifacts": {
+            "repo_memory_profile_json": "repo-memory-profile.json",
+            "repo_memory_profile_markdown": "repo-memory-profile.md",
+        },
+        "status": "repo_memory_profile_written",
+    }
     assert saved["proof_provenance"]["live_contract_proven"] is True
     assert "Live Git-grounded contract proven: `true`" in markdown
     assert "Live safe candidates: `1`" in markdown
@@ -1024,7 +1034,13 @@ def test_repo_memory_cli_accepts_controlled_validation_without_promotion(
     assert rc == 0
     printed = json.loads(capsys.readouterr().out)
     saved = json.loads((out_dir / "repo-memory-profile.json").read_text(encoding="utf-8"))
-    assert printed["controlled_candidate_validation_status"] == "controlled_validation_passed"
+    assert printed == {
+        "artifacts": {
+            "repo_memory_profile_json": "repo-memory-profile.json",
+            "repo_memory_profile_markdown": "repo-memory-profile.md",
+        },
+        "status": "repo_memory_profile_written",
+    }
     assert saved["controlled_candidate_validation"]["current_pr_decision_input"] is False
     assert (
         saved["controlled_candidate_validation"]["decision_boundary"]["automation_allowed"] is False
@@ -1448,9 +1464,80 @@ def test_repo_memory_cli_redacts_success_artifact_paths_in_json_output(
     assert sensitive_value not in captured.err
 
     payload = json.loads(captured.out)
-    assert payload["artifacts"] == {
-        "repo_memory_profile_json": "repo-memory-profile.json",
-        "repo_memory_profile_markdown": "repo-memory-profile.md",
+    assert payload == {
+        "artifacts": {
+            "repo_memory_profile_json": "repo-memory-profile.json",
+            "repo_memory_profile_markdown": "repo-memory-profile.md",
+        },
+        "status": "repo_memory_profile_written",
     }
     assert (out_dir / "repo-memory-profile.json").is_file()
     assert (out_dir / "repo-memory-profile.md").is_file()
+
+
+def test_repo_memory_cli_redacts_profile_derived_values_from_json_stdout(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    sensitive_value = "repo-memory-sensitive-profile-derived-value"
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    out_dir = tmp_path / "repo-memory"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+
+    def build_sensitive_profile(**_: object) -> dict[str, object]:
+        return {
+            "profile_status": sensitive_value,
+            "known_safe_candidate_count": sensitive_value,
+            "live_safe_candidate_count": sensitive_value,
+            "controlled_candidate_validation": {"status": sensitive_value},
+            "safety_gate_evidence": {"record_count": sensitive_value},
+        }
+
+    def write_sensitive_profile(
+        profile: dict[str, object],
+        *,
+        out_dir: Path,
+    ) -> dict[str, Path]:
+        assert sensitive_value in repr(profile)
+        return {
+            "repo_memory_profile_json": out_dir / "repo-memory-profile.json",
+            "repo_memory_profile_markdown": out_dir / "repo-memory-profile.md",
+        }
+
+    monkeypatch.setattr(
+        "sdetkit.repo_memory.build_repo_memory_profile",
+        build_sensitive_profile,
+    )
+    monkeypatch.setattr(
+        "sdetkit.repo_memory.write_profile",
+        write_sensitive_profile,
+    )
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert sensitive_value not in captured.out
+    assert sensitive_value not in captured.err
+    assert json.loads(captured.out) == {
+        "artifacts": {
+            "repo_memory_profile_json": "repo-memory-profile.json",
+            "repo_memory_profile_markdown": "repo-memory-profile.md",
+        },
+        "status": "repo_memory_profile_written",
+    }

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -19,13 +19,24 @@ from sdetkit.replayable_benchmark_harness import (
 from sdetkit.repo_memory import (
     LIVE_PROFILE_STATUS,
     LIVE_PROOF_STATE,
+    _flaky_test_registry,
     build_repo_memory_profile,
     main,
     render_markdown,
 )
 from sdetkit.trusted_flaky_test_registry_producer import (
     NO_TEST_OBSERVATIONS,
+    PRODUCER_VETTED_OBSERVATIONS,
     build_trusted_registry_evidence,
+)
+from sdetkit.trusted_test_observation_classification import (
+    SCHEMA_VERSION as TRUSTED_CLASSIFICATION_SCHEMA,
+)
+from sdetkit.trusted_test_observation_classification import (
+    build_trusted_observation_classification,
+)
+from sdetkit.trusted_test_observation_history import (
+    build_observation_history_record,
 )
 
 FIXTURES = Path("tests/fixtures/remediation_benchmark")
@@ -200,6 +211,100 @@ def _flaky_registry_evidence() -> dict:
             "semantic_equivalence_proven": False,
         },
     }
+
+
+TRUSTED_FINGERPRINT = "f" * 64
+TRUSTED_SECOND_FINGERPRINT = "e" * 64
+TRUSTED_PRIOR_HEAD = "a" * 40
+TRUSTED_CURRENT_HEAD = "b" * 40
+
+
+def _trusted_observation_report(
+    *,
+    run_id: str,
+    head_sha: str,
+    outcome: str,
+    fingerprints: tuple[str, ...] = (TRUSTED_FINGERPRINT,),
+) -> dict:
+    return {
+        "schema_version": "sdetkit.trusted_test_observation_capture.v1",
+        "status": "trusted_main_observations_captured",
+        "source": {
+            "workflow": "CI",
+            "job": "Full CI lane",
+            "run_id": run_id,
+            "head_sha": head_sha,
+            "event_name": "push",
+            "ref_name": "refs/heads/main",
+            "trusted_main": True,
+            "input_read_only": True,
+            "commands_executed_by_reader": False,
+        },
+        "summary": {
+            "observation_count": len(fingerprints),
+            "passed": len(fingerprints) if outcome == "passed" else 0,
+            "failed": len(fingerprints) if outcome == "failed" else 0,
+            "error": len(fingerprints) if outcome == "error" else 0,
+            "skipped": len(fingerprints) if outcome == "skipped" else 0,
+            "raw_test_identity_emitted": False,
+            "flaky_classification_performed": False,
+        },
+        "observations": [
+            {
+                "test_fingerprint": fingerprint,
+                "outcome": outcome,
+            }
+            for fingerprint in fingerprints
+        ],
+        "decision_boundary": {
+            "raw_observation_only": True,
+            "flaky_classification_performed": False,
+            "current_pr_decision_input": False,
+            "automatic_quarantine_allowed": False,
+            "automatic_rerun_allowed": False,
+            "current_failure_suppression_allowed": False,
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def _producer_vetted_registry_evidence(
+    *,
+    fingerprints: tuple[str, ...] = (TRUSTED_FINGERPRINT,),
+) -> dict:
+    records = [
+        build_observation_history_record(
+            _trusted_observation_report(
+                run_id="full-ci-prior",
+                head_sha=TRUSTED_PRIOR_HEAD,
+                outcome="passed",
+                fingerprints=fingerprints,
+            ),
+            source_run_id="full-ci-prior",
+            source_head_sha=TRUSTED_PRIOR_HEAD,
+            recorded_at_utc="2026-06-16T00:00:00Z",
+        ),
+        build_observation_history_record(
+            _trusted_observation_report(
+                run_id="full-ci-current",
+                head_sha=TRUSTED_CURRENT_HEAD,
+                outcome="failed",
+                fingerprints=fingerprints,
+            ),
+            source_run_id="full-ci-current",
+            source_head_sha=TRUSTED_CURRENT_HEAD,
+            recorded_at_utc="2026-06-17T00:00:00Z",
+        ),
+    ]
+    classification = build_trusted_observation_classification(records)
+    return build_trusted_registry_evidence(
+        source_run_id="repo-memory-current",
+        source_head_sha=TRUSTED_CURRENT_HEAD,
+        classification_report=classification,
+    )
 
 
 def _pattern_insights() -> dict:
@@ -476,6 +581,195 @@ def test_repo_memory_ingests_flaky_test_registry_as_advisory_context_only() -> N
     assert boundary["automation_allowed"] is False
     assert boundary["merge_authorized"] is False
     assert boundary["semantic_equivalence_proven"] is False
+
+
+def test_repo_memory_ingests_producer_vetted_fingerprint_registry_without_identity() -> None:
+    profile = build_repo_memory_profile(
+        pattern_insights=_pattern_insights(),
+        benchmark_report=_benchmark_report(),
+        flaky_test_registry_evidence=_producer_vetted_registry_evidence(),
+    )
+
+    flaky = profile["flaky_test_registry"]
+    source = flaky["source"]
+    entry = flaky["entries"][0]
+
+    assert flaky["collection_status"] == "collected"
+    assert flaky["status"] == "advisory_registry_collected"
+    assert flaky["entry_count"] == 1
+    assert source["classification_schema"] == TRUSTED_CLASSIFICATION_SCHEMA
+    assert source["identity_kind"] == "fingerprint_only"
+    assert source["producer_vetted"] is True
+    assert source["raw_test_identity_emitted"] is False
+    assert source["observation_status"] == PRODUCER_VETTED_OBSERVATIONS
+    assert source["observations_collected"] is True
+    assert entry["test_fingerprint"] == TRUSTED_FINGERPRINT
+    assert entry["observed_runs"] == 2
+    assert entry["decisive_observation_count"] == 2
+    assert entry["observed_passes"] == 1
+    assert entry["observed_failures"] == 1
+    assert entry["observed_errors"] == 0
+    assert entry["observed_skipped"] == 0
+    assert entry["review_first"] is True
+    assert entry["patch_application_allowed"] is False
+    assert flaky["decision_boundary"]["current_pr_decision_input"] is False
+    assert flaky["decision_boundary"]["patch_application_allowed"] is False
+
+    serialized = json.dumps(flaky, sort_keys=True)
+    assert '"test_id"' not in serialized
+    assert '"classname"' not in serialized
+    assert '"nodeid"' not in serialized
+
+
+def test_repo_memory_cli_accepts_producer_vetted_fingerprint_registry(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    flaky_path = tmp_path / "producer-vetted-flaky-registry.json"
+    out_dir = tmp_path / "repo-memory-with-producer-vetted-flaky-context"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+    flaky_path.write_text(
+        json.dumps(_producer_vetted_registry_evidence()),
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--flaky-test-registry-evidence",
+            str(flaky_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    capsys.readouterr()
+    saved = json.loads((out_dir / "repo-memory-profile.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "repo-memory-profile.md").read_text(encoding="utf-8")
+
+    flaky = saved["flaky_test_registry"]
+    assert flaky["entry_count"] == 1
+    assert flaky["entries"][0]["test_fingerprint"] == TRUSTED_FINGERPRINT
+    assert flaky["decision_boundary"]["automation_allowed"] is False
+    assert "Observation status: `producer_vetted_flaky_observations_available`" in markdown
+
+
+def test_repo_memory_sorts_producer_vetted_fingerprints_deterministically() -> None:
+    evidence = _producer_vetted_registry_evidence(
+        fingerprints=(TRUSTED_FINGERPRINT, TRUSTED_SECOND_FINGERPRINT)
+    )
+    evidence["entries"].reverse()
+
+    first = _flaky_test_registry(copy.deepcopy(evidence))
+    second = _flaky_test_registry(copy.deepcopy(evidence))
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert [item["test_fingerprint"] for item in first["entries"]] == sorted(
+        (TRUSTED_FINGERPRINT, TRUSTED_SECOND_FINGERPRINT)
+    )
+
+
+def test_repo_memory_rejects_duplicate_producer_vetted_fingerprints() -> None:
+    evidence = _producer_vetted_registry_evidence()
+    evidence["entries"].append(copy.deepcopy(evidence["entries"][0]))
+    evidence["summary"]["entry_count"] = 2
+    evidence["summary"]["flaky_test_count"] = 2
+
+    try:
+        _flaky_test_registry(evidence)
+    except ValueError as exc:
+        assert "duplicate fingerprints" in str(exc)
+    else:
+        raise AssertionError("expected duplicate trusted fingerprints to be rejected")
+
+
+def test_repo_memory_rejects_duplicate_producer_vetted_provenance() -> None:
+    evidence = _producer_vetted_registry_evidence()
+    entry = evidence["entries"][0]
+    entry["observation_provenance"].append(copy.deepcopy(entry["observation_provenance"][0]))
+
+    try:
+        _flaky_test_registry(evidence)
+    except ValueError as exc:
+        assert "duplicate provenance tuples" in str(exc)
+    else:
+        raise AssertionError("expected duplicate trusted provenance to be rejected")
+
+
+def test_repo_memory_rejects_producer_vetted_count_mismatch_and_raw_identity() -> None:
+    mismatched = _producer_vetted_registry_evidence()
+    mismatched["entries"][0]["observed_runs"] = 3
+
+    try:
+        _flaky_test_registry(mismatched)
+    except ValueError as exc:
+        assert "counts are inconsistent" in str(exc)
+    else:
+        raise AssertionError("expected trusted count mismatch to be rejected")
+
+    raw_identity = _producer_vetted_registry_evidence()
+    raw_identity["entries"][0]["test_id"] = "tests/test_service.py::test_retry_path"
+
+    try:
+        _flaky_test_registry(raw_identity)
+    except ValueError as exc:
+        assert "raw test identity" in str(exc)
+    else:
+        raise AssertionError("expected raw identity in trusted registry to be rejected")
+
+
+def test_repo_memory_rejects_invalid_producer_vetted_source_contract() -> None:
+    bad_head = _producer_vetted_registry_evidence()
+    bad_head["source"]["head_sha"] = "abc123"
+
+    try:
+        _flaky_test_registry(bad_head)
+    except ValueError as exc:
+        assert "40-character lower-case hexadecimal" in str(exc)
+    else:
+        raise AssertionError("expected invalid trusted source head to be rejected")
+
+    unvetted = _producer_vetted_registry_evidence()
+    unvetted["source"]["producer_vetted"] = False
+
+    try:
+        _flaky_test_registry(unvetted)
+    except ValueError as exc:
+        assert "must be producer-vetted" in str(exc)
+    else:
+        raise AssertionError("expected unvetted trusted registry to be rejected")
+
+    false_collection = _producer_vetted_registry_evidence()
+    false_collection["source"]["observations_collected"] = False
+
+    try:
+        _flaky_test_registry(false_collection)
+    except ValueError as exc:
+        assert "must claim observations" in str(exc)
+    else:
+        raise AssertionError("expected populated registry without collection claim to fail")
+
+
+def test_repo_memory_rejects_producer_vetted_authority_expansion() -> None:
+    evidence = _producer_vetted_registry_evidence()
+    evidence["entries"][0]["patch_application_allowed"] = True
+
+    try:
+        _flaky_test_registry(evidence)
+    except ValueError as exc:
+        assert "entry expands authority" in str(exc)
+    else:
+        raise AssertionError("expected trusted authority expansion to be rejected")
 
 
 def test_repo_memory_rejects_authority_expanding_flaky_test_registry() -> None:

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -1380,3 +1380,77 @@ def test_repo_memory_cli_redacts_input_io_failure_path(
     assert captured.out == "error=input_io_failure\n"
     assert sensitive_value not in captured.out
     assert sensitive_value not in captured.err
+
+
+def test_repo_memory_cli_redacts_success_artifact_paths_in_text_output(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    sensitive_value = "repo-memory-sensitive-success-path"
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    out_dir = tmp_path / sensitive_value / "repo-memory"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == (
+        "repo_memory_profile_json: repo-memory-profile.json\n"
+        "repo_memory_profile_markdown: repo-memory-profile.md\n"
+    )
+    assert sensitive_value not in captured.out
+    assert sensitive_value not in captured.err
+    assert (out_dir / "repo-memory-profile.json").is_file()
+    assert (out_dir / "repo-memory-profile.md").is_file()
+
+
+def test_repo_memory_cli_redacts_success_artifact_paths_in_json_output(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    sensitive_value = "repo-memory-sensitive-success-json-path"
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    out_dir = tmp_path / sensitive_value / "repo-memory"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert sensitive_value not in captured.out
+    assert sensitive_value not in captured.err
+
+    payload = json.loads(captured.out)
+    assert payload["artifacts"] == {
+        "repo_memory_profile_json": "repo-memory-profile.json",
+        "repo_memory_profile_markdown": "repo-memory-profile.md",
+    }
+    assert (out_dir / "repo-memory-profile.json").is_file()
+    assert (out_dir / "repo-memory-profile.md").is_file()

--- a/tests/test_repo_memory.py
+++ b/tests/test_repo_memory.py
@@ -1279,3 +1279,104 @@ def test_repo_memory_rejects_authority_expanding_failure_vector_contract_evidenc
         assert "FailureVector contract evidence expands authority: automation_allowed" in str(exc)
     else:
         raise AssertionError("expected authority-expanding FailureVector evidence to fail")
+
+
+def test_repo_memory_cli_redacts_validation_exception_details(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    out_dir = tmp_path / "repo-memory"
+    sensitive_value = "repo-memory-sensitive-validation-value"
+
+    insights_path.write_text(json.dumps(_pattern_insights()), encoding="utf-8")
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+
+    def raise_sensitive_validation_error(**_: object) -> dict:
+        raise ValueError(f"rejected secret={sensitive_value}")
+
+    monkeypatch.setattr(
+        "sdetkit.repo_memory.build_repo_memory_profile",
+        raise_sensitive_validation_error,
+    )
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert captured.out == "error=input_validation_failed\n"
+    assert sensitive_value not in captured.out
+    assert sensitive_value not in captured.err
+
+
+def test_repo_memory_cli_redacts_invalid_json_contents(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    sensitive_value = "repo-memory-sensitive-json-value"
+    insights_path = tmp_path / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    out_dir = tmp_path / "repo-memory"
+
+    insights_path.write_text(
+        '{"secret": "' + sensitive_value + '", "broken": ',
+        encoding="utf-8",
+    )
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(insights_path),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert captured.out == "error=invalid_json\n"
+    assert sensitive_value not in captured.out
+    assert sensitive_value not in captured.err
+
+
+def test_repo_memory_cli_redacts_input_io_failure_path(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    sensitive_value = "repo-memory-sensitive-path-value"
+    missing_insights = tmp_path / sensitive_value / "pattern-insights.json"
+    benchmark_path = tmp_path / "benchmark-report.json"
+    out_dir = tmp_path / "repo-memory"
+
+    benchmark_path.write_text(json.dumps(_benchmark_report()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--pattern-insights",
+            str(missing_insights),
+            "--benchmark-report",
+            str(benchmark_path),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert captured.out == "error=input_io_failure\n"
+    assert sensitive_value not in captured.out
+    assert sensitive_value not in captured.err


### PR DESCRIPTION
## Summary
- accept validated producer-vetted fingerprint-only flaky-test registry evidence in RepoMemory
- validate trusted source provenance, deterministic fingerprints, observation counts, duplicate records, and denied authority
- preserve the legacy operator-review registry and trusted no-observation registry paths
- update reliability-spine alignment so RepoMemory ingestion is closed while trusted-main workflow population and PR Quality visibility remain deferred
- make RepoMemory CLI error and success output non-reflective for all user-controlled and profile-derived values

## Why
RepoMemory previously accepted only the legacy `sdetkit.intelligence.flake.v1` shape, which requires raw `test_id` and `fingerprint` fields. The trusted producer emits a validated fingerprint-only registry artifact, but RepoMemory rejected its classification schema. This PR connects that additive advisory evidence path without recovering raw test identity or authorizing quarantine, reruns, failure suppression, patching, or merge.

CodeQL identified three clear-text output flows across alerts #1405 and #1406:

1. caught exception details were reflected in CLI error output;
2. user-controlled `--out-dir` values were reflected through successful artifact paths;
3. profile-derived values were reflected through the successful JSON payload.

The final contract uses fixed error codes and a fully static success payload. Dynamic RepoMemory details remain available only inside the generated JSON and Markdown artifacts.

## Final CLI success payload
```json
{
  "artifacts": {
    "repo_memory_profile_json": "repo-memory-profile.json",
    "repo_memory_profile_markdown": "repo-memory-profile.md"
  },
  "status": "repo_memory_profile_written"
}
```

## Verification
- focused RepoMemory/registry/alignment proof — 81 passed
- CodeQL redaction proof — 6 passed
- `python -m sdetkit security check --root . --format json` — zero new findings, warnings, or errors
- `python -m pre_commit run -a` — passed
- `bash quality.sh cov` — 4,384 passed, 1 skipped, 3 deselected; 96.69% coverage
- `python -m build` and `python -m twine check` — passed for wheel and sdist
- `make proof-after-format` — passed
- exact changed-file scope and authority-boundary static review — passed

## Security remediation
- dynamic exception details removed
- fixed CLI error codes: `invalid_json`, `input_io_failure`, `input_validation_failed`
- configured output-directory paths removed from successful output
- profile-derived status and count values removed from stdout
- fixed artifact filenames retained
- six redaction regression tests cover error paths, artifact-path success paths, and profile-derived success values
- no alert dismissal was performed
- final CodeQL clearance remains subject to fresh analysis of the newest PR head

## Compatibility
- persisted `repo-memory-profile.json` and `repo-memory-profile.md` retain the dynamic profile data
- stdout is intentionally narrowed to a static write acknowledgement
- legacy operator-review ingestion remains preserved
- trusted no-observation ingestion remains preserved

## Risk
- High: this extends the RepoMemory CLI/artifact ingestion surface and changes successful stdout
- Security posture: fail-closed, non-reflective console output
- Rollback: revert the security follow-up commit, or revert the full PR

## Notes
- no workflow files changed
- no observation history, classification, producer, or registry-builder code changed
- trusted-main workflow population remains a separate future slice
- PR Quality visibility remains a separate future slice
- all automation, patch-application, quarantine, rerun, current-failure suppression, semantic-equivalence, and merge authority remain denied
- Refs #1500

## PR card
```text
change_type=feature_with_security_followups
platform_layer=memory
public_surface=CLI/artifact
compatibility=stdout_narrowed_artifacts_preserved
risk=high
scope_small=true
proof_fresh=true
rollback=easy
split_needed=no
verdict=review_after_fresh_ci
automation_allowed=false
patch_application_allowed=false
security_dismissal_allowed=false
merge_authorized=false
```
