### PR TITLE
fix(reporting): detect stale public command surface snapshots

### DIFF
--- a/build/sdetkit/public-command-surface-report.json
+++ b/build/sdetkit/public-command-surface-report.json
@@ -2072,6 +2072,15 @@
     "remediation-readiness-report",
     "workflow-governance-report"
   ],
+  "input_provenance": {
+    "digest_algorithm": "sha256",
+    "generator_schema_version": "sdetkit.public_command_surface_report.v2",
+    "generator_source": "src/sdetkit/public_command_surface_report.py",
+    "input_count": 3,
+    "input_digest": "2ed306fcf20cb4434c41b8d7e7e6fa754b3cab656e9061eaff0d84d65811953e",
+    "source_file": "src/sdetkit/_legacy_cli.py",
+    "source_file_count": 1
+  },
   "merge_authorized": false,
   "operator_summary": {
     "classification_source": "root argparse registration help text",
@@ -2091,7 +2100,7 @@
     "safe_to_patch": false
   },
   "safe_to_patch": false,
-  "schema_version": "sdetkit.public_command_surface_report.v1",
+  "schema_version": "sdetkit.public_command_surface_report.v2",
   "semantic_equivalence_proven": false,
   "source_file": "src/sdetkit/_legacy_cli.py",
   "stable_command_count": 13,

--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -979,6 +979,7 @@ Then use stability-aware command discovery:
     )
     public_command_surface_report.add_argument("--markdown-out", default="")
     public_command_surface_report.add_argument("--format", choices=["json", "text"], default="json")
+    public_command_surface_report.add_argument("--check-freshness", action="store_true")
 
     product_maturity_radar = sub.add_parser(
         "product-maturity-radar",
@@ -2180,6 +2181,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         ]
         if str(ns.markdown_out):
             forwarded.extend(["--markdown-out", str(ns.markdown_out)])
+        if bool(ns.check_freshness):
+            forwarded.append("--check-freshness")
         return _run_module_main("sdetkit.public_command_surface_report", forwarded)
 
     if ns.cmd == "product-maturity-radar":

--- a/src/sdetkit/public_command_surface_report.py
+++ b/src/sdetkit/public_command_surface_report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import hashlib
 import json
 import sys
 from collections import Counter
@@ -9,9 +10,159 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = "sdetkit.public_command_surface_report.v1"
+SCHEMA_VERSION = "sdetkit.public_command_surface_report.v2"
 DEFAULT_OUT = "build/sdetkit/public-command-surface-report.json"
 LEGACY_CLI_PATH = "src/sdetkit/_legacy_cli.py"
