### PR TITLE
test(ci): verify trusted PR Quality publisher live

### DIFF
--- a/docs/ci/pr-quality-trusted-publisher.md
+++ b/docs/ci/pr-quality-trusted-publisher.md
@@ -49,3 +49,15 @@ dismissal, merge, or claims of semantic equivalence.
 The publisher workflow cannot execute from the introducing PR branch because `workflow_run`
 loads the workflow from the default branch. Static contract tests and repository proof validate
 this PR. The next PR provides the first live end-to-end publisher observation.
+
+## Live verification protocol
+
+The trust boundary is accepted only after a real pull request demonstrates both publication and
+idempotent update behavior.
+
+Phase one requires the read-only evidence workflow to produce a minimal handoff, the trusted
+publisher to verify the exact pull-request head, and one SDET Quality Gate comment to appear.
+
+Phase two changes the same pull-request head. The publisher must update the existing comment
+instead of creating a duplicate. Publication artifacts must remain reporting-only and must not
+grant patch, security-dismissal, or merge authority.


### PR DESCRIPTION
## Purpose

This PR is the first live end-to-end verification of the trusted PR Quality publisher now installed
on `main`.

## Phase one acceptance

- read-only `PR Quality Comment` succeeds;
- `pr-quality-publisher-handoff` exists and binds to the exact PR head;
- trusted `PR Quality Publisher` succeeds without checkout;
- publication verification reports `status=passed`;
- exactly one `### SDET Quality Gate` comment appears.

## Phase two acceptance

A second commit will update this same PR. The existing SDET Quality Gate comment must be updated,
not duplicated.

## Authority

This PR is verification-only. It does not authorize automatic merge, patch application, security
dismissal, or semantic-equivalence claims.
