### PR TITLE
fix(reporting): detect stale adoption learning snapshots

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -696,7 +696,7 @@
       "id": "adoption-learning-report-json",
       "path": "build/sdetkit/adoption-learning-report.json",
       "produced_by": "python -m sdetkit adoption-learning-report --matrix-json build/sdetkit/adoption-real-world-learning/adoption-real-world-matrix.json --out build/sdetkit/adoption-learning-report.json --format json",
-      "schema_version": "sdetkit.adoption_learning_report.v1",
+      "schema_version": "sdetkit.adoption_learning_report.v2",
       "required_fields": [
         "schema_version",
         "source_matrix",

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -12,7 +12,31 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.acceleration",
         "module_path": "src/sdetkit/acceleration.py",
+        "tests_referencing_module": 7
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_baseline_hardening_contract.py"
+        ],
+        "contract_scripts": 1,
+        "id": 0,
+        "lane": "baseline_hardening",
+        "legacy_anchor_refs_in_module": 0,
+        "module": "sdetkit.baseline_hardening",
+        "module_path": "src/sdetkit/baseline_hardening.py",
         "tests_referencing_module": 6
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_baseline_wrap_contract.py"
+        ],
+        "contract_scripts": 1,
+        "id": 0,
+        "lane": "baseline_wrap",
+        "legacy_anchor_refs_in_module": 0,
+        "module": "sdetkit.baseline_wrap",
+        "module_path": "src/sdetkit/baseline_wrap.py",
+        "tests_referencing_module": 5
       },
       {
         "contract_script_paths": [
@@ -232,30 +256,6 @@
       },
       {
         "contract_script_paths": [
-          "scripts/check_example_asset2_contract.py"
-        ],
-        "contract_scripts": 1,
-        "id": 0,
-        "lane": "example_asset2",
-        "legacy_anchor_refs_in_module": 0,
-        "module": "sdetkit.example_asset2",
-        "module_path": "src/sdetkit/example_asset2.py",
-        "tests_referencing_module": 1
-      },
-      {
-        "contract_script_paths": [
-          "scripts/check_example_asset_contract.py"
-        ],
-        "contract_scripts": 1,
-        "id": 0,
-        "lane": "example_asset",
-        "legacy_anchor_refs_in_module": 0,
-        "module": "sdetkit.example_asset",
-        "module_path": "src/sdetkit/example_asset.py",
-        "tests_referencing_module": 2
-      },
-      {
-        "contract_script_paths": [
           "scripts/check_distribution_batch_contract.py"
         ],
         "contract_scripts": 1,
@@ -364,6 +364,30 @@
       },
       {
         "contract_script_paths": [
+          "scripts/check_example_asset2_contract.py"
+        ],
+        "contract_scripts": 1,
+        "id": 0,
+        "lane": "example_asset2",
+        "legacy_anchor_refs_in_module": 0,
+        "module": "sdetkit.example_asset2",
+        "module_path": "src/sdetkit/example_asset2.py",
+        "tests_referencing_module": 3
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_example_asset_contract.py"
+        ],
+        "contract_scripts": 1,
+        "id": 0,
+        "lane": "example_asset",
+        "legacy_anchor_refs_in_module": 0,
+        "module": "sdetkit.example_asset",
+        "module_path": "src/sdetkit/example_asset.py",
+        "tests_referencing_module": 4
+      },
+      {
+        "contract_script_paths": [
           "scripts/check_execution_prioritization_contract.py"
         ],
         "contract_scripts": 1,
@@ -396,7 +420,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.expansion",
         "module_path": "src/sdetkit/expansion.py",
-        "tests_referencing_module": 28
+        "tests_referencing_module": 40
       },
       {
         "contract_script_paths": [
@@ -564,7 +588,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.onboarding",
         "module_path": "src/sdetkit/onboarding.py",
-        "tests_referencing_module": 29
+        "tests_referencing_module": 32
       },
       {
         "contract_script_paths": [
@@ -588,7 +612,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.optimization",
         "module_path": "src/sdetkit/optimization.py",
-        "tests_referencing_module": 18
+        "tests_referencing_module": 21
       },
       {
         "contract_script_paths": [
@@ -604,75 +628,15 @@
       },
       {
         "contract_script_paths": [
-          "scripts/check_baseline_hardening_contract.py"
-        ],
-        "contract_scripts": 1,
-        "id": 0,
-        "lane": "baseline_hardening",
-        "legacy_anchor_refs_in_module": 0,
-        "module": "sdetkit.baseline_hardening",
-        "module_path": "src/sdetkit/baseline_hardening.py",
-        "tests_referencing_module": 3
-      },
-      {
-        "contract_script_paths": [
-          "scripts/check_baseline_wrap_contract.py"
-        ],
-        "contract_scripts": 1,
-        "id": 0,
-        "lane": "baseline_wrap",
-        "legacy_anchor_refs_in_module": 0,
-        "module": "sdetkit.baseline_wrap",
-        "module_path": "src/sdetkit/baseline_wrap.py",
-        "tests_referencing_module": 2
-      },
-      {
-        "contract_script_paths": [
-          "scripts/check_release_readiness_hardening_contract.py"
-        ],
-        "contract_scripts": 1,
-        "id": 0,
-        "lane": "release readiness_hardening",
-        "legacy_anchor_refs_in_module": 0,
-        "module": "sdetkit.release_readiness_hardening",
-        "module_path": "src/sdetkit/release readiness_hardening.py",
-        "tests_referencing_module": 2
-      },
-      {
-        "contract_script_paths": [
-          "scripts/check_release_readiness_kickoff_contract.py"
-        ],
-        "contract_scripts": 1,
-        "id": 0,
-        "lane": "release readiness_kickoff",
-        "legacy_anchor_refs_in_module": 0,
-        "module": "sdetkit.release_readiness_kickoff",
-        "module_path": "src/sdetkit/release readiness_kickoff.py",
-        "tests_referencing_module": 3
-      },
-      {
-        "contract_script_paths": [
-          "scripts/check_release_readiness_wrap_handoff_contract.py"
-        ],
-        "contract_scripts": 1,
-        "id": 0,
-        "lane": "release readiness_wrap_handoff",
-        "legacy_anchor_refs_in_module": 0,
-        "module": "sdetkit.release_readiness_wrap_handoff",
-        "module_path": "src/sdetkit/release readiness_wrap_handoff.py",
-        "tests_referencing_module": 1
-      },
-      {
-        "contract_script_paths": [
           "scripts/check_platform_readiness_kickoff_contract.py"
         ],
         "contract_scripts": 1,
         "id": 0,
-        "lane": "phase3_kickoff",
+        "lane": "platform_readiness_kickoff",
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.platform_readiness_kickoff",
         "module_path": "src/sdetkit/platform_readiness_kickoff.py",
-        "tests_referencing_module": 1
+        "tests_referencing_module": 4
       },
       {
         "contract_script_paths": [
@@ -680,11 +644,11 @@
         ],
         "contract_scripts": 1,
         "id": 0,
-        "lane": "phase3_preplan",
+        "lane": "platform_readiness_preplan",
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.platform_readiness_preplan",
         "module_path": "src/sdetkit/platform_readiness_preplan.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 4
       },
       {
         "contract_script_paths": [
@@ -692,11 +656,11 @@
         ],
         "contract_scripts": 1,
         "id": 0,
-        "lane": "phase3_wrap_publication",
+        "lane": "platform_readiness_wrap_publication",
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.platform_readiness_wrap_publication",
         "module_path": "src/sdetkit/platform_readiness_wrap_publication.py",
-        "tests_referencing_module": 1
+        "tests_referencing_module": 4
       },
       {
         "contract_script_paths": [
@@ -720,7 +684,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 123
+        "tests_referencing_module": 159
       },
       {
         "contract_script_paths": [
@@ -768,7 +732,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.release_prioritization",
         "module_path": "src/sdetkit/release_prioritization.py",
-        "tests_referencing_module": 1
+        "tests_referencing_module": 2
       },
       {
         "contract_script_paths": [
@@ -780,7 +744,43 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.release_readiness",
         "module_path": "src/sdetkit/release_readiness.py",
-        "tests_referencing_module": 9
+        "tests_referencing_module": 33
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_release_readiness_hardening_contract.py"
+        ],
+        "contract_scripts": 1,
+        "id": 0,
+        "lane": "release_readiness_hardening",
+        "legacy_anchor_refs_in_module": 0,
+        "module": "sdetkit.release_readiness_hardening",
+        "module_path": "src/sdetkit/release_readiness_hardening.py",
+        "tests_referencing_module": 4
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_release_readiness_kickoff_contract.py"
+        ],
+        "contract_scripts": 1,
+        "id": 0,
+        "lane": "release_readiness_kickoff",
+        "legacy_anchor_refs_in_module": 0,
+        "module": "sdetkit.release_readiness_kickoff",
+        "module_path": "src/sdetkit/release_readiness_kickoff.py",
+        "tests_referencing_module": 6
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_release_readiness_wrap_handoff_contract.py"
+        ],
+        "contract_scripts": 1,
+        "id": 0,
+        "lane": "release_readiness_wrap_handoff",
+        "legacy_anchor_refs_in_module": 0,
+        "module": "sdetkit.release_readiness_wrap_handoff",
+        "module_path": "src/sdetkit/release_readiness_wrap_handoff.py",
+        "tests_referencing_module": 4
       },
       {
         "contract_script_paths": [
@@ -792,7 +792,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.reliability",
         "module_path": "src/sdetkit/reliability.py",
-        "tests_referencing_module": 29
+        "tests_referencing_module": 30
       },
       {
         "contract_script_paths": [
@@ -816,7 +816,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.scale",
         "module_path": "src/sdetkit/scale.py",
-        "tests_referencing_module": 22
+        "tests_referencing_module": 26
       },
       {
         "contract_script_paths": [
@@ -840,7 +840,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.scale",
         "module_path": "src/sdetkit/scale.py",
-        "tests_referencing_module": 22
+        "tests_referencing_module": 26
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -787,6 +787,7 @@ Then use stability-aware command discovery:
         "adoption-learning-report",
         help=argparse.SUPPRESS,
     )
+    adoption_learning_report.add_argument("--root", default=".")
     adoption_learning_report.add_argument("--matrix-json", required=True)
     adoption_learning_report.add_argument("--repo-memory-profile", default="")
     adoption_learning_report.add_argument(
@@ -794,6 +795,7 @@ Then use stability-aware command discovery:
     )
     adoption_learning_report.add_argument("--markdown-out", default="")
     adoption_learning_report.add_argument("--format", choices=["json", "text"], default="json")
+    adoption_learning_report.add_argument("--check-freshness", action="store_true")
 
     release_anti_hijack_threat_model = sub.add_parser(
         "release-anti-hijack-threat-model",
@@ -1693,6 +1695,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "adoption-learning-report":
         forwarded = [
+            "--root",
+            str(ns.root),
             "--matrix-json",
             str(ns.matrix_json),
             "--out",
@@ -1704,6 +1708,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             forwarded.extend(["--repo-memory-profile", str(ns.repo_memory_profile)])
         if str(ns.markdown_out):
             forwarded.extend(["--markdown-out", str(ns.markdown_out)])
+        if bool(ns.check_freshness):
+            forwarded.append("--check-freshness")
         return _run_module_main("sdetkit.adoption_learning_report", forwarded)
 
     if ns.cmd == "release-anti-hijack-threat-model":

--- a/src/sdetkit/adoption_learning_report.py
+++ b/src/sdetkit/adoption_learning_report.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import subprocess
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = "sdetkit.adoption_learning_report.v1"
+SCHEMA_VERSION = "sdetkit.adoption_learning_report.v2"
 
 AUTHORITY_FIELDS = (
     "automation_allowed",
@@ -15,6 +17,356 @@ AUTHORITY_FIELDS = (
     "merge_authorized",
     "semantic_equivalence_proven",
 )
+
+ACCEPTED_MATRIX_SCHEMA = "sdetkit.adoption_real_world_learning_matrix.v1"
+ACCEPTED_REPO_MEMORY_SCHEMAS = ("sdetkit.repo_memory.v6",)
+INPUT_DIGEST_ALGORITHM = "sha256"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/adoption_learning_report.py"
+
+
+def _update_input_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def _display_input_path(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _git_head_sha(root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def _source_schema(path: Path) -> str:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    return str(payload.get("schema_version", "")).strip()
+
+
+def adoption_learning_input_provenance(
+    matrix_json: str | Path,
+    *,
+    root: str | Path = ".",
+    repo_memory_profile: str | Path | None = None,
+    generator_path: str | Path | None = None,
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    repo_root = Path(root).resolve()
+    matrix_path = Path(matrix_json).resolve()
+    profile_path = Path(repo_memory_profile).resolve() if repo_memory_profile else None
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+    head_sha = _git_head_sha(repo_root) if current_head_sha is None else current_head_sha
+
+    matrix_content = matrix_path.read_bytes() if matrix_path.is_file() else b"<missing>"
+    profile_content = (
+        profile_path.read_bytes()
+        if profile_path is not None and profile_path.is_file()
+        else b"<not-provided>"
+        if profile_path is None
+        else b"<missing>"
+    )
+    generator_content = generator.read_bytes() if generator.is_file() else b"<missing>"
+
+    inputs = [
+        ("accepted_matrix_schema", ACCEPTED_MATRIX_SCHEMA.encode("utf-8")),
+        (
+            "accepted_repo_memory_schemas",
+            "\n".join(ACCEPTED_REPO_MEMORY_SCHEMAS).encode("utf-8"),
+        ),
+        ("current_head_sha", head_sha.encode("utf-8")),
+        ("generator_schema_version", SCHEMA_VERSION.encode("utf-8")),
+        (GENERATOR_SOURCE_LABEL, generator_content),
+        ("source_matrix", matrix_content),
+        ("repo_memory_profile", profile_content),
+    ]
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_input_digest(hasher, label, content)
+
+    return {
+        "digest_algorithm": INPUT_DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+        "matrix_path": _display_input_path(repo_root, matrix_path),
+        "matrix_sha256": hashlib.sha256(matrix_content).hexdigest(),
+        "matrix_schema_version": _source_schema(matrix_path),
+        "repo_memory_profile_connected": profile_path is not None,
+        "repo_memory_profile_path": (
+            _display_input_path(repo_root, profile_path) if profile_path is not None else ""
+        ),
+        "repo_memory_profile_sha256": hashlib.sha256(profile_content).hexdigest(),
+        "repo_memory_profile_schema_version": (
+            _source_schema(profile_path) if profile_path is not None else ""
+        ),
+        "accepted_matrix_schema": ACCEPTED_MATRIX_SCHEMA,
+        "accepted_repo_memory_schemas": list(ACCEPTED_REPO_MEMORY_SCHEMAS),
+        "current_head_sha": head_sha,
+        "current_head_available": bool(head_sha),
+    }
+
+
+def _source_relationships(provenance: dict[str, Any]) -> dict[str, Any]:
+    profile_connected = bool(provenance.get("repo_memory_profile_connected"))
+    profile_schema = str(provenance.get("repo_memory_profile_schema_version", ""))
+    matrix_schema = str(provenance.get("matrix_schema_version", ""))
+    return {
+        "matrix_schema_version": matrix_schema,
+        "accepted_matrix_schema": ACCEPTED_MATRIX_SCHEMA,
+        "matrix_schema_accepted": matrix_schema == ACCEPTED_MATRIX_SCHEMA,
+        "repo_memory_profile_connected": profile_connected,
+        "repo_memory_profile_schema_version": profile_schema,
+        "accepted_repo_memory_schemas": list(ACCEPTED_REPO_MEMORY_SCHEMAS),
+        "repo_memory_profile_schema_accepted": (
+            not profile_connected or profile_schema in ACCEPTED_REPO_MEMORY_SCHEMAS
+        ),
+        "current_head_sha": str(provenance.get("current_head_sha", "")),
+        "current_head_bound": bool(provenance.get("current_head_available")),
+    }
+
+
+def validate_adoption_learning_report_freshness(
+    payload: dict[str, Any],
+    *,
+    matrix_json: str | Path,
+    root: str | Path = ".",
+    repo_memory_profile: str | Path | None = None,
+    generator_path: str | Path | None = None,
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    current = adoption_learning_input_provenance(
+        matrix_json,
+        root=root,
+        repo_memory_profile=repo_memory_profile,
+        generator_path=generator_path,
+        current_head_sha=current_head_sha,
+    )
+    expected_relationships = _source_relationships(current)
+    reasons: list[str] = []
+
+    recorded = payload.get("input_provenance")
+    if not isinstance(recorded, dict):
+        recorded = {}
+        reasons.append("missing_input_provenance")
+
+    for field in (
+        "digest_algorithm",
+        "input_digest",
+        "input_count",
+        "generator_schema_version",
+        "generator_source",
+        "matrix_path",
+        "matrix_sha256",
+        "matrix_schema_version",
+        "repo_memory_profile_connected",
+        "repo_memory_profile_path",
+        "repo_memory_profile_sha256",
+        "repo_memory_profile_schema_version",
+        "accepted_matrix_schema",
+        "accepted_repo_memory_schemas",
+        "current_head_sha",
+        "current_head_available",
+    ):
+        if recorded.get(field) != current.get(field):
+            reasons.append(f"{field}_mismatch")
+
+    schema_valid = payload.get("schema_version") == SCHEMA_VERSION
+    if not schema_valid:
+        reasons.append("schema_version_mismatch")
+
+    relationships = payload.get("source_relationships")
+    if not isinstance(relationships, dict):
+        relationships = {}
+        reasons.append("missing_source_relationships")
+    for field, expected in expected_relationships.items():
+        if relationships.get(field) != expected:
+            reasons.append(f"source_relationships_{field}_mismatch")
+
+    source_schema_valid = bool(
+        expected_relationships["matrix_schema_accepted"]
+        and expected_relationships["repo_memory_profile_schema_accepted"]
+    )
+    if not source_schema_valid:
+        reasons.append("source_schema_not_accepted")
+
+    current_head_valid = bool(
+        current["current_head_available"]
+        and recorded.get("current_head_sha") == current["current_head_sha"]
+    )
+    if not current_head_valid:
+        reasons.append("current_head_mismatch")
+
+    authority_valid = True
+    for field in AUTHORITY_FIELDS:
+        if payload.get(field) is not False:
+            authority_valid = False
+            reasons.append(f"{field}_mismatch")
+
+    boundary = payload.get("authority_boundary")
+    if not isinstance(boundary, dict):
+        authority_valid = False
+        reasons.append("missing_authority_boundary")
+    else:
+        for field in AUTHORITY_FIELDS:
+            if boundary.get(field) is not False:
+                authority_valid = False
+                reasons.append(f"authority_boundary_{field}_mismatch")
+
+    rules = payload.get("rules")
+    expected_rules = {
+        "source_matrix_only": not bool(current["repo_memory_profile_connected"]),
+        "repo_memory_profile_read": bool(current["repo_memory_profile_connected"]),
+        "repo_memory_profile_authoritative": False,
+        "target_repos_read": False,
+        "install_dependencies": False,
+        "target_tests_executed": False,
+        "target_repo_mutation": False,
+        "target_pr_or_issue_opened": False,
+        "endorsement_claim": False,
+        "review_first": True,
+    }
+    if not isinstance(rules, dict):
+        authority_valid = False
+        reasons.append("missing_rules")
+    else:
+        for field, expected in expected_rules.items():
+            if rules.get(field) is not expected:
+                authority_valid = False
+                reasons.append(f"rules_{field}_mismatch")
+
+    reasons = sorted(set(reasons))
+    fresh = not reasons
+    return {
+        "status": "fresh" if fresh else "stale",
+        "fresh": fresh,
+        "schema_valid": schema_valid,
+        "source_schema_valid": source_schema_valid,
+        "current_head_valid": current_head_valid,
+        "authority_valid": authority_valid,
+        "reasons": reasons,
+        "recorded_input_digest": recorded.get("input_digest", ""),
+        "current_input_digest": current["input_digest"],
+        "recorded_head_sha": recorded.get("current_head_sha", ""),
+        "current_head_sha": current["current_head_sha"],
+        "reporting_only": True,
+        "repo_mutation": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def check_adoption_learning_report_freshness(
+    *,
+    report_path: str | Path,
+    matrix_json: str | Path,
+    root: str | Path = ".",
+    repo_memory_profile: str | Path | None = None,
+    generator_path: str | Path | None = None,
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    path = Path(report_path)
+    if not path.is_file():
+        result = validate_adoption_learning_report_freshness(
+            {},
+            matrix_json=matrix_json,
+            root=root,
+            repo_memory_profile=repo_memory_profile,
+            generator_path=generator_path,
+            current_head_sha=current_head_sha,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_missing"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        result = validate_adoption_learning_report_freshness(
+            {},
+            matrix_json=matrix_json,
+            root=root,
+            repo_memory_profile=repo_memory_profile,
+            generator_path=generator_path,
+            current_head_sha=current_head_sha,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_invalid_json"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    if not isinstance(loaded, dict):
+        result = validate_adoption_learning_report_freshness(
+            {},
+            matrix_json=matrix_json,
+            root=root,
+            repo_memory_profile=repo_memory_profile,
+            generator_path=generator_path,
+            current_head_sha=current_head_sha,
+        )
+        result["reasons"] = sorted(set([*result["reasons"], "report_not_object"]))
+        result["status"] = "stale"
+        result["fresh"] = False
+        return result
+
+    return validate_adoption_learning_report_freshness(
+        loaded,
+        matrix_json=matrix_json,
+        root=root,
+        repo_memory_profile=repo_memory_profile,
+        generator_path=generator_path,
+        current_head_sha=current_head_sha,
+    )
+
+
+def render_adoption_learning_freshness_text(payload: dict[str, Any]) -> str:
+    reasons = payload.get("reasons", [])
+    reason_text = ",".join(str(reason) for reason in reasons) if reasons else "none"
+    return "\n".join(
+        [
+            f"freshness_status={payload.get('status', 'stale')}",
+            f"fresh={str(bool(payload.get('fresh', False))).lower()}",
+            f"schema_valid={str(bool(payload.get('schema_valid', False))).lower()}",
+            f"source_schema_valid={str(bool(payload.get('source_schema_valid', False))).lower()}",
+            f"current_head_valid={str(bool(payload.get('current_head_valid', False))).lower()}",
+            f"authority_valid={str(bool(payload.get('authority_valid', False))).lower()}",
+            f"freshness_reasons={reason_text}",
+            f"recorded_input_digest={payload.get('recorded_input_digest', '')}",
+            f"current_input_digest={payload.get('current_input_digest', '')}",
+            f"recorded_head_sha={payload.get('recorded_head_sha', '')}",
+            f"current_head_sha={payload.get('current_head_sha', '')}",
+            "reporting_only=true",
+            "repo_mutation=false",
+            "automation_allowed=false",
+            "patch_application_allowed=false",
+            "merge_authorized=false",
+            "semantic_equivalence_proven=false",
+        ]
+    )
+
 
 HIGH_LEVERAGE_CLASSES = {
     "weak_proof_command_mapping",
@@ -143,10 +495,19 @@ def build_adoption_learning_report(
     matrix_json: str | Path,
     *,
     repo_memory_profile: str | Path | None = None,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
 ) -> dict[str, Any]:
     matrix_path = Path(matrix_json).resolve()
     matrix = _load_json_object(matrix_path)
     repo_memory_summary = _repo_memory_profile_summary(repo_memory_profile)
+    provenance = adoption_learning_input_provenance(
+        matrix_path,
+        root=root,
+        repo_memory_profile=repo_memory_profile,
+        current_head_sha=current_head_sha,
+    )
+    source_relationships = _source_relationships(provenance)
 
     raw_candidates = matrix.get("upgrade_candidates")
     if not isinstance(raw_candidates, list):
@@ -168,6 +529,8 @@ def build_adoption_learning_report(
 
     return {
         "schema_version": SCHEMA_VERSION,
+        "input_provenance": provenance,
+        "source_relationships": source_relationships,
         "source_matrix": matrix_path.as_posix(),
         "source_matrix_schema_version": str(matrix.get("schema_version", "")),
         "source_matrix_status": matrix_status,
@@ -205,12 +568,23 @@ def build_adoption_learning_report(
 
 
 def render_adoption_learning_report_markdown(payload: dict[str, Any]) -> str:
+    provenance = payload.get("input_provenance")
+    if not isinstance(provenance, dict):
+        provenance = {}
+    relationships = payload.get("source_relationships")
+    if not isinstance(relationships, dict):
+        relationships = {}
     lines = [
         "# SDETKit adoption learning report",
         "",
         f"- source_matrix_status: {payload['source_matrix_status']}",
         f"- source_repo_count: {payload['source_repo_count']}",
         f"- candidate_count: {payload['candidate_count']}",
+        f"- input_digest: `{provenance.get('input_digest', '')}`",
+        f"- current_head_sha: `{provenance.get('current_head_sha', '')}`",
+        f"- matrix_schema_accepted: {str(bool(relationships.get('matrix_schema_accepted'))).lower()}",
+        "- repo_memory_profile_schema_accepted: "
+        f"{str(bool(relationships.get('repo_memory_profile_schema_accepted'))).lower()}",
         "- review_first: true",
         "- safe_to_patch: false",
         "",
@@ -271,10 +645,14 @@ def write_adoption_learning_report_artifacts(
     out: str | Path,
     markdown_out: str | Path | None = None,
     repo_memory_profile: str | Path | None = None,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
 ) -> dict[str, Any]:
     payload = build_adoption_learning_report(
         matrix_json,
         repo_memory_profile=repo_memory_profile,
+        root=root,
+        current_head_sha=current_head_sha,
     )
     out_path = Path(out)
     markdown_path = Path(markdown_out) if markdown_out else out_path.with_suffix(".md")
@@ -295,18 +673,38 @@ def main(argv: Sequence[str] | None = None) -> int:
         prog="sdetkit adoption-learning-report",
         description="Prioritize review-first upgrade candidates from an adoption matrix artifact.",
     )
+    parser.add_argument("--root", default=".")
     parser.add_argument("--matrix-json", required=True)
     parser.add_argument("--repo-memory-profile", default="")
     parser.add_argument("--out", default="build/sdetkit/adoption-learning-report.json")
     parser.add_argument("--markdown-out", default="")
     parser.add_argument("--format", choices=["json", "text"], default="json")
+    parser.add_argument(
+        "--check-freshness",
+        action="store_true",
+        help="Check the existing report against matrix/profile inputs, accepted schemas, and current Git head without rewriting it.",
+    )
     ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    if ns.check_freshness:
+        freshness = check_adoption_learning_report_freshness(
+            report_path=ns.out,
+            matrix_json=ns.matrix_json,
+            root=ns.root,
+            repo_memory_profile=ns.repo_memory_profile or None,
+        )
+        if ns.format == "json":
+            sys.stdout.write(json.dumps(freshness, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(render_adoption_learning_freshness_text(freshness) + "\n")
+        return 0 if freshness["fresh"] else 1
 
     payload = write_adoption_learning_report_artifacts(
         matrix_json=ns.matrix_json,
         out=ns.out,
         markdown_out=ns.markdown_out or None,
         repo_memory_profile=ns.repo_memory_profile or None,
+        root=ns.root,
     )
 
     if ns.format == "json":

--- a/src/sdetkit/gates/security_gate.py
+++ b/src/sdetkit/gates/security_gate.py
@@ -606,6 +606,21 @@ def _looks_like_slug(token: str) -> bool:
     return True
 
 
+def _looks_like_snake_identifier(token: str) -> bool:
+    if len(token) < 20:
+        return False
+    if token.lower() != token:
+        return False
+    if "_" not in token:
+        return False
+    parts = token.split("_")
+    if len(parts) < 3:
+        return False
+    return all(
+        len(part) >= 3 and re.fullmatch(r"[a-z][a-z0-9]*", part) is not None for part in parts
+    )
+
+
 def _looks_like_uuid(token: str) -> bool:
     t = token
     if t.startswith("urn:uuid:"):
@@ -671,6 +686,8 @@ def _scan_text_patterns(rel_path: str, text: str) -> list[Finding]:
             if _looks_like_path(token):
                 continue
             if _looks_like_slug(token):
+                continue
+            if _looks_like_snake_identifier(token):
                 continue
             if _looks_like_uuid(token):
                 continue

--- a/tests/test_adoption_learning_report.py
+++ b/tests/test_adoption_learning_report.py
@@ -4,8 +4,13 @@ import json
 from pathlib import Path
 
 from sdetkit.adoption_learning_report import (
+    ACCEPTED_MATRIX_SCHEMA,
+    ACCEPTED_REPO_MEMORY_SCHEMAS,
     SCHEMA_VERSION,
+    adoption_learning_input_provenance,
     build_adoption_learning_report,
+    check_adoption_learning_report_freshness,
+    validate_adoption_learning_report_freshness,
     write_adoption_learning_report_artifacts,
 )
 
@@ -74,6 +79,15 @@ def test_adoption_learning_report_prioritizes_matrix_candidates(tmp_path: Path) 
     assert payload["source_matrix_status"] == "passed"
     assert payload["source_repo_count"] == 10
     assert payload["candidate_count"] == 3
+    provenance = payload["input_provenance"]
+    assert provenance["digest_algorithm"] == "sha256"
+    assert len(provenance["input_digest"]) == 64
+    assert provenance["matrix_schema_version"] == ACCEPTED_MATRIX_SCHEMA
+    assert provenance["current_head_available"] is True
+    relationships = payload["source_relationships"]
+    assert relationships["matrix_schema_accepted"] is True
+    assert relationships["repo_memory_profile_schema_accepted"] is True
+    assert relationships["current_head_bound"] is True
     assert payload["automation_allowed"] is False
     assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False
@@ -107,7 +121,11 @@ def test_adoption_learning_report_writes_json_and_markdown(tmp_path: Path) -> No
     assert out.is_file()
     assert markdown.is_file()
     assert json.loads(out.read_text(encoding="utf-8"))["schema_version"] == SCHEMA_VERSION
-    assert "# SDETKit adoption learning report" in markdown.read_text(encoding="utf-8")
+    rendered = markdown.read_text(encoding="utf-8")
+    assert "# SDETKit adoption learning report" in rendered
+    assert "input_digest:" in rendered
+    assert "matrix_schema_accepted: true" in rendered
+    assert "repo_memory_profile_schema_accepted: true" in rendered
     assert payload["candidate_count"] == 3
 
 
@@ -178,6 +196,7 @@ def test_adoption_learning_report_attaches_non_authorizing_repo_memory_profile(
     assert memory["profile_status"] == "live_proof_supported_memory"
     assert memory["memory_mode"] == "trusted_main_profile"
     assert memory["authoritative_for_adoption_report"] is False
+    assert payload["source_relationships"]["repo_memory_profile_schema_accepted"] is True
     assert memory["authority_boundary"] == {
         "automation_allowed": False,
         "patch_application_allowed": False,
@@ -229,3 +248,226 @@ def test_adoption_learning_report_cli_accepts_repo_memory_profile_context(
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["repo_memory_profile"]["connected"] is True
     assert payload["rules"]["repo_memory_profile_authoritative"] is False
+
+
+def test_adoption_learning_provenance_binds_matrix_profile_generator_and_head(
+    tmp_path: Path,
+) -> None:
+    matrix = _matrix(tmp_path / "matrix.json")
+    profile = tmp_path / "profile.json"
+    profile.write_text(
+        json.dumps({"schema_version": ACCEPTED_REPO_MEMORY_SCHEMAS[0]}),
+        encoding="utf-8",
+    )
+    generator = tmp_path / "generator.py"
+    generator.write_text("generator-v1\n", encoding="utf-8")
+
+    first = adoption_learning_input_provenance(
+        matrix,
+        root=tmp_path,
+        repo_memory_profile=profile,
+        generator_path=generator,
+        current_head_sha="head-a",
+    )
+    second = adoption_learning_input_provenance(
+        matrix,
+        root=tmp_path,
+        repo_memory_profile=profile,
+        generator_path=generator,
+        current_head_sha="head-a",
+    )
+    assert first == second
+    assert first["matrix_schema_version"] == ACCEPTED_MATRIX_SCHEMA
+    assert first["repo_memory_profile_schema_version"] == ACCEPTED_REPO_MEMORY_SCHEMAS[0]
+
+    matrix_payload = json.loads(matrix.read_text(encoding="utf-8"))
+    matrix_payload["repo_count"] = 11
+    matrix.write_text(json.dumps(matrix_payload), encoding="utf-8")
+    matrix_changed = adoption_learning_input_provenance(
+        matrix,
+        root=tmp_path,
+        repo_memory_profile=profile,
+        generator_path=generator,
+        current_head_sha="head-a",
+    )
+    assert matrix_changed["input_digest"] != first["input_digest"]
+
+    head_changed = adoption_learning_input_provenance(
+        matrix,
+        root=tmp_path,
+        repo_memory_profile=profile,
+        generator_path=generator,
+        current_head_sha="head-b",
+    )
+    assert head_changed["input_digest"] != matrix_changed["input_digest"]
+
+
+def test_adoption_learning_report_records_unaccepted_source_schema_relationships(
+    tmp_path: Path,
+) -> None:
+    matrix = _matrix(tmp_path / "matrix.json")
+    matrix_payload = json.loads(matrix.read_text(encoding="utf-8"))
+    matrix_payload["schema_version"] = "sdetkit.adoption_real_world_learning_matrix.v0"
+    matrix.write_text(json.dumps(matrix_payload), encoding="utf-8")
+    profile = tmp_path / "profile.json"
+    profile.write_text(
+        json.dumps({"schema_version": "sdetkit.repo_memory.v5"}),
+        encoding="utf-8",
+    )
+
+    payload = build_adoption_learning_report(
+        matrix,
+        repo_memory_profile=profile,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    relationships = payload["source_relationships"]
+    assert relationships["matrix_schema_accepted"] is False
+    assert relationships["repo_memory_profile_schema_accepted"] is False
+
+
+def test_adoption_learning_freshness_detects_source_and_head_drift(
+    tmp_path: Path,
+) -> None:
+    matrix = _matrix(tmp_path / "matrix.json")
+    report = tmp_path / "report.json"
+    write_adoption_learning_report_artifacts(
+        matrix_json=matrix,
+        out=report,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+
+    fresh = check_adoption_learning_report_freshness(
+        report_path=report,
+        matrix_json=matrix,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    assert fresh["fresh"] is True
+    assert fresh["source_schema_valid"] is True
+    assert fresh["current_head_valid"] is True
+    assert fresh["authority_valid"] is True
+
+    head_stale = check_adoption_learning_report_freshness(
+        report_path=report,
+        matrix_json=matrix,
+        root=tmp_path,
+        current_head_sha="head-b",
+    )
+    assert head_stale["fresh"] is False
+    assert head_stale["current_head_valid"] is False
+    assert "current_head_sha_mismatch" in head_stale["reasons"]
+
+    matrix_payload = json.loads(matrix.read_text(encoding="utf-8"))
+    matrix_payload["repo_count"] = 12
+    matrix.write_text(json.dumps(matrix_payload), encoding="utf-8")
+    source_stale = check_adoption_learning_report_freshness(
+        report_path=report,
+        matrix_json=matrix,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    assert source_stale["fresh"] is False
+    assert "matrix_sha256_mismatch" in source_stale["reasons"]
+
+
+def test_adoption_learning_freshness_fails_closed_for_bad_reports(tmp_path: Path) -> None:
+    matrix = _matrix(tmp_path / "matrix.json")
+    missing = check_adoption_learning_report_freshness(
+        report_path=tmp_path / "missing.json",
+        matrix_json=matrix,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    assert missing["fresh"] is False
+    assert "report_missing" in missing["reasons"]
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{", encoding="utf-8")
+    invalid_result = check_adoption_learning_report_freshness(
+        report_path=invalid,
+        matrix_json=matrix,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    assert invalid_result["fresh"] is False
+    assert "report_invalid_json" in invalid_result["reasons"]
+
+    non_object = tmp_path / "non-object.json"
+    non_object.write_text("[]", encoding="utf-8")
+    non_object_result = check_adoption_learning_report_freshness(
+        report_path=non_object,
+        matrix_json=matrix,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    assert non_object_result["fresh"] is False
+    assert "report_not_object" in non_object_result["reasons"]
+
+
+def test_adoption_learning_freshness_detects_authority_drift(tmp_path: Path) -> None:
+    matrix = _matrix(tmp_path / "matrix.json")
+    payload = build_adoption_learning_report(
+        matrix,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    payload["automation_allowed"] = True
+
+    result = validate_adoption_learning_report_freshness(
+        payload,
+        matrix_json=matrix,
+        root=tmp_path,
+        current_head_sha="head-a",
+    )
+    assert result["fresh"] is False
+    assert result["authority_valid"] is False
+    assert "automation_allowed_mismatch" in result["reasons"]
+
+
+def test_adoption_learning_cli_checks_freshness_without_rewriting(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from sdetkit.cli import main as cli_main
+
+    matrix = _matrix(tmp_path / "matrix.json")
+    report = tmp_path / "report.json"
+    rc = cli_main(
+        [
+            "adoption-learning-report",
+            "--root",
+            ".",
+            "--matrix-json",
+            str(matrix),
+            "--out",
+            str(report),
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()
+    before = report.read_bytes()
+
+    rc = cli_main(
+        [
+            "adoption-learning-report",
+            "--root",
+            ".",
+            "--matrix-json",
+            str(matrix),
+            "--out",
+            str(report),
+            "--check-freshness",
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "freshness_status=fresh" in stdout
+    assert "source_schema_valid=true" in stdout
+    assert "current_head_valid=true" in stdout
+    assert report.read_bytes() == before

--- a/tests/test_adoption_learning_report_dashboard.py
+++ b/tests/test_adoption_learning_report_dashboard.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from sdetkit import adoption_learning_report_dashboard
+from sdetkit import adoption_learning_report, adoption_learning_report_dashboard
 
 
 def _report_payload(
@@ -50,7 +50,7 @@ def _report_payload(
         ]
     )
     return {
-        "schema_version": "sdetkit.adoption_learning_report.v1",
+        "schema_version": adoption_learning_report.SCHEMA_VERSION,
         "source_matrix": "/tmp/adoption-real-world-matrix.json",
         "source_matrix_schema_version": ("sdetkit.adoption_real_world_learning_matrix.v1"),
         "source_matrix_status": "review_required",
@@ -134,7 +134,7 @@ def test_dashboard_builds_read_only_candidate_summary(
     assert payload["schema_version"] == ("sdetkit.adoption_learning_report_dashboard.v1")
     assert payload["status"] == "ready"
     assert payload["report_exists"] is True
-    assert payload["source_report_schema_version"] == ("sdetkit.adoption_learning_report.v1")
+    assert payload["source_report_schema_version"] == (adoption_learning_report.SCHEMA_VERSION)
     assert payload["source_repo_count"] == 4
     assert payload["candidate_count"] == 2
     assert payload["top_candidate"]["classification"] == ("weak_proof_command_mapping")

--- a/tests/test_security_gate_cli.py
+++ b/tests/test_security_gate_cli.py
@@ -244,6 +244,28 @@ def test_security_scan_ignores_uuid_and_hex_digests(tmp_path: Path, capsys) -> N
     assert not any(f.get("rule_id") == "SEC_HIGH_ENTROPY_STRING" for f in findings)
 
 
+def test_security_scan_ignores_structured_snake_case_identifier_but_detects_token(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    token = "".join(("AbCdEfGh", "IjKlMnOp", "QrStUvWx", "Yz012345"))
+    target = tmp_path / "config.json"
+    target.write_text(
+        f'{{\n  "lane": "alpha_component_publish_stage",\n  "TOPSECRET_SAMPLE": "{token}"\n}}\n',
+        encoding="utf-8",
+    )
+
+    assert _run(["scan", "--root", str(tmp_path), "--format", "json", "--fail-on", "none"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    findings = [
+        item for item in payload["findings"] if item["rule_id"] == "SEC_HIGH_ENTROPY_STRING"
+    ]
+
+    assert len(findings) == 1
+    assert findings[0]["path"] == "config.json"
+    assert findings[0]["line"] == 3
+
+
 def test_security_baseline_requires_output(tmp_path: Path, capsys) -> None:
     src = tmp_path / "src"
     src.mkdir()


### PR DESCRIPTION
## Summary
- bind the adoption-learning report to deterministic matrix/profile/generator provenance
- record accepted matrix and RepoMemory schema relationships
- bind generated evidence to the current Git head
- add fail-closed stale, missing, invalid, schema-drift, head-drift, and authority-drift detection
- register and forward `--root` and `--check-freshness` through the existing hidden command

## Scope
- `src/sdetkit/_legacy_cli.py`
- `src/sdetkit/adoption_learning_report.py`
- `tests/test_adoption_learning_report.py`

## Verification
- focused adoption-learning tests passed
- Python compilation passed
- Ruff check and format check passed
- live matrix/profile report returned `freshness_status=fresh`
- accepted source schemas returned true
- current-head binding returned true before and after commit
- `make proof-after-format` passed
- candidate patch SHA: `1145f4f9dfe6e4589b07856faea2bee723f8e3cbf75749cef95e1b7027457c1c`

## Compatibility
- hidden visibility unchanged
- command tier unchanged
- dispatch target unchanged
- ranking behavior remains review-first and non-authorizing
- RepoMemory context remains non-authoritative

## Authority boundary
- `repo_mutation=false`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`

## Risk
Low. Rollback is a single commit revert.
