### PR TITLE
fix(reporting): detect stale workflow governance snapshots

### DIFF
--- a/build/sdetkit/workflow-governance-report.json
+++ b/build/sdetkit/workflow-governance-report.json
@@ -21,6 +21,24 @@
   "finding_counts": {
     "permissions_least_privilege": 16
   },
+  "freshness": {
+    "automation_allowed": false,
+    "input_digest_matches": true,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "repo_mutation": false,
+    "reporting_only": true,
+    "semantic_equivalence_proven": false,
+    "status": "fresh"
+  },
+  "input_provenance": {
+    "digest_algorithm": "sha256",
+    "generator_schema_version": "sdetkit.workflow_governance_report.v2",
+    "generator_source": "src/sdetkit/workflow_governance_report.py",
+    "input_count": 57,
+    "input_digest": "ae9832af9e09ae9912e6ac0686f23cf5f44855e04a451526eebdb8101bb03548",
+    "workflow_file_count": 55
+  },
   "merge_authorized": false,
   "operator_summary": {
     "next_action": "Review ranked workflow governance followups before making narrow CI hardening PRs.",
@@ -32,6 +50,493 @@
   },
   "patch_application_allowed": false,
   "permission_review_count": 16,
+  "permission_review_evidence_packet": {
+    "automatic_permission_reduction_allowed": false,
+    "blocked_actions": [
+      "automatic_permission_reduction",
+      "broad_workflow_permission_sweep"
+    ],
+    "groups": [
+      {
+        "granted_write_scopes": [
+          "contents: write",
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "kind": "repository_mutation",
+        "requires_human_review": true,
+        "safe_to_patch": false,
+        "workflow_count": 5,
+        "workflows": [
+          ".github/workflows/dependency-auto-merge.yml",
+          ".github/workflows/maintenance-issue-command-center.yml",
+          ".github/workflows/maintenance-on-demand.yml",
+          ".github/workflows/pre-commit-autoupdate.yml",
+          ".github/workflows/weekly-maintenance.yml"
+        ]
+      },
+      {
+        "granted_write_scopes": [
+          "issues: write",
+          "security-events: write"
+        ],
+        "kind": "security_upload",
+        "requires_human_review": true,
+        "safe_to_patch": false,
+        "workflow_count": 5,
+        "workflows": [
+          ".github/workflows/osv-scanner.yml",
+          ".github/workflows/premium-gate.yml",
+          ".github/workflows/repo-audit.yml",
+          ".github/workflows/security-maintenance-bot.yml",
+          ".github/workflows/security.yml"
+        ]
+      },
+      {
+        "granted_write_scopes": [
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "kind": "pr_issue_interaction",
+        "requires_human_review": true,
+        "safe_to_patch": false,
+        "workflow_count": 4,
+        "workflows": [
+          ".github/workflows/contributor-onboarding-bot.yml",
+          ".github/workflows/maintenance-autopilot.yml",
+          ".github/workflows/pr-helper-bot.yml",
+          ".github/workflows/pr-quality-comment.yml"
+        ]
+      },
+      {
+        "granted_write_scopes": [
+          "id-token: write",
+          "pages: write"
+        ],
+        "kind": "deployment_or_oidc",
+        "requires_human_review": true,
+        "safe_to_patch": false,
+        "workflow_count": 1,
+        "workflows": [
+          ".github/workflows/pages.yml"
+        ]
+      },
+      {
+        "granted_write_scopes": [
+          "attestations: write",
+          "contents: write",
+          "id-token: write"
+        ],
+        "kind": "release_or_provenance",
+        "requires_human_review": true,
+        "safe_to_patch": false,
+        "workflow_count": 1,
+        "workflows": [
+          ".github/workflows/release.yml"
+        ]
+      }
+    ],
+    "next_allowed_action": "collect_human_review_evidence",
+    "permission_review_count": 16,
+    "required_human_evidence": [
+      "workflow intent",
+      "current granted write scopes",
+      "inferred permission reasons from the report",
+      "smallest reviewed permission-only change",
+      "exact proof command",
+      "reviewer decision"
+    ],
+    "review_first": true,
+    "review_tasks": [
+      {
+        "granted_write_scopes": [
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub API or gh-based PR/issue interaction detected.",
+          "Issue create/update API usage detected.",
+          "PR or issue comment/review API usage detected."
+        ],
+        "permission_group": "pr_issue_interaction",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/contributor-onboarding-bot.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "contents: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "Repository write/release/PR branch mutation surface detected."
+        ],
+        "permission_group": "repository_mutation",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/dependency-auto-merge.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub API or gh-based PR/issue interaction detected.",
+          "Issue create/update API usage detected."
+        ],
+        "permission_group": "pr_issue_interaction",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/maintenance-autopilot.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "contents: write",
+          "issues: write"
+        ],
+        "inferred_permission_reasons": [
+          "Repository write/release/PR branch mutation surface detected."
+        ],
+        "permission_group": "repository_mutation",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/maintenance-issue-command-center.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "contents: write",
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub API or gh-based PR/issue interaction detected.",
+          "Issue create/update API usage detected.",
+          "PR or issue comment/review API usage detected.",
+          "Repository write/release/PR branch mutation surface detected."
+        ],
+        "permission_group": "repository_mutation",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/maintenance-on-demand.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "security-events: write"
+        ],
+        "inferred_permission_reasons": [
+          "SARIF/code-scanning upload surface detected."
+        ],
+        "permission_group": "security_upload",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/osv-scanner.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "id-token: write",
+          "pages: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub Pages deployment surface detected.",
+          "OIDC token permission detected; requires environment/provider review."
+        ],
+        "permission_group": "deployment_or_oidc",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/pages.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub API or gh-based PR/issue interaction detected.",
+          "Issue create/update API usage detected.",
+          "PR or issue comment/review API usage detected."
+        ],
+        "permission_group": "pr_issue_interaction",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/pr-helper-bot.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub API or gh-based PR/issue interaction detected.",
+          "PR or issue comment/review API usage detected."
+        ],
+        "permission_group": "pr_issue_interaction",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/pr-quality-comment.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "contents: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "Repository write/release/PR branch mutation surface detected."
+        ],
+        "permission_group": "repository_mutation",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/pre-commit-autoupdate.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "security-events: write"
+        ],
+        "inferred_permission_reasons": [
+          "SARIF/code-scanning upload surface detected."
+        ],
+        "permission_group": "security_upload",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/premium-gate.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "attestations: write",
+          "contents: write",
+          "id-token: write"
+        ],
+        "inferred_permission_reasons": [
+          "OIDC token permission detected; requires environment/provider review.",
+          "Release attestation/provenance surface detected.",
+          "Repository write/release/PR branch mutation surface detected."
+        ],
+        "permission_group": "release_or_provenance",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/release.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "security-events: write"
+        ],
+        "inferred_permission_reasons": [
+          "SARIF/code-scanning upload surface detected."
+        ],
+        "permission_group": "security_upload",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/repo-audit.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "issues: write",
+          "security-events: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub API or gh-based PR/issue interaction detected.",
+          "Issue create/update API usage detected.",
+          "SARIF/code-scanning upload surface detected."
+        ],
+        "permission_group": "security_upload",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/security-maintenance-bot.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "security-events: write"
+        ],
+        "inferred_permission_reasons": [
+          "SARIF/code-scanning upload surface detected."
+        ],
+        "permission_group": "security_upload",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/security.yml"
+      },
+      {
+        "granted_write_scopes": [
+          "contents: write",
+          "issues: write",
+          "pull-requests: write"
+        ],
+        "inferred_permission_reasons": [
+          "GitHub API or gh-based PR/issue interaction detected.",
+          "Issue create/update API usage detected.",
+          "PR or issue comment/review API usage detected.",
+          "Repository write/release/PR branch mutation surface detected."
+        ],
+        "permission_group": "repository_mutation",
+        "recommended_change_type": "workflow_permission_review_evidence",
+        "required_evidence": [
+          "workflow intent",
+          "current granted write scopes",
+          "inferred permission reasons from the report",
+          "smallest reviewed permission-only change",
+          "exact proof command",
+          "reviewer decision"
+        ],
+        "requires_human_review": true,
+        "reviewer_decision_required": true,
+        "safe_to_patch": false,
+        "workflow": ".github/workflows/weekly-maintenance.yml"
+      }
+    ],
+    "safe_to_patch": false,
+    "schema_version": "sdetkit.workflow_permission_review_evidence.v1",
+    "status": "human_review_required"
+  },
   "permission_review_matrix": [
     {
       "granted_write_scope_count": 2,
@@ -169,7 +674,10 @@
         "pull-requests: write"
       ],
       "has_permission_finding": true,
-      "inferred_permission_reasons": [],
+      "inferred_permission_reasons": [
+        "GitHub API or gh-based PR/issue interaction detected.",
+        "PR or issue comment/review API usage detected."
+      ],
       "path": ".github/workflows/pr-quality-comment.yml",
       "recommended_change_type": "permission_reason_review",
       "requires_human_review": true,
@@ -424,7 +932,7 @@
     "workflow_mutation": false
   },
   "safe_to_patch": false,
