### PR TITLE
fix(maintenance): preserve unknown command-center collection states

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -48,6 +48,17 @@ When an enhancement is identified from customer or user feedback:
 - **GHAS campaign planner** → group aged alerts into campaign slices and record owner + expected completion window.
 - **GHAS CodeQL hotspots** → batch-fix the top rule/path hotspot and re-run the planner to validate backlog reduction.
 
+## Current enhancement candidate from maintenance intake (June 2026)
+
+- **Source issue:** #1786
+- **User pain point:** A successful but malformed GitHub API response can be reported as an authoritative zero in the maintenance command center, allowing queue or security decisions to proceed from invalid evidence.
+- **Acceptance criteria:**
+  1. Valid empty collections continue to render an authoritative zero.
+  2. Successful malformed list payloads and malformed workflow-run envelopes render unavailable or unknown instead of zero.
+  3. Queue actions never proceed from an explicit `available=false` collection state.
+  4. Focused regression tests cover the six collection-integrity findings while preserving the existing pagination fallback.
+- **Expected impact:** More trustworthy maintenance queue decisions and a clear distinction between authoritative zero, unavailable collection state, and malformed API evidence.
+
 ## Continuous maintenance hardening loop
 
 The maintenance system now produces ten recurring artifacts:

--- a/tests/test_maintenance_command_center_live_scan.py
+++ b/tests/test_maintenance_command_center_live_scan.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "tools" / "maintenance_command_center.py"
 
@@ -157,3 +159,165 @@ def test_command_center_queue_snapshot_detects_stale_pr_samples() -> None:
     rendered = "\n".join(module._queue_snapshot_lines(live_scan))
     assert "Queue snapshot status: **stale**" in rendered
     assert "Stale open PR samples detected: **1**" in rendered
+
+
+def _payload_client(module, payload):
+    class Client(module.GitHubClient):
+        def _request(self, method, path, payload=None):
+            return response
+
+    response = payload
+    return Client("example", "repo")
+
+
+def test_valid_empty_collections_remain_authoritative_zero() -> None:
+    module = _load_module()
+
+    assert (
+        _payload_client(module, []).paginate(
+            "/repos/example/repo/pulls",
+            {"state": "open"},
+        )
+        == []
+    )
+    assert (
+        _payload_client(module, []).list_without_page(
+            "/repos/example/repo/dependabot/alerts",
+            {"state": "open"},
+        )
+        == []
+    )
+    assert (
+        _payload_client(
+            module,
+            {"workflow_runs": []},
+        ).list_recent_workflow_runs(limit=20)
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"message": "unexpected success payload"},
+        None,
+    ],
+)
+def test_paginate_rejects_malformed_success_payloads(payload) -> None:
+    module = _load_module()
+    client = _payload_client(module, payload)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"^GitHub API invalid payload GET .*expected list",
+    ):
+        client.paginate(
+            "/repos/example/repo/pulls",
+            {"state": "open"},
+        )
+
+
+def test_list_without_page_rejects_malformed_success_payload() -> None:
+    module = _load_module()
+    client = _payload_client(
+        module,
+        {"message": "unexpected success payload"},
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"^GitHub API invalid payload GET .*expected list",
+    ):
+        client.list_without_page(
+            "/repos/example/repo/dependabot/alerts",
+            {"state": "open"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            ["unexpected", "list", "envelope"],
+            "object",
+        ),
+        (
+            {"workflow_runs": {"unexpected": "object"}},
+            "workflow_runs list",
+        ),
+        (
+            {},
+            "workflow_runs list",
+        ),
+    ],
+)
+def test_workflow_scan_rejects_malformed_success_payloads(
+    payload,
+    expected,
+) -> None:
+    module = _load_module()
+    client = _payload_client(module, payload)
+
+    with pytest.raises(
+        RuntimeError,
+        match=rf"^GitHub API invalid payload GET .*expected {expected}",
+    ):
+        client.list_recent_workflow_runs(limit=20)
+
+
+def test_queue_snapshot_honors_explicit_unavailability_without_error() -> None:
+    module = _load_module()
+
+    summary = module._queue_snapshot_summary(
+        {
+            "open_pull_requests": {
+                "available": False,
+                "count": None,
+                "items": [],
+                "error": "",
+            },
+            "open_issues_excluding_command_center": {
+                "available": True,
+                "count": 0,
+                "items": [],
+                "error": "",
+            },
+        }
+    )
+
+    assert summary == {
+        "status": "unknown",
+        "open_pr_count": None,
+        "open_issue_count": 0,
+        "stale_open_pr_sample_count": 0,
+        "next_allowed_action": "retry_live_queue_scan",
+    }
+
+
+def test_collect_live_scan_marks_malformed_collections_unavailable() -> None:
+    module = _load_module()
+    client = _payload_client(
+        module,
+        {"message": "unexpected success payload"},
+    )
+
+    live_scan = module._collect_live_scan(
+        client,
+        open_issues=[],
+        command_center_title="Maintenance command center",
+        now_iso="2026-06-23T00:00:00Z",
+    )
+
+    assert live_scan["open_pull_requests"]["available"] is False
+    assert live_scan["open_pull_requests"]["count"] is None
+    assert live_scan["recent_workflow_runs"]["available"] is False
+    assert live_scan["recent_workflow_runs"]["total"] is None
+    assert live_scan["security_alerts"]["code_scanning"]["available"] is False
+    assert live_scan["security_alerts"]["dependabot"]["available"] is False
+    assert live_scan["security_alerts"]["secret_scanning"]["available"] is False
+
+    rendered = "\n".join(module._live_scan_lines(live_scan))
+    assert "Queue snapshot status: **unknown**" in rendered
+    assert "Open pull requests: **unavailable**" in rendered
+    assert "Recent workflow runs: **unavailable**" in rendered
+    assert "GitHub API invalid payload" in rendered