+
+INPUT_DIGEST_ALGORITHM = "sha256"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/public_command_surface_report.py"
+
+
+def _update_input_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def public_command_surface_input_provenance(
+    root: str | Path = ".",
+    *,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    repo_root = Path(root).resolve()
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+    command_source = repo_root / LEGACY_CLI_PATH
+
+    inputs: list[tuple[str, bytes]] = [
+        ("schema_version", SCHEMA_VERSION.encode("utf-8")),
+        (GENERATOR_SOURCE_LABEL, generator.read_bytes()),
+        (LEGACY_CLI_PATH, command_source.read_bytes()),
+    ]
+
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_input_digest(hasher, label, content)
+
+    return {
+        "digest_algorithm": INPUT_DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "source_file_count": 1,
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+        "source_file": LEGACY_CLI_PATH,
+    }
+
+
+def validate_public_command_surface_report_freshness(
+    root: str | Path,
+    payload: dict[str, Any],
+    *,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    current = public_command_surface_input_provenance(
+        root,
+        generator_path=generator_path,
+    )
+    recorded = payload.get("input_provenance")
+    reasons: list[str] = []
+
+    if not isinstance(recorded, dict):
+        recorded = {}
+        reasons.append("missing_input_provenance")
+
+    for field in (
+        "digest_algorithm",
+        "input_digest",
+        "input_count",
+        "source_file_count",
+        "generator_schema_version",
+        "generator_source",
+        "source_file",
+    ):
+        if recorded.get(field) != current.get(field):
+            reasons.append(f"{field}_mismatch")
+
+    reasons = sorted(set(reasons))
+    fresh = not reasons
+    return {
+        "status": "fresh" if fresh else "stale",
+        "fresh": fresh,
+        "reasons": reasons,
+        "recorded_input_digest": recorded.get("input_digest", ""),
+        "current_input_digest": current["input_digest"],
+        "reporting_only": True,
+        "repo_mutation": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def check_public_command_surface_report_freshness(
+    *,
+    root: str | Path,
+    report_path: str | Path,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    path = Path(report_path)
+    if not path.is_file():
+        result = validate_public_command_surface_report_freshness(
+            root,
+            {},
+            generator_path=generator_path,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_missing"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        result = validate_public_command_surface_report_freshness(
+            root,
+            {},
+            generator_path=generator_path,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_invalid_json"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    if not isinstance(payload, dict):
+        payload = {}
+    return validate_public_command_surface_report_freshness(
+        root,
+        payload,
+        generator_path=generator_path,
+    )
+
+
+def render_public_command_surface_freshness_text(payload: dict[str, Any]) -> str:
+    reasons = payload.get("reasons", [])
+    reason_text = ",".join(str(reason) for reason in reasons) if reasons else "none"
+    return "\n".join(
+        [
+            f"freshness_status={payload.get('status', 'stale')}",
+            f"fresh={str(bool(payload.get('fresh', False))).lower()}",
+            f"freshness_reasons={reason_text}",
+            f"recorded_input_digest={payload.get('recorded_input_digest', '')}",
+            f"current_input_digest={payload.get('current_input_digest', '')}",
+            "reporting_only=true",
+            "repo_mutation=false",
+            "automation_allowed=false",
+            "patch_application_allowed=false",
+            "merge_authorized=false",
+            "semantic_equivalence_proven=false",
+        ]
+    )
+
 
 AUTHORITY_FIELDS = (
     "automation_allowed",
@@ -173,6 +324,7 @@ def build_public_command_surface_report(root: str | Path = ".") -> dict[str, Any
         "schema_version": SCHEMA_VERSION,
         "report_status": "review_required",
         "source_file": LEGACY_CLI_PATH,
+        "input_provenance": public_command_surface_input_provenance(repo_root),
         "command_count": len(commands),
         "stable_command_count": len(stable_commands),
         "hidden_command_count": len(hidden_commands),
@@ -207,6 +359,10 @@ def build_public_command_surface_report(root: str | Path = ".") -> dict[str, Any
 
 
 def render_markdown(payload: dict[str, Any]) -> str:
+    provenance = payload.get("input_provenance", {})
+    if not isinstance(provenance, dict):
+        provenance = {}
+
     lines = [
         "# SDETKit public command surface report",
         "",
@@ -214,6 +370,10 @@ def render_markdown(payload: dict[str, Any]) -> str:
         f"- command_count: {payload['command_count']}",
         f"- stable_command_count: {payload['stable_command_count']}",
         f"- hidden_command_count: {payload['hidden_command_count']}",
+        f"- input_digest: `{provenance.get('input_digest', '')}`",
+        f"- digest_algorithm: `{provenance.get('digest_algorithm', '')}`",
+        f"- input_count: {provenance.get('input_count', 0)}",
+        f"- generator_source: `{provenance.get('generator_source', '')}`",
         "- review_first: true",
         "- safe_to_patch: false",
         "",
@@ -284,7 +444,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--markdown-out", default="")
     parser.add_argument("--format", choices=["json", "text"], default="json")
+    parser.add_argument(
+        "--check-freshness",
+        action="store_true",
+        help="Check the existing report against current deterministic inputs without rewriting it.",
+    )
     ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    if ns.check_freshness:
+        freshness = check_public_command_surface_report_freshness(
+            root=ns.root,
+            report_path=ns.out,
+        )
+        if ns.format == "json":
+            sys.stdout.write(json.dumps(freshness, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(render_public_command_surface_freshness_text(freshness) + "\n")
+        return 0 if freshness["fresh"] else 1
 
     payload = write_artifacts(
         root=ns.root,

--- a/tests/test_public_command_surface_report.py
+++ b/tests/test_public_command_surface_report.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from sdetkit.public_command_surface_report import (
     SCHEMA_VERSION,
     build_public_command_surface_report,
+    check_public_command_surface_report_freshness,
+    public_command_surface_input_provenance,
+    validate_public_command_surface_report_freshness,
     write_artifacts,
 )
 
@@ -22,6 +25,14 @@ def test_public_command_surface_report_classifies_stable_advanced_and_hidden_com
     assert payload["hidden_internal_commands"] == payload["hidden_commands"]
     assert payload["review_first"] is True
     assert payload["safe_to_patch"] is False
+    provenance = payload["input_provenance"]
+    assert provenance["digest_algorithm"] == "sha256"
+    assert len(provenance["input_digest"]) == 64
+    assert provenance["input_count"] == 3
+    assert provenance["source_file_count"] == 1
+    assert provenance["generator_schema_version"] == SCHEMA_VERSION
+    assert provenance["generator_source"] == "src/sdetkit/public_command_surface_report.py"
+    assert provenance["source_file"] == "src/sdetkit/_legacy_cli.py"
 
     commands = {item["command"]: item for item in payload["commands"]}
 
@@ -66,6 +77,8 @@ def test_public_command_surface_report_writes_json_and_markdown(tmp_path: Path) 
     assert "`start`" in rendered
     assert "## Hidden/internal commands" in rendered
     assert "`product-maturity-radar`" in rendered
+    assert "input_digest:" in rendered
+    assert "digest_algorithm: `sha256`" in rendered
     assert "automation_allowed: false" in rendered
 
 
@@ -112,3 +125,193 @@ def test_public_command_surface_report_stays_hidden_from_default_help() -> None:
 
     assert "public-command-surface-report" not in default_help
     assert "public-command-surface-report" in hidden_help
+
+
+def _write_public_command_source(root: Path, *, suffix: str = "") -> Path:
+    path = root / "src" / "sdetkit" / "_legacy_cli.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "import argparse\n\n"
+        "sub = argparse.ArgumentParser().add_subparsers()\n"
+        'sub.add_parser("start", help="[Public / stable] Start")\n' + suffix,
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_public_command_surface_input_digest_is_deterministic_and_root_independent(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first_generator = first / "generator.py"
+    second_generator = second / "generator.py"
+    first_generator.parent.mkdir(parents=True, exist_ok=True)
+    second_generator.parent.mkdir(parents=True, exist_ok=True)
+    first_generator.write_text("generator-v1\n", encoding="utf-8")
+    second_generator.write_text("generator-v1\n", encoding="utf-8")
+    _write_public_command_source(first)
+    _write_public_command_source(second)
+
+    first_payload = public_command_surface_input_provenance(
+        first,
+        generator_path=first_generator,
+    )
+    second_payload = public_command_surface_input_provenance(
+        second,
+        generator_path=second_generator,
+    )
+
+    assert first_payload == second_payload
+    assert first_payload["digest_algorithm"] == "sha256"
+    assert len(first_payload["input_digest"]) == 64
+    assert first_payload["input_count"] == 3
+    assert first_payload["source_file_count"] == 1
+    assert first_payload["generator_schema_version"] == SCHEMA_VERSION
+
+
+def test_public_command_surface_input_digest_changes_with_source_or_generator(
+    tmp_path: Path,
+) -> None:
+    generator = tmp_path / "generator.py"
+    generator.write_text("generator-v1\n", encoding="utf-8")
+    command_source = _write_public_command_source(tmp_path)
+    baseline = public_command_surface_input_provenance(
+        tmp_path,
+        generator_path=generator,
+    )
+
+    command_source.write_text(
+        command_source.read_text(encoding="utf-8") + "\n# changed\n",
+        encoding="utf-8",
+    )
+    source_changed = public_command_surface_input_provenance(
+        tmp_path,
+        generator_path=generator,
+    )
+    assert source_changed["input_digest"] != baseline["input_digest"]
+
+    _write_public_command_source(tmp_path)
+    generator.write_text("generator-v2\n", encoding="utf-8")
+    generator_changed = public_command_surface_input_provenance(
+        tmp_path,
+        generator_path=generator,
+    )
+    assert generator_changed["input_digest"] != baseline["input_digest"]
+
+
+def test_public_command_surface_freshness_detects_matching_and_stale_reports(
+    tmp_path: Path,
+) -> None:
+    command_source = _write_public_command_source(tmp_path)
+    out = tmp_path / "build" / "public-command-surface-report.json"
+    write_artifacts(root=tmp_path, out=out)
+
+    fresh = check_public_command_surface_report_freshness(
+        root=tmp_path,
+        report_path=out,
+    )
+    assert fresh["status"] == "fresh"
+    assert fresh["fresh"] is True
+    assert fresh["reasons"] == []
+    assert fresh["repo_mutation"] is False
+    assert fresh["automation_allowed"] is False
+    assert fresh["patch_application_allowed"] is False
+    assert fresh["merge_authorized"] is False
+    assert fresh["semantic_equivalence_proven"] is False
+
+    command_source.write_text(
+        command_source.read_text(encoding="utf-8") + "\n# stale\n",
+        encoding="utf-8",
+    )
+    stale = check_public_command_surface_report_freshness(
+        root=tmp_path,
+        report_path=out,
+    )
+    assert stale["status"] == "stale"
+    assert stale["fresh"] is False
+    assert "input_digest_mismatch" in stale["reasons"]
+
+
+def test_public_command_surface_freshness_rejects_missing_invalid_or_unprovenanced(
+    tmp_path: Path,
+) -> None:
+    _write_public_command_source(tmp_path)
+
+    missing_provenance = validate_public_command_surface_report_freshness(
+        tmp_path,
+        {"schema_version": SCHEMA_VERSION},
+    )
+    assert missing_provenance["status"] == "stale"
+    assert missing_provenance["fresh"] is False
+    assert "missing_input_provenance" in missing_provenance["reasons"]
+
+    missing_path = tmp_path / "build" / "missing.json"
+    missing = check_public_command_surface_report_freshness(
+        root=tmp_path,
+        report_path=missing_path,
+    )
+    assert missing["status"] == "stale"
+    assert missing["fresh"] is False
+    assert "report_missing" in missing["reasons"]
+
+    invalid_path = tmp_path / "build" / "invalid.json"
+    invalid_path.parent.mkdir(parents=True, exist_ok=True)
+    invalid_path.write_text("{invalid", encoding="utf-8")
+    invalid = check_public_command_surface_report_freshness(
+        root=tmp_path,
+        report_path=invalid_path,
+    )
+    assert invalid["status"] == "stale"
+    assert invalid["fresh"] is False
+    assert "report_invalid_json" in invalid["reasons"]
+
+
+def test_public_command_surface_cli_checks_freshness_without_rewriting(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    command_source = _write_public_command_source(tmp_path)
+    out = tmp_path / "build" / "public-command-surface-report.json"
+    write_artifacts(root=tmp_path, out=out)
+    original = out.read_text(encoding="utf-8")
+
+    from sdetkit.cli import main as cli_main
+
+    rc = cli_main(
+        [
+            "public-command-surface-report",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--check-freshness",
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    assert "freshness_status=fresh" in capsys.readouterr().out
+    assert out.read_text(encoding="utf-8") == original
+
+    command_source.write_text(
+        command_source.read_text(encoding="utf-8") + "\n# stale\n",
+        encoding="utf-8",
+    )
+    rc = cli_main(
+        [
+            "public-command-surface-report",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--check-freshness",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "stale"
+    assert payload["fresh"] is False
+    assert out.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary
- add deterministic SHA-256 input provenance to the public-command-surface report
- add fail-closed freshness checking for fresh, stale, missing, invalid, and unprovenanced reports
- register and forward `--check-freshness` through the existing hidden root command
- regenerate the tracked JSON report under schema v2

## Scope
- `build/sdetkit/public-command-surface-report.json`
- `src/sdetkit/_legacy_cli.py`
- `src/sdetkit/public_command_surface_report.py`
- `tests/test_public_command_surface_report.py`

## Verification
- focused report tests: 9 passed
- Ruff check passed
- Ruff format check passed
- root CLI returned `freshness_status=fresh`
- `make proof-after-format` passed
- exact candidate patch SHA remained `05653bbd8c859c541bed084f667f83f2e0865f63205face005b23903a91588f8`

## Compatibility
- hidden visibility unchanged
- command tier unchanged
- dispatch target unchanged
- argument registration and forwarding extended only
- ignored generated Markdown remains outside the tracked surface

## Authority boundary
- reporting only
- `repo_mutation=false`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`

## Risk
Low. Rollback is a single commit revert.
