### PR TITLE
docs(navigation): publish a curated orphan-docs material map

### DIFF
--- a/docs/docs-map.md
+++ b/docs/docs-map.md
@@ -52,7 +52,7 @@ Use these pages when SDETKit is being evaluated as a repository doctor rather th
 | --- | --- | --- |
 | Adoption surface | [Adopt in your repository](adoption.md), [Artifact reference](artifact-reference.md) | Detect repo shape and proof surfaces before recommending commands. |
 | Evidence and learning loop | [Investigation operator guide](investigation-operator-guide.md), [Adaptive Diagnosis Intelligence](adaptive-diagnosis.md) | Convert repeated gaps into detector/report/memory upgrades. |
-| Roadmap control panels | [Docs map and organization](docs-map.md), [Artifact reference](artifact-reference.md) | Use radar/report outputs to choose focused PRs; do not replace the roadmap. |
+| Roadmap control panels | [Docs map and organization](docs-map.md), [Curated advanced docs material map](orphan-docs-material-map.md), [Artifact reference](artifact-reference.md) | Use radar/report outputs to choose focused PRs; do not replace the roadmap. |
 
 External repositories remain learning targets, not patch targets. Default posture is no install, no target tests, no mutation, no target PRs/issues, and no endorsement claim.
 

--- a/docs/orphan-docs-material-map.md
+++ b/docs/orphan-docs-material-map.md
@@ -1,0 +1,52 @@
+# Curated advanced docs material map
+
+Use this secondary discoverability surface after the canonical operator path is
+working. It helps operators find substantive advanced material without turning
+every historical, specialist, or evidence-oriented page into primary
+navigation.
+
+This page is **not a primary onboarding path**. It does not reclassify
+historical, generated, archived, or report-like pages. Choose a page by the
+task you are performing, then return to [Docs map and organization](docs-map.md)
+for the canonical information architecture.
+
+## Evidence review and release handoff
+
+| Page | Use when | Why it remains secondary |
+| --- | --- | --- |
+| [Operator evidence review guide](operator-evidence-review-guide.md) | Reviewing evidence bundles, dashboards, and report-only findings before deciding the next guarded action. | It assumes the core operator workflow and evidence vocabulary are already understood. |
+| [Release-readiness evidence handoff](release-readiness-evidence-handoff.md) | Preparing or reviewing a release-readiness handoff across evidence producers and consumers. | It is a specialized handoff contract rather than a first-run guide. |
+| [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md) | Inspecting how evidence sources, transforms, and rendered outputs fit together. | It documents a deeper architecture checkpoint, not routine operation. |
+| [Evidence graph summary](evidence-graph-summary.md) | Understanding summarized relationships across diagnostic and release evidence. | It is an advanced evidence-model reference. |
+| [Dashboard and reporting polish](dashboard-reporting-polish.md) | Reviewing how structured evidence is presented consistently across dashboards and reports. | It focuses on presentation quality after the evidence pipeline is already trusted. |
+| [Evidence circuit review pack](evidence-circuit-review-pack.md) | Performing a consolidated review of the evidence-circuit documentation bundle. | It is a review pack for maintainers and auditors, not the primary product path. |
+
+## Operations and follow-up
+
+| Page | Use when | Why it remains secondary |
+| --- | --- | --- |
+| [Upgrade next commands](upgrade-next-commands.md) | Converting an accepted upgrade checkpoint into the next bounded operator commands. | It is a follow-up execution aid tied to upgrade work. |
+| [Next 10 follow-ups](next-10-followups.md) | Reviewing an ordered backlog of subsequent operational improvements. | It is planning material rather than a stable operator contract. |
+| [Operations handbook](operations-handbook.md) | Looking up broader operational practices after the essentials guide is familiar. | It is a deeper handbook and intentionally sits behind the daily runbook. |
+| [Real workflow operations](real-workflow-operations.md) | Studying realistic workflow-operation scenarios and guarded remediation boundaries. | It supplements, rather than replaces, the recommended CI and operator paths. |
+| [Operations execution checklist](operations-execution-checklist.md) | Running a structured checklist for an established operations program. | It is program execution material, not first-use documentation. |
+
+## Policy and repository structure
+
+| Page | Use when | Why it remains secondary |
+| --- | --- | --- |
+| [Policy and baselines](policy-and-baselines.md) | Reviewing how repository policies and evidence baselines constrain automation and review. | It is a governance reference for advanced maintainers. |
+| [Repository index engine](repo-index-engine.md) | Understanding or operating repository indexing and evidence-discovery behavior. | It describes an internal capability rather than a general operator workflow. |
+
+## Examples and positioning
+
+| Page | Use when | Why it remains secondary |
+| --- | --- | --- |
+| [SDETKit versus ad-hoc tooling](sdetkit-vs-ad-hoc.md) | Comparing SDETKit's governed evidence workflow with loosely connected tools. | It is positioning and evaluation material, not an operational prerequisite. |
+| [Examples](examples.md) | Looking for broader command and integration examples after completing the quickstart. | It is a supporting example catalog rather than the canonical first path. |
+
+## Boundary
+
+This map adds discoverability only. It does not authorize documentation moves,
+candidate-page edits, exclusion-rule changes, workflow reruns, issue mutation,
+or merge.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,7 @@ nav:
       - Rollback and remediation examples: integrations/rollback-remediation-examples.md
       - Release verification records: release-verification.md
       - Docs map: docs-map.md
