### PR TITLE
fix(pr-quality): normalize contributor review decision states

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,6 +59,32 @@ When an enhancement is identified from customer or user feedback:
   4. Focused regression tests cover the six collection-integrity findings while preserving the existing pagination fallback.
 - **Expected impact:** More trustworthy maintenance queue decisions and a clear distinction between authoritative zero, unavailable collection state, and malformed API evidence.
 
+## Developer workflow program: Contributor Review and Delivery Workflow
+
+This program connects contributor preparation, PR evidence, the canonical review model, trusted publication, human review, post-merge verification, and release-readiness handoff without expanding automation authority.
+
+### Active roadmap action
+
+```text
+action:
+  id=pr-review-state
+  lane=Developer workflow
+  title=Normalize PR Quality decision states
+  priority=P1
+  risk=medium
+  value=Give contributors one truthful verdict, one blocker, and one next action across every review surface.
+  status=in_progress
+```
+
+**Acceptance criteria**
+
+1. The canonical review state is one of `waiting`, `blocked`, `review`, `ready`, `stale`, or `invalid`.
+2. A `ready` review has no blocker and does not recommend rerunning proof.
+3. Required-check counts match the required-check names shown to contributors.
+4. The review summary, step summary, dashboard, and artifact manifest consume the same state and next action.
+5. Contradictory evidence produces `invalid` rather than a green verdict.
+6. The read-only evidence workflow and trusted publisher topology remain unchanged.
+
 ## Continuous maintenance hardening loop
 
 The maintenance system now produces ten recurring artifacts:

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -14,6 +14,21 @@ from sdetkit.pr_comment_failure_families import render_comment_failure_families
 
 JsonObject = dict[str, Any]
 
