### PR TITLE
fix(reporting): bind product maturity radar claims to current reports

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -666,6 +666,34 @@
       "stability": "advanced"
     },
     {
+      "id": "product-maturity-radar-json",
+      "path": "build/sdetkit/product-maturity-radar.json",
+      "produced_by": "python -m sdetkit product-maturity-radar --root . --out build/sdetkit/product-maturity-radar.json --format json",
+      "schema_version": "sdetkit.product_maturity_radar.v2",
+      "required_fields": [
+        "schema_version",
+        "generated_at",
+        "current_head_sha",
+        "input_digests",
+        "input_provenance",
+        "report_status",
+        "projection_status",
+        "projection_only",
+        "source_authority",
+        "surfaces",
+        "ranked_upgrade_candidates",
+        "claim_sources",
+        "report_dependencies",
+        "dependency_status",
+        "automation_allowed",
+        "patch_application_allowed",
+        "security_dismissal_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "issue-queue-classifier-json",
       "path": "build/sdetkit/issue-queue-classifier.json",
       "produced_by": "python -m sdetkit issue-queue-classifier --issues-json <issues.json> --out build/sdetkit/issue-queue-classifier.json --format text",

--- a/docs/operator-evidence-review-guide.md
+++ b/docs/operator-evidence-review-guide.md
@@ -325,3 +325,23 @@ semantic_equivalence_proven=false
 The dashboard schema is `sdetkit.maintenance_queue_rollup_dashboard.v1`. The default HTML path is `build/sdetkit/maintenance-queue-rollup-dashboard.html`; the recommended JSON path is `build/sdetkit/maintenance-queue-rollup-dashboard.json`.
 
 This dashboard is a read-only review surface. `primary_issue`, `review_required`, and `close_candidate` are prioritization context only and never authorize issue mutation, security dismissal, patch application, proof execution, or merge. Dashboard JSON artifact-contract registration remains a separate follow-up.
+
+
+## Product maturity radar projection trust
+
+`product-maturity-radar` is a reporting-only projection. It does not become the
+source of authority for workflow, adoption, remediation, release, diagnosis, or
+queue claims.
+
+Known dependency reports are discovered at their standard `build/sdetkit` paths.
+Use repeated `--report-json <dependency-id>=<path>` arguments to override those
+paths. Missing reports produce a current but partial projection. A report that
+is present but malformed, schema-incompatible, authority-expanding, bound to a
+different Git head, or missing deterministic provenance invalidates the
+projection.
+
+Run the same command with `--check-freshness` to compare an existing radar with
+the current repository snapshot and dependency-report bytes. The check is
+read-only and returns nonzero for stale or invalid evidence. It never rewrites
+the radar, mutates issues, applies patches, dismisses security findings, or
+authorizes merge.

--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -1019,6 +1019,13 @@ Then use stability-aware command discovery:
         "--out", default="build/sdetkit/product-maturity-radar.json"
     )
     product_maturity_radar.add_argument("--markdown-out", default="")
+    product_maturity_radar.add_argument(
+        "--report-json",
+        action="append",
+        default=[],
+        metavar="DEPENDENCY=PATH",
+    )
+    product_maturity_radar.add_argument("--check-freshness", action="store_true")
     product_maturity_radar.add_argument("--format", choices=["json", "text"], default="json")
 
     fit = sub.add_parser("fit", help="Risk-based fit recommendation planner")
@@ -2253,6 +2260,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         ]
         if str(ns.markdown_out):
             forwarded.extend(["--markdown-out", str(ns.markdown_out)])
