### PR TITLE
refactor(ci): isolate PR Quality publication behind trusted handoff

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -9,8 +9,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  pull-requests: read
   checks: read
   actions: read
   security-events: read
@@ -313,7 +312,7 @@ jobs:
             --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
             --out-dir build/sdetkit/evidence-graph
 
-      - name: Initialize PR comment status
+      - name: Initialize PR publisher handoff status
         if: always()
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -327,9 +326,9 @@ jobs:
           Path("build/pr-quality/comment-status.json").write_text(
               json.dumps(
                   {
-                      "status": "failed",
+                      "status": "handoff_pending",
                       "pr_number": int(os.environ["PR_NUMBER"]),
-                      "reason": "comment step did not complete",
+                      "reason": "trusted publisher workflow has not completed",
                   },
                   indent=2,
                   sort_keys=True,
@@ -1072,7 +1071,7 @@ jobs:
             .sdetkit/adaptive-sentinel/
           if-no-files-found: ignore
 
-      - name: Upload PR quality comment artifacts
+      - name: Upload PR quality evidence artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -1111,711 +1110,87 @@ jobs:
             build/sdetkit/evidence-graph/
             build/sdetkit/operator-loop/
           if-no-files-found: ignore
-
-      - name: Comment on PR
+      - name: Build PR quality publisher handoff
+        if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          set -euo pipefail
+          python - <<'PYHANDOFF'
+          from __future__ import annotations
 
-          publish_dir="build/pr-quality/comment-publish"
-          request_path="$publish_dir/comment-request.json"
-          response_path="$publish_dir/comment-response.json"
-          body_path="$publish_dir/comment-body.md"
-
-          mkdir -p "$publish_dir"
-
-          printf '### SDET Quality Gate\n\n' > "$body_path"
-
-          if [ -s build/pr-quality/pr-review-summary.md ]; then
-            cat build/pr-quality/pr-review-summary.md >> "$body_path"
-          else
-            cat build/pr-quality/pr-comment-body.md >> "$body_path"
-          fi
-
-          cat >> "$body_path" <<'MARKDOWN'
-
-          ---
-
-          <details>
-          <summary><strong>PR Quality product artifacts</strong></summary>
-
-          - `index.html`: artifact landing page.
-          - `pr-review-artifacts-manifest.json`: machine-readable artifact bundle manifest.
-          - `pr-review-summary.md`: concise human review panel.
-          - `pr-review-model.json`: machine-readable review model.
-          - `pr-review-dashboard.html`: browser-ready review dashboard.
-          - `pr-comment-body.md`: full raw evidence body retained in the artifact bundle.
-          - `pr-quality-comment`: uploaded artifact bundle for full diagnostic evidence.
-
-          </details>
-
-          MARKDOWN
-
-          BODY_PATH="$body_path" REQUEST_PATH="$request_path" python - <<'PYCODE'
+          import hashlib
           import json
           import os
+          import shutil
           from pathlib import Path
 
-          body = Path(os.environ["BODY_PATH"]).read_text(encoding="utf-8")
-          Path(os.environ["REQUEST_PATH"]).write_text(
-              json.dumps({"body": body}) + "\n",
+          source_root = Path("build/pr-quality")
+          handoff_root = source_root / "publisher-handoff"
+          payload_root = handoff_root / "payload"
+          if handoff_root.exists():
+              shutil.rmtree(handoff_root)
+          payload_root.mkdir(parents=True)
+
+          required_names = (
+              "pr-comment-body.md",
+              "pr-comment-metadata.json",
+              "pr-review-summary.md",
+          )
+          file_rows = []
+          for name in required_names:
+              source = source_root / name
+              if not source.is_file() or source.is_symlink():
+                  raise SystemExit(f"publisher handoff source is missing or unsafe: {source}")
+              data = source.read_bytes()
+              if not data:
+                  raise SystemExit(f"publisher handoff source is empty: {source}")
+              target = payload_root / name
+              shutil.copyfile(source, target)
+              file_rows.append(
+                  {
+                      "path": f"payload/{name}",
+                      "sha256": hashlib.sha256(data).hexdigest(),
+                      "size_bytes": len(data),
+                  }
+              )
+
+          manifest = {
+              "schema_version": "sdetkit.pr_quality_publisher_handoff.v1",
+              "repository": os.environ["REPOSITORY"],
+              "event_name": "pull_request",
+              "pr_number": int(os.environ["PR_NUMBER"]),
+              "head_sha": os.environ["HEAD_SHA"],
+              "base_sha": os.environ["BASE_SHA"],
+              "source_workflow_name": "PR Quality Comment",
+              "source_workflow_run_id": int(os.environ["SOURCE_RUN_ID"]),
+              "source_workflow_run_attempt": int(os.environ["SOURCE_RUN_ATTEMPT"]),
+              "files": file_rows,
+              "authority_boundary": {
+                  "reporting_only": True,
+                  "patch_application_allowed": False,
+                  "security_dismissal_allowed": False,
+                  "merge_authorized": False,
+                  "semantic_equivalence_proven": False,
+              },
+          }
+          (handoff_root / "manifest.json").write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
-          PYCODE
+          print(f"publisher_handoff_file_count={len(file_rows)}")
+          print(f"publisher_handoff_head_sha={manifest['head_sha']}")
+          PYHANDOFF
 
-          publish_rc=1
-          publish_status="failed"
-          publish_reason="failed to publish SDET Quality Gate comment"
-          existing_id=""
-
-          if existing_id="$(
-            gh api \
-              -H "Accept: application/vnd.github+json" \
-              "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
-              --jq 'first(.[] | select(.user.type == "Bot" and (.body | startswith("### SDET Quality Gate")))) | .id // ""'
-          )"; then
-            if [ -n "$existing_id" ]; then
-              if gh api \
-                --method PATCH \
-                -H "Accept: application/vnd.github+json" \
-                "repos/${REPOSITORY}/issues/comments/${existing_id}" \
-                --input "$request_path" \
-                > "$response_path"; then
-                publish_rc=0
-                publish_status="updated"
-                publish_reason="updated existing SDET Quality Gate comment"
-              else
-                publish_rc=$?
-                publish_reason="failed to update existing SDET Quality Gate comment"
-              fi
-            else
-              if gh api \
-                --method POST \
-                -H "Accept: application/vnd.github+json" \
-                "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
-                --input "$request_path" \
-                > "$response_path"; then
-                publish_rc=0
-                publish_status="posted"
-                publish_reason="posted SDET Quality Gate comment"
-              else
-                publish_rc=$?
-                publish_reason="failed to post new SDET Quality Gate comment"
-              fi
-            fi
-          else
-            publish_rc=$?
-            publish_reason="failed to list existing SDET Quality Gate comments"
-          fi
-
-          COMMENT_STATUS="$publish_status" \
-          COMMENT_REASON="$publish_reason" \
-          RESPONSE_PATH="$response_path" \
-          PR_NUMBER="$PR_NUMBER" \
-          node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-
-          const repoMemoryAuthorityKey = (...parts) =>
-            ['repo', 'memory', 'trajectory', 'authority', ...parts].join('_');
-          const expectedInventoryKey = (...parts) =>
-            ['expected', 'artifact', 'inventory', ...parts].join('_');
-
-          const statusPath = 'build/pr-quality/comment-status.json';
-          const readCommentMetadata = () => {
-            const metadataPath = 'build/pr-quality/pr-comment-metadata.json';
-            try {
-              if (!fs.existsSync(metadataPath)) {
-                return {};
-              }
-              return JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-            } catch (error) {
-              console.warn(
-                `failed to read PR Quality comment metadata: ${
-                  error && error.message ? error.message : error
-                }`
-              );
-              return {};
-            }
-          };
-
-          const writeStatus = (payload) => {
-            const metadata = readCommentMetadata();
-            const expectedInventoryStatusKey = expectedInventoryKey('status');
-            const expectedInventoryNonEmptyKey = expectedInventoryKey('non', 'empty');
-            const expectedInventoryAuthorityAwareKey = expectedInventoryKey('authority', 'aware');
-            const expectedInventoryExpectedArtifactCountKey = expectedInventoryKey('expected', 'artifact', 'count');
-            const expectedInventoryAuthorityEvidenceSourceCountKey = expectedInventoryKey('authority', 'evidence', 'source', 'count');
-            const expectedInventoryMissingAuthorityEvidencePathCountKey = expectedInventoryKey('missing', 'authority', 'evidence', 'path', 'count');
-            const expectedInventoryReportingOnlyKey = expectedInventoryKey('reporting', 'only');
-            const expectedInventoryPatchAutomationKey = expectedInventoryKey('patch', 'automation');
-            const expectedInventorySecurityDismissalKey = expectedInventoryKey('security', 'dismissal');
-            const expectedInventoryMergeAuthorizationKey = expectedInventoryKey('merge', 'authorization');
-            const expectedInventorySemanticEquivalenceClaimKey = expectedInventoryKey('semantic', 'equivalence', 'claim');
-            const repoMemoryAuthorityStatusKey = repoMemoryAuthorityKey('status');
-            const repoMemoryAuthorityRecordCountKey = repoMemoryAuthorityKey('record', 'count');
-            const repoMemoryAuthorityReviewFirstCountKey = repoMemoryAuthorityKey('review', 'first', 'count');
-            const repoMemoryAuthorityAutoFixAllowedCountKey = repoMemoryAuthorityKey('auto', 'fix', 'allowed', 'count');
-            const repoMemoryAuthorityReportingOnlyCountKey = repoMemoryAuthorityKey('reporting', 'only', 'count');
-            const repoMemoryAuthorityPatchApplicationAllowedKey = repoMemoryAuthorityKey('patch', 'application', 'allowed');
-            const repoMemoryAuthoritySecurityDismissalAllowedKey = repoMemoryAuthorityKey('security', 'dismissal', 'allowed');
-            const repoMemoryAuthorityMergeAuthorizedKey = repoMemoryAuthorityKey('merge', 'authorized');
-            const repoMemoryAuthoritySemanticEquivalenceProvenKey = repoMemoryAuthorityKey('semantic', 'equivalence', 'proven');
-            const enrichedPayload = {
-              ...payload,
-              action_report_status: metadata.status || 'unknown',
-              comment_result_title: metadata.result_title || 'unknown',
-              evidence_signal_kind: metadata.evidence_signal_kind || 'unknown',
-              evidence_signal_present: Boolean(metadata.evidence_signal_present),
-              evidence_review_required: Boolean(metadata.evidence_review_required),
-              trajectory_signal_present: Boolean(metadata.trajectory_signal_present),
-              trajectory_record_count: Number(metadata.trajectory_record_count || 0),
-              trajectory_review_first_count: Number(metadata.trajectory_review_first_count || 0),
-              trajectory_auto_fix_allowed_count: Number(metadata.trajectory_auto_fix_allowed_count || 0),
-              runtime_proof_artifacts_present: Boolean(metadata.runtime_proof_artifacts_present),
-              runtime_proof_collection_status: metadata.runtime_proof_collection_status || 'not_collected',
-              runtime_guard_violation_count: Number(metadata.runtime_guard_violation_count || 0),
-              live_benchmark_collection_status: metadata.live_benchmark_collection_status || 'not_collected',
-              live_benchmark_status: metadata.live_benchmark_status || 'not_collected',
-              live_benchmark_scenario_count: Number(metadata.live_benchmark_scenario_count || 0),
-              anti_cheat_rejection_count: Number(metadata.anti_cheat_rejection_count || 0),
-              repo_memory_collection_status: metadata.repo_memory_collection_status || 'not_collected',
-              repo_memory_status: metadata.repo_memory_status || 'not_collected',
-              repo_memory_live_contract_proven: Boolean(metadata.repo_memory_live_contract_proven),
-              [expectedInventoryStatusKey]: metadata[expectedInventoryStatusKey] || 'not_collected',
-              [expectedInventoryNonEmptyKey]: Boolean(metadata[expectedInventoryNonEmptyKey]),
-              [expectedInventoryAuthorityAwareKey]: Boolean(metadata[expectedInventoryAuthorityAwareKey]),
-              [expectedInventoryExpectedArtifactCountKey]: Number(metadata[expectedInventoryExpectedArtifactCountKey] || 0),
-              [expectedInventoryAuthorityEvidenceSourceCountKey]: Number(metadata[expectedInventoryAuthorityEvidenceSourceCountKey] || 0),
-              [expectedInventoryMissingAuthorityEvidencePathCountKey]: Number(metadata[expectedInventoryMissingAuthorityEvidencePathCountKey] || 0),
-              [expectedInventoryReportingOnlyKey]: Boolean(metadata[expectedInventoryReportingOnlyKey]),
-              [expectedInventoryPatchAutomationKey]: Boolean(metadata[expectedInventoryPatchAutomationKey]),
-              [expectedInventorySecurityDismissalKey]: Boolean(metadata[expectedInventorySecurityDismissalKey]),
-              [expectedInventoryMergeAuthorizationKey]: Boolean(metadata[expectedInventoryMergeAuthorizationKey]),
-              [expectedInventorySemanticEquivalenceClaimKey]: Boolean(metadata[expectedInventorySemanticEquivalenceClaimKey]),
-              [repoMemoryAuthorityStatusKey]: metadata[repoMemoryAuthorityStatusKey] || 'not_collected',
-              [repoMemoryAuthorityRecordCountKey]: Number(metadata[repoMemoryAuthorityRecordCountKey] || 0),
-              [repoMemoryAuthorityReviewFirstCountKey]: Number(metadata[repoMemoryAuthorityReviewFirstCountKey] || 0),
-              [repoMemoryAuthorityAutoFixAllowedCountKey]: Number(metadata[repoMemoryAuthorityAutoFixAllowedCountKey] || 0),
-              [repoMemoryAuthorityReportingOnlyCountKey]: Number(metadata[repoMemoryAuthorityReportingOnlyCountKey] || 0),
-              [repoMemoryAuthorityPatchApplicationAllowedKey]: Boolean(metadata[repoMemoryAuthorityPatchApplicationAllowedKey]),
-              [repoMemoryAuthoritySecurityDismissalAllowedKey]: Boolean(metadata[repoMemoryAuthoritySecurityDismissalAllowedKey]),
-              [repoMemoryAuthorityMergeAuthorizedKey]: Boolean(metadata[repoMemoryAuthorityMergeAuthorizedKey]),
-              [repoMemoryAuthoritySemanticEquivalenceProvenKey]: Boolean(metadata[repoMemoryAuthoritySemanticEquivalenceProvenKey]),
-              trusted_history_collection_status: metadata.trusted_history_collection_status || 'not_collected',
-              trusted_history_status: metadata.trusted_history_status || 'not_collected',
-              trusted_history_record_count: Number(metadata.trusted_history_record_count || 0),
-              trusted_history_base_ancestry_verified: Boolean(metadata.trusted_history_base_ancestry_verified),
-              trusted_history_prior_input_read_only: Boolean(metadata.trusted_history_prior_input_read_only),
-              trusted_history_automation_allowed: Boolean(metadata.trusted_history_automation_allowed),
-              trusted_history_merge_authorized: Boolean(metadata.trusted_history_merge_authorized),
-              trusted_history_semantic_equivalence_proven: Boolean(metadata.trusted_history_semantic_equivalence_proven),
-            };
-            fs.mkdirSync(path.dirname(statusPath), { recursive: true });
-            fs.writeFileSync(
-              statusPath,
-              `${JSON.stringify(enrichedPayload, null, 2)}\n`,
-              'utf8'
-            );
-          };
-
-          const status = process.env.COMMENT_STATUS;
-          const payload = {
-            status,
-            pr_number: Number(process.env.PR_NUMBER),
-            reason: process.env.COMMENT_REASON,
-          };
-
-          const responsePath = process.env.RESPONSE_PATH;
-          if ((status === 'posted' || status === 'updated') && fs.existsSync(responsePath)) {
-            const response = JSON.parse(fs.readFileSync(responsePath, 'utf8'));
-            payload.comment_id = response.id;
-            payload.comment_url = response.html_url;
-          }
-
-          writeStatus(payload);
-
-          if (status === 'posted') {
-            process.stdout.write('comment_status=posted\n');
-          } else if (status === 'updated') {
-            process.stdout.write('comment_status=updated\n');
-          } else {
-            console.error(`comment_status=failed reason=${process.env.COMMENT_REASON}`);
-          }
-          NODE
-
-          if [ "$publish_rc" -ne 0 ]; then
-            exit "$publish_rc"
-          fi
-
-      - name: Verify PR Quality comment visibility
+      - name: Upload PR quality publisher handoff
         if: always()
-        run: |
-          python - <<'PY'
-          import json
-          from pathlib import Path
-
-          path = Path("build/pr-quality/comment-status.json")
-          if not path.exists():
-              raise SystemExit("comment_status=missing: build/pr-quality/comment-status.json was not written")
-
-          payload = json.loads(path.read_text(encoding="utf-8"))
-
-          def repo_memory_trajectory_authority_key(*parts: str) -> str:
-              return "_".join(("repo", "memory", "trajectory", "authority", *parts))
-
-          def expected_inventory_key(*parts: str) -> str:
-              return "_".join(("expected", "artifact", "inventory", *parts))
-
-          expected_inventory_status_key = expected_inventory_key("status")
-          expected_inventory_non_empty_key = expected_inventory_key("non", "empty")
-          expected_inventory_authority_aware_key = expected_inventory_key("authority", "aware")
-          expected_inventory_expected_artifact_count_key = expected_inventory_key(
-              "expected", "artifact", "count"
-          )
-          expected_inventory_authority_evidence_source_count_key = expected_inventory_key(
-              "authority", "evidence", "source", "count"
-          )
-          expected_inventory_missing_authority_evidence_path_count_key = expected_inventory_key(
-              "missing", "authority", "evidence", "path", "count"
-          )
-          expected_inventory_reporting_only_key = expected_inventory_key("reporting", "only")
-          expected_inventory_patch_automation_key = expected_inventory_key("patch", "automation")
-          expected_inventory_security_dismissal_key = expected_inventory_key(
-              "security", "dismissal"
-          )
-          expected_inventory_merge_authorization_key = expected_inventory_key(
-              "merge", "authorization"
-          )
-          expected_inventory_semantic_equivalence_claim_key = expected_inventory_key(
-              "semantic", "equivalence", "claim"
-          )
-
-          authority_status_key = repo_memory_trajectory_authority_key("status")
-          authority_record_count_key = repo_memory_trajectory_authority_key("record", "count")
-          authority_review_first_count_key = repo_memory_trajectory_authority_key(
-              "review", "first", "count"
-          )
-          authority_auto_fix_allowed_count_key = repo_memory_trajectory_authority_key(
-              "auto", "fix", "allowed", "count"
-          )
-          authority_reporting_only_count_key = repo_memory_trajectory_authority_key(
-              "reporting", "only", "count"
-          )
-          authority_patch_application_allowed_key = repo_memory_trajectory_authority_key(
-              "patch", "application", "allowed"
-          )
-          authority_security_dismissal_allowed_key = repo_memory_trajectory_authority_key(
-              "security", "dismissal", "allowed"
-          )
-          authority_merge_authorized_key = repo_memory_trajectory_authority_key(
-              "merge", "authorized"
-          )
-          authority_semantic_equivalence_proven_key = repo_memory_trajectory_authority_key(
-              "semantic", "equivalence", "proven"
-          )
-
-          status = str(payload.get("status", "missing"))
-          reason = str(payload.get("reason", ""))
-          action_report_status = str(payload.get("action_report_status", "unknown"))
-          comment_result_title = str(payload.get("comment_result_title", "unknown"))
-          evidence_signal_kind = str(payload.get("evidence_signal_kind", "unknown"))
-          evidence_signal_present = bool(payload.get("evidence_signal_present", False))
-          evidence_review_required = bool(payload.get("evidence_review_required", False))
-          trajectory_record_count = int(payload.get("trajectory_record_count", 0) or 0)
-          trajectory_review_first_count = int(payload.get("trajectory_review_first_count", 0) or 0)
-          trajectory_auto_fix_allowed_count = int(
-              payload.get("trajectory_auto_fix_allowed_count", 0) or 0
-          )
-          runtime_proof_artifacts_present = bool(
-              payload.get("runtime_proof_artifacts_present", False)
-          )
-          runtime_proof_collection_status = str(
-              payload.get("runtime_proof_collection_status", "not_collected")
-          )
-          runtime_guard_violation_count = int(
-              payload.get("runtime_guard_violation_count", 0) or 0
-          )
-          live_benchmark_collection_status = str(
-              payload.get("live_benchmark_collection_status", "not_collected")
-          )
-          live_benchmark_status = str(
-              payload.get("live_benchmark_status", "not_collected")
-          )
-          live_benchmark_scenario_count = int(
-              payload.get("live_benchmark_scenario_count", 0) or 0
-          )
-          anti_cheat_rejection_count = int(
-              payload.get("anti_cheat_rejection_count", 0) or 0
-          )
-          repo_memory_collection_status = str(
-              payload.get("repo_memory_collection_status", "not_collected")
-          )
-          repo_memory_status = str(
-              payload.get("repo_memory_status", "not_collected")
-          )
-          repo_memory_live_contract_proven = bool(
-              payload.get("repo_memory_live_contract_proven", False)
-          )
-          expected_artifact_inventory_status = str(
-              payload.get(expected_inventory_status_key, "not_collected")
-          )
-          expected_artifact_inventory_non_empty = bool(
-              payload.get(expected_inventory_non_empty_key, False)
-          )
-          expected_artifact_inventory_authority_aware = bool(
-              payload.get(expected_inventory_authority_aware_key, False)
-          )
-          expected_artifact_inventory_expected_artifact_count = int(
-              payload.get(expected_inventory_expected_artifact_count_key, 0) or 0
-          )
-          expected_artifact_inventory_authority_evidence_source_count = int(
-              payload.get(expected_inventory_authority_evidence_source_count_key, 0) or 0
-          )
-          expected_artifact_inventory_missing_authority_evidence_path_count = int(
-              payload.get(expected_inventory_missing_authority_evidence_path_count_key, 0)
-              or 0
-          )
-          expected_artifact_inventory_reporting_only = bool(
-              payload.get(expected_inventory_reporting_only_key, False)
-          )
-          expected_artifact_inventory_patch_automation = bool(
-              payload.get(expected_inventory_patch_automation_key, False)
-          )
-          expected_artifact_inventory_security_dismissal = bool(
-              payload.get(expected_inventory_security_dismissal_key, False)
-          )
-          expected_artifact_inventory_merge_authorization = bool(
-              payload.get(expected_inventory_merge_authorization_key, False)
-          )
-          expected_artifact_inventory_semantic_equivalence_claim = bool(
-              payload.get(expected_inventory_semantic_equivalence_claim_key, False)
-          )
-          authority_status = str(payload.get(authority_status_key, "not_collected"))
-          authority_record_count = int(payload.get(authority_record_count_key, 0) or 0)
-          authority_review_first_count = int(
-              payload.get(authority_review_first_count_key, 0) or 0
-          )
-          authority_auto_fix_allowed_count = int(
-              payload.get(authority_auto_fix_allowed_count_key, 0) or 0
-          )
-          authority_reporting_only_count = int(
-              payload.get(authority_reporting_only_count_key, 0) or 0
-          )
-          authority_patch_application_allowed = bool(
-              payload.get(authority_patch_application_allowed_key, False)
-          )
-          authority_security_dismissal_allowed = bool(
-              payload.get(authority_security_dismissal_allowed_key, False)
-          )
-          authority_merge_authorized = bool(
-              payload.get(authority_merge_authorized_key, False)
-          )
-          authority_semantic_equivalence_proven = bool(
-              payload.get(authority_semantic_equivalence_proven_key, False)
-          )
-          history_semantic_key = "_".join(
-              ("trusted", "history", "semantic", "equivalence", "proven")
-          )
-          trusted_history_collection_status = str(
-              payload.get("trusted_history_collection_status", "not_collected")
-          )
-          trusted_history_status = str(
-              payload.get("trusted_history_status", "not_collected")
-          )
-          trusted_history_record_count = int(
-              payload.get("trusted_history_record_count", 0) or 0
-          )
-          trusted_history_base_ancestry_verified = bool(
-              payload.get("trusted_history_base_ancestry_verified", False)
-          )
-          trusted_history_prior_input_read_only = bool(
-              payload.get("trusted_history_prior_input_read_only", False)
-          )
-          trusted_history_automation_allowed = bool(
-              payload.get("trusted_history_automation_allowed", False)
-          )
-          trusted_history_merge_authorized = bool(
-              payload.get("trusted_history_merge_authorized", False)
-          )
-          trusted_history_semantic_equivalence_proven = bool(
-              payload.get(history_semantic_key, False)
-          )
-
-          print(f"comment_status={status}")
-          print(f"comment_reason={reason}")
-          print(f"action_report_status={action_report_status}")
-          print(f"comment_result_title={comment_result_title}")
-          print(f"evidence_signal_kind={evidence_signal_kind}")
-          print(f"evidence_signal_present={str(evidence_signal_present).lower()}")
-          print(f"evidence_review_required={str(evidence_review_required).lower()}")
-          print(f"trajectory_record_count={trajectory_record_count}")
-          print(f"trajectory_review_first_count={trajectory_review_first_count}")
-          print(f"trajectory_auto_fix_allowed_count={trajectory_auto_fix_allowed_count}")
-          print(f"runtime_proof_artifacts_present={str(runtime_proof_artifacts_present).lower()}")
-          print(f"runtime_proof_collection_status={runtime_proof_collection_status}")
-          print(f"runtime_guard_violation_count={runtime_guard_violation_count}")
-          print(f"live_benchmark_collection_status={live_benchmark_collection_status}")
-          print(f"live_benchmark_status={live_benchmark_status}")
-          print(f"live_benchmark_scenario_count={live_benchmark_scenario_count}")
-          print(f"anti_cheat_rejection_count={anti_cheat_rejection_count}")
-          print(f"repo_memory_collection_status={repo_memory_collection_status}")
-          print(f"repo_memory_status={repo_memory_status}")
-          print(
-              f"repo_memory_live_contract_proven={str(repo_memory_live_contract_proven).lower()}"
-          )
-          print(f"expected_artifact_inventory_status={expected_artifact_inventory_status}")
-          print(
-              "expected_artifact_inventory_non_empty="
-              f"{str(expected_artifact_inventory_non_empty).lower()}"
-          )
-          print(
-              "expected_artifact_inventory_authority_aware="
-              f"{str(expected_artifact_inventory_authority_aware).lower()}"
-          )
-          print(
-              expected_inventory_expected_artifact_count_key + '='
-              f"{expected_artifact_inventory_expected_artifact_count}"
-          )
-          print(
-              expected_inventory_authority_evidence_source_count_key + '='
-              f"{expected_artifact_inventory_authority_evidence_source_count}"
-          )
-          print(
-              expected_inventory_missing_authority_evidence_path_count_key + '='
-              f"{expected_artifact_inventory_missing_authority_evidence_path_count}"
-          )
-          print(
-              f"{expected_inventory_reporting_only_key}="
-              f"{str(expected_artifact_inventory_reporting_only).lower()}"
-          )
-          print(
-              f"{expected_inventory_patch_automation_key}="
-              f"{str(expected_artifact_inventory_patch_automation).lower()}"
-          )
-          print(
-              f"{expected_inventory_security_dismissal_key}="
-              f"{str(expected_artifact_inventory_security_dismissal).lower()}"
-          )
-          print(
-              f"{expected_inventory_merge_authorization_key}="
-              f"{str(expected_artifact_inventory_merge_authorization).lower()}"
-          )
-          print(
-              f"{expected_inventory_semantic_equivalence_claim_key}="
-              f"{str(expected_artifact_inventory_semantic_equivalence_claim).lower()}"
-          )
-          print(f"{authority_status_key}={authority_status}")
-          print(f"{authority_record_count_key}={authority_record_count}")
-          print(f"{authority_review_first_count_key}={authority_review_first_count}")
-          print(
-              f"{authority_auto_fix_allowed_count_key}={authority_auto_fix_allowed_count}"
-          )
-          print(f"{authority_reporting_only_count_key}={authority_reporting_only_count}")
-          print(
-              f"{authority_patch_application_allowed_key}="
-              f"{str(authority_patch_application_allowed).lower()}"
-          )
-          print(
-              f"{authority_security_dismissal_allowed_key}="
-              f"{str(authority_security_dismissal_allowed).lower()}"
-          )
-          print(
-              f"{authority_merge_authorized_key}="
-              f"{str(authority_merge_authorized).lower()}"
-          )
-          print(
-              f"{authority_semantic_equivalence_proven_key}="
-              f"{str(authority_semantic_equivalence_proven).lower()}"
-          )
-          print(f"trusted_history_collection_status={trusted_history_collection_status}")
-          print(f"trusted_history_status={trusted_history_status}")
-          print(f"trusted_history_record_count={trusted_history_record_count}")
-          print(
-              "trusted_history_base_ancestry_verified="
-              f"{str(trusted_history_base_ancestry_verified).lower()}"
-          )
-          print(
-              "trusted_history_prior_input_read_only="
-              f"{str(trusted_history_prior_input_read_only).lower()}"
-          )
-          print(
-              "trusted_history_automation_allowed="
-              f"{str(trusted_history_automation_allowed).lower()}"
-          )
-          print(
-              "trusted_history_merge_authorized="
-              f"{str(trusted_history_merge_authorized).lower()}"
-          )
-          print(
-              f"{history_semantic_key}="
-              f"{str(trusted_history_semantic_equivalence_proven).lower()}"
-          )
-
-          if status not in {"posted", "updated"}:
-              raise SystemExit(f"PR Quality comment was not posted or updated: status={status} reason={reason}")
-
-          if action_report_status == "unknown":
-              raise SystemExit("PR Quality comment signal metadata missing: action_report_status=unknown")
-          if comment_result_title == "unknown":
-              raise SystemExit("PR Quality comment signal metadata missing: comment_result_title=unknown")
-          if evidence_signal_kind not in {"none", "proof", "review"}:
-              raise SystemExit(
-                  "PR Quality comment signal metadata invalid: "
-                  f"evidence_signal_kind={evidence_signal_kind}"
-              )
-
-          if not runtime_proof_artifacts_present:
-              raise SystemExit(
-                  "PR Quality runtime proof artifacts missing from rendered comment metadata"
-              )
-          if runtime_proof_collection_status != "collected":
-              raise SystemExit(
-                  "PR Quality runtime proof collection failed after diagnostic comment publication: "
-                  f"status={runtime_proof_collection_status}"
-              )
-          if live_benchmark_collection_status != "collected":
-              raise SystemExit(
-                  "PR Quality live benchmark collection failed after diagnostic comment publication: "
-                  f"status={live_benchmark_collection_status}"
-              )
-          if live_benchmark_status != "passed":
-              raise SystemExit(
-                  "PR Quality live benchmark evidence failed: "
-                  f"status={live_benchmark_status}"
-              )
-          if live_benchmark_scenario_count != 6 or anti_cheat_rejection_count != 2:
-              raise SystemExit(
-                  "PR Quality live benchmark contract incomplete: "
-                  f"scenarios={live_benchmark_scenario_count} "
-                  f"anti_cheat_rejections={anti_cheat_rejection_count}"
-              )
-          if repo_memory_collection_status != "collected":
-              raise SystemExit(
-                  "PR Quality RepoMemory collection failed after diagnostic comment publication: "
-                  f"status={repo_memory_collection_status}"
-              )
-          if repo_memory_status != "live_proof_supported_memory":
-              raise SystemExit(
-                  "PR Quality RepoMemory live-proof status missing: "
-                  f"status={repo_memory_status}"
-              )
-          if not repo_memory_live_contract_proven:
-              raise SystemExit("PR Quality RepoMemory live contract was not proven")
-          if expected_artifact_inventory_status != "passed":
-              raise SystemExit(
-                  "PR Quality expected artifact inventory verification failed: "
-                  f"status={expected_artifact_inventory_status}"
-              )
-          if not expected_artifact_inventory_non_empty:
-              raise SystemExit("PR Quality expected artifact inventory was empty")
-          if not expected_artifact_inventory_authority_aware:
-              raise SystemExit("PR Quality expected artifact inventory was not authority-aware")
-          if expected_artifact_inventory_expected_artifact_count < 1:
-              raise SystemExit("PR Quality expected artifact inventory had no artifacts")
-          if expected_artifact_inventory_authority_evidence_source_count < 1:
-              raise SystemExit(
-                  "PR Quality expected artifact inventory had no authority evidence sources"
-              )
-          if expected_artifact_inventory_missing_authority_evidence_path_count:
-              raise SystemExit(
-                  "PR Quality expected artifact inventory is missing authority evidence paths: "
-                  f"count={expected_artifact_inventory_missing_authority_evidence_path_count}"
-              )
-          if not expected_artifact_inventory_reporting_only:
-              raise SystemExit(
-                  "PR Quality expected artifact inventory verification was not reporting-only"
-              )
-          if expected_artifact_inventory_patch_automation:
-              raise SystemExit(
-                  "PR Quality expected artifact inventory attempted to allow patch automation"
-              )
-          if expected_artifact_inventory_security_dismissal:
-              raise SystemExit(
-                  "PR Quality expected artifact inventory attempted to allow security dismissal"
-              )
-          if expected_artifact_inventory_merge_authorization:
-              raise SystemExit(
-                  "PR Quality expected artifact inventory attempted to authorize merge"
-              )
-          if expected_artifact_inventory_semantic_equivalence_claim:
-              raise SystemExit(
-                  "PR Quality expected artifact inventory attempted to claim semantic equivalence"
-              )
-          if authority_status != "authority_boundary_evidence_observed":
-              raise SystemExit(
-                  "PR Quality RepoMemory trajectory authority evidence missing: "
-                  f"status={authority_status}"
-              )
-          if authority_record_count < 1:
-              raise SystemExit(
-                  "PR Quality RepoMemory trajectory authority evidence has no records"
-              )
-          if authority_patch_application_allowed:
-              raise SystemExit(
-                  "PR Quality RepoMemory trajectory authority attempted to allow patch application"
-              )
-          if authority_security_dismissal_allowed:
-              raise SystemExit(
-                  "PR Quality RepoMemory trajectory authority attempted to allow security dismissal"
-              )
-          if authority_merge_authorized:
-              raise SystemExit(
-                  "PR Quality RepoMemory trajectory authority attempted to authorize merge"
-              )
-          if authority_semantic_equivalence_proven:
-              raise SystemExit(
-                  "PR Quality RepoMemory trajectory authority attempted to claim semantic equivalence"
-              )
-          if trusted_history_collection_status != "collected":
-              raise SystemExit(
-                  "PR Quality trusted accepted-main history collection failed after "
-                  "diagnostic comment publication: "
-                  f"status={trusted_history_collection_status}"
-              )
-          if trusted_history_status != "trusted_history_verified":
-              raise SystemExit(
-                  "PR Quality trusted accepted-main history was not verified: "
-                  f"status={trusted_history_status}"
-              )
-          if trusted_history_record_count < 1:
-              raise SystemExit("PR Quality trusted accepted-main history has no records")
-          if not trusted_history_base_ancestry_verified:
-              raise SystemExit(
-                  "PR Quality trusted accepted-main history base ancestry was not verified"
-              )
-          if not trusted_history_prior_input_read_only:
-              raise SystemExit(
-                  "PR Quality trusted accepted-main history did not preserve read-only input"
-              )
-          if trusted_history_automation_allowed:
-              raise SystemExit("PR Quality trusted history attempted to allow automation")
-          if trusted_history_merge_authorized:
-              raise SystemExit("PR Quality trusted history attempted to authorize merge")
-          if trusted_history_semantic_equivalence_proven:
-              raise SystemExit(
-                  "PR Quality trusted history attempted to claim semantic equivalence"
-              )
-
-          trusted_snapshot_history_exit_path = Path(
-              "build/pr-quality/trusted-diagnostic-signal-snapshot-history/exit-code.txt"
-          )
-          trusted_snapshot_history_exit_code = (
-              trusted_snapshot_history_exit_path.read_text(encoding="utf-8").strip()
-              if trusted_snapshot_history_exit_path.exists()
-              else "missing"
-          )
-          print(
-              "trusted_diagnostic_signal_snapshot_history_exit_code="
-              f"{trusted_snapshot_history_exit_code}"
-          )
-          if trusted_snapshot_history_exit_code not in {"0", "2"}:
-              raise SystemExit(
-                  "PR Quality trusted diagnostic snapshot history validation failed after "
-                  "diagnostic comment publication: "
-                  f"exit_code={trusted_snapshot_history_exit_code}"
-              )
-          PY
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: pr-quality-publisher-handoff
+          path: build/pr-quality/publisher-handoff/
+          retention-days: 3
+          if-no-files-found: error

--- a/.github/workflows/pr-quality-publisher.yml
+++ b/.github/workflows/pr-quality-publisher.yml
@@ -1,0 +1,961 @@
+# Trusted default-branch publisher for PR Quality evidence.
+# This workflow must not checkout or execute pull-request repository code.
+name: PR Quality Publisher
+
+on:
+  workflow_run:
+    workflows: ["PR Quality Comment"]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: pr-quality-publisher-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download verified publisher handoff candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: pr-quality-publisher-handoff
+          path: build/pr-quality-publisher/handoff
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify exact-head publisher handoff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
+          EXPECTED_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          test -n "$PR_NUMBER"
+          mkdir -p build/pr-quality-publisher build/pr-quality
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${EXPECTED_REPOSITORY}/pulls/${PR_NUMBER}" \
+            > build/pr-quality-publisher/current-pr.json
+
+          python3 - <<'PYVERIFY'
+          from __future__ import annotations
+
+          import hashlib
+          import json
+          import os
+          import shutil
+          from pathlib import Path, PurePosixPath
+
+          root = Path("build/pr-quality-publisher/handoff")
+          manifest_path = root / "manifest.json"
+          if not manifest_path.is_file() or manifest_path.is_symlink():
+              raise SystemExit("publisher handoff manifest is missing or unsafe")
+
+          expected_files = {
+              "manifest.json",
+              "payload/pr-comment-body.md",
+              "payload/pr-comment-metadata.json",
+              "payload/pr-review-summary.md",
+          }
+          actual_files = set()
+          for path in root.rglob("*"):
+              if path.is_symlink():
+                  raise SystemExit(f"publisher handoff contains a symlink: {path}")
+              if path.is_file():
+                  relative = path.relative_to(root).as_posix()
+                  pure = PurePosixPath(relative)
+                  if pure.is_absolute() or ".." in pure.parts:
+                      raise SystemExit(f"publisher handoff contains an unsafe path: {relative}")
+                  actual_files.add(relative)
+          if actual_files != expected_files:
+              raise SystemExit(
+                  "publisher handoff file allowlist mismatch: "
+                  f"expected={sorted(expected_files)} actual={sorted(actual_files)}"
+              )
+
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          if manifest.get("schema_version") != "sdetkit.pr_quality_publisher_handoff.v1":
+              raise SystemExit("publisher handoff schema mismatch")
+          expected_pr = int(os.environ["PR_NUMBER"])
+          checks = {
+              "repository": os.environ["EXPECTED_REPOSITORY"],
+              "event_name": "pull_request",
+              "pr_number": expected_pr,
+              "head_sha": os.environ["EXPECTED_HEAD_SHA"],
+              "source_workflow_name": "PR Quality Comment",
+              "source_workflow_run_id": int(os.environ["EXPECTED_RUN_ID"]),
+              "source_workflow_run_attempt": int(os.environ["EXPECTED_RUN_ATTEMPT"]),
+          }
+          for key, expected in checks.items():
+              actual = manifest.get(key)
+              if actual != expected:
+                  raise SystemExit(
+                      f"publisher handoff binding mismatch: {key}={actual!r} expected={expected!r}"
+                  )
+
+          current_pr = json.loads(
+              Path("build/pr-quality-publisher/current-pr.json").read_text(encoding="utf-8")
+          )
+          if int(current_pr.get("number", 0)) != expected_pr:
+              raise SystemExit("current PR number does not match publisher event")
+          if current_pr.get("state") != "open":
+              raise SystemExit(f"publisher refuses a non-open PR: state={current_pr.get('state')}")
+          current_head = (
+              current_pr.get("head", {}).get("sha")
+              if isinstance(current_pr.get("head"), dict)
+              else None
+          )
+          if current_head != os.environ["EXPECTED_HEAD_SHA"]:
+              raise SystemExit(
+                  "publisher refuses stale evidence: "
+                  f"current_head={current_head} evidence_head={os.environ['EXPECTED_HEAD_SHA']}"
+              )
+
+          authority = manifest.get("authority_boundary")
+          expected_authority = {
+              "reporting_only": True,
+              "patch_application_allowed": False,
+              "security_dismissal_allowed": False,
+              "merge_authorized": False,
+              "semantic_equivalence_proven": False,
+          }
+          if authority != expected_authority:
+              raise SystemExit("publisher handoff authority boundary mismatch")
+
+          rows = manifest.get("files")
+          if not isinstance(rows, list) or len(rows) != 3:
+              raise SystemExit("publisher handoff manifest file inventory mismatch")
+          expected_payload = expected_files - {"manifest.json"}
+          observed_payload = set()
+          for row in rows:
+              if not isinstance(row, dict):
+                  raise SystemExit("publisher handoff file row must be an object")
+              relative = str(row.get("path", ""))
+              if relative not in expected_payload:
+                  raise SystemExit(f"publisher handoff manifest path is not allowed: {relative}")
+              observed_payload.add(relative)
+              path = root / relative
+              data = path.read_bytes()
+              if len(data) != int(row.get("size_bytes", -1)):
+                  raise SystemExit(f"publisher handoff size mismatch: {relative}")
+              if hashlib.sha256(data).hexdigest() != row.get("sha256"):
+                  raise SystemExit(f"publisher handoff digest mismatch: {relative}")
+          if observed_payload != expected_payload:
+              raise SystemExit("publisher handoff manifest inventory is incomplete")
+
+          summary = (root / "payload/pr-review-summary.md").read_text(encoding="utf-8")
+          if not summary.lstrip().startswith("# PR Quality Review Summary"):
+              raise SystemExit("publisher handoff summary does not match the review contract")
+          metadata = json.loads(
+              (root / "payload/pr-comment-metadata.json").read_text(encoding="utf-8")
+          )
+          if not isinstance(metadata, dict):
+              raise SystemExit("publisher handoff metadata must be a JSON object")
+
+          destination = Path("build/pr-quality")
+          for relative in sorted(expected_payload):
+              source = root / relative
+              shutil.copyfile(source, destination / Path(relative).name)
+
+          verification = {
+              "schema_version": "sdetkit.pr_quality_publisher_verification.v1",
+              "status": "passed",
+              "pr_number": expected_pr,
+              "head_sha": os.environ["EXPECTED_HEAD_SHA"],
+              "source_workflow_run_id": int(os.environ["EXPECTED_RUN_ID"]),
+              "artifact_file_count": len(expected_payload),
+              "reporting_only": True,
+              "merge_authorized": False,
+          }
+          Path("build/pr-quality-publisher/verification.json").write_text(
+              json.dumps(verification, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print("publisher_handoff_verification=passed")
+          print(f"publisher_exact_head_sha={verification['head_sha']}")
+          PYVERIFY
+
+      - name: Initialize PR comment publication status
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          python3 - <<'PYSTATUS'
+          import json
+          import os
+          from pathlib import Path
+
+          Path("build/pr-quality/comment-status.json").write_text(
+              json.dumps(
+                  {
+                      "status": "failed",
+                      "pr_number": int(os.environ["PR_NUMBER"]),
+                      "reason": "trusted publisher did not complete",
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PYSTATUS
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          publish_dir="build/pr-quality/comment-publish"
+          request_path="$publish_dir/comment-request.json"
+          response_path="$publish_dir/comment-response.json"
+          body_path="$publish_dir/comment-body.md"
+
+          mkdir -p "$publish_dir"
+
+          printf '### SDET Quality Gate\n\n' > "$body_path"
+          printf '> Trusted publisher verified the handoff for PR #%s at head `%s` from workflow run `%s`. Evidence is advisory and does not authorize merge.\n\n' "$PR_NUMBER" "$EXPECTED_HEAD_SHA" "$SOURCE_RUN_ID" >> "$body_path"
+
+          if [ -s build/pr-quality/pr-review-summary.md ]; then
+            cat build/pr-quality/pr-review-summary.md >> "$body_path"
+          else
+            cat build/pr-quality/pr-comment-body.md >> "$body_path"
+          fi
+
+          cat >> "$body_path" <<'MARKDOWN'
+
+          ---
+
+          <details>
+          <summary><strong>PR Quality product artifacts</strong></summary>
+
+          - `index.html`: artifact landing page.
+          - `pr-review-artifacts-manifest.json`: machine-readable artifact bundle manifest.
+          - `pr-review-summary.md`: concise human review panel.
+          - `pr-review-model.json`: machine-readable review model.
+          - `pr-review-dashboard.html`: browser-ready review dashboard.
+          - `pr-comment-body.md`: full raw evidence body retained in the artifact bundle.
+          - `pr-quality-comment`: uploaded artifact bundle for full diagnostic evidence.
+
+          </details>
+
+          MARKDOWN
+
+          BODY_PATH="$body_path" python3 - <<'PYSANITIZE'
+          from __future__ import annotations
+
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path(os.environ["BODY_PATH"])
+          body = path.read_text(encoding="utf-8")
+          encoded = body.encode("utf-8")
+          if len(encoded) > 60000:
+              raise SystemExit(f"PR Quality comment body exceeds publisher limit: {len(encoded)}")
+          if any(ord(char) < 32 and char not in "\n\r\t" for char in body):
+              raise SystemExit("PR Quality comment body contains unsafe control characters")
+          if re.search(r"<\s*(script|iframe|object|embed|img)\b", body, re.IGNORECASE):
+              raise SystemExit("PR Quality comment body contains blocked active HTML")
+          if re.search(r"javascript\s*:", body, re.IGNORECASE):
+              raise SystemExit("PR Quality comment body contains a blocked javascript URL")
+          body = re.sub(r"(?<![\w`])@(?=[A-Za-z0-9-])", "@\u200b", body)
+          path.write_text(body, encoding="utf-8")
+          PYSANITIZE
+
+          BODY_PATH="$body_path" REQUEST_PATH="$request_path" python - <<'PYCODE'
+          import json
+          import os
+          from pathlib import Path
+
+          body = Path(os.environ["BODY_PATH"]).read_text(encoding="utf-8")
+          Path(os.environ["REQUEST_PATH"]).write_text(
+              json.dumps({"body": body}) + "\n",
+              encoding="utf-8",
+          )
+          PYCODE
+
+          publish_rc=1
+          publish_status="failed"
+          publish_reason="failed to publish SDET Quality Gate comment"
+          existing_id=""
+
+          if existing_id="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq 'first(.[] | select(.user.type == "Bot" and (.body | startswith("### SDET Quality Gate")))) | .id // ""'
+          )"; then
+            if [ -n "$existing_id" ]; then
+              if gh api \
+                --method PATCH \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${REPOSITORY}/issues/comments/${existing_id}" \
+                --input "$request_path" \
+                > "$response_path"; then
+                publish_rc=0
+                publish_status="updated"
+                publish_reason="updated existing SDET Quality Gate comment"
+              else
+                publish_rc=$?
+                publish_reason="failed to update existing SDET Quality Gate comment"
+              fi
+            else
+              if gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                --input "$request_path" \
+                > "$response_path"; then
+                publish_rc=0
+                publish_status="posted"
+                publish_reason="posted SDET Quality Gate comment"
+              else
+                publish_rc=$?
+                publish_reason="failed to post new SDET Quality Gate comment"
+              fi
+            fi
+          else
+            publish_rc=$?
+            publish_reason="failed to list existing SDET Quality Gate comments"
+          fi
+
+          COMMENT_STATUS="$publish_status" \
+          COMMENT_REASON="$publish_reason" \
+          RESPONSE_PATH="$response_path" \
+          PR_NUMBER="$PR_NUMBER" \
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const repoMemoryAuthorityKey = (...parts) =>
+            ['repo', 'memory', 'trajectory', 'authority', ...parts].join('_');
+          const expectedInventoryKey = (...parts) =>
+            ['expected', 'artifact', 'inventory', ...parts].join('_');
+
+          const statusPath = 'build/pr-quality/comment-status.json';
+          const readCommentMetadata = () => {
+            const metadataPath = 'build/pr-quality/pr-comment-metadata.json';
+            try {
+              if (!fs.existsSync(metadataPath)) {
+                return {};
+              }
+              return JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+            } catch (error) {
+              console.warn(
+                `failed to read PR Quality comment metadata: ${
+                  error && error.message ? error.message : error
+                }`
+              );
+              return {};
+            }
+          };
+
+          const writeStatus = (payload) => {
+            const metadata = readCommentMetadata();
+            const expectedInventoryStatusKey = expectedInventoryKey('status');
+            const expectedInventoryNonEmptyKey = expectedInventoryKey('non', 'empty');
+            const expectedInventoryAuthorityAwareKey = expectedInventoryKey('authority', 'aware');
+            const expectedInventoryExpectedArtifactCountKey = expectedInventoryKey('expected', 'artifact', 'count');
+            const expectedInventoryAuthorityEvidenceSourceCountKey = expectedInventoryKey('authority', 'evidence', 'source', 'count');
+            const expectedInventoryMissingAuthorityEvidencePathCountKey = expectedInventoryKey('missing', 'authority', 'evidence', 'path', 'count');
+            const expectedInventoryReportingOnlyKey = expectedInventoryKey('reporting', 'only');
+            const expectedInventoryPatchAutomationKey = expectedInventoryKey('patch', 'automation');
+            const expectedInventorySecurityDismissalKey = expectedInventoryKey('security', 'dismissal');
+            const expectedInventoryMergeAuthorizationKey = expectedInventoryKey('merge', 'authorization');
+            const expectedInventorySemanticEquivalenceClaimKey = expectedInventoryKey('semantic', 'equivalence', 'claim');
+            const repoMemoryAuthorityStatusKey = repoMemoryAuthorityKey('status');
+            const repoMemoryAuthorityRecordCountKey = repoMemoryAuthorityKey('record', 'count');
+            const repoMemoryAuthorityReviewFirstCountKey = repoMemoryAuthorityKey('review', 'first', 'count');
+            const repoMemoryAuthorityAutoFixAllowedCountKey = repoMemoryAuthorityKey('auto', 'fix', 'allowed', 'count');
+            const repoMemoryAuthorityReportingOnlyCountKey = repoMemoryAuthorityKey('reporting', 'only', 'count');
+            const repoMemoryAuthorityPatchApplicationAllowedKey = repoMemoryAuthorityKey('patch', 'application', 'allowed');
+            const repoMemoryAuthoritySecurityDismissalAllowedKey = repoMemoryAuthorityKey('security', 'dismissal', 'allowed');
+            const repoMemoryAuthorityMergeAuthorizedKey = repoMemoryAuthorityKey('merge', 'authorized');
+            const repoMemoryAuthoritySemanticEquivalenceProvenKey = repoMemoryAuthorityKey('semantic', 'equivalence', 'proven');
+            const enrichedPayload = {
+              ...payload,
+              action_report_status: metadata.status || 'unknown',
+              comment_result_title: metadata.result_title || 'unknown',
+              evidence_signal_kind: metadata.evidence_signal_kind || 'unknown',
+              evidence_signal_present: Boolean(metadata.evidence_signal_present),
+              evidence_review_required: Boolean(metadata.evidence_review_required),
+              trajectory_signal_present: Boolean(metadata.trajectory_signal_present),
+              trajectory_record_count: Number(metadata.trajectory_record_count || 0),
+              trajectory_review_first_count: Number(metadata.trajectory_review_first_count || 0),
+              trajectory_auto_fix_allowed_count: Number(metadata.trajectory_auto_fix_allowed_count || 0),
+              runtime_proof_artifacts_present: Boolean(metadata.runtime_proof_artifacts_present),
+              runtime_proof_collection_status: metadata.runtime_proof_collection_status || 'not_collected',
+              runtime_guard_violation_count: Number(metadata.runtime_guard_violation_count || 0),
+              live_benchmark_collection_status: metadata.live_benchmark_collection_status || 'not_collected',
+              live_benchmark_status: metadata.live_benchmark_status || 'not_collected',
+              live_benchmark_scenario_count: Number(metadata.live_benchmark_scenario_count || 0),
+              anti_cheat_rejection_count: Number(metadata.anti_cheat_rejection_count || 0),
+              repo_memory_collection_status: metadata.repo_memory_collection_status || 'not_collected',
+              repo_memory_status: metadata.repo_memory_status || 'not_collected',
+              repo_memory_live_contract_proven: Boolean(metadata.repo_memory_live_contract_proven),
+              [expectedInventoryStatusKey]: metadata[expectedInventoryStatusKey] || 'not_collected',
+              [expectedInventoryNonEmptyKey]: Boolean(metadata[expectedInventoryNonEmptyKey]),
+              [expectedInventoryAuthorityAwareKey]: Boolean(metadata[expectedInventoryAuthorityAwareKey]),
+              [expectedInventoryExpectedArtifactCountKey]: Number(metadata[expectedInventoryExpectedArtifactCountKey] || 0),
+              [expectedInventoryAuthorityEvidenceSourceCountKey]: Number(metadata[expectedInventoryAuthorityEvidenceSourceCountKey] || 0),
+              [expectedInventoryMissingAuthorityEvidencePathCountKey]: Number(metadata[expectedInventoryMissingAuthorityEvidencePathCountKey] || 0),
+              [expectedInventoryReportingOnlyKey]: Boolean(metadata[expectedInventoryReportingOnlyKey]),
+              [expectedInventoryPatchAutomationKey]: Boolean(metadata[expectedInventoryPatchAutomationKey]),
+              [expectedInventorySecurityDismissalKey]: Boolean(metadata[expectedInventorySecurityDismissalKey]),
+              [expectedInventoryMergeAuthorizationKey]: Boolean(metadata[expectedInventoryMergeAuthorizationKey]),
+              [expectedInventorySemanticEquivalenceClaimKey]: Boolean(metadata[expectedInventorySemanticEquivalenceClaimKey]),
+              [repoMemoryAuthorityStatusKey]: metadata[repoMemoryAuthorityStatusKey] || 'not_collected',
+              [repoMemoryAuthorityRecordCountKey]: Number(metadata[repoMemoryAuthorityRecordCountKey] || 0),
+              [repoMemoryAuthorityReviewFirstCountKey]: Number(metadata[repoMemoryAuthorityReviewFirstCountKey] || 0),
+              [repoMemoryAuthorityAutoFixAllowedCountKey]: Number(metadata[repoMemoryAuthorityAutoFixAllowedCountKey] || 0),
+              [repoMemoryAuthorityReportingOnlyCountKey]: Number(metadata[repoMemoryAuthorityReportingOnlyCountKey] || 0),
+              [repoMemoryAuthorityPatchApplicationAllowedKey]: Boolean(metadata[repoMemoryAuthorityPatchApplicationAllowedKey]),
+              [repoMemoryAuthoritySecurityDismissalAllowedKey]: Boolean(metadata[repoMemoryAuthoritySecurityDismissalAllowedKey]),
+              [repoMemoryAuthorityMergeAuthorizedKey]: Boolean(metadata[repoMemoryAuthorityMergeAuthorizedKey]),
+              [repoMemoryAuthoritySemanticEquivalenceProvenKey]: Boolean(metadata[repoMemoryAuthoritySemanticEquivalenceProvenKey]),
+              trusted_history_collection_status: metadata.trusted_history_collection_status || 'not_collected',
+              trusted_history_status: metadata.trusted_history_status || 'not_collected',
+              trusted_history_record_count: Number(metadata.trusted_history_record_count || 0),
+              trusted_history_base_ancestry_verified: Boolean(metadata.trusted_history_base_ancestry_verified),
+              trusted_history_prior_input_read_only: Boolean(metadata.trusted_history_prior_input_read_only),
+              trusted_history_automation_allowed: Boolean(metadata.trusted_history_automation_allowed),
+              trusted_history_merge_authorized: Boolean(metadata.trusted_history_merge_authorized),
+              trusted_history_semantic_equivalence_proven: Boolean(metadata.trusted_history_semantic_equivalence_proven),
+            };
+            fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+            fs.writeFileSync(
+              statusPath,
+              `${JSON.stringify(enrichedPayload, null, 2)}\n`,
+              'utf8'
+            );
+          };
+
+          const status = process.env.COMMENT_STATUS;
+          const payload = {
+            status,
+            pr_number: Number(process.env.PR_NUMBER),
+            reason: process.env.COMMENT_REASON,
+          };
+
+          const responsePath = process.env.RESPONSE_PATH;
+          if ((status === 'posted' || status === 'updated') && fs.existsSync(responsePath)) {
+            const response = JSON.parse(fs.readFileSync(responsePath, 'utf8'));
+            payload.comment_id = response.id;
+            payload.comment_url = response.html_url;
+          }
+
+          writeStatus(payload);
+
+          if (status === 'posted') {
+            process.stdout.write('comment_status=posted\n');
+          } else if (status === 'updated') {
+            process.stdout.write('comment_status=updated\n');
+          } else {
+            console.error(`comment_status=failed reason=${process.env.COMMENT_REASON}`);
+          }
+          NODE
+
+          if [ "$publish_rc" -ne 0 ]; then
+            exit "$publish_rc"
+          fi
+
+      - name: Verify PR Quality comment visibility
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("build/pr-quality/comment-status.json")
+          if not path.exists():
+              raise SystemExit("comment_status=missing: build/pr-quality/comment-status.json was not written")
+
+          payload = json.loads(path.read_text(encoding="utf-8"))
+
+          def repo_memory_trajectory_authority_key(*parts: str) -> str:
+              return "_".join(("repo", "memory", "trajectory", "authority", *parts))
+
+          def expected_inventory_key(*parts: str) -> str:
+              return "_".join(("expected", "artifact", "inventory", *parts))
+
+          expected_inventory_status_key = expected_inventory_key("status")
+          expected_inventory_non_empty_key = expected_inventory_key("non", "empty")
+          expected_inventory_authority_aware_key = expected_inventory_key("authority", "aware")
+          expected_inventory_expected_artifact_count_key = expected_inventory_key(
+              "expected", "artifact", "count"
+          )
+          expected_inventory_authority_evidence_source_count_key = expected_inventory_key(
+              "authority", "evidence", "source", "count"
+          )
+          expected_inventory_missing_authority_evidence_path_count_key = expected_inventory_key(
+              "missing", "authority", "evidence", "path", "count"
+          )
+          expected_inventory_reporting_only_key = expected_inventory_key("reporting", "only")
+          expected_inventory_patch_automation_key = expected_inventory_key("patch", "automation")
+          expected_inventory_security_dismissal_key = expected_inventory_key(
+              "security", "dismissal"
+          )
+          expected_inventory_merge_authorization_key = expected_inventory_key(
+              "merge", "authorization"
+          )
+          expected_inventory_semantic_equivalence_claim_key = expected_inventory_key(
+              "semantic", "equivalence", "claim"
+          )
+
+          authority_status_key = repo_memory_trajectory_authority_key("status")
+          authority_record_count_key = repo_memory_trajectory_authority_key("record", "count")
+          authority_review_first_count_key = repo_memory_trajectory_authority_key(
+              "review", "first", "count"
+          )
+          authority_auto_fix_allowed_count_key = repo_memory_trajectory_authority_key(
+              "auto", "fix", "allowed", "count"
+          )
+          authority_reporting_only_count_key = repo_memory_trajectory_authority_key(
+              "reporting", "only", "count"
+          )
+          authority_patch_application_allowed_key = repo_memory_trajectory_authority_key(
+              "patch", "application", "allowed"
+          )
+          authority_security_dismissal_allowed_key = repo_memory_trajectory_authority_key(
+              "security", "dismissal", "allowed"
+          )
+          authority_merge_authorized_key = repo_memory_trajectory_authority_key(
+              "merge", "authorized"
+          )
+          authority_semantic_equivalence_proven_key = repo_memory_trajectory_authority_key(
+              "semantic", "equivalence", "proven"
+          )
+
+          status = str(payload.get("status", "missing"))
+          reason = str(payload.get("reason", ""))
+          action_report_status = str(payload.get("action_report_status", "unknown"))
+          comment_result_title = str(payload.get("comment_result_title", "unknown"))
+          evidence_signal_kind = str(payload.get("evidence_signal_kind", "unknown"))
+          evidence_signal_present = bool(payload.get("evidence_signal_present", False))
+          evidence_review_required = bool(payload.get("evidence_review_required", False))
+          trajectory_record_count = int(payload.get("trajectory_record_count", 0) or 0)
+          trajectory_review_first_count = int(payload.get("trajectory_review_first_count", 0) or 0)
+          trajectory_auto_fix_allowed_count = int(
+              payload.get("trajectory_auto_fix_allowed_count", 0) or 0
+          )
+          runtime_proof_artifacts_present = bool(
+              payload.get("runtime_proof_artifacts_present", False)
+          )
+          runtime_proof_collection_status = str(
+              payload.get("runtime_proof_collection_status", "not_collected")
+          )
+          runtime_guard_violation_count = int(
+              payload.get("runtime_guard_violation_count", 0) or 0
+          )
+          live_benchmark_collection_status = str(
+              payload.get("live_benchmark_collection_status", "not_collected")
+          )
+          live_benchmark_status = str(
+              payload.get("live_benchmark_status", "not_collected")
+          )
+          live_benchmark_scenario_count = int(
+              payload.get("live_benchmark_scenario_count", 0) or 0
+          )
+          anti_cheat_rejection_count = int(
+              payload.get("anti_cheat_rejection_count", 0) or 0
+          )
+          repo_memory_collection_status = str(
+              payload.get("repo_memory_collection_status", "not_collected")
+          )
+          repo_memory_status = str(
+              payload.get("repo_memory_status", "not_collected")
+          )
+          repo_memory_live_contract_proven = bool(
+              payload.get("repo_memory_live_contract_proven", False)
+          )
+          expected_artifact_inventory_status = str(
+              payload.get(expected_inventory_status_key, "not_collected")
+          )
+          expected_artifact_inventory_non_empty = bool(
+              payload.get(expected_inventory_non_empty_key, False)
+          )
+          expected_artifact_inventory_authority_aware = bool(
+              payload.get(expected_inventory_authority_aware_key, False)
+          )
+          expected_artifact_inventory_expected_artifact_count = int(
+              payload.get(expected_inventory_expected_artifact_count_key, 0) or 0
+          )
+          expected_artifact_inventory_authority_evidence_source_count = int(
+              payload.get(expected_inventory_authority_evidence_source_count_key, 0) or 0
+          )
+          expected_artifact_inventory_missing_authority_evidence_path_count = int(
+              payload.get(expected_inventory_missing_authority_evidence_path_count_key, 0)
+              or 0
+          )
+          expected_artifact_inventory_reporting_only = bool(
+              payload.get(expected_inventory_reporting_only_key, False)
+          )
+          expected_artifact_inventory_patch_automation = bool(
+              payload.get(expected_inventory_patch_automation_key, False)
+          )
+          expected_artifact_inventory_security_dismissal = bool(
+              payload.get(expected_inventory_security_dismissal_key, False)
+          )
+          expected_artifact_inventory_merge_authorization = bool(
+              payload.get(expected_inventory_merge_authorization_key, False)
+          )
+          expected_artifact_inventory_semantic_equivalence_claim = bool(
+              payload.get(expected_inventory_semantic_equivalence_claim_key, False)
+          )
+          authority_status = str(payload.get(authority_status_key, "not_collected"))
+          authority_record_count = int(payload.get(authority_record_count_key, 0) or 0)
+          authority_review_first_count = int(
+              payload.get(authority_review_first_count_key, 0) or 0
+          )
+          authority_auto_fix_allowed_count = int(
+              payload.get(authority_auto_fix_allowed_count_key, 0) or 0
+          )
+          authority_reporting_only_count = int(
+              payload.get(authority_reporting_only_count_key, 0) or 0
+          )
+          authority_patch_application_allowed = bool(
+              payload.get(authority_patch_application_allowed_key, False)
+          )
+          authority_security_dismissal_allowed = bool(
+              payload.get(authority_security_dismissal_allowed_key, False)
+          )
+          authority_merge_authorized = bool(
+              payload.get(authority_merge_authorized_key, False)
+          )
+          authority_semantic_equivalence_proven = bool(
+              payload.get(authority_semantic_equivalence_proven_key, False)
+          )
+          history_semantic_key = "_".join(
+              ("trusted", "history", "semantic", "equivalence", "proven")
+          )
+          trusted_history_collection_status = str(
+              payload.get("trusted_history_collection_status", "not_collected")
+          )
+          trusted_history_status = str(
+              payload.get("trusted_history_status", "not_collected")
+          )
+          trusted_history_record_count = int(
+              payload.get("trusted_history_record_count", 0) or 0
+          )
+          trusted_history_base_ancestry_verified = bool(
+              payload.get("trusted_history_base_ancestry_verified", False)
+          )
+          trusted_history_prior_input_read_only = bool(
+              payload.get("trusted_history_prior_input_read_only", False)
+          )
+          trusted_history_automation_allowed = bool(
+              payload.get("trusted_history_automation_allowed", False)
+          )
+          trusted_history_merge_authorized = bool(
+              payload.get("trusted_history_merge_authorized", False)
+          )
+          trusted_history_semantic_equivalence_proven = bool(
+              payload.get(history_semantic_key, False)
+          )
+
+          print(f"comment_status={status}")
+          print(f"comment_reason={reason}")
+          print(f"action_report_status={action_report_status}")
+          print(f"comment_result_title={comment_result_title}")
+          print(f"evidence_signal_kind={evidence_signal_kind}")
+          print(f"evidence_signal_present={str(evidence_signal_present).lower()}")
+          print(f"evidence_review_required={str(evidence_review_required).lower()}")
+          print(f"trajectory_record_count={trajectory_record_count}")
+          print(f"trajectory_review_first_count={trajectory_review_first_count}")
+          print(f"trajectory_auto_fix_allowed_count={trajectory_auto_fix_allowed_count}")
+          print(f"runtime_proof_artifacts_present={str(runtime_proof_artifacts_present).lower()}")
+          print(f"runtime_proof_collection_status={runtime_proof_collection_status}")
+          print(f"runtime_guard_violation_count={runtime_guard_violation_count}")
+          print(f"live_benchmark_collection_status={live_benchmark_collection_status}")
+          print(f"live_benchmark_status={live_benchmark_status}")
+          print(f"live_benchmark_scenario_count={live_benchmark_scenario_count}")
+          print(f"anti_cheat_rejection_count={anti_cheat_rejection_count}")
+          print(f"repo_memory_collection_status={repo_memory_collection_status}")
+          print(f"repo_memory_status={repo_memory_status}")
+          print(
+              f"repo_memory_live_contract_proven={str(repo_memory_live_contract_proven).lower()}"
+          )
+          print(f"expected_artifact_inventory_status={expected_artifact_inventory_status}")
+          print(
+              "expected_artifact_inventory_non_empty="
+              f"{str(expected_artifact_inventory_non_empty).lower()}"
+          )
+          print(
+              "expected_artifact_inventory_authority_aware="
+              f"{str(expected_artifact_inventory_authority_aware).lower()}"
+          )
+          print(
+              expected_inventory_expected_artifact_count_key + '='
+              f"{expected_artifact_inventory_expected_artifact_count}"
+          )
+          print(
+              expected_inventory_authority_evidence_source_count_key + '='
+              f"{expected_artifact_inventory_authority_evidence_source_count}"
+          )
+          print(
+              expected_inventory_missing_authority_evidence_path_count_key + '='
+              f"{expected_artifact_inventory_missing_authority_evidence_path_count}"
+          )
+          print(
+              f"{expected_inventory_reporting_only_key}="
+              f"{str(expected_artifact_inventory_reporting_only).lower()}"
+          )
+          print(
+              f"{expected_inventory_patch_automation_key}="
+              f"{str(expected_artifact_inventory_patch_automation).lower()}"
+          )
+          print(
+              f"{expected_inventory_security_dismissal_key}="
+              f"{str(expected_artifact_inventory_security_dismissal).lower()}"
+          )
+          print(
+              f"{expected_inventory_merge_authorization_key}="
+              f"{str(expected_artifact_inventory_merge_authorization).lower()}"
+          )
+          print(
+              f"{expected_inventory_semantic_equivalence_claim_key}="
+              f"{str(expected_artifact_inventory_semantic_equivalence_claim).lower()}"
+          )
+          print(f"{authority_status_key}={authority_status}")
+          print(f"{authority_record_count_key}={authority_record_count}")
+          print(f"{authority_review_first_count_key}={authority_review_first_count}")
+          print(
+              f"{authority_auto_fix_allowed_count_key}={authority_auto_fix_allowed_count}"
+          )
+          print(f"{authority_reporting_only_count_key}={authority_reporting_only_count}")
+          print(
+              f"{authority_patch_application_allowed_key}="
+              f"{str(authority_patch_application_allowed).lower()}"
+          )
+          print(
+              f"{authority_security_dismissal_allowed_key}="
+              f"{str(authority_security_dismissal_allowed).lower()}"
+          )
+          print(
+              f"{authority_merge_authorized_key}="
+              f"{str(authority_merge_authorized).lower()}"
+          )
+          print(
+              f"{authority_semantic_equivalence_proven_key}="
+              f"{str(authority_semantic_equivalence_proven).lower()}"
+          )
+          print(f"trusted_history_collection_status={trusted_history_collection_status}")
+          print(f"trusted_history_status={trusted_history_status}")
+          print(f"trusted_history_record_count={trusted_history_record_count}")
+          print(
+              "trusted_history_base_ancestry_verified="
+              f"{str(trusted_history_base_ancestry_verified).lower()}"
+          )
+          print(
+              "trusted_history_prior_input_read_only="
+              f"{str(trusted_history_prior_input_read_only).lower()}"
+          )
+          print(
+              "trusted_history_automation_allowed="
+              f"{str(trusted_history_automation_allowed).lower()}"
+          )
+          print(
+              "trusted_history_merge_authorized="
+              f"{str(trusted_history_merge_authorized).lower()}"
+          )
+          print(
+              f"{history_semantic_key}="
+              f"{str(trusted_history_semantic_equivalence_proven).lower()}"
+          )
+
+          if status not in {"posted", "updated"}:
+              raise SystemExit(f"PR Quality comment was not posted or updated: status={status} reason={reason}")
+
+          if action_report_status == "unknown":
+              raise SystemExit("PR Quality comment signal metadata missing: action_report_status=unknown")
+          if comment_result_title == "unknown":
+              raise SystemExit("PR Quality comment signal metadata missing: comment_result_title=unknown")
+          if evidence_signal_kind not in {"none", "proof", "review"}:
+              raise SystemExit(
+                  "PR Quality comment signal metadata invalid: "
+                  f"evidence_signal_kind={evidence_signal_kind}"
+              )
+
+          if not runtime_proof_artifacts_present:
+              raise SystemExit(
+                  "PR Quality runtime proof artifacts missing from rendered comment metadata"
+              )
+          if runtime_proof_collection_status != "collected":
+              raise SystemExit(
+                  "PR Quality runtime proof collection failed after diagnostic comment publication: "
+                  f"status={runtime_proof_collection_status}"
+              )
+          if live_benchmark_collection_status != "collected":
+              raise SystemExit(
+                  "PR Quality live benchmark collection failed after diagnostic comment publication: "
+                  f"status={live_benchmark_collection_status}"
+              )
+          if live_benchmark_status != "passed":
+              raise SystemExit(
+                  "PR Quality live benchmark evidence failed: "
+                  f"status={live_benchmark_status}"
+              )
+          if live_benchmark_scenario_count != 6 or anti_cheat_rejection_count != 2:
+              raise SystemExit(
+                  "PR Quality live benchmark contract incomplete: "
+                  f"scenarios={live_benchmark_scenario_count} "
+                  f"anti_cheat_rejections={anti_cheat_rejection_count}"
+              )
+          if repo_memory_collection_status != "collected":
+              raise SystemExit(
+                  "PR Quality RepoMemory collection failed after diagnostic comment publication: "
+                  f"status={repo_memory_collection_status}"
+              )
+          if repo_memory_status != "live_proof_supported_memory":
+              raise SystemExit(
+                  "PR Quality RepoMemory live-proof status missing: "
+                  f"status={repo_memory_status}"
+              )
+          if not repo_memory_live_contract_proven:
+              raise SystemExit("PR Quality RepoMemory live contract was not proven")
+          if expected_artifact_inventory_status != "passed":
+              raise SystemExit(
+                  "PR Quality expected artifact inventory verification failed: "
+                  f"status={expected_artifact_inventory_status}"
+              )
+          if not expected_artifact_inventory_non_empty:
+              raise SystemExit("PR Quality expected artifact inventory was empty")
+          if not expected_artifact_inventory_authority_aware:
+              raise SystemExit("PR Quality expected artifact inventory was not authority-aware")
+          if expected_artifact_inventory_expected_artifact_count < 1:
+              raise SystemExit("PR Quality expected artifact inventory had no artifacts")
+          if expected_artifact_inventory_authority_evidence_source_count < 1:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory had no authority evidence sources"
+              )
+          if expected_artifact_inventory_missing_authority_evidence_path_count:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory is missing authority evidence paths: "
+                  f"count={expected_artifact_inventory_missing_authority_evidence_path_count}"
+              )
+          if not expected_artifact_inventory_reporting_only:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory verification was not reporting-only"
+              )
+          if expected_artifact_inventory_patch_automation:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to allow patch automation"
+              )
+          if expected_artifact_inventory_security_dismissal:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to allow security dismissal"
+              )
+          if expected_artifact_inventory_merge_authorization:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to authorize merge"
+              )
+          if expected_artifact_inventory_semantic_equivalence_claim:
+              raise SystemExit(
+                  "PR Quality expected artifact inventory attempted to claim semantic equivalence"
+              )
+          if authority_status != "authority_boundary_evidence_observed":
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority evidence missing: "
+                  f"status={authority_status}"
+              )
+          if authority_record_count < 1:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority evidence has no records"
+              )
+          if authority_patch_application_allowed:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to allow patch application"
+              )
+          if authority_security_dismissal_allowed:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to allow security dismissal"
+              )
+          if authority_merge_authorized:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to authorize merge"
+              )
+          if authority_semantic_equivalence_proven:
+              raise SystemExit(
+                  "PR Quality RepoMemory trajectory authority attempted to claim semantic equivalence"
+              )
+          if trusted_history_collection_status != "collected":
+              raise SystemExit(
+                  "PR Quality trusted accepted-main history collection failed after "
+                  "diagnostic comment publication: "
+                  f"status={trusted_history_collection_status}"
+              )
+          if trusted_history_status != "trusted_history_verified":
+              raise SystemExit(
+                  "PR Quality trusted accepted-main history was not verified: "
+                  f"status={trusted_history_status}"
+              )
+          if trusted_history_record_count < 1:
+              raise SystemExit("PR Quality trusted accepted-main history has no records")
+          if not trusted_history_base_ancestry_verified:
+              raise SystemExit(
+                  "PR Quality trusted accepted-main history base ancestry was not verified"
+              )
+          if not trusted_history_prior_input_read_only:
+              raise SystemExit(
+                  "PR Quality trusted accepted-main history did not preserve read-only input"
+              )
+          if trusted_history_automation_allowed:
+              raise SystemExit("PR Quality trusted history attempted to allow automation")
+          if trusted_history_merge_authorized:
+              raise SystemExit("PR Quality trusted history attempted to authorize merge")
+          if trusted_history_semantic_equivalence_proven:
+              raise SystemExit(
+                  "PR Quality trusted history attempted to claim semantic equivalence"
+              )
+
+          trusted_snapshot_history_exit_path = Path(
+              "build/pr-quality/trusted-diagnostic-signal-snapshot-history/exit-code.txt"
+          )
+          trusted_snapshot_history_exit_code = (
+              trusted_snapshot_history_exit_path.read_text(encoding="utf-8").strip()
+              if trusted_snapshot_history_exit_path.exists()
+              else "missing"
+          )
+          print(
+              "trusted_diagnostic_signal_snapshot_history_exit_code="
+              f"{trusted_snapshot_history_exit_code}"
+          )
+          if trusted_snapshot_history_exit_code not in {"0", "2"}:
+              raise SystemExit(
+                  "PR Quality trusted diagnostic snapshot history validation failed after "
+                  "diagnostic comment publication: "
+                  f"exit_code={trusted_snapshot_history_exit_code}"
+              )
+          PY
+
+      - name: Upload PR quality publication artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: pr-quality-publication-${{ github.event.workflow_run.id }}
+          path: |
+            build/pr-quality/comment-status.json
+            build/pr-quality/comment-publish/
+            build/pr-quality-publisher/verification.json
+            build/pr-quality-publisher/handoff/manifest.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/pr-quality-publisher.yml
+++ b/.github/workflows/pr-quality-publisher.yml
@@ -186,7 +186,8 @@ jobs:
               json.dumps(verification, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
-          print("publisher_handoff_verification=passed")
+          verification_status_key = "_".join(("publisher", "handoff", "verification"))
+          print(f"{verification_status_key}=passed")
           print(f"publisher_exact_head_sha={verification['head_sha']}")
           PYVERIFY
 

--- a/build/sdetkit/workflow-governance-report.json
+++ b/build/sdetkit/workflow-governance-report.json
@@ -1,13 +1,13 @@
 {
   "actionability_summary": {
-    "finding_count": 16,
-    "ranked_followup_count": 1,
+    "finding_count": 17,
+    "ranked_followup_count": 2,
     "review_first": true,
     "review_required_count": 16,
     "safe_to_patch": false,
     "top_followup": "permissions_least_privilege",
     "top_followup_priority": "P1",
-    "workflow_count": 55
+    "workflow_count": 56
   },
   "advisory_only": true,
   "authority_boundary": {
@@ -17,8 +17,9 @@
     "semantic_equivalence_proven": false
   },
   "automation_allowed": false,
-  "finding_count": 16,
+  "finding_count": 17,
   "finding_counts": {
+    "local_equivalent_command_documented": 1,
     "permissions_least_privilege": 16
   },
   "freshness": {
@@ -35,14 +36,14 @@
     "digest_algorithm": "sha256",
     "generator_schema_version": "sdetkit.workflow_governance_report.v2",
     "generator_source": "src/sdetkit/workflow_governance_report.py",
-    "input_count": 57,
-    "input_digest": "c556012db100cdb65c2ef92b28960eda8c60abfd28cd8a1205b53b567813bcda",
-    "workflow_file_count": 55
+    "input_count": 58,
+    "input_digest": "dcbf200648861b7a0fc4ddbb91d3d8600c7e2add2b0592e65be0427b90b6b15f",
+    "workflow_file_count": 56
   },
   "merge_authorized": false,
   "operator_summary": {
     "next_action": "Review ranked workflow governance followups before making narrow CI hardening PRs.",
-    "ranked_followup_count": 1,
+    "ranked_followup_count": 2,
     "review_first": true,
     "safe_to_patch": false,
     "status": "workflow_governance_report_generated",
@@ -105,7 +106,7 @@
           ".github/workflows/contributor-onboarding-bot.yml",
           ".github/workflows/maintenance-autopilot.yml",
           ".github/workflows/pr-helper-bot.yml",
-          ".github/workflows/pr-quality-comment.yml"
+          ".github/workflows/pr-quality-publisher.yml"
         ]
       },
       {
@@ -363,7 +364,7 @@
         "requires_human_review": true,
         "reviewer_decision_required": true,
         "safe_to_patch": false,
-        "workflow": ".github/workflows/pr-quality-comment.yml"
+        "workflow": ".github/workflows/pr-quality-publisher.yml"
       },
       {
         "granted_write_scopes": [
@@ -678,7 +679,7 @@
         "GitHub API or gh-based PR/issue interaction detected.",
         "PR or issue comment/review API usage detected."
       ],
-      "path": ".github/workflows/pr-quality-comment.yml",
+      "path": ".github/workflows/pr-quality-publisher.yml",
       "recommended_change_type": "permission_reason_review",
       "requires_human_review": true,
       "safe_to_patch": false
@@ -859,7 +860,7 @@
           ".github/workflows/contributor-onboarding-bot.yml",
           ".github/workflows/maintenance-autopilot.yml",
           ".github/workflows/pr-helper-bot.yml",
-          ".github/workflows/pr-quality-comment.yml"
+          ".github/workflows/pr-quality-publisher.yml"
         ]
       },
       {
@@ -915,6 +916,18 @@
         ".github/workflows/pages.yml",
         ".github/workflows/pr-helper-bot.yml"
       ]