+CANONICAL_REVIEW_STATES = (
+    "waiting",
+    "blocked",
+    "review",
+    "ready",
+    "stale",
+    "invalid",
+)
+KNOWN_ACTION_REPORT_STATUSES = {
+    "green",
+    "incomplete",
+    "review_required",
+    "safe_fix_available",
+}
+
 TRUSTED_HISTORY = "_".join(("trusted", "history"))
 FLAKY_TEST_REGISTRY_COLLECTION_STATUS = "_".join(
     ("flaky", "test", "registry", "collection", "status")
@@ -2368,6 +2383,89 @@ def _review_model_ghas_blocker_details(
     }
 
 
+def _canonical_review_state(
+    *,
+    source_status: str,
+    failed_checks: int,
+    required_queued_checks: int,
+    required_startup_failures: int,
+    missing_required_contexts: int,
+    evidence_review_required: bool,
+    stale_only_security_signal: bool,
+) -> str:
+    if stale_only_security_signal:
+        return "stale"
+    if source_status == "green" and (
+        failed_checks > 0
+        or required_queued_checks > 0
+        or required_startup_failures > 0
+        or missing_required_contexts > 0
+    ):
+        return "invalid"
+    if required_queued_checks > 0 and failed_checks == 0 and required_startup_failures == 0:
+        return "waiting"
+    if (
+        failed_checks > 0
+        or required_startup_failures > 0
+        or missing_required_contexts > 0
+        or source_status
+        in {
+            "incomplete",
+            "review_required",
+            "safe_fix_available",
+        }
+    ):
+        return "blocked"
+    if source_status not in KNOWN_ACTION_REPORT_STATUSES:
+        return "invalid"
+    if evidence_review_required:
+        return "review"
+    return "ready"
+
+
+def _canonical_review_decision(
+    *,
+    review_state: str,
+    blocker_title: str,
+    blocker_action: str,
+) -> tuple[str, str, str]:
+    if review_state == "waiting":
+        return (
+            "none",
+            "wait_for_required_checks",
+            "wait_for_required_checks",
+        )
+    if review_state == "blocked":
+        return (
+            blocker_title or "Required contributor proof is blocked",
+            blocker_action or "resolve_primary_blocker",
+            "do_not_merge_until_blocker_resolved",
+        )
+    if review_state == "review":
+        return (
+            "none",
+            "review_listed_evidence",
+            "human_review_required_before_merge",
+        )
+    if review_state == "ready":
+        return (
+            "none",
+            "review_and_decide",
+            "automated_proof_complete_human_decision_required",
+        )
+    if review_state == "stale":
+        return (
+            "Evidence is stale for the current PR head",
+            WAIT_FOR_CODE_SCANNING_REFRESH,
+            WAIT_FOR_CODE_SCANNING_REFRESH,
+        )
+    return (
+        "PR Quality review evidence is internally inconsistent",
+        "repair_review_evidence",
+        "do_not_merge_until_review_model_repaired",
+    )
+
+
 def build_pr_quality_review_model(
     *,
     status: str,
@@ -2481,7 +2579,32 @@ def build_pr_quality_review_model(
             )
             if label:
                 labels.append(label)
-        return labels[:10]
+        return labels
+
+    failed_check_names = _check_labels(check_intelligence.get("failed_checks"))
+    required_queued_check_names = _check_labels(
+        [
+            item
+            for item in _as_list(check_intelligence.get("queued_checks"))
+            if bool(_as_dict(item).get("required", False))
+        ]
+    )
+    required_startup_failure_names = _check_labels(
+        [
+            item
+            for item in _as_list(check_intelligence.get("startup_failures"))
+            if bool(_as_dict(item).get("required", False))
+        ]
+    )
+    missing_required_context_names = [
+        _string(item)
+        for item in _as_list(check_intelligence.get("missing_required_contexts"))
+        if _string(item)
+    ]
+    failed_count = len(failed_check_names)
+    required_queued = len(required_queued_check_names)
+    required_startup = len(required_startup_failure_names)
+    missing_required = len(missing_required_context_names)
 
     recommended_actions = [
         str(item)
@@ -2531,6 +2654,21 @@ def build_pr_quality_review_model(
             "reporting_only": True,
         }
 
+    review_state = _canonical_review_state(
+        source_status=status,
+        failed_checks=failed_count,
+        required_queued_checks=required_queued,
+        required_startup_failures=required_startup,
+        missing_required_contexts=missing_required,
+        evidence_review_required=evidence_review_required,
+        stale_only_security_signal=stale_only_security_signal,
+    )
+    canonical_blocker, next_action, merge_assessment = _canonical_review_decision(
+        review_state=review_state,
+        blocker_title=primary_title,
+        blocker_action=primary_action,
+    )
+
     return {
         "schema_version": "sdetkit.pr_quality.review_model.v2",
         "schema": {
@@ -2538,7 +2676,7 @@ def build_pr_quality_review_model(
             "version": 2,
             "previous_version": "sdetkit.pr_quality.review_model.v1",
             "compatibility": "additive",
-            "decision_logic": "unchanged",
+            "decision_logic": "canonical_review_state_v1",
             "authority_boundary": "reporting_only",
         },
         "generated_by": "sdetkit.pr_quality_action_report",
@@ -2558,16 +2696,16 @@ def build_pr_quality_review_model(
         "recommended_actions": recommended_actions[:10],
         "failure_vector_signal": failure_vector_signal,
         "ghas_blocker_details": ghas_blocker_details,
-        "failed_check_names": _check_labels(check_intelligence.get("failed_checks")),
-        "required_queued_check_names": _check_labels(check_intelligence.get("queued_checks")),
-        "required_startup_failure_names": _check_labels(check_intelligence.get("startup_failures")),
-        "missing_required_context_names": [
-            _string(item)
-            for item in _as_list(check_intelligence.get("missing_required_contexts"))
-            if _string(item)
-        ][:10],
+        "failed_check_names": failed_check_names,
+        "required_queued_check_names": required_queued_check_names,
+        "required_startup_failure_names": required_startup_failure_names,
+        "missing_required_context_names": missing_required_context_names,
         "decision": {
+            "review_state": review_state,
             "status": status,
+            "source_status": status,
+            "state_consistent": review_state != "invalid",
+            "primary_blocker": canonical_blocker,
             "merge_assessment": merge_assessment,
             "next_action": next_action,
             "risk_surface": surface,
@@ -2611,7 +2749,7 @@ def _reviewer_dashboard_lines(
         check_intelligence=check_intelligence,
         evidence_narrative=evidence_narrative,
     )
-    decision = _as_dict(model.get("decision"))
+    decision = _normalized_review_decision(model)
     authority = _as_dict(model.get("authority_boundary"))
     proof_commands = [
         str(command)
@@ -2624,7 +2762,8 @@ def _reviewer_dashboard_lines(
         "",
         "| Item | Value |",
         "|---|---|",
-        f"| SDETKit status | `{_review_model_scalar(decision.get('status'))}` |",
+        f"| Review state | `{_review_model_state(model)}` |",
+        f"| Source status | `{_review_model_scalar(decision.get('source_status') or decision.get('status'))}` |",
         f"| Merge assessment | `{_review_model_scalar(decision.get('merge_assessment'))}` |",
         f"| Next reviewer action | `{_review_model_scalar(decision.get('next_action'))}` |",
         f"| Changed risk surface | `{_markdown_table_value(decision.get('risk_surface'))}` |",
@@ -2667,6 +2806,10 @@ def _reviewer_dashboard_lines(
 
 def _review_model_state(model: JsonObject) -> str:
     decision = _as_dict(model.get("decision"))
+    canonical = _review_model_scalar(decision.get("review_state"))
+    if canonical in CANONICAL_REVIEW_STATES:
+        return canonical
+
     status = _review_model_scalar(decision.get("status") or "unknown")
     failed_total = _int(decision.get("failed_checks"))
     queued_total = _int(decision.get("required_queued_checks"))
@@ -2675,45 +2818,76 @@ def _review_model_state(model: JsonObject) -> str:
     review_first = bool(decision.get("review_first_evidence"))
     stale_only_security_signal = bool(decision.get(STALE_ONLY_SECURITY_SIGNAL))
 
-    needs_attention = (
-        (status != "green" and not stale_only_security_signal)
-        or failed_total > 0
-        or queued_total > 0
-        or startup_total > 0
-        or missing_total > 0
-        or (review_first and not stale_only_security_signal)
-        or stale_only_security_signal
+    return _canonical_review_state(
+        source_status=status,
+        failed_checks=failed_total,
+        required_queued_checks=queued_total,
+        required_startup_failures=startup_total,
+        missing_required_contexts=missing_total,
+        evidence_review_required=review_first,
+        stale_only_security_signal=stale_only_security_signal,
     )
-    is_blocked = (
-        (status != "green" and not stale_only_security_signal)
-        or failed_total > 0
-        or startup_total > 0
-        or missing_total > 0
-    )
-
-    if is_blocked:
-        return "needs_attention"
-    if needs_attention:
-        return "review_required"
-    return "green"
 
 
 def _review_model_state_class(review_state: str) -> str:
-    if review_state == "green":
+    if review_state == "ready":
         return "status-green"
-    if review_state == "review_required":
+    if review_state in {"waiting", "review", "stale"}:
         return "status-review"
     return "status-failed"
 
 
 def _review_model_state_label(review_state: str) -> str:
-    return review_state.replace("_", " ")
+    return {
+        "waiting": "waiting for CI",
+        "blocked": "blocked",
+        "review": "human review required",
+        "ready": "ready for human decision",
+        "stale": "stale evidence",
+        "invalid": "invalid evidence",
+    }.get(review_state, review_state.replace("_", " "))
+
+
+def _normalized_review_decision(model: JsonObject) -> JsonObject:
+    decision = dict(_as_dict(model.get("decision")))
+    review_state = _review_model_state(model)
+    source_status = _review_model_scalar(
+        decision.get("source_status") or decision.get("status") or "unknown"
+    )
+    primary_blocker = _as_dict(model.get("primary_blocker"))
+    blocker_title = _review_model_scalar(
+        decision.get("primary_blocker") or primary_blocker.get("title") or ""
+    )
+    blocker_action = _review_model_scalar(
+        primary_blocker.get("action") or decision.get("next_action") or ""
+    )
+    (
+        canonical_blocker,
+        canonical_action,
+        canonical_merge_assessment,
+    ) = _canonical_review_decision(
+        review_state=review_state,
+        blocker_title=blocker_title,
+        blocker_action=blocker_action,
+    )
+
+    decision.update(
+        {
+            "review_state": review_state,
+            "status": source_status,
+            "source_status": source_status,
+            "state_consistent": review_state != "invalid",
+            "primary_blocker": canonical_blocker,
+            "merge_assessment": canonical_merge_assessment,
+            "next_action": canonical_action,
+        }
+    )
+    return decision
 
 
 def render_pr_quality_review_summary(model: JsonObject) -> str:
-    decision = _as_dict(model.get("decision"))
+    decision = _normalized_review_decision(model)
     authority = _as_dict(model.get("authority_boundary"))
-    primary_blocker = _as_dict(model.get("primary_blocker"))
     failure_vector_signal = _as_dict(model.get("failure_vector_signal"))
     ghas_blocker_details = _as_dict(model.get("ghas_blocker_details"))
     proof_commands = [
@@ -2773,42 +2947,18 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "</details>",
         ]
 
-    status = _review_model_scalar(decision.get("status") or "unknown")
+    status = _review_model_scalar(
+        decision.get("source_status") or decision.get("status") or "unknown"
+    )
     failed_total = _count(decision.get("failed_checks"))
     queued_total = _count(decision.get("required_queued_checks"))
     startup_total = _count(decision.get("required_startup_failures"))
     missing_total = _count(decision.get("missing_required_contexts"))
-    review_first = bool(decision.get("review_first_evidence"))
     stale_only_security_signal = bool(decision.get(STALE_ONLY_SECURITY_SIGNAL))
-    first_blocker = _review_model_scalar(
-        primary_blocker.get("title") or decision.get("signal_title") or "none"
-    )
-    first_action = _review_model_scalar(
-        primary_blocker.get("action") or decision.get("next_action") or "none"
-    )
-    first_recommended_action = recommended_actions[0] if recommended_actions else first_action
-
-    needs_attention = (
-        (status != "green" and not stale_only_security_signal)
-        or failed_total > 0
-        or queued_total > 0
-        or startup_total > 0
-        or missing_total > 0
-        or (review_first and not stale_only_security_signal)
-        or stale_only_security_signal
-    )
-    is_blocked = (
-        (status != "green" and not stale_only_security_signal)
-        or failed_total > 0
-        or startup_total > 0
-        or missing_total > 0
-    )
-    if is_blocked:
-        review_state = "needs_attention"
-    elif needs_attention:
-        review_state = "review_required"
-    else:
-        review_state = "green"
+    review_state = _review_model_state(model)
+    first_blocker = _review_model_scalar(decision.get("primary_blocker") or "none")
+    first_action = _review_model_scalar(decision.get("next_action") or "none")
+    first_recommended_action = first_action
 
     failure_actual = _review_model_scalar(failure_vector_signal.get("actual_failure") or "none")
     failure_source = _review_model_scalar(failure_vector_signal.get("source") or "none")
@@ -2840,7 +2990,12 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "- `pr-comment-body.md` — raw rendered comment body",
         ]
 
-    active_blocker_open = is_blocked or (review_first and not stale_only_security_signal)
+    active_blocker_open = review_state in {
+        "blocked",
+        "review",
+        "stale",
+        "invalid",
+    }
     failure_vector_open = active_blocker_open and failure_actual not in {"", "none"}
     proof_open = active_blocker_open and bool(proof_commands)
     ghas_findings = [
@@ -2856,7 +3011,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         *_markdown_table(
             [
                 ("Review state", review_state),
-                ("Status", decision.get("status")),
+                ("Source status", status),
                 ("First blocker", first_blocker),
                 ("Recommended action", first_recommended_action),
                 ("Failed checks", failed_total),
@@ -2902,21 +3057,32 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         f"| Stale-only security signal | `{str(stale_only_security_signal).lower()}` |",
         "",
     ]
-    if recommended_actions:
-        blocker_body.extend(["### Recommended next action", ""])
-        blocker_body.extend(f"- {action}" for action in recommended_actions[:10])
-    else:
-        blocker_body.extend(["### Recommended next action", "", "- none"])
+    blocker_body.extend(
+        [
+            "### Canonical next action",
+            "",
+            f"- `{first_action}`",
+        ]
+    )
+    additional_guidance = [
+        action for action in recommended_actions if action and action != first_action
+    ]
+    if additional_guidance:
+        blocker_body.extend(["", "### Additional guidance", ""])
+        blocker_body.extend(f"- {action}" for action in additional_guidance[:5])
+
+    decision_detail_title = {
+        "waiting": "⏳ Waiting for required checks",
+        "blocked": "🚨 Active blocker / decision details",
+        "review": "👀 Human review required",
+        "ready": "✅ Ready for human decision",
+        "stale": "🟡 Stale evidence / refresh required",
+        "invalid": "❌ Invalid review evidence",
+    }.get(review_state, "Decision details")
 
     lines.extend(
         _details(
-            "🟡 Refresh-pending decision details"
-            if stale_only_security_signal
-            else (
-                "🚨 Active blocker / decision details"
-                if active_blocker_open
-                else "✅ Decision details"
-            ),
+            decision_detail_title,
             blocker_body,
             open_by_default=active_blocker_open,
         )
@@ -3140,7 +3306,7 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
         expected_paths[0] if expected_paths else "index.html",
     )
 
-    decision = _as_dict(model.get("decision"))
+    decision = _normalized_review_decision(model)
     authority = _as_dict(model.get("authority_boundary"))
 
     return {
@@ -3171,7 +3337,7 @@ def build_pr_quality_artifacts_manifest(model: JsonObject) -> JsonObject:
 
 
 def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
-    decision = _as_dict(model.get("decision"))
+    decision = _normalized_review_decision(model)
     authority = _as_dict(model.get("authority_boundary"))
 
     review_state = _review_model_state(model)
@@ -3377,7 +3543,7 @@ def render_pr_quality_artifact_index_html(model: JsonObject) -> str:
 
 
 def render_pr_quality_review_html(model: JsonObject) -> str:
-    decision = _as_dict(model.get("decision"))
+    decision = _normalized_review_decision(model)
     authority = _as_dict(model.get("authority_boundary"))
     primary_blocker = _as_dict(model.get("primary_blocker"))
     failure_vector_signal = _as_dict(model.get("failure_vector_signal"))
@@ -3418,64 +3584,58 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
         except (TypeError, ValueError):
             return 0
 
-    status = _review_model_scalar(decision.get("status") or "unknown")
+    status = _review_model_scalar(
+        decision.get("source_status") or decision.get("status") or "unknown"
+    )
+    review_state = _review_model_state(model)
+    status_class = _review_model_state_class(review_state)
+    hero_label = _review_model_state_label(review_state)
+    state_caption = {
+        "waiting": (
+            "Required checks are still running. Wait for the named checks "
+            "before changing or merging the pull request."
+        ),
+        "blocked": (
+            "A required proof contract is blocked. Resolve the named blocker "
+            "and rerun the focused proof."
+        ),
+        "review": (
+            "Automated proof is complete, but the listed evidence requires "
+            "human review before merge."
+        ),
+        "ready": (
+            "Automated proof is complete and internally consistent. Review "
+            "scope, risk, and authority before deciding."
+        ),
+        "stale": (
+            "Published evidence does not represent the current pull request "
+            "state. Refresh exact-head evidence before review or merge."
+        ),
+        "invalid": (
+            "The review evidence contradicts itself. Repair the evidence "
+            "model before relying on this verdict."
+        ),
+    }.get(review_state, "Review the current PR Quality evidence.")
+
     next_action = _review_model_scalar(decision.get("next_action") or "unknown")
     merge_assessment = _review_model_scalar(decision.get("merge_assessment") or "unknown")
     risk_surface = _review_model_scalar(decision.get("risk_surface") or "unknown")
     signal = _review_model_scalar(decision.get("comment_signal") or "none")
-    first_blocker = _review_model_scalar(
-        primary_blocker.get("title") or decision.get("signal_title") or "none"
-    )
-    first_action = _review_model_scalar(primary_blocker.get("action") or next_action or "none")
+    first_blocker = _review_model_scalar(decision.get("primary_blocker") or "none")
+    first_action = next_action
 
     failed_total = _count(decision.get("failed_checks"))
     queued_total = _count(decision.get("required_queued_checks"))
     startup_total = _count(decision.get("required_startup_failures"))
     missing_total = _count(decision.get("missing_required_contexts"))
     review_first = bool(decision.get("review_first_evidence"))
-    stale_only_security_signal = bool(decision.get(STALE_ONLY_SECURITY_SIGNAL))
-    needs_attention = (
-        (status != "green" and not stale_only_security_signal)
-        or failed_total > 0
-        or queued_total > 0
-        or startup_total > 0
-        or missing_total > 0
-        or (review_first and not stale_only_security_signal)
-        or stale_only_security_signal
-    )
-    is_blocked = (
-        (status != "green" and not stale_only_security_signal)
-        or failed_total > 0
-        or startup_total > 0
-        or missing_total > 0
-    )
-
-    if is_blocked:
-        status_class = "status-failed"
-        hero_label = "needs attention"
-        state_caption = (
-            "Failure signals are present. Review the mini triage, first blocker, "
-            "recommended action, and proof to rerun before any merge decision."
-        )
-    elif needs_attention:
-        status_class = "status-review"
-        hero_label = "review required"
-        state_caption = (
-            "Review-first evidence is present. Confirm the listed evidence and proof "
-            "before any merge decision."
-        )
-    else:
-        status_class = "status-green"
-        hero_label = "green"
-        state_caption = (
-            "No PR Quality blocker is currently reported. Keep the listed proof and "
-            "authority boundary visible before any merge decision."
-        )
+    needs_attention = review_state != "ready"
 
     hero_class = f"hero {status_class}"
 
     decision_rows = [
-        ("Status", decision.get("status")),
+        ("Review state", review_state),
+        ("Source status", status),
         ("Merge assessment", decision.get("merge_assessment")),
         ("Next action", decision.get("next_action")),
         ("Risk surface", decision.get("risk_surface")),
@@ -3491,9 +3651,9 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
         ("Cleared security signal", decision.get("cleared_security_signal")),
     ]
     blocker_rows = [
-        ("Title", primary_blocker.get("title") or first_blocker),
+        ("Title", first_blocker),
         ("Surface", primary_blocker.get("surface") or risk_surface),
-        ("Action", primary_blocker.get("action") or first_action),
+        ("Action", first_action),
         ("Code", primary_blocker.get("code")),
         ("Path", primary_blocker.get("path")),
         ("Details", primary_blocker.get("details")),
@@ -3589,7 +3749,7 @@ def render_pr_quality_review_html(model: JsonObject) -> str:
     else:
         proof_html = "<p><code>none</code></p>"
 
-    first_recommended_action = recommended_actions[0] if recommended_actions else first_action
+    first_recommended_action = first_action
     triage_html = ""
     if needs_attention:
         triage_html = (

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3039,9 +3039,10 @@ def test_pr_quality_comment_v3_renders_reviewer_dashboard_top_card() -> None:
     assert "## Reviewer dashboard" in body
     assert "## Reviewer dashboard" in body.split("## Quality summary", maxsplit=1)[0]
     assert "### Decision" in body
-    assert "| SDETKit status | `green` |" in body
-    assert "| Merge assessment | `verify_listed_proof_before_routine_merge` |" in body
-    assert "| Next reviewer action | `rerun_proof` |" in body
+    assert "| Review state | `ready` |" in body
+    assert "| Source status | `green` |" in body
+    assert "| Merge assessment | `automated_proof_complete_human_decision_required` |" in body
+    assert "| Next reviewer action | `review_and_decide` |" in body
     assert "| Changed risk surface | `workflow` |" in body
     assert "| Signal title | Workflow evidence changed |" in body
     assert "| Review-first evidence | `false` |" in body
@@ -3113,9 +3114,13 @@ def test_pr_quality_review_model_is_structured_product_surface() -> None:
 
     assert model["schema_version"] == "sdetkit.pr_quality.review_model.v2"
     assert model["decision"] == {
+        "review_state": "ready",
         "status": "green",
-        "merge_assessment": "verify_listed_proof_before_routine_merge",
-        "next_action": "rerun_proof",
+        "source_status": "green",
+        "state_consistent": True,
+        "primary_blocker": "none",
+        "merge_assessment": ("automated_proof_complete_human_decision_required"),
+        "next_action": "review_and_decide",
         "risk_surface": "diagnostic_engine",
         "signal_title": "Diagnostic intelligence evidence changed",
         "comment_signal": "Evidence proof signal",
@@ -3213,8 +3218,10 @@ def test_write_comment_body_writes_review_model_artifact(tmp_path: Path) -> None
 
     model = json.loads(review_model_out.read_text(encoding="utf-8"))
     assert model["schema_version"] == "sdetkit.pr_quality.review_model.v2"
-    assert model["decision"]["merge_assessment"] == "verify_listed_proof_before_routine_merge"
-    assert model["decision"]["next_action"] == "rerun_proof"
+    assert model["decision"]["merge_assessment"] == (
+        "automated_proof_complete_human_decision_required"
+    )
+    assert model["decision"]["next_action"] == "review_and_decide"
     assert model["decision"]["risk_surface"] == "diagnostic_engine"
     assert model["proof_to_rerun"] == [
         "python -m pytest -q tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py -o addopts=",
@@ -3308,8 +3315,9 @@ def test_write_comment_body_writes_review_summary_artifact(tmp_path: Path) -> No
 
     summary = review_summary_out.read_text(encoding="utf-8")
     assert "# PR Quality Review Summary" in summary
-    assert "| Merge assessment | `verify_listed_proof_before_routine_merge` |" in summary
-    assert "| Next action | `rerun_proof` |" in summary
+    assert "| Merge assessment | `automated_proof_complete_human_decision_required` |" in summary
+    assert "| Next action | `review_and_decide` |" in summary
+    assert "| First blocker | `none` |" in summary
     assert "| Risk surface | `diagnostic_engine` |" in summary
     assert "```bash" in summary
     assert "python -m pre_commit run -a" in summary
@@ -3402,8 +3410,9 @@ def test_write_comment_body_writes_review_html_dashboard_artifact(tmp_path: Path
     assert "Required queued checks" in html
     assert "Missing required contexts" in html
     assert "white-space: pre-wrap" in html
-    assert "verify_listed_proof_before_routine_merge" in html
-    assert "rerun_proof" in html
+    assert "automated_proof_complete_human_decision_required" in html
+    assert "review_and_decide" in html
+    assert "rerun_proof" not in html
     assert "python -m pre_commit run -a" in html
     assert "Reporting-only" in html
     assert "does not authorize merge" in html
@@ -3461,18 +3470,22 @@ def test_review_html_dashboard_visualizes_error_state() -> None:
 
     html = report.render_pr_quality_review_html(model)
 
-    assert "needs attention" in html
+    assert "blocked" in html
+    assert "fix_lint" in html
     assert "status-failed" in html
     assert 'class="hero status-failed"' in html
     assert 'class="hero-top"' in html
     assert 'class="state-caption"' in html
-    assert "Failure signals are present." in html
+    assert (
+        "A required proof contract is blocked. Resolve the named "
+        "blocker and rerun the focused proof." in html
+    )
     assert "section-kicker" in html
-    assert "Needs Attention" in html
+    assert "Review state" in html
     assert "First blocker" in html
     assert "Ruff check failed" in html
     assert "fix_lint" in html
-    assert "Failure signals" in html
+    assert "Source status" in html
     assert "Failed checks" in html
     assert "quality" in html
     assert "Queued required checks" in html
@@ -3534,9 +3547,9 @@ def test_review_summary_includes_error_state_mini_triage() -> None:
     summary = report.render_pr_quality_review_summary(model)
 
     assert "## Mini triage" in summary
-    assert "| Review state | `needs_attention` |" in summary
+    assert "| Review state | `blocked` |" in summary
     assert "| First blocker | `Ruff check failed` |" in summary
-    assert "| Recommended action | `Fix the lint finding.` |" in summary
+    assert "| Recommended action | `fix_lint` |" in summary
     assert "| Failed checks | `1` |" in summary
     assert "| Failed check names | `quality` |" in summary
     assert "| Queued required checks | `1` |" in summary
@@ -3669,7 +3682,7 @@ def test_review_model_schema_v2_includes_artifact_index_metadata() -> None:
         "version": 2,
         "previous_version": "sdetkit.pr_quality.review_model.v1",
         "compatibility": "additive",
-        "decision_logic": "unchanged",
+        "decision_logic": "canonical_review_state_v1",
         "authority_boundary": "reporting_only",
     }
     assert model["generated_by"] == "sdetkit.pr_quality_action_report"
@@ -3758,41 +3771,50 @@ def _build_review_state_matrix_model(
     )
 
 
-def test_review_surfaces_cover_green_review_required_and_needs_attention_states() -> None:
+def test_review_surfaces_cover_ready_review_and_blocked_states() -> None:
     cases = [
         {
-            "name": "green",
+            "name": "ready",
             "model": _build_review_state_matrix_model(
                 status="green",
                 evidence_review_required=False,
             ),
-            "review_state": "green",
+            "review_state": "ready",
             "class_name": "status-green",
-            "label": "green",
-            "caption": "No PR Quality blocker is currently reported.",
+            "label": "ready for human decision",
+            "caption": (
+                "Automated proof is complete and internally consistent. "
+                "Review scope, risk, and authority before deciding."
+            ),
         },
         {
-            "name": "review_required",
+            "name": "review",
             "model": _build_review_state_matrix_model(
                 status="green",
                 evidence_review_required=True,
             ),
-            "review_state": "review_required",
+            "review_state": "review",
             "class_name": "status-review",
-            "label": "review required",
-            "caption": "Review-first evidence is present.",
+            "label": "human review required",
+            "caption": (
+                "Automated proof is complete, but the listed evidence "
+                "requires human review before merge."
+            ),
         },
         {
-            "name": "needs_attention",
+            "name": "blocked",
             "model": _build_review_state_matrix_model(
                 status="failed",
                 evidence_review_required=False,
                 failed_check=True,
             ),
-            "review_state": "needs_attention",
+            "review_state": "blocked",
             "class_name": "status-failed",
-            "label": "needs attention",
-            "caption": "Failure signals are present.",
+            "label": "blocked",
+            "caption": (
+                "A required proof contract is blocked. Resolve the named "
+                "blocker and rerun the focused proof."
+            ),
         },
     ]
 
@@ -3851,8 +3873,11 @@ def test_review_artifacts_manifest_describes_bundle_contract() -> None:
         "merge_authorization": False,
         "semantic_equivalence_claim": False,
     }
-    assert manifest["decision"]["review_state"] == "green"
-    assert manifest["decision"]["merge_assessment"] == "no_sdetkit_action_required"
+    assert manifest["decision"]["review_state"] == "ready"
+    assert manifest["decision"]["merge_assessment"] == (
+        "automated_proof_complete_human_decision_required"
+    )
+    assert manifest["decision"]["next_action"] == "review_and_decide"
 
     paths = manifest["expected_artifact_paths"]
     assert paths[0] == "index.html"
@@ -4202,11 +4227,11 @@ def test_pr_quality_review_summary_opens_blocker_sections_and_collapses_noise() 
     assert "does not authorize merge" in body
 
 
-def test_pr_quality_review_summary_keeps_green_details_collapsed() -> None:
+def test_pr_quality_review_summary_normalizes_legacy_green_decision() -> None:
     model = {
         "decision": {
             "status": "green",
-            "merge_assessment": "verify_listed_proof_before_routine_merge",
+            "merge_assessment": ("verify_listed_proof_before_routine_merge"),
             "next_action": "rerun_proof",
             "risk_surface": "none",
             "signal_title": "Green",
@@ -4249,10 +4274,15 @@ def test_pr_quality_review_summary_keeps_green_details_collapsed() -> None:
 
     body = report.render_pr_quality_review_summary(model)
 
-    assert "<details>\n<summary>✅ Decision details</summary>" in body
+    assert "| Review state | `ready` |" in body
+    assert "| First blocker | `none` |" in body
+    assert "| Recommended action | `review_and_decide` |" in body
+    assert "| Merge assessment | `automated_proof_complete_human_decision_required` |" in body
+    assert "<details>\n<summary>✅ Ready for human decision</summary>" in body
     assert "<details>\n<summary>🧭 Failure vector deep dive</summary>" in body
     assert "<details>\n<summary>🧪 Proof to rerun</summary>" in body
     assert "<details open>" not in body
+    assert "rerun_proof" not in body
 
 
 def test_review_model_includes_ghas_code_scanning_blocker_details() -> None:
@@ -4633,10 +4663,10 @@ def test_stale_only_ghas_alert_is_refresh_pending_not_active_blocker() -> None:
         ("stale", "only", "security", "signal")
     )
 
-    assert "| Review state | `review_required` |" in body
+    assert "| Review state | `stale` |" in body
     assert f"| Merge assessment | `{wait_for_refresh}` |" in body
     assert "| Stale-only security signal | `true` |" in body
-    assert "🟡 Refresh-pending decision details" in body
+    assert "🟡 Stale evidence / refresh required" in body
     assert "🛡️ GHAS / CodeQL refresh details" in body
     assert "🚨 Active blocker / decision details" not in body
     assert "do_not_merge_until_blocker_resolved" not in body
@@ -5312,3 +5342,199 @@ def test_action_report_renders_trusted_registry_aggregate_without_decision_chang
     assert "Trusted history producer-vetted registry current PR decision input: `false`" in rendered
     assert "Automation allowed by trusted history: `false`" in rendered
     assert "Merge authorized by trusted history: `false`" in rendered
+
+
+def _decision_model(
+    *,
+    status: str = "green",
+    failed_checks: list[dict] | None = None,
+    queued_checks: list[dict] | None = None,
+    startup_failures: list[dict] | None = None,
+    missing_required_contexts: list[str] | None = None,
+    evidence_review_required: bool = False,
+    evidence_signal_lines: list[str] | None = None,
+    primary_blocker: dict | None = None,
+    evidence_narrative: dict | None = None,
+) -> dict:
+    return report.build_pr_quality_review_model(
+        status=status,
+        evidence_signal_heading=(
+            "Evidence review signal" if evidence_review_required else "Evidence proof signal"
+        ),
+        evidence_signal_lines=(
+            evidence_signal_lines
+            if evidence_signal_lines is not None
+            else ["- Proof signal: `present`"]
+        ),
+        evidence_review_required=evidence_review_required,
+        action_report={
+            "primary_blocker": primary_blocker or {},
+            "recommended_actions": [],
+            "proof_commands": [],
+        },
+        check_intelligence={
+            "failed_checks": failed_checks or [],
+            "queued_checks": queued_checks or [],
+            "startup_failures": startup_failures or [],
+            "missing_required_contexts": (missing_required_contexts or []),
+        },
+        evidence_narrative=evidence_narrative or {},
+    )
+
+
+def test_review_model_ready_state_has_no_blocker_or_rerun_action() -> None:
+    model = _decision_model(
+        queued_checks=[
+            {
+                "name": "Full CI lane",
+                "required": False,
+            }
+        ],
+        evidence_narrative={
+            "primary_signal": {
+                "surface": "diagnostic_engine",
+                "title": "Diagnostic intelligence evidence changed",
+            },
+            "graph": {
+                "top_blocker": {
+                    "title": "Diagnostic intelligence evidence changed",
+                    "surface": "diagnostic_engine",
+                    "action": "rerun_proof",
+                }
+            },
+        },
+    )
+
+    decision = model["decision"]
+    assert decision["review_state"] == "ready"
+    assert decision["primary_blocker"] == "none"
+    assert decision["next_action"] == "review_and_decide"
+    assert decision["required_queued_checks"] == 0
+    assert model["required_queued_check_names"] == []
+
+
+def test_review_model_waiting_state_names_only_required_checks() -> None:
+    model = _decision_model(
+        status="incomplete",
+        queued_checks=[
+            {"name": "ci", "required": True},
+            {"name": "Full CI lane", "required": False},
+        ],
+        missing_required_contexts=["ci"],
+        evidence_signal_lines=[],
+    )
+
+    decision = model["decision"]
+    assert decision["review_state"] == "waiting"
+    assert decision["primary_blocker"] == "none"
+    assert decision["next_action"] == "wait_for_required_checks"
+    assert decision["required_queued_checks"] == 1
+    assert model["required_queued_check_names"] == ["ci"]
+
+
+def test_review_model_invalidates_green_status_with_required_queue() -> None:
+    model = _decision_model(
+        status="green",
+        queued_checks=[
+            {
+                "name": "ci",
+                "required": True,
+            }
+        ],
+    )
+
+    decision = model["decision"]
+    assert decision["review_state"] == "invalid"
+    assert decision["state_consistent"] is False
+    assert decision["next_action"] == "repair_review_evidence"
+    assert decision["required_queued_checks"] == 1
+    assert model["required_queued_check_names"] == ["ci"]
+
+
+def test_review_model_invalidates_green_status_with_failed_check() -> None:
+    model = _decision_model(
+        status="green",
+        failed_checks=[{"name": "quality"}],
+        primary_blocker={
+            "title": "Quality check failed",
+            "action": "fix_quality",
+        },
+        evidence_signal_lines=[],
+    )
+
+    decision = model["decision"]
+    assert decision["review_state"] == "invalid"
+    assert decision["state_consistent"] is False
+    assert decision["primary_blocker"] == "PR Quality review evidence is internally inconsistent"
+    assert decision["next_action"] == "repair_review_evidence"
+
+
+def test_review_model_review_state_is_not_a_blocker() -> None:
+    model = _decision_model(
+        evidence_review_required=True,
+        evidence_narrative={
+            "primary_signal": {
+                "surface": "workflow",
+                "title": "Workflow evidence changed",
+            }
+        },
+    )
+
+    decision = model["decision"]
+    assert decision["review_state"] == "review"
+    assert decision["primary_blocker"] == "none"
+    assert decision["next_action"] == "review_listed_evidence"
+    assert decision["merge_assessment"] == "human_review_required_before_merge"
+
+
+def test_review_model_blocked_state_exposes_one_blocker_and_action() -> None:
+    model = _decision_model(
+        status="review_required",
+        failed_checks=[{"name": "ruff"}],
+        primary_blocker={
+            "title": "Ruff lint contract failed",
+            "action": "fix_ruff_failure",
+        },
+        evidence_signal_lines=[],
+    )
+
+    decision = model["decision"]
+    assert decision["review_state"] == "blocked"
+    assert decision["primary_blocker"] == "Ruff lint contract failed"
+    assert decision["next_action"] == "fix_ruff_failure"
+    assert decision["failed_checks"] == 1
+    assert model["failed_check_names"] == ["ruff"]
+
+
+def test_review_summary_and_dashboard_share_canonical_decision() -> None:
+    model = _decision_model()
+
+    summary = report.render_pr_quality_review_summary(model)
+    dashboard = "\n".join(
+        report._reviewer_dashboard_lines(
+            status="green",
+            evidence_signal_heading="Evidence proof signal",
+            evidence_signal_lines=["- Proof signal: `present`"],
+            evidence_review_required=False,
+            action_report={
+                "primary_blocker": {},
+                "recommended_actions": [],
+                "proof_commands": [],
+            },
+            check_intelligence={
+                "failed_checks": [],
+                "queued_checks": [],
+                "startup_failures": [],
+                "missing_required_contexts": [],
+            },
+            evidence_narrative={},
+        )
+    )
+
+    assert "| Review state | `ready` |" in summary
+    assert "| First blocker | `none` |" in summary
+    assert "| Recommended action | `review_and_decide` |" in summary
+    assert "### Canonical next action" in summary
+    assert "- `review_and_decide`" in summary
+    assert "| Review state | `ready` |" in dashboard
+    assert "| Next reviewer action | `review_and_decide` |" in dashboard

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1279,3 +1279,30 @@ def test_pr_quality_inventory_metadata_keys_avoid_raw_high_entropy_literals() ->
         for key in guarded_keys:
             assert f'"{key}"' not in source
             assert f"'{key}'" not in source
+
+
+def test_pr_quality_decision_state_contract_is_canonical() -> None:
+    source = Path("src/sdetkit/pr_quality_action_report.py").read_text(encoding="utf-8")
+    evidence_workflow = _workflow_text()
+    publisher = _publisher_text()
+
+    for state in (
+        "waiting",
+        "blocked",
+        "review",
+        "ready",
+        "stale",
+        "invalid",
+    ):
+        assert f'"{state}"' in source
+
+    assert "canonical_review_state_v1" in source
+    assert '"review_state": review_state' in source
+    assert '"primary_blocker": canonical_blocker' in source
+    assert '"next_action": next_action' in source
+    assert "cat build/pr-quality/pr-review-summary.md" in evidence_workflow
+
+    assert "workflow_run:" in publisher
+    assert "actions/checkout" not in publisher
+    assert "issues: write" in publisher
+    assert "pull-requests: write" in publisher


### PR DESCRIPTION
## Contributor problem

PR Quality could publish a green verdict while simultaneously presenting a
blocker, a proof-rerun instruction, mismatched required-check counts, or a
different next action in another review surface.

## Roadmap action

```text
action:
  id=pr-review-state
  lane=Developer workflow
  title=Normalize PR Quality decision states
  priority=P1
  risk=medium
  status=in_progress
```

## Change

- define six canonical review states:
  `waiting`, `blocked`, `review`, `ready`, `stale`, and `invalid`;
- derive one canonical blocker, next action, and merge assessment;
- distinguish optional queued checks from required queued checks;
- classify contradictory green evidence as `invalid`;
- normalize legacy review-model input before rendering;
- align Markdown, HTML, artifact-center, manifest, and reviewer-dashboard
  surfaces to the same decision;
- register the Contributor Review and Delivery Workflow in the roadmap.

## Scope

Exactly four files:

- `docs/roadmap.md`
- `src/sdetkit/pr_quality_action_report.py`
- `tests/test_pr_quality_action_report.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

## Preserved trust boundary

The read-only evidence workflow and trusted default-branch publisher remain
unchanged. This PR does not change workflow permissions, exact-head handoff
validation, issue state, security dismissal, or merge authority.

## Proof

- focused PR Quality model, renderer, manifest, and workflow-contract tests;
- Python compilation;
- repository-standard mypy;
- exact four-file pre-commit;
- `make proof-after-format`;
- post-proof focused tests and mypy;
- protected-workflow and staged-scope verification.

## Review focus

1. Confirm each evidence condition maps to one canonical review state.
2. Confirm `ready` has no blocker and uses `review_and_decide`.
3. Confirm required pending checks map to `waiting`.
4. Confirm contradictory green evidence maps to `invalid`.
5. Confirm every rendered surface uses the normalized decision.
6. Confirm both protected workflow files remain unchanged.

## Authority boundary

Review-first and reporting-only. This PR does not authorize workflow reruns,
issue mutation, automated patching, security dismissal, merge, or
semantic-equivalence claims.