+      - Curated advanced docs material map: orphan-docs-material-map.md
       - Docs navigation cleanup progress: docs-nav-cleanup-progress.md
       - Archive navigation policy: archive-navigation-policy.md
       - Environment compatibility matrix: environment-compatibility.md

--- a/tests/test_docs_orphan_discoverability.py
+++ b/tests/test_docs_orphan_discoverability.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+MKDOCS = ROOT / "mkdocs.yml"
+
+CANDIDATES = (
+    "operator-evidence-review-guide.md",
+    "release-readiness-evidence-handoff.md",
+    "upgrade-next-commands.md",
+    "policy-and-baselines.md",
+    "evidence-circuit-architecture-checkpoint.md",
+    "evidence-graph-summary.md",
+    "repo-index-engine.md",
+    "dashboard-reporting-polish.md",
+    "evidence-circuit-review-pack.md",
+    "next-10-followups.md",
+    "operations-handbook.md",
+    "real-workflow-operations.md",
+    "sdetkit-vs-ad-hoc.md",
+    "examples.md",
+    "operations-execution-checklist.md",
+)
+
+GROUP_HEADINGS = (
+    "## Evidence review and release handoff",
+    "## Operations and follow-up",
+    "## Policy and repository structure",
+    "## Examples and positioning",
+)
+
+FORBIDDEN_LINK_PREFIXES = (
+    "archive/",
+    "artifacts/",
+    "roadmap/reports/",
+    "business_execution/",
+)
+
+
+def _nav_targets() -> list[str]:
+    pattern = re.compile(r":\s+([A-Za-z0-9_./-]+\.md)\s*$")
+    return [
+        match.group(1)
+        for line in MKDOCS.read_text(encoding="utf-8").splitlines()
+        if (match := pattern.search(line))
+    ]
+
+
+def _exclude_block() -> str:
+    lines = MKDOCS.read_text(encoding="utf-8").splitlines()
+    start = lines.index("exclude_docs: |")
+    block = []
+    for line in lines[start:]:
+        if block and line and not line.startswith("  "):
+            break
+        block.append(line)
+    return "\n".join(block) + "\n"
+
+
+def test_material_map_exists_with_exact_structure() -> None:
+    path = DOCS / "orphan-docs-material-map.md"
+    text = path.read_text(encoding="utf-8")
+
+    assert len(re.findall(r"(?m)^# ", text)) == 1
+    assert text.startswith("# Curated advanced docs material map\n")
+    normalized_text = " ".join(text.split())
+    assert "not a primary onboarding path" in normalized_text
+    assert "does not reclassify" in normalized_text
+    assert "Choose a page by the task" in normalized_text
+    assert text.count("| Page | Use when | Why it remains secondary |") == 4
+
+    for heading in GROUP_HEADINGS:
+        assert text.count(heading) == 1
+
+
+def test_all_ranked_candidates_are_linked_once() -> None:
+    text = (DOCS / "orphan-docs-material-map.md").read_text(encoding="utf-8")
+
+    for candidate in CANDIDATES:
+        assert (DOCS / candidate).is_file()
+        assert text.count(f"]({candidate})") == 1
+
+
+def test_candidates_stay_out_of_direct_navigation() -> None:
+    nav_targets = _nav_targets()
+
+    for candidate in CANDIDATES:
+        assert candidate not in nav_targets
+
+    assert nav_targets.count("orphan-docs-material-map.md") == 1
+
+
+def test_canonical_docs_map_links_secondary_material_map() -> None:
+    text = (DOCS / "docs-map.md").read_text(encoding="utf-8")
+
+    assert text.count("[Curated advanced docs material map](orphan-docs-material-map.md)") == 1
+
+
+def test_material_map_does_not_link_intentional_non_primary_families() -> None:
+    text = (DOCS / "orphan-docs-material-map.md").read_text(encoding="utf-8")
+    markdown_targets = re.findall(r"\[[^\]]+\]\(([^)]+)\)", text)
+
+    for target in markdown_targets:
+        normalized = target.split("#", 1)[0]
+        assert not normalized.startswith(FORBIDDEN_LINK_PREFIXES)
+        assert not normalized.endswith("-report.md")
+        assert "big-upgrade-report-" not in normalized
+        assert "ultra-upgrade-report-" not in normalized
+
+
+def test_mkdocs_exclusion_contract_is_unchanged() -> None:
+    expected = """exclude_docs: |
+  /README.md
+  artifacts/**
+  roadmap/reports/**
+  *-report.md
+  impact-*-*-report.md
+  big-upgrade-report-*.md
+  ultra-upgrade-report-*.md
+  executive-*.md
+  cto-*.md
+  production-*.md
+  kpi-baseline-week-*.md
+  repo-*-20*.md
+  agentos-*.md
+  automation-templates-engine.md
+  integrations-*.md
+  !integrations-and-extension-boundary.md
+"""
+    assert _exclude_block() == expected