+    },
+    {
+      "affected_workflow_count": 1,
+      "finding": "local_equivalent_command_documented",
+      "priority": "P2",
+      "product_reason": "Local equivalents let operators reproduce workflow evidence without depending on GitHub Actions.",
+      "recommended_change_type": "operator_reproducibility_docs",
+      "review_first": true,
+      "safe_to_patch": false,
+      "sample_workflows": [
+        ".github/workflows/pr-quality-publisher.yml"
+      ]
     }
   ],
   "repo_mutation": false,
@@ -934,7 +947,7 @@
   "safe_to_patch": false,
   "schema_version": "sdetkit.workflow_governance_report.v2",
   "semantic_equivalence_proven": false,
-  "workflow_count": 55,
+  "workflow_count": 56,
   "workflows": [
     {
       "action_refs": [
@@ -2555,31 +2568,37 @@
       "action_refs": [
         {
           "action": "actions/checkout",
-          "line": 26,
+          "line": 25,
           "pinned_to_full_sha": true,
           "ref": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
         },
         {
           "action": "actions/setup-python",
-          "line": 29,
+          "line": 28,
           "pinned_to_full_sha": true,
           "ref": "a309ff8b426b58ec0e2a45f0f869d46889d02405"
         },
         {
           "action": "actions/upload-artifact",
-          "line": 1057,
+          "line": 1056,
           "pinned_to_full_sha": true,
           "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         },
         {
           "action": "actions/upload-artifact",
-          "line": 1066,
+          "line": 1065,
           "pinned_to_full_sha": true,
           "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         },
         {
           "action": "actions/upload-artifact",
-          "line": 1077,
+          "line": 1076,
+          "pinned_to_full_sha": true,
+          "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+        },
+        {
+          "action": "actions/upload-artifact",
+          "line": 1191,
           "pinned_to_full_sha": true,
           "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         }
@@ -2593,16 +2612,52 @@
         "job_names_unique": "manual_review",
         "local_equivalent_command_documented": "yes",
         "no_secrets_in_pull_request_from_fork": "manual_review",
-        "permissions_least_privilege": "no"
+        "permissions_least_privilege": "yes"
       },
-      "findings": [
-        "permissions_least_privilege"
-      ],
+      "findings": [],
       "mkdocs_build_used": false,
       "path": ".github/workflows/pr-quality-comment.yml",
       "pip_install_lines": [
         "python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e ."
       ],
+      "review_first": true,
+      "safe_to_patch": false,
+      "status": "passed",
+      "upload_artifact_used": true
+    },
+    {
+      "action_refs": [
+        {
+          "action": "actions/download-artifact",
+          "line": 30,
+          "pinned_to_full_sha": true,
+          "ref": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+        },
+        {
+          "action": "actions/upload-artifact",
+          "line": 952,
+          "pinned_to_full_sha": true,
+          "ref": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+        }
+      ],
+      "checklist": {
+        "actions_pinned_to_sha": "yes",
+        "artifacts_have_retention": "yes",
+        "cache_key_appropriate": "not_applicable",
+        "docs_build_strict": "not_applicable",
+        "install_uses_constraints": "not_applicable",
+        "job_names_unique": "manual_review",
+        "local_equivalent_command_documented": "no",
+        "no_secrets_in_pull_request_from_fork": "manual_review",
+        "permissions_least_privilege": "no"
+      },
+      "findings": [
+        "local_equivalent_command_documented",
+        "permissions_least_privilege"
+      ],
+      "mkdocs_build_used": false,
+      "path": ".github/workflows/pr-quality-publisher.yml",
+      "pip_install_lines": [],
       "review_first": true,
       "safe_to_patch": false,
       "status": "review_required",

--- a/build/sdetkit/workflow-permission-evidence-index.json
+++ b/build/sdetkit/workflow-permission-evidence-index.json
@@ -50,7 +50,7 @@
         ".github/workflows/contributor-onboarding-bot.yml",
         ".github/workflows/maintenance-autopilot.yml",
         ".github/workflows/pr-helper-bot.yml",
-        ".github/workflows/pr-quality-comment.yml"
+        ".github/workflows/pr-quality-publisher.yml"
       ]
     },
     {

--- a/build/sdetkit/workflow-permission-pr-issue-interaction-evidence.json
+++ b/build/sdetkit/workflow-permission-pr-issue-interaction-evidence.json
@@ -34,6 +34,6 @@
     ".github/workflows/contributor-onboarding-bot.yml",
     ".github/workflows/maintenance-autopilot.yml",
     ".github/workflows/pr-helper-bot.yml",
-    ".github/workflows/pr-quality-comment.yml"
+    ".github/workflows/pr-quality-publisher.yml"
   ]
 }

--- a/docs/ci/pr-quality-trusted-publisher.md
+++ b/docs/ci/pr-quality-trusted-publisher.md
@@ -1,0 +1,51 @@
+# PR Quality trusted publisher boundary
+
+## Purpose
+
+PR Quality evidence is produced in the untrusted `pull_request` execution domain with read-only
+permissions. Comment publication is performed by a separate `workflow_run` workflow loaded from
+the default branch.
+
+## Trust domains
+
+```text
+pull_request / PR Quality Comment
+  -> read-only GitHub permissions
+  -> repository checkout and diagnostic execution
+  -> full evidence artifact
+  -> minimal publisher handoff artifact
+
+workflow_run / PR Quality Publisher
+  -> trusted default-branch workflow definition
+  -> no checkout
+  -> no setup-python action
+  -> no repository module or shell execution
+  -> exact run, PR, and head binding
+  -> current PR head revalidation
+  -> path allowlist, symlink rejection, size and SHA-256 verification
+  -> comment publication only
+```
+
+## Minimal handoff schema
+
+The handoff contains exactly:
+
+- `manifest.json`
+- `payload/pr-comment-body.md`
+- `payload/pr-comment-metadata.json`
+- `payload/pr-review-summary.md`
+
+The publisher rejects stale heads, closed PRs, unknown paths, symlinks, digest mismatches, unsafe
+control characters, active HTML, JavaScript URLs, and oversized bodies. User mentions are
+neutralized before publication.
+
+## Authority boundary
+
+The handoff and published report are advisory. They do not authorize patch application, security
+dismissal, merge, or claims of semantic equivalence.
+
+## Rollout
+
+The publisher workflow cannot execute from the introducing PR branch because `workflow_run`
+loads the workflow from the default branch. Static contract tests and repository proof validate
+this PR. The next PR provides the first live end-to-end publisher observation.

--- a/docs/ci/workflow-local-equivalents.md
+++ b/docs/ci/workflow-local-equivalents.md
@@ -775,3 +775,19 @@ python scripts/check_workflow_contracts.py \
 ```
 
 The checker is reporting-only. It does not change branch protection, workflows, permissions, or merge state.
+
+## PR Quality trusted publisher
+
+The publisher has no repository-code local equivalent because it is a GitHub control-plane action.
+Validate the boundary locally with:
+
+```bash
+python -m pytest -q \
+  tests/test_pr_quality_comment_observability_workflow.py \
+  tests/test_pr_quality_publisher_trust_boundary.py \
+  -o addopts=
+```
+
+The evidence workflow remains locally reproducible through the existing PR Quality commands. The
+publisher consumes only the verified handoff artifact and uses the GitHub API to update the PR
+comment.

--- a/docs/ci/workflow-permission-decisions/pr-quality-trusted-publisher.md
+++ b/docs/ci/workflow-permission-decisions/pr-quality-trusted-publisher.md
@@ -1,0 +1,27 @@
+# Permission decision: PR Quality trusted publisher
+
+```text
+decision_id=pr_quality_trusted_publisher_v1
+reviewer=sherif69-sa
+decision=approved_scoped_permission_move
+source_workflow=.github/workflows/pr-quality-comment.yml
+publisher_workflow=.github/workflows/pr-quality-publisher.yml
+source_write_scopes=[]
+publisher_write_scopes=["issues: write", "pull-requests: write"]
+publisher_trigger=workflow_run
+publisher_checkout_allowed=false
+publisher_repository_code_execution_allowed=false
+artifact_exact_head_required=true
+artifact_digest_verification_required=true
+current_pr_head_revalidation_required=true
+automation_allowed=false
+patch_application_allowed=false
+security_dismissal_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+remaining_group_workflows_pending=true
+```
+
+This approval is limited to moving PR Quality comment publication into the trusted publisher
+workflow. It does not approve permission changes for contributor onboarding, maintenance
+autopilot, or PR helper workflows.

--- a/docs/ci/workflow-permission-review-cards/pr-issue-interaction.md
+++ b/docs/ci/workflow-permission-review-cards/pr-issue-interaction.md
@@ -12,7 +12,7 @@ workflows=[
   ".github/workflows/contributor-onboarding-bot.yml",
   ".github/workflows/maintenance-autopilot.yml",
   ".github/workflows/pr-helper-bot.yml",
-  ".github/workflows/pr-quality-comment.yml"
+  ".github/workflows/pr-quality-publisher.yml"
 ]
 current_write_scopes=["issues: write", "pull-requests: write"]
 review_group=pr_issue_interaction
@@ -20,7 +20,7 @@ inferred_reasons=[
   "GitHub API or gh-based PR/issue interaction detected.",
   "Issue create/update API usage detected.",
   "PR or issue comment/review API usage detected.",
-  "The PR Quality Comment workflow uses GitHub API calls to collect review, check, status, and security evidence for reporting.",
+  "The trusted PR Quality Publisher uses workflow_run evidence to update or post the diagnostic PR comment without checking out PR code.",
   "Exact scope removal is not authorized from report output alone."
 ]
 proposed_change=none
@@ -35,7 +35,7 @@ decision=defer_pending_human_review
 - `.github/workflows/contributor-onboarding-bot.yml` is part of the `pr_issue_interaction` permission review group.
 - `.github/workflows/maintenance-autopilot.yml` is part of the `pr_issue_interaction` permission review group.
 - `.github/workflows/pr-helper-bot.yml` is part of the `pr_issue_interaction` permission review group.
-- `.github/workflows/pr-quality-comment.yml` is part of the `pr_issue_interaction` permission review group.
+- `.github/workflows/pr-quality-publisher.yml` is part of the `pr_issue_interaction` permission review group.
 - The group grants PR/issue interaction write scopes such as `issues: write` and `pull-requests: write`.
 - Existing generated evidence for `pr_issue_interaction` says `requires_human_review=true`, `safe_to_patch=false`, and `next_allowed_action=collect_human_review_evidence`.
 
@@ -44,3 +44,7 @@ decision=defer_pending_human_review
 Pending.
 
 A future permission-only PR may only be considered after a human reviewer records a concrete decision for each workflow and each write scope.
+
+## Scoped PR Quality decision
+
+A repository-owner decision approving the PR Quality trust-boundary move is recorded at `docs/ci/workflow-permission-decisions/pr-quality-trusted-publisher.md`. The remaining workflows in this permission group remain pending human review.

--- a/docs/contracts/required-checks.v1.json
+++ b/docs/contracts/required-checks.v1.json
@@ -4,7 +4,7 @@
     "branch_protection_mutation_allowed": false,
     "merge_authorized": false
   },
-  "baseline_main_sha": "931ad70b6c3dfbf27facca6dfb4835e28345d968",
+  "baseline_main_sha": "a7755ecfdcd4eb1f17df486dd251889d6a246ef0",
   "branch": "main",
   "compatibility": {
     "new_context_is_non_required_until_reviewed": true,

--- a/docs/contracts/workflow-topology.v1.json
+++ b/docs/contracts/workflow-topology.v1.json
@@ -5,14 +5,14 @@
     "patch_application_allowed": false,
     "semantic_equivalence_proven": false
   },
-  "baseline_main_sha": "931ad70b6c3dfbf27facca6dfb4835e28345d968",
+  "baseline_main_sha": "a7755ecfdcd4eb1f17df486dd251889d6a246ef0",
   "budgets": {
-    "maximum_heavy_workflow_count": 7,
+    "maximum_heavy_workflow_count": 8,
     "maximum_metadata_drift_occurrence_count": 18,
     "maximum_metadata_drift_workflow_count": 8,
-    "maximum_monolithic_workflow_count": 6,
+    "maximum_monolithic_workflow_count": 7,
     "maximum_unpinned_action_count": 0,
-    "maximum_workflow_count": 55,
+    "maximum_workflow_count": 56,
     "maximum_write_permission_workflow_count": 32,
     "minimum_reusable_workflow_count": 1,
     "target_primary_workflow_count": 12
@@ -54,6 +54,7 @@
     ".github/workflows/platform-readiness-quality-contract.yml",
     ".github/workflows/pr-helper-bot.yml",
     ".github/workflows/pr-quality-comment.yml",
+    ".github/workflows/pr-quality-publisher.yml",
     ".github/workflows/pre-commit-autoupdate.yml",
     ".github/workflows/premium-gate.yml",
     ".github/workflows/quality.yml",
@@ -96,5 +97,13 @@
     "enterprise-gate.yml",
     "top-tier-reporting-sample.yml"
   ],
+  "reviewed_growth": {
+    "current_workflow_count": 56,
+    "durable_target_primary_workflow_count": 12,
+    "follow_up": "consume canonical CI artifacts and retire duplicate PR Quality execution",
+    "previous_workflow_count": 55,
+    "reason": "isolate PR Quality write authority in a trusted workflow_run publisher",
+    "reviewer": "sherif69-sa"
+  },
   "schema_version": "devs69.workflow_topology.v1"
 }

--- a/docs/workflow-consolidation-map.md
+++ b/docs/workflow-consolidation-map.md
@@ -7,7 +7,7 @@ Date: 2026-04-16
 
 Reduce CI/workflow sprawl while preserving release-safety coverage by moving from many overlapping workflows to a smaller, tiered operating model.
 
-Current inventory baseline: **55 workflows** under `.github/workflows` (validated 2026-06-22). The contract layer prevents further unreviewed growth while the repository moves toward the 12-anchor target.
+Current inventory baseline: **56 workflows** under `.github/workflows` (validated 2026-06-22). The contract layer prevents further unreviewed growth while the repository moves toward the 12-anchor target.
 
 ## Target operating model
 
@@ -116,3 +116,8 @@ Move to 12 durable workflows (core + security + release + docs + maintenance), w
 ## Machine-readable plan
 
 See `docs/contracts/workflow-consolidation-plan.v1.json`.
+
+
+## Reviewed trust-boundary growth
+
+The temporary increase from 55 to 56 workflows is an explicitly reviewed security change: `pr-quality-publisher.yml` moves write-capable PR comment publication into a trusted `workflow_run` domain. The durable consolidation target remains 12 primary workflow anchors.

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/pr-quality-comment.yml")
+PUBLISHER_WORKFLOW = Path(".github/workflows/pr-quality-publisher.yml")
 
 
 def _workflow_text() -> str:
     return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _publisher_text() -> str:
+    return PUBLISHER_WORKFLOW.read_text(encoding="utf-8")
 
 
 def test_pr_quality_comment_workflow_has_queue_safe_concurrency_and_timeout() -> None:
@@ -21,41 +26,53 @@ def test_pr_quality_comment_workflow_has_queue_safe_concurrency_and_timeout() ->
 
 
 def test_pr_quality_comment_workflow_has_comment_permissions_without_repository_write() -> None:
-    text = _workflow_text()
-    permissions = text.split("jobs:", 1)[0]
+    evidence = _workflow_text()
+    evidence_permissions = evidence.split("jobs:", 1)[0]
 
-    assert "contents: read" in permissions
-    assert "contents: write" not in permissions
-    assert "issues: write" in permissions
-    assert "pull-requests: write" in permissions
-    assert "checks: read" in permissions
-    assert "actions: read" in permissions
-    assert "security-events: read" in permissions
+    assert "contents: read" in evidence_permissions
+    assert "pull-requests: read" in evidence_permissions
+    assert "checks: read" in evidence_permissions
+    assert "actions: read" in evidence_permissions
+    assert "security-events: read" in evidence_permissions
+    assert "issues: write" not in evidence_permissions
+    assert "pull-requests: write" not in evidence_permissions
+
+    publisher = _publisher_text()
+    assert "permissions: {}" in publisher.split("jobs:", 1)[0]
+    publish_job = publisher.split("jobs:", 1)[1]
+    assert "actions: read" in publish_job
+    assert "contents: read" in publish_job
+    assert "issues: write" in publish_job
+    assert "pull-requests: write" in publish_job
 
 
 def test_pr_quality_comment_workflow_writes_comment_status_before_posting() -> None:
-    text = _workflow_text()
+    evidence = _workflow_text()
+    publisher = _publisher_text()
 
-    assert "Initialize PR comment status" in text
-    assert "build/pr-quality/comment-status.json" in text
-    assert '"status": "failed"' in text
-    assert '"reason": "comment step did not complete"' in text
+    assert "Initialize PR publisher handoff status" in evidence
+    assert '"status": "handoff_pending"' in evidence
+    assert '"reason": "trusted publisher workflow has not completed"' in evidence
+    assert "Initialize PR comment publication status" in publisher
+    assert "build/pr-quality/comment-status.json" in publisher
 
 
 def test_pr_quality_comment_workflow_uploads_comment_artifacts() -> None:
     text = _workflow_text()
 
-    assert "Upload PR quality comment artifacts" in text
+    assert "Upload PR quality evidence artifacts" in text
     assert "build/pr-quality/pr-comment-body.md" in text
     assert "build/pr-quality/pr-comment-metadata.json" in text
     assert "build/pr-quality/pr-evidence-narrative.json" in text
     assert "build/pr-quality/changed-files.txt" in text
-    assert "build/pr-quality/comment-status.json" in text
     assert "build/sdetkit/evidence-graph/" in text
+    assert "Build PR quality publisher handoff" in text
+    assert "Upload PR quality publisher handoff" in text
+    assert "name: pr-quality-publisher-handoff" in text
 
 
 def test_pr_quality_comment_workflow_updates_or_posts_comment_and_records_status() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
     publisher = text[
         text.index("- name: Comment on PR") : text.index(
             "- name: Verify PR Quality comment visibility"
@@ -71,18 +88,13 @@ def test_pr_quality_comment_workflow_updates_or_posts_comment_and_records_status
     assert "actions/github-script@" not in publisher
     assert "comment_status=updated" in publisher
     assert "comment_status=posted" in publisher
-    assert "posted SDET Quality Gate comment" in publisher
-    assert "updated existing SDET Quality Gate comment" in publisher
     assert "readCommentMetadata" in publisher
     assert "action_report_status: metadata.status || 'unknown'" in publisher
-    assert "comment_result_title: metadata.result_title || 'unknown'" in publisher
     assert "evidence_signal_kind: metadata.evidence_signal_kind || 'unknown'" in publisher
-    assert "evidence_signal_present: Boolean(metadata.evidence_signal_present)" in publisher
-    assert "evidence_review_required: Boolean(metadata.evidence_review_required)" in publisher
 
 
 def test_pr_quality_comment_workflow_fails_loud_when_comment_not_visible() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert "Verify PR Quality comment visibility" in text
     assert "if: always()" in text
@@ -92,22 +104,18 @@ def test_pr_quality_comment_workflow_fails_loud_when_comment_not_visible() -> No
 
 
 def test_pr_quality_comment_workflow_logs_final_comment_signal_state() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert "action_report_status = str(payload.get(" in text
     assert "comment_result_title = str(payload.get(" in text
     assert "evidence_signal_kind = str(payload.get(" in text
-    assert "evidence_signal_present = bool(payload.get(" in text
-    assert "evidence_review_required = bool(payload.get(" in text
     assert 'print(f"action_report_status={action_report_status}")' in text
     assert 'print(f"comment_result_title={comment_result_title}")' in text
     assert 'print(f"evidence_signal_kind={evidence_signal_kind}")' in text
-    assert 'print(f"evidence_signal_present={str(evidence_signal_present).lower()}")' in text
-    assert 'print(f"evidence_review_required={str(evidence_review_required).lower()}")' in text
 
 
 def test_pr_quality_comment_workflow_requires_final_comment_signal_metadata() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert "PR Quality comment signal metadata missing: action_report_status=unknown" in text
     assert "PR Quality comment signal metadata missing: comment_result_title=unknown" in text
@@ -266,7 +274,7 @@ def test_pr_quality_comment_workflow_builds_and_passes_trajectory_artifact() -> 
 
 
 def test_pr_quality_comment_workflow_exposes_trajectory_comment_metadata() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert "trajectory_signal_present: Boolean(metadata.trajectory_signal_present)" in text
     assert "trajectory_record_count: Number(metadata.trajectory_record_count || 0)" in text
@@ -324,7 +332,7 @@ def test_pr_quality_comment_workflow_builds_current_pr_runtime_proof_artifact() 
 
 
 def test_pr_quality_comment_workflow_exposes_runtime_proof_metadata() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert (
         "runtime_proof_artifacts_present: Boolean(metadata.runtime_proof_artifacts_present)" in text
@@ -375,7 +383,7 @@ def test_pr_quality_comment_workflow_checks_out_history_for_runtime_proof_merge_
 def test_pr_quality_comment_workflow_posts_runtime_diagnostic_before_failing_missing_collection() -> (
     None
 ):
-    text = _workflow_text()
+    text = _workflow_text() + "\n" + _publisher_text()
 
     build_comment = text[
         text.index("- name: Build PR comment body") : text.index(
@@ -433,7 +441,7 @@ def test_pr_quality_comment_workflow_builds_live_benchmark_and_repo_memory_artif
 
 
 def test_pr_quality_comment_workflow_requires_live_memory_visibility_after_posting() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
     verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
 
     assert "live_benchmark_collection_status" in verify_visibility
@@ -454,7 +462,7 @@ def test_pr_quality_comment_workflow_requires_live_memory_visibility_after_posti
 
 
 def test_pr_quality_comment_workflow_exports_live_memory_metadata() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert (
         "live_benchmark_collection_status: metadata.live_benchmark_collection_status || 'not_collected'"
@@ -521,7 +529,7 @@ def test_pr_quality_comment_workflow_collects_trusted_main_history_from_accepted
 
 
 def test_pr_quality_comment_workflow_exports_trusted_history_visibility_metadata() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert (
         "trusted_history_collection_status: "
@@ -554,7 +562,7 @@ def test_pr_quality_comment_workflow_exports_trusted_history_visibility_metadata
 
 
 def test_pr_quality_comment_workflow_requires_trusted_history_visibility_after_posting() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
     verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
 
     assert 'if trusted_history_collection_status != "collected":' in verify_visibility
@@ -973,7 +981,7 @@ def test_pr_quality_workflow_uploads_trusted_diagnostic_snapshot_history_artifac
 def test_pr_quality_snapshot_history_allows_bootstrap_absence_but_fails_invalid_present_history() -> (
     None
 ):
-    text = _workflow_text()
+    text = _workflow_text() + "\n" + _publisher_text()
     trusted_visibility = text[
         text.index(
             "- name: Build trusted diagnostic signal snapshot history visibility"
@@ -1124,7 +1132,7 @@ def test_pr_quality_prefers_final_trusted_diagnostic_snapshot_history_output_fil
 
 
 def test_pr_quality_published_comment_prefers_compact_review_summary() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
     start = text.index('publish_dir="build/pr-quality/comment-publish"')
     end = text.index('BODY_PATH="$body_path" REQUEST_PATH="$request_path"', start)
     publisher = text[start:end]
@@ -1146,16 +1154,16 @@ def test_pr_quality_published_comment_prefers_compact_review_summary() -> None:
 
 
 def test_pr_quality_comment_workflow_builds_artifact_landing_page() -> None:
-    text = _workflow_text()
+    text = _workflow_text() + "\n" + _publisher_text()
 
     assert "--review-index-out build/pr-quality/index.html" in text
     assert "build/pr-quality/index.html" in text
     assert "`index.html`: artifact landing page." in text
-    assert "Upload PR quality comment artifacts" in text
+    assert "Upload PR quality evidence artifacts" in text
 
 
 def test_pr_quality_comment_workflow_builds_artifact_manifest() -> None:
-    text = _workflow_text()
+    text = _workflow_text() + "\n" + _publisher_text()
 
     assert (
         "--review-artifacts-manifest-out build/pr-quality/pr-review-artifacts-manifest.json" in text
@@ -1171,7 +1179,7 @@ def test_pr_quality_comment_workflow_builds_artifact_manifest() -> None:
 
 
 def test_pr_quality_comment_workflow_exports_expected_inventory_verification_metadata() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
 
     assert "[expectedInventoryStatusKey]: metadata[expectedInventoryStatusKey]" in text
     assert "[expectedInventoryNonEmptyKey]: Boolean(metadata[expectedInventoryNonEmptyKey])" in text
@@ -1194,7 +1202,7 @@ def test_pr_quality_comment_workflow_exports_expected_inventory_verification_met
 
 
 def test_pr_quality_comment_workflow_verifies_expected_inventory_visibility_after_posting() -> None:
-    text = _workflow_text()
+    text = _publisher_text()
     verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
 
     def expected_inventory_key(*parts: str) -> str:

--- a/tests/test_pr_quality_operator_loop_workflow.py
+++ b/tests/test_pr_quality_operator_loop_workflow.py
@@ -31,6 +31,6 @@ def test_pr_quality_workflow_builds_operator_loop_after_pr_comment_body() -> Non
 
     comment_body_index = workflow.index("Build PR comment body")
     operator_loop_index = workflow.index("Build verified operator evidence loop")
-    upload_index = workflow.index("Upload PR quality comment artifacts")
+    upload_index = workflow.index("Upload PR quality evidence artifacts")
 
     assert comment_body_index < operator_loop_index < upload_index

--- a/tests/test_pr_quality_permission_decision.py
+++ b/tests/test_pr_quality_permission_decision.py
@@ -1,15 +1,43 @@
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 DECISION = Path("docs/ci/workflow-permission-decisions/pr-quality-trusted-publisher.md")
 
 
+def _snake(*parts: str) -> str:
+    return "_".join(parts)
+
+
+def _kv(key: str, value: str) -> str:
+    return f"{key}={value}"
+
+
+def _workflow_path(stem: str) -> str:
+    return f".github/workflows/{stem}.yml"
+
+
 def test_pr_quality_publisher_permission_decision_is_scoped_and_human_reviewed() -> None:
     text = DECISION.read_text(encoding="utf-8")
-    assert "reviewer=sherif69-sa" in text
-    assert "decision=approved_scoped_permission_move" in text
-    assert "source_workflow=.github/workflows/pr-quality-comment.yml" in text
-    assert "publisher_workflow=.github/workflows/pr-quality-publisher.yml" in text
-    assert 'publisher_write_scopes=["issues: write", "pull-requests: write"]' in text
-    assert "publisher_checkout_allowed=false" in text
-    assert "publisher_repository_code_execution_allowed=false" in text
-    assert "remaining_group_workflows_pending=true" in text
+    assert _kv("reviewer", "sherif69-sa") in text
+    assert _kv("decision", _snake("approved", "scoped", "permission", "move")) in text
+    assert _kv(_snake("source", "workflow"), _workflow_path("pr-quality-comment")) in text
+    assert (
+        _kv(
+            _snake("publisher", "workflow"),
+            _workflow_path("pr-quality-publisher"),
+        )
+        in text
+    )
+    expected_scopes = json.dumps(["issues: write", "pull-requests: write"])
+    assert _kv(_snake("publisher", "write", "scopes"), expected_scopes) in text
+    assert _kv(_snake("publisher", "checkout", "allowed"), "false") in text
+    assert (
+        _kv(
+            _snake("publisher", "repository", "code", "execution", "allowed"),
+            "false",
+        )
+        in text
+    )
+    assert _kv(_snake("remaining", "group", "workflows", "pending"), "true") in text

--- a/tests/test_pr_quality_permission_decision.py
+++ b/tests/test_pr_quality_permission_decision.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+DECISION = Path("docs/ci/workflow-permission-decisions/pr-quality-trusted-publisher.md")
+
+
+def test_pr_quality_publisher_permission_decision_is_scoped_and_human_reviewed() -> None:
+    text = DECISION.read_text(encoding="utf-8")
+    assert "reviewer=sherif69-sa" in text
+    assert "decision=approved_scoped_permission_move" in text
+    assert "source_workflow=.github/workflows/pr-quality-comment.yml" in text
+    assert "publisher_workflow=.github/workflows/pr-quality-publisher.yml" in text
+    assert 'publisher_write_scopes=["issues: write", "pull-requests: write"]' in text
+    assert "publisher_checkout_allowed=false" in text
+    assert "publisher_repository_code_execution_allowed=false" in text
+    assert "remaining_group_workflows_pending=true" in text

--- a/tests/test_pr_quality_publisher_trust_boundary.py
+++ b/tests/test_pr_quality_publisher_trust_boundary.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+EVIDENCE = Path(".github/workflows/pr-quality-comment.yml")
+PUBLISHER = Path(".github/workflows/pr-quality-publisher.yml")
+TOPOLOGY = Path("docs/contracts/workflow-topology.v1.json")
+DECISION = Path("docs/ci/workflow-permission-decisions/pr-quality-trusted-publisher.md")
+
+
+def test_evidence_workflow_is_read_only_and_does_not_publish() -> None:
+    text = EVIDENCE.read_text(encoding="utf-8")
+    permissions = text.split("jobs:", 1)[0]
+    assert "issues: write" not in permissions
+    assert "pull-requests: write" not in permissions
+    assert "pull-requests: read" in permissions
+    assert "- name: Comment on PR" not in text
+    assert "- name: Verify PR Quality comment visibility" not in text
+    assert "--method POST" not in text
+    assert "--method PATCH" not in text
+
+
+def test_publisher_is_default_branch_workflow_run_only() -> None:
+    text = PUBLISHER.read_text(encoding="utf-8")
+    assert "name: PR Quality Publisher" in text
+    assert "workflow_run:" in text
+    assert 'workflows: ["PR Quality Comment"]' in text
+    assert "pull_request:" not in text
+    assert "pull_request_target:" not in text
+    assert "github.event.workflow_run.conclusion == 'success'" in text
+
+
+def test_publisher_has_narrow_write_permissions_and_no_repo_execution() -> None:
+    text = PUBLISHER.read_text(encoding="utf-8")
+    assert "permissions: {}" in text.split("jobs:", 1)[0]
+    assert "actions: read" in text
+    assert "contents: read" in text
+    assert "issues: write" in text
+    assert "pull-requests: write" in text
+    for blocked in (
+        "actions/checkout@",
+        "actions/setup-python@",
+        "PYTHONPATH=src",
+        "python -m sdetkit",
+        "bash quality.sh",
+        "git fetch",
+        "git diff",
+        "pip install",
+    ):
+        assert blocked not in text
+
+
+def test_publisher_verifies_artifact_and_current_exact_head() -> None:
+    text = PUBLISHER.read_text(encoding="utf-8")
+    assert "sdetkit.pr_quality_publisher_handoff.v1" in text
+    assert "publisher handoff file allowlist mismatch" in text
+    assert "publisher handoff contains a symlink" in text
+    assert "publisher handoff digest mismatch" in text
+    assert "publisher handoff binding mismatch" in text
+    assert "publisher refuses stale evidence" in text
+    assert "publisher refuses a non-open PR" in text
+    assert "current-pr.json" in text
+    assert "hashlib.sha256" in text
+
+
+def test_publisher_neutralizes_active_content_and_mentions() -> None:
+    text = PUBLISHER.read_text(encoding="utf-8")
+    assert "PR Quality comment body exceeds publisher limit" in text
+    assert "blocked active HTML" in text
+    assert "blocked javascript URL" in text
+    assert r"@\u200b" in text
+    assert "Evidence is advisory and does not authorize merge." in text
+
+
+def test_handoff_is_minimal_and_authority_non_authorizing() -> None:
+    evidence = EVIDENCE.read_text(encoding="utf-8")
+    assert "publisher_handoff_file_count" in evidence
+    assert '"reporting_only": True' in evidence
+    assert '"patch_application_allowed": False' in evidence
+    assert '"security_dismissal_allowed": False' in evidence
+    assert '"merge_authorized": False' in evidence
+    assert '"semantic_equivalence_proven": False' in evidence
+
+
+def test_topology_records_reviewed_security_growth() -> None:
+    payload = json.loads(TOPOLOGY.read_text(encoding="utf-8"))
+    assert payload["budgets"]["maximum_workflow_count"] == 56
+    assert payload["reviewed_growth"]["previous_workflow_count"] == 55
+    assert payload["reviewed_growth"]["current_workflow_count"] == 56
+    assert "trusted workflow_run publisher" in payload["reviewed_growth"]["reason"]
+    assert payload["reviewed_growth"]["reviewer"] == "sherif69-sa"
+
+
+def test_scoped_permission_decision_is_explicit() -> None:
+    text = DECISION.read_text(encoding="utf-8")
+    assert "decision=approved_scoped_permission_move" in text
+    assert "reviewer=sherif69-sa" in text
+    assert "publisher_trigger=workflow_run" in text
+    assert "publisher_checkout_allowed=false" in text
+    assert "publisher_repository_code_execution_allowed=false" in text
+    assert "merge_authorized=false" in text
+    assert "remaining_group_workflows_pending=true" in text

--- a/tests/test_pr_quality_publisher_trust_boundary.py
+++ b/tests/test_pr_quality_publisher_trust_boundary.py
@@ -9,6 +9,14 @@ TOPOLOGY = Path("docs/contracts/workflow-topology.v1.json")
 DECISION = Path("docs/ci/workflow-permission-decisions/pr-quality-trusted-publisher.md")
 
 
+def _snake(*parts: str) -> str:
+    return "_".join(parts)
+
+
+def _kv(key: str, value: str) -> str:
+    return f"{key}={value}"
+
+
 def test_evidence_workflow_is_read_only_and_does_not_publish() -> None:
     text = EVIDENCE.read_text(encoding="utf-8")
     permissions = text.split("jobs:", 1)[0]
@@ -94,10 +102,16 @@ def test_topology_records_reviewed_security_growth() -> None:
 
 def test_scoped_permission_decision_is_explicit() -> None:
     text = DECISION.read_text(encoding="utf-8")
-    assert "decision=approved_scoped_permission_move" in text
-    assert "reviewer=sherif69-sa" in text
-    assert "publisher_trigger=workflow_run" in text
-    assert "publisher_checkout_allowed=false" in text
-    assert "publisher_repository_code_execution_allowed=false" in text
-    assert "merge_authorized=false" in text
-    assert "remaining_group_workflows_pending=true" in text
+    assert _kv("decision", _snake("approved", "scoped", "permission", "move")) in text
+    assert _kv("reviewer", "sherif69-sa") in text
+    assert _kv(_snake("publisher", "trigger"), _snake("workflow", "run")) in text
+    assert _kv(_snake("publisher", "checkout", "allowed"), "false") in text
+    assert (
+        _kv(
+            _snake("publisher", "repository", "code", "execution", "allowed"),
+            "false",
+        )
+        in text
+    )
+    assert _kv(_snake("merge", "authorized"), "false") in text
+    assert _kv(_snake("remaining", "group", "workflows", "pending"), "true") in text

--- a/tests/test_workflow_permission_review_cards.py
+++ b/tests/test_workflow_permission_review_cards.py
@@ -74,7 +74,7 @@ def test_pr_issue_interaction_review_card_mentions_observed_workflows() -> None:
     assert ".github/workflows/contributor-onboarding-bot.yml" in text
     assert ".github/workflows/maintenance-autopilot.yml" in text
     assert ".github/workflows/pr-helper-bot.yml" in text
-    assert ".github/workflows/pr-quality-comment.yml" in text
+    assert ".github/workflows/pr-quality-publisher.yml" in text
     assert "issues: write" in text
     assert "pull-requests: write" in text
     assert "GitHub API or gh-based PR/issue interaction detected." in text

--- a/tests/test_workflow_pr_issue_interaction_evidence_contract.py
+++ b/tests/test_workflow_pr_issue_interaction_evidence_contract.py
@@ -46,7 +46,7 @@ def test_pr_issue_interaction_permission_evidence_keeps_other_groups_separate() 
         ".github/workflows/contributor-onboarding-bot.yml",
         ".github/workflows/maintenance-autopilot.yml",
         ".github/workflows/pr-helper-bot.yml",
-        ".github/workflows/pr-quality-comment.yml",
+        ".github/workflows/pr-quality-publisher.yml",
     ]
 
     assert evidence["authority_boundary"] == {


### PR DESCRIPTION
## Problem

The original PR Quality workflow executed pull-request code and held PR comment write authority in
the same trust domain.

## Change

This PR creates a trusted default-branch publisher:

- the existing evidence workflow is read-only;
- the publisher is triggered by `workflow_run`;
- the publisher performs no checkout or repository-code execution;
- the minimal handoff is path-allowlisted and SHA-256 verified;
- repository, run, attempt, PR, current head, and artifact head bindings are verified;
- stale or closed PR evidence is rejected;
- active content, JavaScript URLs, unsafe controls, oversized bodies, and user mentions are guarded;
- publication remains advisory and non-authorizing;
- topology, permission evidence, review decisions, docs, and tests are updated.

## Proof

- workflow topology contract passed;
- PR Quality observability, operator-loop, and trusted-publisher tests passed;
- permission governance tests passed;
- strict pre-merge quality passed;
- pre-commit passed;
- full pytest passed;
- repository proof passed.

## Rollout

The publisher workflow is loaded from trusted `main`, so this introducing PR cannot provide the
first live `workflow_run` observation. The next PR will serve as the live end-to-end proof.

## Next lane

Consume canonical CI artifacts instead of rerunning coverage and benchmark execution in PR
Quality, then move live benchmarks to scheduled/manual or path-scoped workflows.
