### PR TITLE
docs(adoption): clarify hidden maintainer learning commands

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -149,6 +149,19 @@ human decisions.
 
 ## Review real-world adoption learning
 
+These commands are intentionally hidden maintainer-only learning lanes. They are absent from
+default root help by design so adopter-facing discovery remains focused:
+
+- `adoption-real-world-learning-matrix`
+- `adoption-learning-report`
+
+Maintainers can reveal both commands with `python -m sdetkit --show-hidden --help`. Direct
+command help remains available through `python -m sdetkit <command> --help`.
+
+Hidden status is a discoverability contract, not action authority. Both commands remain
+review-first and do not authorize proof execution, patch application, branch or pull-request
+creation, security remediation, alert dismissal, or merge.
+
 Maintainers can aggregate read-only observations from a verified matrix of external repository roots, then convert the resulting matrix artifact into a review-first learning report.
 
 First, generate the real-world learning matrix from repository roots whose licenses and local paths have already been verified:

--- a/tests/test_cli_hidden_surface.py
+++ b/tests/test_cli_hidden_surface.py
@@ -1,10 +1,17 @@
 from sdetkit import cli
 
+HIDDEN_ADOPTION_LEARNING_COMMANDS = (
+    "adoption-learning-report",
+    "adoption-real-world-learning-matrix",
+)
+
 
 def test_root_help_hides_commands_by_default() -> None:
     help_text = cli._build_root_parser()[0].format_help()
     assert "docs-qa" not in help_text
     assert "proof" not in help_text
+    for command in HIDDEN_ADOPTION_LEARNING_COMMANDS:
+        assert command not in help_text
 
 
 def test_root_help_can_show_hidden_commands() -> None:
@@ -12,6 +19,24 @@ def test_root_help_can_show_hidden_commands() -> None:
     assert "docs-qa" in help_text
     assert "proof" in help_text
     assert "--show-hidden" in help_text
+    for command in HIDDEN_ADOPTION_LEARNING_COMMANDS:
+        assert command in help_text
+
+
+def test_hidden_adoption_learning_commands_keep_direct_help(capsys) -> None:
+    for command in HIDDEN_ADOPTION_LEARNING_COMMANDS:
+        parser = cli._build_root_parser()[0]
+
+        try:
+            parser.parse_args([command, "--help"])
+        except SystemExit as exc:
+            assert exc.code == 0
+        else:
+            raise AssertionError(f"{command} --help did not exit")
+
+        help_text = capsys.readouterr().out
+        assert "usage:" in help_text
+        assert command in help_text
 
 
 def test_root_playbooks_command_dispatches_to_playbooks_surface(capsys) -> None:


### PR DESCRIPTION
## Summary
- clarify that `adoption-learning-report` and `adoption-real-world-learning-matrix` are intentionally hidden maintainer-only learning lanes
- document default-help exclusion, `--show-hidden` discovery, and direct command help
- add focused regression coverage for the visibility contract

## Why
- adopter-facing root help should remain focused
- maintainer learning commands still need an explicit, test-protected discovery contract
- hidden status must not be interpreted as execution, patch, security-remediation, dismissal, branch, PR, or merge authority

## Verification
- `python -m pytest -q tests/test_cli_hidden_surface.py -o addopts=`
- `python -m pytest -q tests/test_adoption_learning_report.py tests/test_adoption_real_world_learning_matrix.py -o addopts=`
- `python -m ruff check tests/test_cli_hidden_surface.py`
- `python -m ruff format --check tests/test_cli_hidden_surface.py`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `make proof-after-format`

## Risk
- Low
- Public behavior, parser registration, dispatch, tiers, schemas, artifacts, workflows, and permissions are unchanged
- Rollback: revert the single commit

## Notes
- compatibility is preserved
- scope is limited to `docs/adoption.md` and `tests/test_cli_hidden_surface.py`
- this PR does not authorize automation or merge
