### PR TITLE
feat(adoption): make adopt-scan authority boundary explicit

### DIFF
--- a/docs/repo-adoption-scan.md
+++ b/docs/repo-adoption-scan.md
@@ -20,3 +20,23 @@ python -m sdetkit adopt-scan . --format json --out build/sdetkit-adopt-scan.json
 2. Fix high-severity adoption gaps first, especially missing tests and missing CI.
 3. Publish the recommended JSON artifacts in CI.
 4. Use the adaptive dashboard and diagnosis output for evidence-based remediation rather than random fixes.
+
+## Authority boundary
+
+`adopt-scan` is advisory and review-first. It inventories repository evidence and recommends
+commands, but it does not run those commands automatically or authorize repository changes.
+
+Every JSON result records:
+
+```text
+automation_allowed=false
+patch_application_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+automatic_security_fix_allowed=false
+automatic_dismissal_allowed=false
+```
+
+The same values are available under the `authority_boundary` object and in text output.
+A human owner must review recommendations and decide whether any later branch, patch, alert
+disposition, or merge action is appropriate.

--- a/src/sdetkit/repo_adoption_scan.py
+++ b/src/sdetkit/repo_adoption_scan.py
@@ -7,6 +7,16 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "sdetkit.repo_adoption_scan.v1"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+    "automatic_security_fix_allowed",
+    "automatic_dismissal_allowed",
+)
+
 SKIP_DIRS = {
     ".git",
     ".venv",
@@ -18,6 +28,10 @@ SKIP_DIRS = {
     ".ruff_cache",
     "__pycache__",
 }
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
 
 
 def _rel(path: Path, root: Path) -> str:
@@ -182,6 +196,8 @@ def build_repo_adoption_scan(root: Path, *, max_files: int = 4000) -> dict[str, 
         "next_owner_action": gaps[0]["fix"]
         if gaps
         else "Adopt the canonical gate/review path in CI now.",
+        **_authority_boundary(),
+        "authority_boundary": _authority_boundary(),
     }
 
 
@@ -200,6 +216,8 @@ def render_text(payload: dict[str, Any]) -> str:
     lines.append("recommended_commands:")
     lines.extend(f"- {command}" for command in payload["recommended_commands"])
     lines.append(f"next_owner_action={payload['next_owner_action']}")
+    for field in AUTHORITY_FIELDS:
+        lines.append(f"{field}={str(bool(payload.get(field, True))).lower()}")
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_repo_adoption_scan.py
+++ b/tests/test_repo_adoption_scan.py
@@ -6,6 +6,21 @@ from pathlib import Path
 from sdetkit import repo_adoption_scan
 from sdetkit.cli import main as top_level_main
 
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+    "automatic_security_fix_allowed",
+    "automatic_dismissal_allowed",
+)
+
+
+def _assert_no_authority(payload: dict[str, object]) -> None:
+    for field in AUTHORITY_FIELDS:
+        assert payload[field] is False
+    assert payload["authority_boundary"] == {field: False for field in AUTHORITY_FIELDS}
+
 
 def test_repo_adoption_scan_detects_stack_and_gaps(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
@@ -22,6 +37,7 @@ def test_repo_adoption_scan_detects_stack_and_gaps(tmp_path: Path) -> None:
     assert "TEST_SURFACE_MISSING" in codes
     assert "CI_CONTRACT_MISSING" in codes
     assert any("sdetkit review" in command for command in payload["recommended_commands"])
+    _assert_no_authority(payload)
 
 
 def test_repo_adoption_scan_ready_repo_has_canonical_commands(tmp_path: Path) -> None:
@@ -42,6 +58,7 @@ def test_repo_adoption_scan_ready_repo_has_canonical_commands(tmp_path: Path) ->
     assert payload["ok"] is True
     assert payload["risk_score"] == 0
     assert payload["next_owner_action"] == "Adopt the canonical gate/review path in CI now."
+    _assert_no_authority(payload)
 
 
 def test_top_level_cli_adopt_scan_passthrough(tmp_path: Path) -> None:
@@ -56,3 +73,13 @@ def test_top_level_cli_adopt_scan_passthrough(tmp_path: Path) -> None:
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["stack"]["javascript"] is True
     assert payload["adoption_gaps"]
+    _assert_no_authority(payload)
+
+
+def test_repo_adoption_scan_text_renders_no_authority(tmp_path: Path) -> None:
+    payload = repo_adoption_scan.build_repo_adoption_scan(tmp_path)
+
+    rendered = repo_adoption_scan.render_text(payload)
+
+    for field in AUTHORITY_FIELDS:
+        assert f"{field}=false" in rendered


### PR DESCRIPTION
## Summary

- Add an explicit six-field no-authority contract to `adopt-scan` JSON and text output.
- Preserve the existing `sdetkit.repo_adoption_scan.v1` schema and all current scan behavior.
- Add builder, root CLI, and text-rendering tests.
- Document that recommendations require human review.

## Why

The read-only adoption command-family audit found that `adopt-scan` is a real, tested public entrypoint, but its output did not explicitly carry the authority boundary used by newer adoption surfaces.

## Compatibility

- Command name unchanged.
- CLI arguments unchanged.
- Existing JSON fields unchanged.
- Schema version unchanged.
- New fields are additive.
- No workflow, permission, command-tier, or behavior changes.

## Proof

- Focused `repo_adoption_scan` and public-command-surface tests passed.
- JSON and text smoke contracts passed.
- Ruff check and format check passed.
- Mypy passed for the owner module.
- `make proof-after-format` passed.
- Exact scope: three files.

## Authority boundary

```text
automation_allowed=false
patch_application_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
```

## PR card

```text
pr_card:
  title=feat(adoption): make adopt-scan authority boundary explicit
  branch=feat/adoption-adopt-scan-authority-boundary
  change_type=authority_contract
  problem=adopt-scan recommendations lacked an explicit no-authority output contract
  user_value=operators can distinguish recommendations from authorized actions
  risk=low
  compatibility=preserved
  public_surface=yes
  files_expected=src/sdetkit/repo_adoption_scan.py,tests/test_repo_adoption_scan.py,docs/repo-adoption-scan.md
  rollback=easy
  proof_plan=focused tests; JSON/text smoke; Ruff; mypy; make proof-after-format; natural CI
```
