### PR TITLE
feat(adoption): make adoption authority boundary explicit

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -118,7 +118,34 @@ automation_allowed=false
 patch_application_allowed=false
 merge_authorized=false
 semantic_equivalence_proven=false
+automatic_security_fix_allowed=false
+automatic_dismissal_allowed=false
 ```
+
+## Adoption follow-up authority boundary
+
+The public `adoption` command builds prioritized follow-up recommendations from fit and gate
+decision artifacts:
+
+```bash
+python -m sdetkit adoption   --fit build/sdetkit-fit-recommendation.json   --summary build/gate-decision-summary.json   --format json   --out build/adoption-followup.json
+```
+
+Its recommendations are advisory and review-first. JSON, Markdown, history JSONL, and history
+rollup outputs explicitly preserve:
+
+```text
+automation_allowed=false
+patch_application_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+automatic_security_fix_allowed=false
+automatic_dismissal_allowed=false
+```
+
+A recommendation or escalation signal does not authorize command execution, patch application,
+security remediation, alert dismissal, branch creation, or merge. Those actions remain separate
+human decisions.
 
 ## Review real-world adoption learning
 

--- a/src/sdetkit/adoption.py
+++ b/src/sdetkit/adoption.py
@@ -8,6 +8,19 @@ from typing import Any
 
 from sdetkit._datetime import UTC
 
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+    "automatic_security_fix_allowed",
+    "automatic_dismissal_allowed",
+)
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
 
 def _load_optional(path: Path) -> dict[str, Any] | None:
     if not path.exists():
@@ -147,6 +160,8 @@ def build_followup(
         "decision": decision,
         "next_command": top["action"],
         "recommendations": normalized,
+        **_authority_boundary(),
+        "authority_boundary": _authority_boundary(),
     }
 
 
@@ -175,6 +190,9 @@ def _to_markdown(payload: dict[str, Any]) -> str:
         rationale = str(rec.get("rationale", "")).strip()
         if rationale:
             lines.append(f"   - Rationale: {rationale}")
+    lines.extend(["", "## Authority boundary"])
+    for field in AUTHORITY_FIELDS:
+        lines.append(f"- {field}: `{str(bool(payload.get(field, True))).lower()}`")
     lines.append("")
     return "\n".join(lines)
 
@@ -254,6 +272,8 @@ def _build_history_rollup(
         },
         "latest_next_command": latest.get("next_command", ""),
         "latest_generated_at": latest.get("generated_at", ""),
+        **_authority_boundary(),
+        "authority_boundary": _authority_boundary(),
     }
 
 

--- a/tests/test_adoption_cli.py
+++ b/tests/test_adoption_cli.py
@@ -5,6 +5,21 @@ from pathlib import Path
 
 from sdetkit import adoption
 
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+    "automatic_security_fix_allowed",
+    "automatic_dismissal_allowed",
+)
+
+
+def _assert_no_authority(payload: dict[str, object]) -> None:
+    for field in AUTHORITY_FIELDS:
+        assert payload[field] is False
+    assert payload["authority_boundary"] == {field: False for field in AUTHORITY_FIELDS}
+
 
 def test_adoption_cli_json_output_with_missing_inputs(tmp_path: Path, capsys) -> None:
     rc = adoption.main(
@@ -24,6 +39,7 @@ def test_adoption_cli_json_output_with_missing_inputs(tmp_path: Path, capsys) ->
     assert payload["decision_context"]["policy_profile"] == "balanced"
     assert payload["decision_context"]["fit_artifact_present"] is False
     assert payload["decision_context"]["summary_artifact_present"] is False
+    _assert_no_authority(payload)
 
 
 def test_adoption_cli_writes_markdown(tmp_path: Path, capsys) -> None:
@@ -48,6 +64,9 @@ def test_adoption_cli_writes_markdown(tmp_path: Path, capsys) -> None:
     assert "Why now:" in rendered
     assert "Rationale:" in rendered
     assert "Policy profile:" in rendered
+    assert "## Authority boundary" in rendered
+    for field in AUTHORITY_FIELDS:
+        assert f"- {field}: `false`" in rendered
 
 
 def test_adoption_cli_history_and_rollup(tmp_path: Path, capsys) -> None:
@@ -78,6 +97,10 @@ def test_adoption_cli_history_and_rollup(tmp_path: Path, capsys) -> None:
     assert "escalation_recommended" in rollup_payload
     assert rollup_payload["escalation_reason"] in {"none", "consecutive_no_ship", "high_p0_rate"}
     assert rollup_payload["thresholds"]["escalation_consecutive_no_ship"] == 2
+    _assert_no_authority(payload)
+    _assert_no_authority(rollup_payload)
+    latest_history = json.loads(history.read_text(encoding="utf-8").strip().splitlines()[-1])
+    _assert_no_authority(latest_history)
 
 
 def test_adoption_cli_rollup_escalation_on_consecutive_no_ship(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Add an explicit six-field no-authority contract to the public `adoption` command.
- Preserve the existing `sdetkit.adoption_followup.v1` and `sdetkit.adoption_followup_history.v1` schemas.
- Cover JSON, Markdown, history JSONL, and history-rollup outputs.
- Document that recommendations and escalation signals require human review.

## Why

The adoption command-family audit ranked `adoption` with the same authority-contract gap that
PR #1830 closed for `adopt-scan`.

## Compatibility

- Command name and CLI arguments unchanged.
- Existing JSON and history fields unchanged.
- Schema versions unchanged.
- Recommendation ordering and actions unchanged.
- Escalation thresholds and calculations unchanged.
- New authority fields are additive.
- No workflows, permissions, command tiers, or aliases changed.

## Proof

- Focused adoption CLI, alias, contract, and public-command-surface tests passed.
- JSON, Markdown, history, and rollup smoke contracts passed.
- Ruff check and format check passed.
- Mypy passed for the owner module.
- `make proof-after-format` passed.
- Exact scope: three files.

## Authority boundary

```text
automation_allowed=false
patch_application_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
automatic_security_fix_allowed=false
automatic_dismissal_allowed=false
```

## PR card

```text
pr_card:
  title=feat(adoption): make adoption authority boundary explicit
  branch=feat/adoption-command-authority-boundary
  change_type=authority_contract
  problem=adoption recommendations and history outputs lacked an explicit no-authority contract
  user_value=operators can distinguish recommendations and escalation signals from authorized actions
  risk=low
  compatibility=preserved
  public_surface=yes
  files_expected=src/sdetkit/adoption.py,tests/test_adoption_cli.py,docs/adoption.md
  rollback=easy
  proof_plan=focused tests; four output-mode smoke checks; Ruff; mypy; proof-after-format; natural CI
```
