### PR TITLE
fix(security): preserve unknown GHAS alert states in trackers

### DIFF
--- a/.github/workflows/ghas-alert-sla-bot.yml
+++ b/.github/workflows/ghas-alert-sla-bot.yml
@@ -17,6 +17,9 @@ jobs:
   ghas-alert-sla:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
       - name: Create GHAS alert SLA tracker issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
@@ -25,6 +28,13 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const {
+              collectedAlerts,
+              unavailableAlerts,
+              metricOrUnknown,
+              countOrUnknown,
+              formatMetric,
+            } = require(`${process.env.GITHUB_WORKSPACE}/scripts/ghas_tracker_state.js`);
             const weekOf = new Date().toISOString().slice(0, 10);
             const labels = [
               { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
@@ -52,16 +62,20 @@ jobs:
 
             async function fetchAlerts(path, label) {
               try {
-                return await github.paginate(`GET ${path}`, {
+                const alerts = await github.paginate(`GET ${path}`, {
                   owner,
                   repo,
                   state: 'open',
                   per_page: 100,
                   headers,
                 });
+                return collectedAlerts(alerts, label);
               } catch (error) {
-                notes.push(`${label} unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`);
-                return [];
+                const result = unavailableAlerts(label, error);
+                notes.push(
+                  `${result.note}. Add GHAS_READ_TOKEN if broader security scopes are required.`
+                );
+                return result;
               }
             }
 
@@ -113,27 +127,41 @@ jobs:
             const dependabotAlerts = await fetchAlerts('/repos/{owner}/{repo}/dependabot/alerts', 'Dependabot alerts');
             const secretAlerts = await fetchAlerts('/repos/{owner}/{repo}/secret-scanning/alerts', 'Secret scanning alerts');
 
-            const codeSeverity = summarizeSeverity(
+            const codeSeverity = metricOrUnknown(
               codeAlerts,
-              (alert) => alert.rule?.security_severity_level || alert.rule?.severity || 'unknown'
+              (alerts) => summarizeSeverity(
+                alerts,
+                (alert) => alert.rule?.security_severity_level || alert.rule?.severity || 'unknown'
+              )
             );
-            const dependabotSeverity = summarizeSeverity(
+            const dependabotSeverity = metricOrUnknown(
               dependabotAlerts,
-              (alert) => alert.security_vulnerability?.severity || alert.severity || 'unknown'
+              (alerts) => summarizeSeverity(
+                alerts,
+                (alert) => alert.security_vulnerability?.severity || alert.severity || 'unknown'
+              )
             );
 
-            const secretBypassed = secretAlerts.filter((alert) => alert.push_protection_bypassed === true);
-            const secretBypassedAged = secretBypassed.filter((alert) => ageDays(alert) >= 7).length;
+            const secretBypassed = metricOrUnknown(
+              secretAlerts,
+              (alerts) => alerts.filter((alert) => alert.push_protection_bypassed === true).length
+            );
+            const secretBypassedAged = metricOrUnknown(
+              secretAlerts,
+              (alerts) => alerts.filter(
+                (alert) => alert.push_protection_bypassed === true && ageDays(alert) >= 7
+              ).length
+            );
             const severityOrder = ['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'];
-            const highSeverityCodeAged = codeAlerts.filter((alert) => {
+            const highSeverityCodeAged = metricOrUnknown(codeAlerts, (alerts) => alerts.filter((alert) => {
               const severity = alert.rule?.security_severity_level || alert.rule?.severity || 'unknown';
               return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
-            }).length;
-            const criticalDependabotAged = dependabotAlerts.filter((alert) => {
+            }).length);
+            const criticalDependabotAged = metricOrUnknown(dependabotAlerts, (alerts) => alerts.filter((alert) => {
               const severity = alert.security_vulnerability?.severity || alert.severity || 'unknown';
               return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
-            }).length;
-            const oldCodeRules = topOldCodeRules(codeAlerts);
+            }).length);
+            const oldCodeRules = metricOrUnknown(codeAlerts, topOldCodeRules);
 
             const title = `⏱️ GHAS alert SLA tracker (${weekOf})`;
             const body = [
@@ -160,19 +188,26 @@ jobs:
               `- Push-protection bypassed secret alerts aged 7+ days: **${secretBypassedAged}**`,
               '',
               '## Severity slices',
-              ...mapLines(codeSeverity, 'Code scanning severity', severityOrder),
-              ...mapLines(dependabotSeverity, 'Dependabot severity', severityOrder),
+              ...(codeSeverity === 'unknown' ? ['- Code scanning severity: unknown'] : mapLines(codeSeverity, 'Code scanning severity', severityOrder)),
+              ...(dependabotSeverity === 'unknown' ? ['- Dependabot severity: unknown'] : mapLines(dependabotSeverity, 'Dependabot severity', severityOrder)),
               '',
               '## Older CodeQL rules to batch together',
-              ...(oldCodeRules.length
-                ? oldCodeRules.map(([rule, count]) => `- ${rule}: **${count}** alert(s) aged 14+ days`)
-                : ['- No code-scanning rules currently breach the 14+ day SLA window.']),
+              ...(oldCodeRules === 'unknown'
+                ? ['- Code-scanning rule age data: unknown.']
+                : (oldCodeRules.length
+                  ? oldCodeRules.map(([rule, count]) => `- ${rule}: **${count}** alert(s) aged 14+ days`)
+                  : ['- No code-scanning rules currently breach the 14+ day SLA window.'])),
               '',
               '## Suggested execution lane',
               '- [ ] Convert every 14+ day high-severity code or Dependabot alert into an owned issue or PR.',
               '- [ ] Group 14+ day CodeQL alerts by rule into one focused remediation batch and use Copilot Autofix when appropriate.',
               '- [ ] Treat push-protection bypassed secret alerts as same-week work until resolved or explicitly dismissed.',
               '- [ ] Link resulting PRs or follow-up issues back to this SLA tracker for audit history.',
+              '',
+              '## Collection status',
+              `- Code scanning: **${codeAlerts.status}**`,
+              `- Dependabot: **${dependabotAlerts.status}**`,
+              `- Secret scanning: **${secretAlerts.status}**`,
               '',
               '## Review links',
               `- Code scanning: https://github.com/${owner}/${repo}/security/code-scanning`,

--- a/.github/workflows/ghas-review-bot.yml
+++ b/.github/workflows/ghas-review-bot.yml
@@ -18,6 +18,9 @@ jobs:
   ghas-review-digest:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
       - name: Build and publish GHAS digest
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
@@ -26,6 +29,12 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const {
+              collectedAlerts,
+              unavailableAlerts,
+              metricOrUnknown,
+              countOrUnknown,
+            } = require(`${process.env.GITHUB_WORKSPACE}/scripts/ghas_tracker_state.js`);
             const weekOf = new Date().toISOString().slice(0, 10);
             const labels = [
               { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
@@ -44,22 +53,21 @@ jobs:
 
             const fallbackNotes = [];
             const dayMs = 24 * 60 * 60 * 1000;
-            const staleWorkflowDays = 14;
             const trackedWorkflows = [
-              'security.yml',
-              'osv-scanner.yml',
-              'dependency-audit.yml',
-              'security-maintenance-bot.yml',
-              'dependency-auto-merge.yml',
-              'sbom.yml',
-              'ghas-review-bot.yml',
-              'ghas-campaign-bot.yml',
-              'ghas-alert-sla-bot.yml',
-              'ghas-metrics-export-bot.yml',
-              'security-configuration-audit-bot.yml',
-              'secret-protection-review-bot.yml',
-              'dependency-review.yml',
-              'dependency-radar-bot.yml',
+              { file: 'security.yml', maxAgeDays: 14 },
+              { file: 'osv-scanner.yml', maxAgeDays: 14 },
+              { file: 'dependency-audit.yml', maxAgeDays: 14 },
+              { file: 'security-maintenance-bot.yml', maxAgeDays: 14 },
+              { file: 'dependency-auto-merge.yml', maxAgeDays: 14 },
+              { file: 'sbom.yml', maxAgeDays: 14 },
+              { file: 'ghas-review-bot.yml', maxAgeDays: 14 },
+              { file: 'ghas-campaign-bot.yml', maxAgeDays: 14 },
+              { file: 'ghas-alert-sla-bot.yml', maxAgeDays: 14 },
+              { file: 'ghas-metrics-export-bot.yml', maxAgeDays: 14 },
+              { file: 'security-configuration-audit-bot.yml', maxAgeDays: 35 },
+              { file: 'secret-protection-review-bot.yml', maxAgeDays: 14 },
+              { file: 'dependency-review.yml', maxAgeDays: 14 },
+              { file: 'dependency-radar-bot.yml', maxAgeDays: 14 },
             ];
 
             const workflowRows = [];
@@ -70,7 +78,8 @@ jobs:
               }
               return Math.max(0, Math.floor((Date.now() - at) / dayMs));
             };
-            for (const workflowFile of trackedWorkflows) {
+            for (const trackedWorkflow of trackedWorkflows) {
+              const workflowFile = trackedWorkflow.file;
               try {
                 const runs = await github.rest.actions.listWorkflowRuns({
                   owner,
@@ -85,7 +94,8 @@ jobs:
                   status: latest ? (latest.conclusion || latest.status || 'unknown') : 'no-runs',
                   updatedAt: latest?.updated_at || 'n/a',
                   ageDays,
-                  stale14d: ageDays !== null ? ageDays >= staleWorkflowDays : null,
+                  maxAgeDays: trackedWorkflow.maxAgeDays,
+                  stale: ageDays !== null ? ageDays >= trackedWorkflow.maxAgeDays : null,
                   url: latest?.html_url || `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               } catch (error) {
@@ -94,7 +104,8 @@ jobs:
                   status: 'inspection-failed',
                   updatedAt: 'n/a',
                   ageDays: null,
-                  stale14d: null,
+                  maxAgeDays: trackedWorkflow.maxAgeDays,
+                  stale: null,
                   url: `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
                 fallbackNotes.push(`Unable to inspect ${workflowFile}: ${error.message}`);
@@ -108,7 +119,7 @@ jobs:
               'x-github-api-version': '2022-11-28',
             };
 
-            async function fetchCount(path, label, priority = 'open') {
+            async function fetchAlerts(path, label, priority = 'open') {
               try {
                 const response = await github.request(`GET ${path}`, {
                   owner,
@@ -117,48 +128,25 @@ jobs:
                   per_page: 100,
                   headers,
                 });
-                return {
-                  count: Array.isArray(response.data) ? response.data.length : 0,
-                  note: null,
-                };
+                return collectedAlerts(response.data, label);
               } catch (error) {
-                return {
-                  count: 'unknown',
-                  note: `${label} unavailable: ${error.message}. Add secret GHAS_READ_TOKEN for private security APIs if needed.`,
-                };
+                return unavailableAlerts(label, error);
               }
             }
 
-            async function fetchSecretPushProtectionBypassCount() {
-              try {
-                const response = await github.request('GET /repos/{owner}/{repo}/secret-scanning/alerts', {
-                  owner,
-                  repo,
-                  state: 'open',
-                  per_page: 100,
-                  headers,
-                });
-                const alerts = Array.isArray(response.data) ? response.data : [];
-                return {
-                  count: alerts.filter((alert) => alert.push_protection_bypassed === true).length,
-                  note: null,
-                };
-              } catch (error) {
-                return {
-                  count: 'unknown',
-                  note: `Secret scanning push-protection review unavailable: ${error.message}. Add secret GHAS_READ_TOKEN for private security APIs if needed.`,
-                };
-              }
-            }
+            const codeScanning = await fetchAlerts('/repos/{owner}/{repo}/code-scanning/alerts', 'Code scanning');
+            const dependabot = await fetchAlerts('/repos/{owner}/{repo}/dependabot/alerts', 'Dependabot alerts');
+            const secretScanning = await fetchAlerts('/repos/{owner}/{repo}/secret-scanning/alerts', 'Secret scanning alerts');
+            const pushProtectionBypassed = metricOrUnknown(
+              secretScanning,
+              (alerts) => alerts.filter((alert) => alert.push_protection_bypassed === true).length
+            );
 
-            const codeScanning = await fetchCount('/repos/{owner}/{repo}/code-scanning/alerts', 'Code scanning');
-            const dependabot = await fetchCount('/repos/{owner}/{repo}/dependabot/alerts', 'Dependabot alerts');
-            const secretScanning = await fetchCount('/repos/{owner}/{repo}/secret-scanning/alerts', 'Secret scanning alerts');
-            const pushProtectionBypassed = await fetchSecretPushProtectionBypassCount();
-
-            for (const result of [codeScanning, dependabot, secretScanning, pushProtectionBypassed]) {
+            for (const result of [codeScanning, dependabot, secretScanning]) {
               if (result.note) {
-                fallbackNotes.push(result.note);
+                fallbackNotes.push(
+                  `${result.note}. Add secret GHAS_READ_TOKEN for private security APIs if needed.`
+                );
               }
             }
 
@@ -172,6 +160,11 @@ jobs:
               `- Open secret scanning alerts: **${secretScanning.count}**`,
               `- Secret scanning review queue (push-protection/bypass follow-up): **${pushProtectionBypassed.count}**`,
               '',
+              '## Collection status',
+              `- Code scanning: **${codeScanning.status}**`,
+              `- Dependabot: **${dependabot.status}**`,
+              `- Secret scanning: **${secretScanning.status}**`,
+              '',
               '## Review links',
               `- Code scanning: https://github.com/${owner}/${repo}/security/code-scanning`,
               `- Dependabot: https://github.com/${owner}/${repo}/security/dependabot`,
@@ -179,9 +172,9 @@ jobs:
               `- Security overview: https://github.com/${owner}/${repo}/security`,
               '',
               '## Workflow freshness',
-              '| Workflow | Latest result | Updated at | Age (days) | 14d stale | Link |',
-              '| --- | --- | --- | --- | --- | --- |',
-              ...workflowRows.map((row) => `| ${row.workflow} | ${row.status} | ${row.updatedAt} | ${row.ageDays ?? 'n/a'} | ${row.stale14d === null ? 'n/a' : (row.stale14d ? 'yes' : 'no')} | [open](${row.url}) |`),
+              '| Workflow | Latest result | Updated at | Age (days) | Maximum age (days) | Stale | Link |',
+              '| --- | --- | --- | --- | --- | --- | --- |',
+              ...workflowRows.map((row) => `| ${row.workflow} | ${row.status} | ${row.updatedAt} | ${row.ageDays ?? 'n/a'} | ${row.maxAgeDays} | ${row.stale === null ? 'n/a' : (row.stale ? 'yes' : 'no')} | [open](${row.url}) |`),
               '',
               '## Required follow-up',
               '- [ ] Review every open GHAS alert and document disposition for anything that is still open at the end of the week.',

--- a/.github/workflows/security-configuration-audit-bot.yml
+++ b/.github/workflows/security-configuration-audit-bot.yml
@@ -28,6 +28,11 @@ jobs:
             const fs = require('fs');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const {
+              collectedAlerts,
+              unavailableAlerts,
+              countOrUnknown,
+            } = require(`${process.env.GITHUB_WORKSPACE}/scripts/ghas_tracker_state.js`);
             const monthOf = new Date().toISOString().slice(0, 7);
             const labels = [
               { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
@@ -82,10 +87,20 @@ jobs:
                   repo,
                   headers,
                 });
-                return response.data;
+                if (
+                  response.data === null
+                  || typeof response.data !== 'object'
+                  || Array.isArray(response.data)
+                ) {
+                  const note = 'Repository security configuration returned an invalid payload; reporting unknown.';
+                  notes.push(note);
+                  return { status: 'invalid', configuration: null, note };
+                }
+                return { status: 'collected', configuration: response.data, note: null };
               } catch (error) {
-                notes.push(`Repository security configuration unavailable: ${error.message}`);
-                return null;
+                const note = `Repository security configuration unavailable: ${error.message}`;
+                notes.push(note);
+                return { status: 'unavailable', configuration: null, note };
               }
             }
 
@@ -98,15 +113,22 @@ jobs:
                   per_page: 100,
                   headers,
                 });
-                return Array.isArray(response.data) ? response.data.length : 0;
+                const result = collectedAlerts(response.data, label);
+                if (result.note) {
+                  notes.push(result.note);
+                }
+                return result;
               } catch (error) {
-                notes.push(`${label} unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`);
-                return null;
+                const result = unavailableAlerts(label, error);
+                notes.push(
+                  `${result.note}. Add GHAS_READ_TOKEN if broader security scopes are required.`
+                );
+                return result;
               }
             }
-            const formatCount = (count) => (count === null ? 'unavailable' : count);
 
-            const configuration = await fetchConfiguration();
+            const configurationResult = await fetchConfiguration();
+            const configuration = configurationResult.configuration;
             const codeAlerts = await fetchAlerts('/repos/{owner}/{repo}/code-scanning/alerts', 'Code scanning alerts');
             const secretAlerts = await fetchAlerts('/repos/{owner}/{repo}/secret-scanning/alerts', 'Secret scanning alerts');
             const dependabotAlerts = await fetchAlerts('/repos/{owner}/{repo}/dependabot/alerts', 'Dependabot alerts');
@@ -139,6 +161,12 @@ jobs:
               configuration && configuration.dependency_graph_autosubmit_action
                 ? `- Automatic dependency submission: **${configuration.dependency_graph_autosubmit_action}**`
                 : '- Automatic dependency submission: unavailable.',
+              '',
+              '## Collection status',
+              `- Repository security configuration: **${configurationResult.status}**`,
+              `- Code scanning: **${codeAlerts.status}**`,
+              `- Secret scanning: **${secretAlerts.status}**`,
+              `- Dependabot: **${dependabotAlerts.status}**`,
               '',
               '## Open alert snapshot',
               `- Code scanning alerts: **${formatCount(codeAlerts)}**`,

--- a/docs/security.md
+++ b/docs/security.md
@@ -67,3 +67,23 @@ Use the GitHub Security tab to review alerts:
 ## Security Control Tower modes
 
 See [security-gate.md](security-gate.md) for offline-first scan/report/fix behavior, optional online scanning, and SARIF output.
+
+## GHAS tracker collection semantics
+
+Security trackers distinguish an **authoritative zero** from an **unknown**
+collection state:
+
+- **Authoritative zero** means the relevant GitHub security API responded
+  successfully with a valid empty alert array.
+- **Unknown** means the API was unavailable, access was denied, or the response
+  payload was not a valid alert array.
+- Any age bucket, severity slice, bypass count, or other derived metric remains
+  `unknown` when its source collection is unknown.
+- Tracker issues include source-specific collection status so operators can
+  distinguish a current empty queue from incomplete evidence.
+- Workflow freshness is cadence-aware; the monthly security-configuration
+  audit uses a 35-day maximum age rather than the weekly 14-day threshold.
+
+These workflows are reporting surfaces. Their output does not authorize alert
+dismissal, security-configuration mutation, workflow reruns, patch automation,
+merge, or semantic-equivalence claims.

--- a/scripts/ghas_tracker_state.js
+++ b/scripts/ghas_tracker_state.js
@@ -1,0 +1,76 @@
+'use strict';
+
+function payloadType(payload) {
+  if (payload === null) return 'null';
+  if (Array.isArray(payload)) return 'array';
+  return typeof payload;
+}
+
+function invalidAlertPayload(label, payload) {
+  return {
+    status: 'invalid',
+    alerts: null,
+    count: null,
+    note: `${label} returned an invalid ${payloadType(payload)} payload; reporting unknown.`,
+  };
+}
+
+function collectedAlerts(payload, label = 'Alerts') {
+  if (!Array.isArray(payload)) {
+    return invalidAlertPayload(label, payload);
+  }
+  return {
+    status: 'collected',
+    alerts: payload,
+    count: payload.length,
+    note: null,
+  };
+}
+
+function unavailableAlerts(label, error) {
+  const detail = error && error.message ? error.message : String(error || 'unknown error');
+  return {
+    status: 'unavailable',
+    alerts: null,
+    count: null,
+    note: `${label} unavailable: ${detail}`,
+  };
+}
+
+function countOrUnknown(result) {
+  if (
+    result
+    && result.status === 'collected'
+    && Number.isInteger(result.count)
+  ) {
+    return result.count;
+  }
+  return 'unknown';
+}
+
+function metricOrUnknown(result, compute) {
+  if (
+    !result
+    || result.status !== 'collected'
+    || !Array.isArray(result.alerts)
+  ) {
+    return 'unknown';
+  }
+  return compute(result.alerts);
+}
+
+function formatMetric(value) {
+  if (value === null || value === undefined || value === 'unknown') {
+    return 'unknown';
+  }
+  return value;
+}
+
+module.exports = {
+  collectedAlerts,
+  unavailableAlerts,
+  invalidAlertPayload,
+  metricOrUnknown,
+  countOrUnknown,
+  formatMetric,
+};

--- a/tests/test_ghas_tracker_state_contract.py
+++ b/tests/test_ghas_tracker_state_contract.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts/ghas_tracker_state.js"
+WORKFLOWS = {
+    "sla": ROOT / ".github/workflows/ghas-alert-sla-bot.yml",
+    "review": ROOT / ".github/workflows/ghas-review-bot.yml",
+    "configuration": (ROOT / ".github/workflows/security-configuration-audit-bot.yml"),
+}
+
+
+def _node_json(expression: str) -> Any:
+    source = f"""
+const helper = require({json.dumps(str(HELPER))});
+const value = ({expression});
+process.stdout.write(JSON.stringify(value));
+"""
+    completed = subprocess.run(
+        ["node", "-e", source],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_available_empty_is_authoritative_zero() -> None:
+    result = _node_json("helper.collectedAlerts([], 'Dependabot alerts')")
+    assert result == {
+        "status": "collected",
+        "alerts": [],
+        "count": 0,
+        "note": None,
+    }
+    assert _node_json("helper.countOrUnknown(helper.collectedAlerts([], 'Dependabot alerts'))") == 0
+
+
+def test_available_nonempty_preserves_exact_count() -> None:
+    result = _node_json(
+        "helper.collectedAlerts([{number: 1}, {number: 2}], 'Code scanning alerts')"
+    )
+    assert result["status"] == "collected"
+    assert result["count"] == 2
+    assert len(result["alerts"]) == 2
+
+
+def test_unavailable_and_invalid_are_unknown_never_zero() -> None:
+    unavailable = _node_json(
+        "helper.unavailableAlerts('Secret scanning alerts', new Error('forbidden'))"
+    )
+    assert unavailable["status"] == "unavailable"
+    assert unavailable["count"] is None
+    assert "forbidden" in unavailable["note"]
+
+    invalid = _node_json("helper.collectedAlerts(null, 'Dependabot alerts')")
+    assert invalid["status"] == "invalid"
+    assert invalid["count"] is None
+    assert "invalid null payload" in invalid["note"]
+
+    assert (
+        _node_json("helper.countOrUnknown(helper.unavailableAlerts('x', new Error('no access')))")
+        == "unknown"
+    )
+    assert _node_json("helper.countOrUnknown(helper.collectedAlerts(null, 'x'))") == "unknown"
+
+
+def test_derived_metrics_remain_unknown_when_collection_is_unknown() -> None:
+    assert (
+        _node_json(
+            "helper.metricOrUnknown("
+            "helper.unavailableAlerts('x', new Error('denied')), "
+            "(alerts) => alerts.length)"
+        )
+        == "unknown"
+    )
+    assert (
+        _node_json(
+            "helper.metricOrUnknown("
+            "helper.collectedAlerts([{severity: 'high'}], 'x'), "
+            "(alerts) => alerts.filter((item) => "
+            "item.severity === 'high').length)"
+        )
+        == 1
+    )
+
+
+def test_workflows_use_shared_state_contract() -> None:
+    texts = {key: path.read_text(encoding="utf-8") for key, path in WORKFLOWS.items()}
+
+    for text in texts.values():
+        assert "scripts/ghas_tracker_state.js" in text
+        assert "countOrUnknown" in text
+        assert "Collection status" in text
+        assert "process.env.GHAS_TOKEN || github.token" in text
+
+    assert "return [];" not in texts["sla"]
+    assert "Array.isArray(response.data) ? response.data.length : 0" not in texts["review"]
+    assert "Array.isArray(response.data) ? response.data.length : 0" not in texts["configuration"]
+
+
+def test_review_bot_uses_cadence_aware_workflow_freshness() -> None:
+    text = WORKFLOWS["review"].read_text(encoding="utf-8")
+
+    assert "{ file: 'security-configuration-audit-bot.yml', maxAgeDays: 35 }" in text
+    assert "ageDays >= trackedWorkflow.maxAgeDays" in text
+    assert "Maximum age (days)" in text
+    assert "const staleWorkflowDays = 14;" not in text
+
+
+def test_security_workflow_permissions_do_not_expand() -> None:
+    expected_permissions = {
+        "sla": {"contents": "read", "issues": "write", "security-events": "read"},
+        "review": {
+            "actions": "read",
+            "contents": "read",
+            "issues": "write",
+            "security-events": "read",
+        },
+        "configuration": {
+            "contents": "read",
+            "issues": "write",
+            "security-events": "read",
+        },
+    }
+
+    for key, path in WORKFLOWS.items():
+        text = path.read_text(encoding="utf-8")
+        block_match = re.search(
+            r"(?ms)^permissions:\n(?P<body>(?:  [^\n]+\n)+)",
+            text,
+        )
+        assert block_match is not None
+        body = block_match.group("body")
+        observed = {}
+        for line in body.splitlines():
+            name, value = line.strip().split(":", 1)
+            observed[name] = value.strip()
+        assert observed == expected_permissions[key]
+
+
+def test_actions_remain_pinned_and_no_security_mutation_is_added() -> None:
+    for path in WORKFLOWS.values():
+        text = path.read_text(encoding="utf-8")
+        actions = re.findall(r"uses:\s*[^@\s]+@([0-9a-f]{40})", text)
+        assert actions
+        assert all(len(sha) == 40 for sha in actions)
+
+        forbidden = (
+            "dismissAlert",
+            "dismissed_reason",
+            "updateRepositorySecurityConfiguration",
+            "PATCH /repos/{owner}/{repo}/code-security-configuration",
+        )
+        assert not any(token in text for token in forbidden)
+
+
+def test_security_docs_define_zero_and_unknown() -> None:
+    text = (ROOT / "docs/security.md").read_text(encoding="utf-8")
+    assert "## GHAS tracker collection semantics" in text
+    assert "Authoritative zero" in text
+    assert "Unknown" in text
+    normalized_text = " ".join(text.split())
+    assert "does not authorize alert dismissal" in normalized_text


### PR DESCRIPTION
## Problem

GHAS reporting workflows could turn unavailable or invalid API responses into
zero-alert claims. The weekly digest also applied a 14-day freshness threshold
to a monthly security-configuration audit.

## Change

- add a dependency-free shared GHAS collection-state helper;
- preserve `collected`, `unavailable`, and `invalid` states;
- treat zero as authoritative only for a valid empty alert array;
- render totals and derived SLA metrics as `unknown` when collection is not
  authoritative;
- add source-specific collection-status sections;
- make workflow freshness cadence-aware, with 35 days for the monthly
  security-configuration audit;
- add fixture-driven helper and workflow contract tests;
- document zero-versus-unknown semantics.

## Security review

- no secrets or tokens changed;
- no workflow permissions expanded;
- no dependencies added;
- no alert dismissal or security-setting mutation introduced;
- no publish or release behavior changed;
- workflows remain reporting-only.

## Proof

- JavaScript syntax and runtime contract proof;
- workflow YAML validation;
- fixture-driven unknown-state tests;
- workflow alias and production-doc reference regression tests;
- mypy;
- exact six-file pre-commit;
- `make proof-after-format`;
- post-proof focused regression tests.

## Authority boundary

This change does not authorize alert dismissal, security-configuration
mutation, workflow reruns, patch automation, merge, or semantic-equivalence
claims.