--- a/tools/maintenance_command_center.py
+++ b/tools/maintenance_command_center.py
@@ -17,6 +17,17 @@ _utc = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
 DEFAULT_HTTP_TIMEOUT_SECONDS = 30
 
 
+def _invalid_payload_error(
+    *,
+    path: str,
+    expected: str,
+    payload: Any,
+) -> RuntimeError:
+    return RuntimeError(
+        f"GitHub API invalid payload GET {path}: expected {expected}, got {type(payload).__name__}"
+    )
+
+
 def _iso_now() -> str:
     return dt.datetime.now(_utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -69,9 +80,14 @@ class GitHubClient:
             if params:
                 query.update(params)
             qs = urllib.parse.urlencode(query)
-            chunk = self._request("GET", f"{path}?{qs}")
+            request_path = f"{path}?{qs}"
+            chunk = self._request("GET", request_path)
             if not isinstance(chunk, list):
-                break
+                raise _invalid_payload_error(
+                    path=request_path,
+                    expected="list",
+                    payload=chunk,
+                )
             out.extend(chunk)
             if len(chunk) < 100:
                 break
@@ -85,8 +101,15 @@ class GitHubClient:
         if params:
             query.update(params)
         qs = urllib.parse.urlencode(query)
-        chunk = self._request("GET", f"{path}?{qs}")
-        return chunk if isinstance(chunk, list) else []
+        request_path = f"{path}?{qs}"
+        chunk = self._request("GET", request_path)
+        if not isinstance(chunk, list):
+            raise _invalid_payload_error(
+                path=request_path,
+                expected="list",
+                payload=chunk,
+            )
+        return chunk
 
     def list_open_issues(self) -> list[dict[str, Any]]:
         issues = self.paginate(f"/repos/{self.owner}/{self.repo}/issues", {"state": "open"})
@@ -97,14 +120,22 @@ class GitHubClient:
 
     def list_recent_workflow_runs(self, *, limit: int = 20) -> list[dict[str, Any]]:
         per_page = max(min(limit, 100), 1)
-        payload = self._request(
-            "GET",
-            f"/repos/{self.owner}/{self.repo}/actions/runs?per_page={per_page}",
-        )
+        request_path = f"/repos/{self.owner}/{self.repo}/actions/runs?per_page={per_page}"
+        payload = self._request("GET", request_path)
         if not isinstance(payload, dict):
-            return []
-        runs = payload.get("workflow_runs", [])
-        return runs if isinstance(runs, list) else []
+            raise _invalid_payload_error(
+                path=request_path,
+                expected="object",
+                payload=payload,
+            )
+        runs = payload.get("workflow_runs")
+        if not isinstance(runs, list):
+            raise _invalid_payload_error(
+                path=request_path,
+                expected="workflow_runs list",
+                payload=runs,
+            )
+        return runs
 
     def ensure_label(self, *, name: str, color: str, description: str) -> None:
         try:
@@ -419,7 +450,12 @@ def _queue_snapshot_summary(live_scan: dict[str, Any]) -> dict[str, Any]:
     prs = live_scan.get("open_pull_requests") or live_scan.get("pull_requests", {})
     issues = live_scan.get("open_issues_excluding_command_center") or live_scan.get("issues", {})
 
-    if prs.get("error") or issues.get("error"):
+    if (
+        prs.get("available") is False
+        or issues.get("available") is False
+        or prs.get("error")
+        or issues.get("error")
+    ):
         return {
             "status": "unknown",
             "open_pr_count": prs.get("count"),


### PR DESCRIPTION
## Problem

The maintenance command center currently treats several successful but
malformed GitHub API payloads as empty collections. That makes invalid evidence
indistinguishable from an authoritative zero and can produce incorrect queue or
security posture decisions.

Context: #1786

## Change

- reject non-list payloads from paginated and non-paginated collection APIs;
- reject malformed workflow-run envelopes and collections;
- preserve valid empty collections as authoritative zero;
- make queue snapshot status honor explicit `available=false`;
- add regression coverage for all six audited collection-integrity findings;
- record the June maintenance-intake enhancement in the roadmap.

## Scope

Exactly three files:

- `tools/maintenance_command_center.py`
- `tests/test_maintenance_command_center_live_scan.py`
- `docs/roadmap.md`

## Preserved boundaries

- no workflow YAML changes;
- no permission or secret changes;
- no issue mutation or automatic closure;
- no tracker-priority or overflow-policy changes;
- no workflow rerun;
- no unrelated owner-file mypy cleanup.

## Proof

- focused command-center regression tests;
- Python compilation;
- repository-standard `mypy src`;
- exact three-file pre-commit;
- `make proof-after-format`;
- post-proof focused tests and repository-standard mypy;
- forbidden-file hash and staged-scope verification.

## Authority boundary

This PR is opened for review only. It does not authorize workflow reruns,
issue mutation, automated patching, merge, or semantic-equivalence claims.
