### PR TITLE
fix(ci): keep PR Quality visibility inside trusted handoff

### DIFF
--- a/.github/workflows/pr-quality-publisher.yml
+++ b/.github/workflows/pr-quality-publisher.yml
@@ -928,24 +928,16 @@ jobs:
                   "PR Quality trusted history attempted to claim semantic equivalence"
               )
 
-          trusted_snapshot_history_exit_path = Path(
-              "build/pr-quality/trusted-diagnostic-signal-snapshot-history/exit-code.txt"
+          snapshot_history_validation_key = "_".join(
+              ("trusted", "diagnostic", "signal", "snapshot", "history", "validation")
           )
-          trusted_snapshot_history_exit_code = (
-              trusted_snapshot_history_exit_path.read_text(encoding="utf-8").strip()
-              if trusted_snapshot_history_exit_path.exists()
-              else "missing"
+          snapshot_history_validation_value = "_".join(
+              ("represented", "by", "verified", "handoff", "metadata")
           )
           print(
-              "trusted_diagnostic_signal_snapshot_history_exit_code="
-              f"{trusted_snapshot_history_exit_code}"
+              f"{snapshot_history_validation_key}="
+              f"{snapshot_history_validation_value}"
           )
-          if trusted_snapshot_history_exit_code not in {"0", "2"}:
-              raise SystemExit(
-                  "PR Quality trusted diagnostic snapshot history validation failed after "
-                  "diagnostic comment publication: "
-                  f"exit_code={trusted_snapshot_history_exit_code}"
-              )
           PY
 
       - name: Upload PR quality publication artifacts

--- a/docs/ci/pr-quality-trusted-publisher.md
+++ b/docs/ci/pr-quality-trusted-publisher.md
@@ -39,6 +39,10 @@ The publisher rejects stale heads, closed PRs, unknown paths, symlinks, digest m
 control characters, active HTML, JavaScript URLs, and oversized bodies. User mentions are
 neutralized before publication.
 
+Publisher visibility verification consumes only digest-bound metadata copied from the
+minimal handoff. It does not reopen evidence-workflow filesystem paths in the trusted
+publisher workspace.
+
 ## Authority boundary
 
 The handoff and published report are advisory. They do not authorize patch application, security

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -981,13 +981,18 @@ def test_pr_quality_workflow_uploads_trusted_diagnostic_snapshot_history_artifac
 def test_pr_quality_snapshot_history_allows_bootstrap_absence_but_fails_invalid_present_history() -> (
     None
 ):
-    text = _workflow_text() + "\n" + _publisher_text()
-    trusted_visibility = text[
-        text.index(
+    evidence = _workflow_text()
+    publisher = _publisher_text()
+    trusted_visibility = evidence[
+        evidence.index(
             "- name: Build trusted diagnostic signal snapshot history visibility"
-        ) : text.index("- name: Build verified operator evidence loop")
+        ) : evidence.index("- name: Build verified operator evidence loop")
     ]
-    verify_visibility = text[text.index("- name: Verify PR Quality comment visibility") :]
+    verify_visibility = publisher[
+        publisher.index("- name: Verify PR Quality comment visibility") : publisher.index(
+            "- name: Upload PR quality publication artifacts"
+        )
+    ]
 
     history_file_count = "_".join(("trusted", "snapshot", "history", "file", "count"))
     assert f"{history_file_count}=0" in trusted_visibility
@@ -998,10 +1003,14 @@ def test_pr_quality_snapshot_history_allows_bootstrap_absence_but_fails_invalid_
     assert "Collection status: `not_collected`" in trusted_visibility
     assert "Collection status: `collection_failed`" in trusted_visibility
     assert "failed validation or is incomplete" in trusted_visibility
-    guard_name = "_".join(("trusted", "snapshot", "history", "exit", "code"))
-    assert f'{guard_name} not in {{"0", "2"}}' in verify_visibility
-    assert "validation failed after " in verify_visibility
-    assert "diagnostic comment publication" in verify_visibility
+
+    snapshot_exit_path = "build/pr-quality/trusted-diagnostic-signal-snapshot-history/exit-code.txt"
+    assert snapshot_exit_path in evidence
+    assert snapshot_exit_path not in verify_visibility
+    assert 'snapshot_history_validation_key = "_".join(' in verify_visibility
+    assert 'snapshot_history_validation_value = "_".join(' in verify_visibility
+    assert 'if trusted_history_collection_status != "collected":' in verify_visibility
+    assert 'if trusted_history_status != "trusted_history_verified":' in verify_visibility
 
 
 def test_pr_quality_snapshot_history_falls_back_to_latest_ancestor_artifact_with_stream() -> None:

--- a/tests/test_pr_quality_publisher_trust_boundary.py
+++ b/tests/test_pr_quality_publisher_trust_boundary.py
@@ -115,3 +115,25 @@ def test_scoped_permission_decision_is_explicit() -> None:
     )
     assert _kv(_snake("merge", "authorized"), "false") in text
     assert _kv(_snake("remaining", "group", "workflows", "pending"), "true") in text
+
+
+def test_publisher_visibility_stays_inside_verified_handoff_boundary() -> None:
+    publisher = PUBLISHER.read_text(encoding="utf-8")
+    evidence = EVIDENCE.read_text(encoding="utf-8")
+    visibility = publisher[
+        publisher.index("- name: Verify PR Quality comment visibility") : publisher.index(
+            "- name: Upload PR quality publication artifacts"
+        )
+    ]
+
+    snapshot_exit_path = "build/pr-quality/trusted-diagnostic-signal-snapshot-history/exit-code.txt"
+
+    assert snapshot_exit_path in evidence
+    assert snapshot_exit_path not in visibility
+    assert 'snapshot_history_validation_key = "_".join(' in visibility
+    assert '("trusted", "diagnostic", "signal", "snapshot", "history", "validation")' in visibility
+    assert 'snapshot_history_validation_value = "_".join(' in visibility
+    assert '("represented", "by", "verified", "handoff", "metadata")' in visibility
+    assert 'if trusted_history_collection_status != "collected":' in visibility
+    assert 'if trusted_history_status != "trusted_history_verified":' in visibility
+    assert "publisher handoff digest mismatch" in publisher


### PR DESCRIPTION
## Problem

The first live trusted-publisher run on PR #1846 verified the exact-head handoff and posted the SDET
Quality Gate comment, then failed because the visibility step reopened an evidence-workflow
filesystem path that is intentionally absent from the minimal trusted handoff.

## Root cause

`trusted-diagnostic-signal-snapshot-history/exit-code.txt` belongs to the evidence workspace. The
trusted publisher receives only digest-bound handoff files and must verify visibility from their
metadata.

## Change

- remove the off-handoff snapshot-history file read;
- retain trusted-history metadata validation;
- emit an explicit verified-handoff metadata marker;
- update observability and trust-boundary tests to forbid off-handoff reads;
- document the boundary.

## Security review

- permissions changed: no
- checkout or repository-code execution added: no
- handoff schema expanded: no
- security dismissal authority changed: no
- merge authority changed: no

## Proof

- YAML parsing;
- focused publisher and observability tests;
- workflow contracts;
- changed-surface security scan;
- strict pre-merge quality;
- pre-commit;
- full pytest;
- repository proof.

## Rollout

Merge this hotfix first. Then push phase two to PR #1846 and verify that the publisher succeeds and
updates the existing SDET Quality Gate comment without duplication.
