### PR TITLE
fix(reporting): detect stale remediation readiness snapshots

### DIFF
--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -968,6 +968,7 @@ Then use stability-aware command discovery:
     )
     remediation_readiness_report.add_argument("--markdown-out", default="")
     remediation_readiness_report.add_argument("--format", choices=["json", "text"], default="json")
+    remediation_readiness_report.add_argument("--check-freshness", action="store_true")
 
     public_command_surface_report = sub.add_parser(
         "public-command-surface-report",
@@ -2168,6 +2169,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             forwarded.extend(["--policy", str(ns.policy)])
         if str(ns.markdown_out):
             forwarded.extend(["--markdown-out", str(ns.markdown_out)])
+        if bool(ns.check_freshness):
+            forwarded.append("--check-freshness")
         return _run_module_main("sdetkit.remediation_readiness_report", forwarded)
 
     if ns.cmd == "public-command-surface-report":

--- a/src/sdetkit/remediation_readiness_report.py
+++ b/src/sdetkit/remediation_readiness_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from collections.abc import Sequence
@@ -10,10 +11,263 @@ from typing import Any
 from sdetkit import adaptive_remediation_policy
 from sdetkit.protected_verifier import verify_candidate
 
-SCHEMA_VERSION = "sdetkit.remediation_readiness_report.v1"
+SCHEMA_VERSION = "sdetkit.remediation_readiness_report.v2"
 DEFAULT_OUT = "build/sdetkit/remediation-readiness-report.json"
 DEFAULT_POLICY_PATH = "config/adaptive_remediation_policy.default.json"
 SAFETYGATE_POLICY_PATH = "docs/contracts/safety-gate-policy-matrix.v1.json"
+
+INPUT_DIGEST_ALGORITHM = "sha256"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/remediation_readiness_report.py"
+CONTRACT_FILES = (
+    "src/sdetkit/safety_gate.py",
+    "src/sdetkit/failure_vector.py",
+    SAFETYGATE_POLICY_PATH,
+    "docs/safety-gate-policy-matrix.md",
+    "src/sdetkit/adaptive_remediation_policy.py",
+    "src/sdetkit/adaptive_patch_plan.py",
+    "src/sdetkit/adaptive_fix_audit.py",
+    "src/sdetkit/protected_verifier.py",
+    "src/sdetkit/patch_scorer.py",
+    DEFAULT_POLICY_PATH,
+)
+
+
+def _update_input_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def _display_input_path(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def remediation_readiness_input_provenance(
+    root: str | Path = ".",
+    *,
+    policy_path: str | Path | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    repo_root = Path(root).resolve()
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+    policy_file = Path(policy_path) if policy_path is not None else Path(DEFAULT_POLICY_PATH)
+    if not policy_file.is_absolute():
+        policy_file = repo_root / policy_file
+
+    candidate_paths: list[tuple[str, Path]] = [(GENERATOR_SOURCE_LABEL, generator)]
+    for configured_path in CONTRACT_FILES:
+        path = repo_root / configured_path
+        candidate_paths.append((configured_path, path))
+
+    policy_label = _display_input_path(repo_root, policy_file)
+    if all(label != policy_label for label, _path in candidate_paths):
+        candidate_paths.append((policy_label, policy_file))
+
+    unique_paths: dict[str, Path] = {}
+    for label, path in candidate_paths:
+        unique_paths.setdefault(label, path)
+
+    inputs: list[tuple[str, bytes]] = [
+        ("schema_version", SCHEMA_VERSION.encode("utf-8")),
+    ]
+    missing_inputs: list[str] = []
+    for label, path in sorted(unique_paths.items()):
+        if path.is_file():
+            content = path.read_bytes()
+        else:
+            content = b"<missing>"
+            missing_inputs.append(label)
+        inputs.append((label, content))
+
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_input_digest(hasher, label, content)
+
+    return {
+        "digest_algorithm": INPUT_DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "input_file_count": len(unique_paths),
+        "missing_input_count": len(missing_inputs),
+        "missing_inputs": missing_inputs,
+        "input_paths": sorted(unique_paths),
+        "policy_path": policy_label,
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+    }
+
+
+def validate_remediation_readiness_report_freshness(
+    root: str | Path,
+    payload: dict[str, Any],
+    *,
+    policy_path: str | Path | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    current = remediation_readiness_input_provenance(
+        root,
+        policy_path=policy_path,
+        generator_path=generator_path,
+    )
+    reasons: list[str] = []
+    recorded = payload.get("input_provenance")
+    if not isinstance(recorded, dict):
+        recorded = {}
+        reasons.append("missing_input_provenance")
+
+    for field in (
+        "digest_algorithm",
+        "input_digest",
+        "input_count",
+        "input_file_count",
+        "missing_input_count",
+        "missing_inputs",
+        "input_paths",
+        "policy_path",
+        "generator_schema_version",
+        "generator_source",
+    ):
+        if recorded.get(field) != current.get(field):
+            reasons.append(f"{field}_mismatch")
+
+    schema_valid = payload.get("schema_version") == SCHEMA_VERSION
+    if not schema_valid:
+        reasons.append("schema_version_mismatch")
+
+    authority_valid = True
+    for field in AUTHORITY_FIELDS:
+        if payload.get(field) is not False:
+            authority_valid = False
+            reasons.append(f"{field}_mismatch")
+
+    boundary = payload.get("authority_boundary")
+    if not isinstance(boundary, dict):
+        authority_valid = False
+        reasons.append("missing_authority_boundary")
+    else:
+        for field in AUTHORITY_FIELDS:
+            if boundary.get(field) is not False:
+                authority_valid = False
+                reasons.append(f"authority_boundary_{field}_mismatch")
+
+    rules = payload.get("rules")
+    expected_rules = {
+        "read_only": True,
+        "dry_run_only": True,
+        "target_repo_mutation": False,
+        "review_first": True,
+        "safe_to_patch": False,
+    }
+    if not isinstance(rules, dict):
+        authority_valid = False
+        reasons.append("missing_rules")
+    else:
+        for field, expected in expected_rules.items():
+            if rules.get(field) is not expected:
+                authority_valid = False
+                reasons.append(f"rules_{field}_mismatch")
+
+    reasons = sorted(set(reasons))
+    fresh = not reasons
+    return {
+        "status": "fresh" if fresh else "stale",
+        "fresh": fresh,
+        "schema_valid": schema_valid,
+        "authority_valid": authority_valid,
+        "reasons": reasons,
+        "recorded_input_digest": recorded.get("input_digest", ""),
+        "current_input_digest": current["input_digest"],
+        "reporting_only": True,
+        "repo_mutation": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def check_remediation_readiness_report_freshness(
+    *,
+    root: str | Path,
+    report_path: str | Path,
+    policy_path: str | Path | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    path = Path(report_path)
+    if not path.is_file():
+        result = validate_remediation_readiness_report_freshness(
+            root,
+            {},
+            policy_path=policy_path,
+            generator_path=generator_path,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_missing"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        result = validate_remediation_readiness_report_freshness(
+            root,
+            {},
+            policy_path=policy_path,
+            generator_path=generator_path,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_invalid_json"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    if not isinstance(loaded, dict):
+        result = validate_remediation_readiness_report_freshness(
+            root,
+            {},
+            policy_path=policy_path,
+            generator_path=generator_path,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_not_object"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    return validate_remediation_readiness_report_freshness(
+        root,
+        loaded,
+        policy_path=policy_path,
+        generator_path=generator_path,
+    )
+
+
+def render_remediation_readiness_freshness_text(payload: dict[str, Any]) -> str:
+    reasons = payload.get("reasons", [])
+    reason_text = ",".join(str(reason) for reason in reasons) if reasons else "none"
+    return "\n".join(
+        [
+            f"freshness_status={payload.get('status', 'stale')}",
+            f"fresh={str(bool(payload.get('fresh', False))).lower()}",
+            f"schema_valid={str(bool(payload.get('schema_valid', False))).lower()}",
+            f"authority_valid={str(bool(payload.get('authority_valid', False))).lower()}",
+            f"freshness_reasons={reason_text}",
+            f"recorded_input_digest={payload.get('recorded_input_digest', '')}",
+            f"current_input_digest={payload.get('current_input_digest', '')}",
+            "reporting_only=true",
+            "repo_mutation=false",
+            "automation_allowed=false",
+            "patch_application_allowed=false",
+            "merge_authorized=false",
+            "semantic_equivalence_proven=false",
+        ]
+    )
+
 
 AUTHORITY_FIELDS = (
     "automation_allowed",
@@ -208,18 +462,7 @@ def build_remediation_readiness_report(
 
     blocking_gaps = [name for name, passed in readiness_checks.items() if not passed]
 
-    contract_files = [
-        "src/sdetkit/safety_gate.py",
-        "src/sdetkit/failure_vector.py",
-        SAFETYGATE_POLICY_PATH,
-        "docs/safety-gate-policy-matrix.md",
-        "src/sdetkit/adaptive_remediation_policy.py",
-        "src/sdetkit/adaptive_patch_plan.py",
-        "src/sdetkit/adaptive_fix_audit.py",
-        "src/sdetkit/protected_verifier.py",
-        "src/sdetkit/patch_scorer.py",
-        DEFAULT_POLICY_PATH,
-    ]
+    contract_files = list(CONTRACT_FILES)
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -229,6 +472,10 @@ def build_remediation_readiness_report(
         if policy_file.is_relative_to(repo_root)
         else policy_file.as_posix(),
         "policy": _policy_summary(policy),
+        "input_provenance": remediation_readiness_input_provenance(
+            repo_root,
+            policy_path=policy_file,
+        ),
         "safety_gate_policy": safety_gate_policy,
         "contract_files": [
             _contract_status(repo_root / path, display_path=path) for path in contract_files
@@ -283,12 +530,17 @@ def build_remediation_readiness_report(
 
 
 def render_markdown(payload: dict[str, Any]) -> str:
+    provenance = _as_dict(payload.get("input_provenance"))
     lines = [
         "# SDETKit remediation readiness report",
         "",
         f"- report_status: {payload['report_status']}",
         f"- policy_path: `{payload['policy_path']}`",
         f"- blocking_gap_count: {payload['blocking_gap_count']}",
+        f"- input_digest: `{provenance.get('input_digest', '')}`",
+        f"- digest_algorithm: `{provenance.get('digest_algorithm', '')}`",
+        f"- input_count: {provenance.get('input_count', 0)}",
+        f"- generator_source: `{provenance.get('generator_source', '')}`",
         "- verifier_backed: true",
         "- dry_run_only: true",
         "- review_first: true",
@@ -384,7 +636,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--markdown-out", default="")
     parser.add_argument("--format", choices=["json", "text"], default="json")
+    parser.add_argument(
+        "--check-freshness",
+        action="store_true",
+        help="Check the existing report against current inputs, schema, and authority without rewriting it.",
+    )
     ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    if ns.check_freshness:
+        freshness = check_remediation_readiness_report_freshness(
+            root=ns.root,
+            policy_path=ns.policy or None,
+            report_path=ns.out,
+        )
+        if ns.format == "json":
+            sys.stdout.write(json.dumps(freshness, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(render_remediation_readiness_freshness_text(freshness) + "\n")
+        return 0 if freshness["fresh"] else 1
 
     payload = write_artifacts(
         root=ns.root,

--- a/tests/test_remediation_readiness_report.py
+++ b/tests/test_remediation_readiness_report.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from sdetkit.remediation_readiness_report import (
     SCHEMA_VERSION,
     build_remediation_readiness_report,
+    check_remediation_readiness_report_freshness,
+    remediation_readiness_input_provenance,
+    validate_remediation_readiness_report_freshness,
     write_artifacts,
 )
 
@@ -16,6 +19,13 @@ def test_remediation_readiness_report_is_verifier_backed_and_non_authorizing() -
     assert payload["schema_version"] == SCHEMA_VERSION
     assert payload["report_status"] == "review_required"
     assert payload["blocking_gap_count"] == 0
+    provenance = payload["input_provenance"]
+    assert provenance["digest_algorithm"] == "sha256"
+    assert len(provenance["input_digest"]) == 64
+    assert provenance["generator_schema_version"] == SCHEMA_VERSION
+    assert provenance["generator_source"] == "src/sdetkit/remediation_readiness_report.py"
+    assert provenance["policy_path"] == "config/adaptive_remediation_policy.default.json"
+    assert provenance["missing_input_count"] == 0
 
     checks = payload["readiness_checks"]
     assert checks["policy_accepts_review_only_dry_run_plan"] is True
@@ -98,6 +108,8 @@ def test_remediation_readiness_report_writes_json_and_markdown(tmp_path: Path) -
 
     rendered = markdown.read_text(encoding="utf-8")
     assert "# SDETKit remediation readiness report" in rendered
+    assert "input_digest:" in rendered
+    assert "digest_algorithm: `sha256`" in rendered
     assert "verifier_backed: true" in rendered
     assert "dry_run_only: true" in rendered
     assert "SafetyGate proof contract" in rendered
@@ -141,3 +153,191 @@ def test_remediation_readiness_report_stays_hidden_from_default_help() -> None:
 
     assert "remediation-readiness-report" not in default_help
     assert "remediation-readiness-report" in hidden_help
+
+
+def test_remediation_readiness_input_digest_is_deterministic_and_root_independent(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    first_generator = first / "generator.py"
+    second_generator = second / "generator.py"
+    first_generator.write_text("generator-v1\n", encoding="utf-8")
+    second_generator.write_text("generator-v1\n", encoding="utf-8")
+
+    first_payload = remediation_readiness_input_provenance(
+        first,
+        generator_path=first_generator,
+    )
+    second_payload = remediation_readiness_input_provenance(
+        second,
+        generator_path=second_generator,
+    )
+
+    assert first_payload == second_payload
+    assert first_payload["digest_algorithm"] == "sha256"
+    assert len(first_payload["input_digest"]) == 64
+    assert first_payload["generator_schema_version"] == SCHEMA_VERSION
+    assert first_payload["missing_input_count"] > 0
+
+
+def test_remediation_readiness_input_digest_changes_with_policy_or_generator(
+    tmp_path: Path,
+) -> None:
+    generator = tmp_path / "generator.py"
+    generator.write_text("generator-v1\n", encoding="utf-8")
+    baseline = remediation_readiness_input_provenance(
+        tmp_path,
+        generator_path=generator,
+    )
+
+    policy = tmp_path / "config" / "adaptive_remediation_policy.default.json"
+    policy.parent.mkdir(parents=True)
+    policy.write_text('{"schema_version":"policy-v1"}\n', encoding="utf-8")
+    policy_changed = remediation_readiness_input_provenance(
+        tmp_path,
+        generator_path=generator,
+    )
+    assert policy_changed["input_digest"] != baseline["input_digest"]
+
+    policy.unlink()
+    generator.write_text("generator-v2\n", encoding="utf-8")
+    generator_changed = remediation_readiness_input_provenance(
+        tmp_path,
+        generator_path=generator,
+    )
+    assert generator_changed["input_digest"] != baseline["input_digest"]
+
+
+def test_remediation_readiness_freshness_detects_matching_and_stale_reports(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "reports" / "remediation-readiness-report.json"
+    write_artifacts(root=tmp_path, out=out)
+
+    fresh = check_remediation_readiness_report_freshness(
+        root=tmp_path,
+        report_path=out,
+    )
+    assert fresh["status"] == "fresh"
+    assert fresh["fresh"] is True
+    assert fresh["schema_valid"] is True
+    assert fresh["authority_valid"] is True
+    assert fresh["reasons"] == []
+    assert fresh["repo_mutation"] is False
+    assert fresh["automation_allowed"] is False
+    assert fresh["patch_application_allowed"] is False
+    assert fresh["merge_authorized"] is False
+
+    policy = tmp_path / "config" / "adaptive_remediation_policy.default.json"
+    policy.parent.mkdir(parents=True)
+    policy.write_text('{"schema_version":"policy-v1"}\n', encoding="utf-8")
+    stale = check_remediation_readiness_report_freshness(
+        root=tmp_path,
+        report_path=out,
+    )
+    assert stale["status"] == "stale"
+    assert stale["fresh"] is False
+    assert "input_digest_mismatch" in stale["reasons"]
+
+
+def test_remediation_readiness_freshness_rejects_schema_and_authority_drift(
+    tmp_path: Path,
+) -> None:
+    payload = build_remediation_readiness_report(tmp_path)
+    payload["schema_version"] = "sdetkit.remediation_readiness_report.v0"
+    payload["patch_application_allowed"] = True
+    payload["authority_boundary"]["merge_authorized"] = True
+    payload["rules"]["safe_to_patch"] = True
+
+    result = validate_remediation_readiness_report_freshness(tmp_path, payload)
+
+    assert result["status"] == "stale"
+    assert result["fresh"] is False
+    assert result["schema_valid"] is False
+    assert result["authority_valid"] is False
+    assert "schema_version_mismatch" in result["reasons"]
+    assert "patch_application_allowed_mismatch" in result["reasons"]
+    assert "authority_boundary_merge_authorized_mismatch" in result["reasons"]
+    assert "rules_safe_to_patch_mismatch" in result["reasons"]
+
+
+def test_remediation_readiness_freshness_rejects_missing_invalid_and_non_object(
+    tmp_path: Path,
+) -> None:
+    missing = check_remediation_readiness_report_freshness(
+        root=tmp_path,
+        report_path=tmp_path / "missing.json",
+    )
+    assert missing["fresh"] is False
+    assert "report_missing" in missing["reasons"]
+
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text("{invalid", encoding="utf-8")
+    invalid = check_remediation_readiness_report_freshness(
+        root=tmp_path,
+        report_path=invalid_path,
+    )
+    assert invalid["fresh"] is False
+    assert "report_invalid_json" in invalid["reasons"]
+
+    non_object_path = tmp_path / "non-object.json"
+    non_object_path.write_text("[]\n", encoding="utf-8")
+    non_object = check_remediation_readiness_report_freshness(
+        root=tmp_path,
+        report_path=non_object_path,
+    )
+    assert non_object["fresh"] is False
+    assert "report_not_object" in non_object["reasons"]
+
+
+def test_remediation_readiness_cli_checks_freshness_without_rewriting(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from sdetkit.cli import main as cli_main
+
+    out = tmp_path / "reports" / "remediation-readiness-report.json"
+    write_artifacts(root=tmp_path, out=out)
+    original = out.read_text(encoding="utf-8")
+
+    rc = cli_main(
+        [
+            "remediation-readiness-report",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--check-freshness",
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "freshness_status=fresh" in stdout
+    assert "schema_valid=true" in stdout
+    assert "authority_valid=true" in stdout
+    assert out.read_text(encoding="utf-8") == original
+
+    policy = tmp_path / "config" / "adaptive_remediation_policy.default.json"
+    policy.parent.mkdir(parents=True)
+    policy.write_text('{"schema_version":"policy-v1"}\n', encoding="utf-8")
+    rc = cli_main(
+        [
+            "remediation-readiness-report",
+            "--root",
+            str(tmp_path),
+            "--out",
+            str(out),
+            "--check-freshness",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 1
+    stale = json.loads(capsys.readouterr().out)
+    assert stale["fresh"] is False
+    assert out.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary
- add deterministic SHA-256 provenance for remediation-readiness inputs
- add fail-closed freshness validation for input, schema, authority, and rules drift
- add missing, invalid JSON, and non-object report handling
- register and forward `--check-freshness` through the existing hidden root command

## Scope
- `src/sdetkit/_legacy_cli.py`
- `src/sdetkit/remediation_readiness_report.py`
- `tests/test_remediation_readiness_report.py`

## Verification
- focused remediation-readiness tests passed
- Ruff check and format check passed
- generated live report returned `freshness_status=fresh`
- schema and authority validation returned true
- `make proof-after-format` passed
- candidate patch SHA: `2252ff89abbd46bbc61e51eeaec9fe5b34cfb18aafc95d4b6864e9e49bf2a135`

## Compatibility
- hidden command visibility unchanged
- command tier unchanged
- dispatch target unchanged
- report generation behavior remains review-first and non-authorizing

## Authority boundary
- `repo_mutation=false`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`

## Risk
Low. Rollback is a single commit revert.