+        for report_json in ns.report_json:
+            forwarded.extend(["--report-json", str(report_json)])
+        if bool(ns.check_freshness):
+            forwarded.append("--check-freshness")
         return _run_module_main("sdetkit.product_maturity_radar", forwarded)
 
     if ns.cmd == "fit":

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -24,6 +24,7 @@ from . import (
     maintenance_queue_rollup,
     maintenance_queue_rollup_dashboard,
     pr_quality_runtime_proof_artifacts,
+    product_maturity_radar,
     professional_naming_cleanup_plan,
     professional_naming_inventory,
     protected_verifier,
@@ -762,6 +763,39 @@ def build_index() -> dict[str, Any]:
                     "primary_signal_issue",
                     "recommended_next_action",
                     "automation_allowed",
+                    "merge_authorized",
+                    "semantic_equivalence_proven",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "product-maturity-radar-json",
+                "path": product_maturity_radar.DEFAULT_OUT,
+                "produced_by": (
+                    "python -m sdetkit product-maturity-radar "
+                    "--root . "
+                    "--out build/sdetkit/product-maturity-radar.json "
+                    "--format json"
+                ),
+                "schema_version": product_maturity_radar.SCHEMA_VERSION,
+                "required_fields": [
+                    "schema_version",
+                    "generated_at",
+                    "current_head_sha",
+                    "input_digests",
+                    "input_provenance",
+                    "report_status",
+                    "projection_status",
+                    "projection_only",
+                    "source_authority",
+                    "surfaces",
+                    "ranked_upgrade_candidates",
+                    "claim_sources",
+                    "report_dependencies",
+                    "dependency_status",
+                    "automation_allowed",
+                    "patch_application_allowed",
+                    "security_dismissal_allowed",
                     "merge_authorized",
                     "semantic_equivalence_proven",
                 ],

--- a/src/sdetkit/product_maturity_radar.py
+++ b/src/sdetkit/product_maturity_radar.py
@@ -1,15 +1,36 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import re
 import subprocess
 import sys
 from collections import Counter
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
+
+from . import (
+    adoption_learning_report,
+    automation_health,
+    maintenance_queue_rollup,
+    public_command_surface_report,
+    release_anti_hijack_threat_model,
+    remediation_readiness_report,
+    workflow_governance_report,
+)
+from .report_provenance import (
+    attach_provenance,
+    build_input_provenance,
+    check_report_path,
+    collect_source_run_ids,
+    normalize_int_ids,
+    render_freshness_text,
+    resolve_current_head,
+)
 
 
 def _accepted_candidate_history(root: Path) -> set[str]:
@@ -91,7 +112,68 @@ def _candidate_accepted_on_main(candidate_title: str, accepted_subjects: set[str
     return False
 
 
-SCHEMA_VERSION = "sdetkit.product_maturity_radar.v1"
+SCHEMA_VERSION = "sdetkit.product_maturity_radar.v2"
+
+DEFAULT_OUT = "build/sdetkit/product-maturity-radar.json"
+GENERATOR_SOURCE = "src/sdetkit/product_maturity_radar.py"
+NON_GIT_HEAD_SHA = "0" * 40
+
+REPORT_DEPENDENCY_SPECS: dict[str, dict[str, Any]] = {
+    "workflow_governance": {
+        "path": "build/sdetkit/workflow-governance-report.json",
+        "schema_version": workflow_governance_report.SCHEMA_VERSION,
+        "surfaces": ("workflow",),
+    },
+    "remediation_readiness": {
+        "path": "build/sdetkit/remediation-readiness-report.json",
+        "schema_version": remediation_readiness_report.SCHEMA_VERSION,
+        "surfaces": ("remediation",),
+    },
+    "public_command_surface": {
+        "path": "build/sdetkit/public-command-surface-report.json",
+        "schema_version": public_command_surface_report.SCHEMA_VERSION,
+        "surfaces": ("docs", "packaging"),
+    },
+    "adoption_learning": {
+        "path": "build/sdetkit/adoption-learning-report.json",
+        "schema_version": adoption_learning_report.SCHEMA_VERSION,
+        "surfaces": ("adoption", "learning"),
+    },
+    "release_anti_hijack": {
+        "path": "build/sdetkit/release-anti-hijack-threat-model.json",
+        "schema_version": release_anti_hijack_threat_model.SCHEMA_VERSION,
+        "surfaces": ("security_release",),
+    },
+    "automation_health": {
+        "path": automation_health.DEFAULT_OUT,
+        "schema_version": automation_health.SCHEMA_VERSION,
+        "surfaces": ("diagnosis",),
+    },
+    "maintenance_queue_rollup": {
+        "path": maintenance_queue_rollup.DEFAULT_OUT,
+        "schema_version": maintenance_queue_rollup.SCHEMA_VERSION,
+        "surfaces": ("evidence", "diagnosis"),
+    },
+}
+
+SURFACE_REPORT_DEPENDENCIES: dict[str, tuple[str, ...]] = {
+    surface: tuple(
+        dependency_id
+        for dependency_id, spec in REPORT_DEPENDENCY_SPECS.items()
+        if surface in spec["surfaces"]
+    )
+    for surface in (
+        "evidence",
+        "diagnosis",
+        "adoption",
+        "workflow",
+        "docs",
+        "security_release",
+        "packaging",
+        "learning",
+        "remediation",
+    )
+}
 
 AUTHORITY_FIELDS = (
     "automation_allowed",
@@ -801,9 +883,392 @@ def _operator_summary(ranked: Sequence[dict[str, Any]]) -> dict[str, Any]:
     return summary
 
 
-def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
+def _resolve_radar_head(
+    root: Path,
+    *,
+    current_head_sha: str | None = None,
+) -> tuple[str, str]:
+    if current_head_sha is not None:
+        return resolve_current_head(root, override=current_head_sha), "verified"
+    try:
+        return resolve_current_head(root), "verified"
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        return NON_GIT_HEAD_SHA, "unavailable"
+
+
+def _parse_report_overrides(values: Sequence[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for value in values:
+        dependency_id, separator, raw_path = value.partition("=")
+        dependency_id = dependency_id.strip()
+        raw_path = raw_path.strip()
+        if not separator or not dependency_id or not raw_path:
+            raise ValueError("--report-json values must use <dependency-id>=<path>")
+        if dependency_id not in REPORT_DEPENDENCY_SPECS:
+            supported = ", ".join(sorted(REPORT_DEPENDENCY_SPECS))
+            raise ValueError(f"unknown report dependency {dependency_id!r}; supported: {supported}")
+        overrides[dependency_id] = raw_path
+    return overrides
+
+
+def _resolve_report_paths(
+    root: Path,
+    report_json: Sequence[str],
+) -> dict[str, Path]:
+    overrides = _parse_report_overrides(report_json)
+    resolved: dict[str, Path] = {}
+    for dependency_id, spec in REPORT_DEPENDENCY_SPECS.items():
+        raw = overrides.get(dependency_id, str(spec["path"]))
+        path = Path(raw)
+        resolved[dependency_id] = path if path.is_absolute() else root / path
+    return resolved
+
+
+def _load_dependency_payload(path: Path) -> tuple[dict[str, Any] | None, str]:
+    if not path.is_file():
+        return None, "missing"
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None, "invalid_json"
+    if not isinstance(loaded, dict):
+        return None, "invalid_type"
+    return loaded, "loaded"
+
+
+def _dependency_record(
+    *,
+    dependency_id: str,
+    path: Path,
+    expected_schema: str,
+    current_head_sha: str,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    payload, load_status = _load_dependency_payload(path)
+    record: dict[str, Any] = {
+        "id": dependency_id,
+        "path": path.as_posix(),
+        "expected_schema_version": expected_schema,
+        "observed_schema_version": "",
+        "status": "missing",
+        "reasons": [],
+        "current_head_sha": "",
+        "input_digest": "",
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    if load_status == "missing":
+        record["reasons"] = ["dependency_report_missing"]
+        return record, None
+    if load_status != "loaded" or payload is None:
+        record["status"] = "invalid"
+        record["reasons"] = [f"dependency_report_{load_status}"]
+        return record, None
+
+    observed_schema = str(payload.get("schema_version") or "")
+    record["observed_schema_version"] = observed_schema
+    provenance = payload.get("input_provenance")
+    provenance = provenance if isinstance(provenance, dict) else {}
+    observed_head = str(
+        payload.get("current_head_sha") or provenance.get("generated_from_head_sha") or ""
+    )
+    input_digest = str(provenance.get("input_digest") or "")
+    record["current_head_sha"] = observed_head
+    record["input_digest"] = input_digest
+
+    invalid_reasons: list[str] = []
+    stale_reasons: list[str] = []
+    if observed_schema != expected_schema:
+        invalid_reasons.append("dependency_schema_version_mismatch")
+    if any(
+        payload.get(field) is True
+        for field in (
+            "automation_allowed",
+            "patch_application_allowed",
+            "security_dismissal_allowed",
+            "merge_authorized",
+            "semantic_equivalence_proven",
+        )
+    ):
+        invalid_reasons.append("dependency_authority_expansion")
+    if not provenance:
+        stale_reasons.append("dependency_input_provenance_missing")
+    if observed_head != current_head_sha:
+        stale_reasons.append("dependency_head_mismatch")
+    if re.fullmatch(r"[0-9a-f]{64}", input_digest) is None:
+        stale_reasons.append("dependency_input_digest_invalid")
+    if provenance.get("generator_schema_version") != expected_schema:
+        stale_reasons.append("dependency_generator_schema_mismatch")
+
+    reasons = sorted(set([*invalid_reasons, *stale_reasons]))
+    record["reasons"] = reasons
+    if invalid_reasons:
+        record["status"] = "invalid"
+    elif stale_reasons:
+        record["status"] = "stale"
+    else:
+        record["status"] = "fresh"
+    return record, payload
+
+
+def _evaluate_report_dependencies(
+    root: Path,
+    *,
+    report_json: Sequence[str],
+    current_head_sha: str,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]], dict[str, Path]]:
+    paths = _resolve_report_paths(root, report_json)
+    records: list[dict[str, Any]] = []
+    payloads: dict[str, dict[str, Any]] = {}
+    for dependency_id, spec in REPORT_DEPENDENCY_SPECS.items():
+        record, payload = _dependency_record(
+            dependency_id=dependency_id,
+            path=paths[dependency_id],
+            expected_schema=str(spec["schema_version"]),
+            current_head_sha=current_head_sha,
+        )
+        records.append(record)
+        if payload is not None:
+            payloads[dependency_id] = payload
+    return records, payloads, paths
+
+
+def _dependency_summary(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    counts = Counter(str(record.get("status") or "unknown") for record in records)
+    invalid_count = counts.get("invalid", 0) + counts.get("stale", 0)
+    missing_count = counts.get("missing", 0)
+    if invalid_count:
+        projection_status = "invalid"
+    elif missing_count:
+        projection_status = "partial"
+    else:
+        projection_status = "current"
+    return {
+        "projection_status": projection_status,
+        "dependency_count": len(records),
+        "fresh_dependency_count": counts.get("fresh", 0),
+        "missing_dependency_count": missing_count,
+        "stale_dependency_count": counts.get("stale", 0),
+        "invalid_dependency_count": counts.get("invalid", 0),
+        "status_counts": dict(sorted(counts.items())),
+        "valid_for_projection": invalid_count == 0,
+        "complete_projection": projection_status == "current",
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _claim_source(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "report_id": str(record.get("id") or ""),
+        "path": str(record.get("path") or ""),
+        "status": str(record.get("status") or "missing"),
+        "schema_version": str(record.get("observed_schema_version") or ""),
+        "expected_schema_version": str(record.get("expected_schema_version") or ""),
+        "current_head_sha": str(record.get("current_head_sha") or ""),
+        "input_digest": str(record.get("input_digest") or ""),
+        "reporting_only": True,
+        "source_authority": False,
+    }
+
+
+def _attach_claim_sources(
+    surfaces: Sequence[dict[str, Any]],
+    records: Sequence[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, Any]]]]:
+    by_id = {str(record["id"]): record for record in records}
+    claim_sources: dict[str, list[dict[str, Any]]] = {}
+    enriched: list[dict[str, Any]] = []
+    for surface in surfaces:
+        surface_name = str(surface["name"])
+        sources = [
+            _claim_source(by_id[dependency_id])
+            for dependency_id in SURFACE_REPORT_DEPENDENCIES.get(surface_name, ())
+        ]
+        claim_sources[surface_name] = sources
+        candidates = [
+            {**candidate, "claim_sources": list(sources)}
+            for candidate in surface["upgrade_candidates"]
+        ]
+        enriched.append(
+            {
+                **surface,
+                "claim_sources": list(sources),
+                "upgrade_candidates": candidates,
+            }
+        )
+    return enriched, claim_sources
+
+
+def _repository_snapshot_bytes(
+    root: Path,
+    *,
+    exclude_paths: Sequence[str | Path] = (),
+) -> bytes:
+    excluded = {
+        (Path(path) if Path(path).is_absolute() else root / Path(path)).resolve()
+        for path in exclude_paths
+    }
+    manifest = [
+        {
+            "path": _rel(root, path),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+        for path in _iter_files(root)
+        if path.resolve() not in excluded
+    ]
+    return json.dumps(
+        manifest,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def product_maturity_radar_input_provenance(
+    *,
+    repo_root: str | Path = ".",
+    report_json: Sequence[str] = (),
+    exclude_paths: Sequence[str | Path] = (),
+    generator_path: str | Path | None = None,
+    current_head_sha: str | None = None,
+    generated_at: str | None = None,
+) -> tuple[
+    dict[str, Any],
+    list[dict[str, Any]],
+    dict[str, dict[str, Any]],
+    str,
+    str,
+]:
+    root = Path(repo_root).resolve()
+    head, head_status = _resolve_radar_head(
+        root,
+        current_head_sha=current_head_sha,
+    )
+    records, payloads, paths = _evaluate_report_dependencies(
+        root,
+        report_json=report_json,
+        current_head_sha=head,
+    )
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+    data_inputs: dict[str, bytes] = {
+        "repository_snapshot": _repository_snapshot_bytes(
+            root,
+            exclude_paths=exclude_paths,
+        ),
+    }
+    for dependency_id, path in sorted(paths.items()):
+        data_inputs[f"dependency:{dependency_id}"] = (
+            path.read_bytes() if path.is_file() else b"<missing>"
+        )
+
+    source_issue_numbers: list[object] = []
+    for payload in payloads.values():
+        raw = payload.get("source_issue_numbers", [])
+        if isinstance(raw, list):
+            source_issue_numbers.extend(raw)
+
+    artifact_schemas = {
+        dependency_id: str(
+            next(
+                record["observed_schema_version"] or record["status"]
+                for record in records
+                if record["id"] == dependency_id
+            )
+        )
+        for dependency_id in sorted(REPORT_DEPENDENCY_SPECS)
+    }
+
+    provenance = build_input_provenance(
+        schema_version=SCHEMA_VERSION,
+        generator_source=GENERATOR_SOURCE,
+        generator_bytes=generator.read_bytes(),
+        data_inputs=data_inputs,
+        root=root,
+        source_issue_numbers=normalize_int_ids(source_issue_numbers),
+        source_run_ids=collect_source_run_ids(payloads=tuple(payloads.values())),
+        input_artifact_schemas=artifact_schemas,
+        current_head_sha=head,
+        generated_at=generated_at,
+    )
+    return provenance, records, payloads, head, head_status
+
+
+def check_product_maturity_radar_freshness(
+    *,
+    repo_root: str | Path = ".",
+    report_path: str | Path = DEFAULT_OUT,
+    markdown_path: str | Path | None = None,
+    report_json: Sequence[str] = (),
+    generator_path: str | Path | None = None,
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    report = Path(report_path)
+    markdown = Path(markdown_path) if markdown_path is not None else report.with_suffix(".md")
+    provenance, records, _, _, head_status = product_maturity_radar_input_provenance(
+        repo_root=repo_root,
+        report_json=report_json,
+        exclude_paths=(report, markdown),
+        generator_path=generator_path,
+        current_head_sha=current_head_sha,
+    )
+    result = check_report_path(
+        report,
+        provenance,
+        expected_schema_version=SCHEMA_VERSION,
+    )
+    current_summary = _dependency_summary(records)
+    result["projection_status"] = current_summary["projection_status"]
+    result["dependency_status"] = current_summary
+    result["head_binding_status"] = head_status
+
+    if report.is_file():
+        try:
+            loaded = json.loads(report.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            loaded = {}
+        if isinstance(loaded, dict):
+            if loaded.get("dependency_status") != current_summary:
+                result["reasons"] = sorted(set([*result["reasons"], "dependency_status_mismatch"]))
+            if loaded.get("projection_status") != current_summary["projection_status"]:
+                result["reasons"] = sorted(set([*result["reasons"], "projection_status_mismatch"]))
+
+    if current_summary["projection_status"] == "invalid":
+        result["reasons"] = sorted(set([*result["reasons"], "stale_or_invalid_dependency"]))
+
+    if result["reasons"]:
+        result["status"] = "stale"
+        result["fresh"] = False
+    return result
+
+
+def build_product_maturity_radar(
+    repo_root: str | Path = ".",
+    *,
+    report_json: Sequence[str] = (),
+    exclude_paths: Sequence[str | Path] = (),
+    generated_at: str | None = None,
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
     root = Path(repo_root).resolve()
     text_index = _repo_text_index(root)
+    provenance, dependency_records, _, _, head_status = product_maturity_radar_input_provenance(
+        repo_root=root,
+        report_json=report_json,
+        exclude_paths=exclude_paths,
+        current_head_sha=current_head_sha,
+        generated_at=generated_at,
+    )
+    dependency_status = _dependency_summary(dependency_records)
 
     surfaces = [
         _evidence_surface(root, text_index),
@@ -816,14 +1281,27 @@ def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
         _learning_surface(root),
         _remediation_surface(root, text_index),
     ]
+    surfaces, claim_sources = _attach_claim_sources(
+        surfaces,
+        dependency_records,
+    )
     ranked = _rank_candidates(surfaces, root)
     status_counts = Counter(str(surface["status"]) for surface in surfaces)
     total_score = sum(int(surface["score"]) for surface in surfaces)
     total_max_score = sum(int(surface["max_score"]) for surface in surfaces)
 
-    return {
+    if dependency_status["projection_status"] == "invalid":
+        report_status = "invalid_dependency"
+    else:
+        report_status = "review_required" if ranked else "passed"
+
+    payload = {
         "schema_version": SCHEMA_VERSION,
-        "report_status": "review_required" if ranked else "passed",
+        "report_status": report_status,
+        "projection_status": dependency_status["projection_status"],
+        "projection_only": True,
+        "source_authority": False,
+        "head_binding_status": head_status,
         "repo_root": root.as_posix(),
         "surface_count": len(surfaces),
         "candidate_count": len(ranked),
@@ -832,10 +1310,15 @@ def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
         "status_counts": dict(sorted(status_counts.items())),
         "surfaces": surfaces,
         "ranked_upgrade_candidates": ranked,
+        "claim_sources": claim_sources,
+        "report_dependencies": dependency_records,
+        "dependency_status": dependency_status,
         "actionability_summary": _actionability_summary(ranked),
         "operator_summary": _operator_summary(ranked),
         "rules": {
             "advisory_only": True,
+            "projection_only": True,
+            "source_reports_authoritative": False,
             "repo_mutation": False,
             "workflow_mutation": False,
             "target_repo_mutation": False,
@@ -843,10 +1326,12 @@ def build_product_maturity_radar(repo_root: str | Path = ".") -> dict[str, Any]:
         },
         "automation_allowed": False,
         "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
         "merge_authorized": False,
         "semantic_equivalence_proven": False,
         "authority_boundary": _authority_boundary(),
     }
+    return attach_provenance(payload, provenance)
 
 
 def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
@@ -854,36 +1339,72 @@ def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
         "# SDETKit product maturity radar",
         "",
         f"- report_status: {payload['report_status']}",
+        f"- projection_status: {payload.get('projection_status', 'unknown')}",
+        f"- current_head_sha: {payload.get('current_head_sha', '')}",
+        f"- generated_at: {payload.get('generated_at', '')}",
         f"- surface_count: {payload['surface_count']}",
         f"- candidate_count: {payload['candidate_count']}",
         f"- total_score: {payload['total_score']}/{payload['total_max_score']}",
+        "- projection_only: true",
+        "- source_authority: false",
         "- advisory_only: true",
         "- repo_mutation: false",
         "- review_first: true",
         "",
-        "## Actionability summary",
+        "## Dependency status",
         "",
-        f"- status: `{payload['actionability_summary']['status']}`",
-        f"- patch_ready_candidate_count: `{payload['actionability_summary']['patch_ready_candidate_count']}`",
-        f"- blocked_review_first_candidate_count: `{payload['actionability_summary']['blocked_review_first_candidate_count']}`",
-        f"- accepted_on_main_candidate_count: `{payload['actionability_summary']['accepted_on_main_candidate_count']}`",
-        f"- next_allowed_action: `{payload['actionability_summary']['next_allowed_action']}`",
-        "- safe_to_patch: false",
+        f"- status: `{payload.get('dependency_status', {}).get('projection_status', 'unknown')}`",
+        f"- fresh_dependency_count: `{payload.get('dependency_status', {}).get('fresh_dependency_count', 0)}`",
+        f"- missing_dependency_count: `{payload.get('dependency_status', {}).get('missing_dependency_count', 0)}`",
+        f"- stale_dependency_count: `{payload.get('dependency_status', {}).get('stale_dependency_count', 0)}`",
+        f"- invalid_dependency_count: `{payload.get('dependency_status', {}).get('invalid_dependency_count', 0)}`",
         "",
-        "## Surfaces",
-        "",
-        "| Surface | Status | Score | Candidates |",
-        "| --- | --- | ---: | ---: |",
+        "| Report dependency | Status | Schema | Head |",
+        "| --- | --- | --- | --- |",
     ]
 
-    for surface in payload["surfaces"]:
+    for dependency in payload.get("report_dependencies", []):
         lines.append(
-            "| {title} | `{status}` | {score}/{max_score} | {candidate_count} |".format(
+            "| {id} | `{status}` | `{schema}` | `{head}` |".format(
+                id=dependency.get("id", ""),
+                status=dependency.get("status", ""),
+                schema=dependency.get("observed_schema_version", ""),
+                head=dependency.get("current_head_sha", ""),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Actionability summary",
+            "",
+            f"- status: `{payload['actionability_summary']['status']}`",
+            f"- patch_ready_candidate_count: `{payload['actionability_summary']['patch_ready_candidate_count']}`",
+            f"- blocked_review_first_candidate_count: `{payload['actionability_summary']['blocked_review_first_candidate_count']}`",
+            f"- accepted_on_main_candidate_count: `{payload['actionability_summary']['accepted_on_main_candidate_count']}`",
+            f"- next_allowed_action: `{payload['actionability_summary']['next_allowed_action']}`",
+            "- safe_to_patch: false",
+            "",
+            "## Surfaces",
+            "",
+            "| Surface | Status | Score | Candidates | Claim sources |",
+            "| --- | --- | ---: | ---: | --- |",
+        ]
+    )
+
+    for surface in payload["surfaces"]:
+        source_text = ", ".join(
+            f"{source['report_id']}:{source['status']}"
+            for source in surface.get("claim_sources", [])
+        )
+        lines.append(
+            "| {title} | `{status}` | {score}/{max_score} | {candidate_count} | {sources} |".format(
                 title=surface["title"],
                 status=surface["status"],
                 score=surface["score"],
                 max_score=surface["max_score"],
                 candidate_count=surface["candidate_count"],
+                sources=source_text or "none",
             )
         )
 
@@ -903,6 +1424,10 @@ def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
             lines.append(
                 f"   - ranking_status: `{candidate.get('ranking_status', 'fresh_candidate')}`"
             )
+            for source in candidate.get("claim_sources", []):
+                lines.append(
+                    f"   - claim_source: `{source.get('report_id')}:{source.get('status')}`"
+                )
             if candidate.get("ranking_status") == "blocked_review_first_candidate":
                 lines.append(
                     f"   - blocked_by: `{candidate.get('blocked_by', 'human_review_evidence_required')}`"
@@ -925,6 +1450,7 @@ def render_product_maturity_radar_markdown(payload: dict[str, Any]) -> str:
             "",
             "- automation_allowed: false",
             "- patch_application_allowed: false",
+            "- security_dismissal_allowed: false",
             "- merge_authorized: false",
             "- semantic_equivalence_proven: false",
             "",
@@ -938,16 +1464,29 @@ def write_product_maturity_radar(
     repo_root: str | Path,
     out: str | Path,
     markdown_out: str | Path | None = None,
+    report_json: Sequence[str] = (),
+    generated_at: str | None = None,
+    current_head_sha: str | None = None,
 ) -> dict[str, Any]:
-    payload = build_product_maturity_radar(repo_root=repo_root)
     out_path = Path(out)
-    markdown_path = Path(markdown_out) if markdown_out else out_path.with_suffix(".md")
+    markdown_path = Path(markdown_out) if markdown_out is not None else out_path.with_suffix(".md")
+    payload = build_product_maturity_radar(
+        repo_root=repo_root,
+        report_json=report_json,
+        exclude_paths=(out_path, markdown_path),
+        generated_at=generated_at,
+        current_head_sha=current_head_sha,
+    )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     markdown_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     markdown_path.write_text(
-        render_product_maturity_radar_markdown(payload) + "\n", encoding="utf-8"
+        render_product_maturity_radar_markdown(payload) + "\n",
+        encoding="utf-8",
     )
     return payload
 
@@ -955,18 +1494,45 @@ def write_product_maturity_radar(
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="sdetkit product-maturity-radar",
-        description="Build a repo-wide advisory product maturity radar for roadmap planning.",
+        description="Build a report-backed advisory product maturity projection.",
     )
     parser.add_argument("--root", default=".")
-    parser.add_argument("--out", default="build/sdetkit/product-maturity-radar.json")
+    parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--markdown-out", default="")
+    parser.add_argument(
+        "--report-json",
+        action="append",
+        default=[],
+        metavar="DEPENDENCY=PATH",
+        help="Override a known report dependency path; repeatable.",
+    )
     parser.add_argument("--format", choices=["json", "text"], default="json")
+    parser.add_argument(
+        "--check-freshness",
+        action="store_true",
+        help="Check the existing radar against current repository and report inputs.",
+    )
     ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    if ns.check_freshness:
+        freshness = check_product_maturity_radar_freshness(
+            repo_root=ns.root,
+            report_path=ns.out,
+            markdown_path=ns.markdown_out or None,
+            report_json=ns.report_json,
+        )
+        if ns.format == "json":
+            sys.stdout.write(json.dumps(freshness, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(render_freshness_text(freshness) + "\n")
+            sys.stdout.write(f"projection_status={freshness.get('projection_status', 'unknown')}\n")
+        return 0 if freshness["fresh"] else 1
 
     payload = write_product_maturity_radar(
         repo_root=ns.root,
         out=ns.out,
         markdown_out=ns.markdown_out or None,
+        report_json=ns.report_json,
     )
 
     if ns.format == "json":

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -579,3 +579,23 @@ def test_artifact_contract_index_write_index_roundtrip(tmp_path: Path) -> None:
     write_index(out)
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload == build_index()
+
+
+def test_product_maturity_radar_contract_is_registered() -> None:
+    from sdetkit import product_maturity_radar
+
+    payload = build_index()
+    artifacts = {artifact["id"]: artifact for artifact in payload["artifacts"]}
+    contract = artifacts["product-maturity-radar-json"]
+
+    assert contract["path"] == product_maturity_radar.DEFAULT_OUT
+    assert contract["schema_version"] == product_maturity_radar.SCHEMA_VERSION
+    assert {
+        "generated_at",
+        "current_head_sha",
+        "input_provenance",
+        "projection_status",
+        "report_dependencies",
+        "dependency_status",
+        "claim_sources",
+    }.issubset(contract["required_fields"])

--- a/tests/test_product_maturity_radar.py
+++ b/tests/test_product_maturity_radar.py
@@ -298,3 +298,198 @@ def test_product_maturity_radar_matches_accepted_candidate_title_drift() -> None
         "ci: continue workflow hardening from governance report findings",
         {"ci: explain workflow permission findings"},
     )
+
+
+def _dependency_report_payload(
+    *,
+    schema_version: str,
+    head: str,
+    input_digest: str = "a" * 64,
+) -> dict:
+    return {
+        "schema_version": schema_version,
+        "current_head_sha": head,
+        "input_provenance": {
+            "digest_algorithm": "sha256",
+            "input_digest": input_digest,
+            "input_count": 1,
+            "generator_schema_version": schema_version,
+            "generator_source": "fixture.py",
+            "generator_sha256": "b" * 64,
+            "generated_at": "2026-06-23T00:00:00Z",
+            "generated_from_head_sha": head,
+            "source_issue_count": 0,
+            "source_issue_numbers": [],
+            "source_run_ids": [],
+            "input_digests": {"fixture": "c" * 64},
+            "input_artifact_schemas": {},
+        },
+        "source_issue_numbers": [],
+        "source_run_ids": [],
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _write_dependency_reports(
+    root: Path,
+    *,
+    stale_dependency: str = "",
+) -> list[str]:
+    overrides: list[str] = []
+    head, _ = radar_module._resolve_radar_head(root)
+    for dependency_id, spec in radar_module.REPORT_DEPENDENCY_SPECS.items():
+        path = root / str(spec["path"])
+        dependency_head = "f" * 40 if dependency_id == stale_dependency else head
+        payload = _dependency_report_payload(
+            schema_version=str(spec["schema_version"]),
+            head=dependency_head,
+        )
+        _write(path, json.dumps(payload))
+        overrides.append(f"{dependency_id}={path}")
+    return overrides
+
+
+def test_product_maturity_radar_v2_is_partial_without_dependency_reports(
+    tmp_path: Path,
+) -> None:
+    _fixture_repo(tmp_path)
+    payload = build_product_maturity_radar(tmp_path)
+
+    assert payload["schema_version"].endswith(".v2")
+    assert payload["projection_status"] == "partial"
+    assert payload["projection_only"] is True
+    assert payload["source_authority"] is False
+    assert payload["dependency_status"]["missing_dependency_count"] == len(
+        radar_module.REPORT_DEPENDENCY_SPECS
+    )
+    assert payload["dependency_status"]["valid_for_projection"] is True
+    assert len(payload["current_head_sha"]) == 40
+    assert len(payload["input_provenance"]["input_digest"]) == 64
+    assert set(payload["claim_sources"]) == {
+        "adoption",
+        "diagnosis",
+        "docs",
+        "evidence",
+        "learning",
+        "packaging",
+        "remediation",
+        "security_release",
+        "workflow",
+    }
+    assert all("claim_sources" in surface for surface in payload["surfaces"])
+    assert all("claim_sources" in candidate for candidate in payload["ranked_upgrade_candidates"])
+
+
+def test_product_maturity_radar_accepts_current_report_dependencies(
+    tmp_path: Path,
+) -> None:
+    _fixture_repo(tmp_path)
+    overrides = _write_dependency_reports(tmp_path)
+    payload = build_product_maturity_radar(
+        tmp_path,
+        report_json=overrides,
+        generated_at="2026-06-23T00:00:00Z",
+    )
+
+    assert payload["projection_status"] == "current"
+    assert payload["dependency_status"]["fresh_dependency_count"] == len(
+        radar_module.REPORT_DEPENDENCY_SPECS
+    )
+    assert payload["dependency_status"]["missing_dependency_count"] == 0
+    assert payload["dependency_status"]["stale_dependency_count"] == 0
+    assert payload["dependency_status"]["invalid_dependency_count"] == 0
+    assert all(dependency["status"] == "fresh" for dependency in payload["report_dependencies"])
+
+
+def test_product_maturity_radar_invalidates_stale_dependency(
+    tmp_path: Path,
+) -> None:
+    _fixture_repo(tmp_path)
+    overrides = _write_dependency_reports(
+        tmp_path,
+        stale_dependency="workflow_governance",
+    )
+    payload = build_product_maturity_radar(tmp_path, report_json=overrides)
+
+    assert payload["projection_status"] == "invalid"
+    assert payload["report_status"] == "invalid_dependency"
+    workflow = next(
+        dependency
+        for dependency in payload["report_dependencies"]
+        if dependency["id"] == "workflow_governance"
+    )
+    assert workflow["status"] == "stale"
+    assert "dependency_head_mismatch" in workflow["reasons"]
+
+
+def test_product_maturity_radar_freshness_detects_dependency_mutation(
+    tmp_path: Path,
+) -> None:
+    _fixture_repo(tmp_path)
+    overrides = _write_dependency_reports(tmp_path)
+    out = tmp_path / "radar.json"
+
+    write_product_maturity_radar(
+        repo_root=tmp_path,
+        out=out,
+        report_json=overrides,
+        generated_at="2026-06-23T00:00:00Z",
+    )
+    fresh = radar_module.check_product_maturity_radar_freshness(
+        repo_root=tmp_path,
+        report_path=out,
+        report_json=overrides,
+    )
+    assert fresh["fresh"] is True
+    assert fresh["projection_status"] == "current"
+
+    dependency_path = tmp_path / str(
+        radar_module.REPORT_DEPENDENCY_SPECS["automation_health"]["path"]
+    )
+    dependency = json.loads(dependency_path.read_text(encoding="utf-8"))
+    dependency["mutation_probe"] = True
+    dependency_path.write_text(json.dumps(dependency), encoding="utf-8")
+
+    stale = radar_module.check_product_maturity_radar_freshness(
+        repo_root=tmp_path,
+        report_path=out,
+        report_json=overrides,
+    )
+    assert stale["fresh"] is False
+    assert "input_digest_mismatch" in stale["reasons"]
+
+
+def test_product_maturity_radar_cli_freshness_and_report_overrides(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _fixture_repo(tmp_path)
+    overrides = _write_dependency_reports(tmp_path)
+    out = tmp_path / "radar.json"
+
+    from sdetkit.cli import main as cli_main
+
+    args = [
+        "product-maturity-radar",
+        "--root",
+        str(tmp_path),
+        "--out",
+        str(out),
+    ]
+    for override in overrides:
+        args.extend(["--report-json", override])
+
+    assert cli_main([*args, "--format", "json"]) == 0
+    generated = json.loads(capsys.readouterr().out)
+    assert generated["projection_status"] == "current"
+
+    original = out.read_text(encoding="utf-8")
+    assert cli_main([*args, "--check-freshness", "--format", "text"]) == 0
+    stdout = capsys.readouterr().out
+    assert "freshness_status=fresh" in stdout
+    assert "projection_status=current" in stdout
+    assert out.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Problem
The product-maturity radar was advisory but did not bind claims to current dependency reports, schemas, provenance, or Git head.

## Change
- upgrade the radar to schema v2;
- bind it to repository and dependency-report bytes;
- map every surface and candidate to report claim sources;
- classify dependencies as fresh, missing, stale, or invalid;
- keep missing reports as a partial projection;
- invalidate present stale, malformed, schema-drifted, authority-expanding, or wrong-head evidence;
- add read-only fail-closed `--check-freshness`;
- register CLI forwarding and artifact contracts.

## Correctness corrections during implementation
- Generated radar JSON/Markdown outputs are explicitly excluded from the repository-input snapshot.
- The expected nonzero stale probe is emitted and validated as JSON, independently from the human-readable freshness output.

## Authority boundary
Reporting only. No repository mutation, patch automation, security dismissal, merge authorization, or semantic-equivalence claim.

## Proof
Focused tests, live current projection, live stale dependency rejection, changed-surface security scan, strict pre-merge, pre-commit, full pytest, and repository proof.