### PR DESCRIPTION
## Problem

The documentation radar identified high-value advanced pages that are
discoverable through scattered links but are absent from the direct MkDocs
navigation. Adding every orphan page directly would overload the primary
operator path and conflict with the repository's intentional archive and
generated-content boundaries.

## Change

- add one curated secondary material-map page for 15 ranked advanced docs;
- group the pages by evidence review, operations, policy/repository structure,
  and examples/positioning;
- link the map from the canonical docs map;
- add exactly one secondary MkDocs navigation entry;
- add deterministic tests that keep all 15 candidate pages out of direct
  navigation and preserve the exclusion contract.

## Scope

Exactly four files:

- `docs/docs-map.md`
- `docs/orphan-docs-material-map.md`
- `mkdocs.yml`
- `tests/test_docs_orphan_discoverability.py`

The 15 candidate pages are not edited, moved, renamed, or staged.

## Proof

- focused discoverability, docs-map, exclusion, and front-door tests;
- strict MkDocs build with the pinned docs environment;
- candidate-page invariants against the accepted base SHA;
- unchanged `exclude_docs` block;
- mypy;
- exact four-file pre-commit;
- `make proof-after-format`;
- post-proof focused tests and strict MkDocs build.

## Authority boundary

This documentation-only change does not authorize issue mutation, workflow
reruns, automated patching, merge, or semantic-equivalence claims.