-  "schema_version": "sdetkit.workflow_governance_report.v1",
+  "schema_version": "sdetkit.workflow_governance_report.v2",
   "semantic_equivalence_proven": false,
   "workflow_count": 55,
   "workflows": [
@@ -434,7 +942,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -483,7 +991,7 @@
           "action": "actions/checkout",
           "line": 26,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -526,7 +1034,7 @@
           "action": "actions/checkout",
           "line": 18,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -569,7 +1077,7 @@
           "action": "actions/checkout",
           "line": 27,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -612,7 +1120,7 @@
           "action": "actions/checkout",
           "line": 33,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -657,13 +1165,13 @@
           "action": "actions/checkout",
           "line": 28,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/checkout",
           "line": 34,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -681,7 +1189,7 @@
           "action": "actions/checkout",
           "line": 69,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -699,7 +1207,7 @@
           "action": "actions/checkout",
           "line": 158,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -717,7 +1225,7 @@
           "action": "actions/checkout",
           "line": 186,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -735,7 +1243,7 @@
           "action": "actions/checkout",
           "line": 240,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -753,7 +1261,7 @@
           "action": "actions/checkout",
           "line": 274,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -837,7 +1345,7 @@
           "action": "actions/checkout",
           "line": 21,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -867,7 +1375,7 @@
       "mkdocs_build_used": false,
       "path": ".github/workflows/dependency-audit.yml",
       "pip_install_lines": [
-        "python -m pip install -c constraints-ci.txt pip-audit==2.10.0",
+        "python -m pip install -c constraints-ci.txt pip-audit==2.10.1",
         "python -m pip install -c constraints-ci.txt -e ."
       ],
       "review_first": true,
@@ -918,7 +1426,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -967,7 +1475,7 @@
           "action": "actions/checkout",
           "line": 17,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/dependency-review-action",
@@ -1002,7 +1510,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/upload-artifact",
@@ -1043,7 +1551,7 @@
           "action": "actions/checkout",
           "line": 32,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "lycheeverse/lychee-action",
@@ -1078,7 +1586,7 @@
           "action": "actions/checkout",
           "line": 23,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1115,13 +1623,13 @@
           "action": "actions/checkout",
           "line": 18,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/checkout",
           "line": 24,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1165,7 +1673,7 @@
           "action": "actions/checkout",
           "line": 25,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1215,7 +1723,7 @@
           "action": "actions/checkout",
           "line": 31,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1317,7 +1825,7 @@
           "action": "actions/checkout",
           "line": 20,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/github-script",
@@ -1364,7 +1872,7 @@
           "action": "actions/checkout",
           "line": 21,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/github-script",
@@ -1440,7 +1948,7 @@
           "action": "actions/checkout",
           "line": 18,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1484,7 +1992,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1533,7 +2041,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1611,7 +2119,7 @@
           "action": "actions/checkout",
           "line": 22,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1662,7 +2170,7 @@
           "action": "actions/checkout",
           "line": 24,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1701,7 +2209,7 @@
           "action": "actions/checkout",
           "line": 42,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1758,7 +2266,7 @@
           "action": "actions/checkout",
           "line": 31,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1802,7 +2310,7 @@
           "action": "actions/checkout",
           "line": 30,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1876,7 +2384,7 @@
           "action": "actions/checkout",
           "line": 24,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1933,7 +2441,7 @@
           "action": "actions/checkout",
           "line": 25,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -1983,7 +2491,7 @@
           "action": "actions/checkout",
           "line": 42,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2031,7 +2539,7 @@
           "action": "actions/checkout",
           "line": 26,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2041,19 +2549,19 @@
         },
         {
           "action": "actions/upload-artifact",
-          "line": 967,
+          "line": 1057,
           "pinned_to_full_sha": true,
           "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         },
         {
           "action": "actions/upload-artifact",
-          "line": 976,
+          "line": 1066,
           "pinned_to_full_sha": true,
           "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         },
         {
           "action": "actions/upload-artifact",
-          "line": 987,
+          "line": 1077,
           "pinned_to_full_sha": true,
           "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         }
@@ -2088,7 +2596,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2133,7 +2641,7 @@
           "action": "actions/checkout",
           "line": 20,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2185,7 +2693,7 @@
           "action": "actions/checkout",
           "line": 22,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2222,7 +2730,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2271,7 +2779,7 @@
           "action": "actions/checkout",
           "line": 30,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2329,7 +2837,7 @@
           "action": "actions/checkout",
           "line": 24,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         }
       ],
       "checklist": {
@@ -2360,7 +2868,7 @@
           "action": "actions/checkout",
           "line": 28,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2370,7 +2878,7 @@
         },
         {
           "action": "actions/upload-artifact",
-          "line": 814,
+          "line": 1237,
           "pinned_to_full_sha": true,
           "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         }
@@ -2403,7 +2911,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2453,7 +2961,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2502,7 +3010,7 @@
           "action": "actions/checkout",
           "line": 18,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2575,7 +3083,7 @@
           "action": "actions/checkout",
           "line": 20,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/github-script",
@@ -2610,7 +3118,7 @@
           "action": "actions/checkout",
           "line": 26,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "github/codeql-action/upload-sarif",
@@ -2653,7 +3161,7 @@
           "action": "actions/checkout",
           "line": 25,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "github/codeql-action/init",
@@ -2702,7 +3210,7 @@
           "action": "actions/checkout",
           "line": 15,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2745,7 +3253,7 @@
           "action": "actions/checkout",
           "line": 18,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2780,7 +3288,7 @@
           "action": "actions/checkout",
           "line": 20,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2843,7 +3351,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
@@ -2892,7 +3400,7 @@
           "action": "actions/checkout",
           "line": 19,
           "pinned_to_full_sha": true,
-          "ref": "df4cb1c069e1874edd31b4311f1884172cec0e10"
+          "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/upload-artifact",

--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -955,6 +955,7 @@ Then use stability-aware command discovery:
     )
     workflow_governance_report.add_argument("--markdown-out", default="")
     workflow_governance_report.add_argument("--format", choices=["json", "text"], default="json")
+    workflow_governance_report.add_argument("--check-freshness", action="store_true")
 
     remediation_readiness_report = sub.add_parser(
         "remediation-readiness-report",
@@ -2149,6 +2150,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         ]
         if str(ns.markdown_out):
             forwarded.extend(["--markdown-out", str(ns.markdown_out)])
+        if bool(ns.check_freshness):
+            forwarded.append("--check-freshness")
         return _run_module_main("sdetkit.workflow_governance_report", forwarded)
 
     if ns.cmd == "remediation-readiness-report":

--- a/src/sdetkit/workflow_governance_report.py
+++ b/src/sdetkit/workflow_governance_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sys
@@ -8,7 +9,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = "sdetkit.workflow_governance_report.v1"
+SCHEMA_VERSION = "sdetkit.workflow_governance_report.v2"
 WORKFLOW_PERMISSION_REVIEW_EVIDENCE_SCHEMA_VERSION = (
     "sdetkit.workflow_permission_review_evidence.v1"
 )
@@ -22,6 +23,152 @@ AUTHORITY_FIELDS = (
 
 FULL_SHA_RE = re.compile(r"^[a-fA-F0-9]{40}$")
 USES_RE = re.compile(r"uses:\s*([^@\s#]+)@([^\s#]+)")
+INPUT_DIGEST_ALGORITHM = "sha256"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/workflow_governance_report.py"
+
+
+def _update_input_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def workflow_governance_input_provenance(
+    repo_root: str | Path = ".",
+    *,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+    workflows = _workflow_files(root)
+
+    inputs: list[tuple[str, bytes]] = [
+        ("schema_version", SCHEMA_VERSION.encode("utf-8")),
+        (GENERATOR_SOURCE_LABEL, generator.read_bytes()),
+    ]
+    inputs.extend((_rel(root, path), path.read_bytes()) for path in workflows)
+
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_input_digest(hasher, label, content)
+
+    return {
+        "digest_algorithm": INPUT_DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "workflow_file_count": len(workflows),
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+    }
+
+
+def validate_workflow_governance_report_freshness(
+    repo_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    current = workflow_governance_input_provenance(
+        repo_root,
+        generator_path=generator_path,
+    )
+    recorded = payload.get("input_provenance")
+    reasons: list[str] = []
+
+    if not isinstance(recorded, dict):
+        recorded = {}
+        reasons.append("missing_input_provenance")
+
+    for field in (
+        "digest_algorithm",
+        "input_digest",
+        "input_count",
+        "workflow_file_count",
+        "generator_schema_version",
+        "generator_source",
+    ):
+        if recorded.get(field) != current.get(field):
+            reasons.append(f"{field}_mismatch")
+
+    reasons = sorted(set(reasons))
+    fresh = not reasons
+    return {
+        "status": "fresh" if fresh else "stale",
+        "fresh": fresh,
+        "reasons": reasons,
+        "recorded_input_digest": recorded.get("input_digest", ""),
+        "current_input_digest": current["input_digest"],
+        "reporting_only": True,
+        "repo_mutation": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def check_workflow_governance_report_freshness(
+    *,
+    repo_root: str | Path,
+    report_path: str | Path,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    path = Path(report_path)
+    if not path.is_file():
+        result = validate_workflow_governance_report_freshness(
+            repo_root,
+            {},
+            generator_path=generator_path,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_missing"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        result = validate_workflow_governance_report_freshness(
+            repo_root,
+            {},
+            generator_path=generator_path,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_invalid_json"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    if not isinstance(payload, dict):
+        payload = {}
+    return validate_workflow_governance_report_freshness(
+        repo_root,
+        payload,
+        generator_path=generator_path,
+    )
+
+
+def render_workflow_governance_freshness_text(payload: dict[str, Any]) -> str:
+    reasons = payload.get("reasons", [])
+    reason_text = ",".join(str(reason) for reason in reasons) if reasons else "none"
+    return "\n".join(
+        [
+            f"freshness_status={payload.get('status', 'stale')}",
+            f"fresh={str(bool(payload.get('fresh', False))).lower()}",
+            f"freshness_reasons={reason_text}",
+            f"recorded_input_digest={payload.get('recorded_input_digest', '')}",
+            f"current_input_digest={payload.get('current_input_digest', '')}",
+            "reporting_only=true",
+            "repo_mutation=false",
+            "automation_allowed=false",
+            "patch_application_allowed=false",
+            "merge_authorized=false",
+            "semantic_equivalence_proven=false",
+        ]
+    )
 
 
 def _authority_boundary() -> dict[str, bool]:
@@ -545,6 +692,7 @@ def _permission_review_evidence_packet(
 
 def build_workflow_governance_report(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root).resolve()
+    input_provenance = workflow_governance_input_provenance(root)
     workflows = [analyze_workflow(root, path) for path in _workflow_files(root)]
     review_required = [item for item in workflows if item["status"] == "review_required"]
 
@@ -585,6 +733,17 @@ def build_workflow_governance_report(repo_root: str | Path = ".") -> dict[str, A
 
     return {
         "schema_version": SCHEMA_VERSION,
+        "input_provenance": input_provenance,
+        "freshness": {
+            "status": "fresh",
+            "input_digest_matches": True,
+            "reporting_only": True,
+            "repo_mutation": False,
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
         "report_status": report_status,
         "repo_root": root.as_posix(),
         "workflow_count": len(workflows),
@@ -645,6 +804,10 @@ def render_workflow_governance_markdown(payload: dict[str, Any]) -> str:
         f"- workflow_count: {payload['workflow_count']}",
         f"- review_required_count: {payload['review_required_count']}",
         f"- finding_count: {payload.get('finding_count', 0)}",
+        f"- input_digest: `{payload.get('input_provenance', {}).get('input_digest', '')}`",
+        f"- digest_algorithm: `{payload.get('input_provenance', {}).get('digest_algorithm', '')}`",
+        f"- workflow_file_count: {payload.get('input_provenance', {}).get('workflow_file_count', 0)}",
+        f"- freshness_status: `{payload.get('freshness', {}).get('status', 'stale')}`",
         "- advisory_only: true",
         "- workflow_mutation: false",
         "- review_first: true",
@@ -852,7 +1015,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--out", default="build/sdetkit/workflow-governance-report.json")
     parser.add_argument("--markdown-out", default="")
     parser.add_argument("--format", choices=["json", "text"], default="json")
+    parser.add_argument(
+        "--check-freshness",
+        action="store_true",
+        help="Check the existing report against current deterministic inputs without rewriting it.",
+    )
     ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    if ns.check_freshness:
+        freshness = check_workflow_governance_report_freshness(
+            repo_root=ns.root,
+            report_path=ns.out,
+        )
+        if ns.format == "json":
+            sys.stdout.write(json.dumps(freshness, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(render_workflow_governance_freshness_text(freshness) + "\n")
+        return 0 if freshness["fresh"] else 1
 
     payload = write_workflow_governance_report(
         repo_root=ns.root,

--- a/tests/test_workflow_governance_report.py
+++ b/tests/test_workflow_governance_report.py
@@ -7,6 +7,9 @@ from sdetkit.workflow_governance_report import (
     SCHEMA_VERSION,
     analyze_workflow,
     build_workflow_governance_report,
+    check_workflow_governance_report_freshness,
+    validate_workflow_governance_report_freshness,
+    workflow_governance_input_provenance,
     write_workflow_governance_report,
 )
 
@@ -630,3 +633,168 @@ jobs:
     workflow_text = workflow.read_text(encoding="utf-8")
     assert "gh api --method POST" in workflow_text
     assert "gh api --method PATCH" in workflow_text
+
+
+def test_workflow_governance_input_digest_is_deterministic_and_root_independent(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first_generator = _write(first / "generator.py", "generator-v1\n")
+    second_generator = _write(second / "generator.py", "generator-v1\n")
+    _write(first / ".github" / "workflows" / "b.yml", "name: b\n")
+    _write(first / ".github" / "workflows" / "a.yml", "name: a\n")
+    _write(second / ".github" / "workflows" / "a.yml", "name: a\n")
+    _write(second / ".github" / "workflows" / "b.yml", "name: b\n")
+
+    first_payload = workflow_governance_input_provenance(first, generator_path=first_generator)
+    second_payload = workflow_governance_input_provenance(second, generator_path=second_generator)
+
+    assert first_payload == second_payload
+    assert first_payload["digest_algorithm"] == "sha256"
+    assert len(first_payload["input_digest"]) == 64
+    assert first_payload["workflow_file_count"] == 2
+    assert first_payload["input_count"] == 4
+    assert first_payload["generator_schema_version"] == SCHEMA_VERSION
+
+
+def test_workflow_governance_input_digest_changes_with_workflow_or_generator(
+    tmp_path: Path,
+) -> None:
+    generator = _write(tmp_path / "generator.py", "generator-v1\n")
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "ci.yml",
+        "name: ci\n",
+    )
+    baseline = workflow_governance_input_provenance(tmp_path, generator_path=generator)
+
+    workflow.write_text("name: ci-updated\n", encoding="utf-8")
+    workflow_changed = workflow_governance_input_provenance(tmp_path, generator_path=generator)
+    assert workflow_changed["input_digest"] != baseline["input_digest"]
+
+    workflow.write_text("name: ci\n", encoding="utf-8")
+    generator.write_text("generator-v2\n", encoding="utf-8")
+    generator_changed = workflow_governance_input_provenance(tmp_path, generator_path=generator)
+    assert generator_changed["input_digest"] != baseline["input_digest"]
+
+
+def test_workflow_governance_freshness_detects_matching_and_stale_reports(
+    tmp_path: Path,
+) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "ci.yml",
+        """
+name: ci
+on: [push]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+""",
+    )
+    out = tmp_path / "build" / "workflow-governance-report.json"
+    write_workflow_governance_report(repo_root=tmp_path, out=out)
+
+    fresh = check_workflow_governance_report_freshness(repo_root=tmp_path, report_path=out)
+    assert fresh["status"] == "fresh"
+    assert fresh["fresh"] is True
+    assert fresh["reasons"] == []
+    assert fresh["repo_mutation"] is False
+    assert fresh["automation_allowed"] is False
+    assert fresh["patch_application_allowed"] is False
+    assert fresh["merge_authorized"] is False
+    assert fresh["semantic_equivalence_proven"] is False
+
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8") + "\n# changed\n",
+        encoding="utf-8",
+    )
+    stale = check_workflow_governance_report_freshness(repo_root=tmp_path, report_path=out)
+    assert stale["status"] == "stale"
+    assert stale["fresh"] is False
+    assert "input_digest_mismatch" in stale["reasons"]
+
+
+def test_workflow_governance_freshness_rejects_missing_or_invalid_provenance(
+    tmp_path: Path,
+) -> None:
+    missing = validate_workflow_governance_report_freshness(
+        tmp_path, {"schema_version": SCHEMA_VERSION}
+    )
+    assert missing["status"] == "stale"
+    assert missing["fresh"] is False
+    assert "missing_input_provenance" in missing["reasons"]
+
+    report = tmp_path / "build" / "workflow-governance-report.json"
+    report.parent.mkdir(parents=True)
+    report.write_text("{invalid", encoding="utf-8")
+    invalid = check_workflow_governance_report_freshness(repo_root=tmp_path, report_path=report)
+    assert invalid["status"] == "stale"
+    assert invalid["fresh"] is False
+    assert "report_invalid_json" in invalid["reasons"]
+
+
+def test_workflow_governance_cli_checks_freshness_without_rewriting(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "ci.yml",
+        """
+name: ci
+on: [push]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+""",
+    )
+    out = tmp_path / "build" / "workflow-governance-report.json"
+    write_workflow_governance_report(repo_root=tmp_path, out=out)
+    original = out.read_text(encoding="utf-8")
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "workflow-governance-report",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--check-freshness",
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    assert "freshness_status=fresh" in capsys.readouterr().out
+    assert out.read_text(encoding="utf-8") == original
+
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8") + "\n# stale\n",
+        encoding="utf-8",
+    )
+    rc = cli_main(
+        [
+            "workflow-governance-report",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--check-freshness",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "stale"
+    assert payload["fresh"] is False
+    assert out.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary
- Add deterministic SHA-256 provenance over workflow inputs, generator code, and report schema.
- Add a read-only `--check-freshness` mode that returns nonzero for stale, missing, or invalid reports without rewriting them.
- Wire the hidden root CLI parser and forwarding contract.
- Regenerate the tracked workflow-governance JSON artifact.
- Keep Markdown rendering as scratch evidence because `build/` is repository-ignored.

## Problem
The committed workflow-governance snapshot could silently drift from accepted `main`. It omitted the live-proven PR Quality comment permission reasons and retained older workflow evidence.

Commit-SHA equality is intentionally not used as the freshness gate because the report is itself committed and would create a self-referential SHA cycle.

## Verification
- Focused workflow-governance and permission-review-card tests: 24 passed.
- Deterministic digest behavior covered by focused tests.
- Missing provenance and invalid JSON are classified stale.
- Root CLI forwards `--check-freshness`.
- Freshness checking is read-only.
- Regenerated JSON validates as fresh.
- Scratch Markdown rendering validated.
- `make proof-after-format` passed.
- Final tracked scope: exactly four files; no workflow or permission changes.

## Risk and rollback
- Risk: low; internal reporting metadata, CLI forwarding, validation, tests, and one tracked report artifact.
- Rollback: revert this commit to restore schema v1 behavior.

## PR card
```text
pr_card:
  title=fix(reporting): detect stale workflow governance snapshots
  branch=fix/workflow-governance-report-freshness
  change_type=reporting_reliability
  problem=committed workflow-governance reports can silently become stale
  user_value=operators can prove ranked follow-ups match current workflow and generator inputs
  risk=low
  public_surface=hidden_internal_command_flag
  compatibility=schema_version_bumped_to_v2
  files_expected=src/sdetkit/workflow_governance_report.py,tests/test_workflow_governance_report.py,src/sdetkit/_legacy_cli.py,build/sdetkit/workflow-governance-report.json
  proof_plan=focused tests; read-only freshness check; regenerated JSON; scratch Markdown validation; proof-after-format; natural PR CI
  rollback=easy
  split_needed=no
  verdict=fix_now
```

## Authority boundary
```text
automation_allowed=false
patch_application_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
```
