### PR TITLE
fix(pr-quality): remove duplicate decision-state assignments

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -85,6 +85,14 @@ action:
 5. Contradictory evidence produces `invalid` rather than a green verdict.
 6. The read-only evidence workflow and trusted publisher topology remain unchanged.
 
+**Current remediation sub-slice**
+
+- **Title:** Remove duplicate decision-state assignments.
+- **Reason:** Post-merge CodeQL alerts `#1428` through `#1432` identified five locals that were computed twice during the canonical-state refactor.
+- **Scope:** `src/sdetkit/pr_quality_action_report.py`, its focused regression tests, and this roadmap record.
+- **Completion gate:** The five alerts are absent on the remediation PR head, all canonical-state tests remain green, and the trusted publisher files remain unchanged.
+- **Status:** `remediation_in_progress`
+
 ## Continuous maintenance hardening loop
 
 The maintenance system now produces ten recurring artifacts:

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2466,6 +2466,25 @@ def _canonical_review_decision(
     )
 
 
+def _review_model_fallback_action(
+    *,
+    status: str,
+    action: str,
+    evidence_review_required: bool,
+    evidence_signal_lines: list[str],
+    stale_only_security_signal: bool,
+) -> str:
+    if stale_only_security_signal:
+        return WAIT_FOR_CODE_SCANNING_REFRESH
+    if status != "green":
+        return action or "review_primary_blocker"
+    if evidence_review_required:
+        return action or "review_listed_evidence"
+    if evidence_signal_lines:
+        return action or "rerun_listed_proof"
+    return "none"
+
+
 def build_pr_quality_review_model(
     *,
     status: str,
@@ -2514,21 +2533,13 @@ def build_pr_quality_review_model(
         or ""
     )
 
-    if stale_only_security_signal:
-        merge_assessment = WAIT_FOR_CODE_SCANNING_REFRESH
-        next_action = WAIT_FOR_CODE_SCANNING_REFRESH
-    elif status != "green":
-        merge_assessment = "do_not_merge_until_blocker_resolved"
-        next_action = action or "review_primary_blocker"
-    elif evidence_review_required:
-        merge_assessment = "human_review_required_before_merge"
-        next_action = action or "review_listed_evidence"
-    elif evidence_signal_lines:
-        merge_assessment = "verify_listed_proof_before_routine_merge"
-        next_action = action or "rerun_listed_proof"
-    else:
-        merge_assessment = "no_sdetkit_action_required"
-        next_action = "none"
+    fallback_action = _review_model_fallback_action(
+        status=status,
+        action=action,
+        evidence_review_required=evidence_review_required,
+        evidence_signal_lines=evidence_signal_lines,
+        stale_only_security_signal=stale_only_security_signal,
+    )
 
     cleared_security_signal = any(
         "Security review cleared for changed code" in line
@@ -2559,11 +2570,6 @@ def build_pr_quality_review_model(
             for command in _as_list(action_report.get("proof_commands"))
             if isinstance(command, str) and command.strip()
         ]
-
-    failed_count = len(_as_list(check_intelligence.get("failed_checks")))
-    required_queued = _required_count(_as_list(check_intelligence.get("queued_checks")))
-    required_startup = _required_count(_as_list(check_intelligence.get("startup_failures")))
-    missing_required = len(_as_list(check_intelligence.get("missing_required_contexts")))
 
     def _check_labels(items: object) -> list[str]:
         labels: list[str] = []
@@ -2614,7 +2620,7 @@ def build_pr_quality_review_model(
 
     primary_title = _string(primary_blocker.get("title") or title)
     primary_surface = _string(primary_blocker.get("surface") or surface)
-    primary_action = _string(primary_blocker.get("action") or action or next_action)
+    primary_action = _string(primary_blocker.get("action") or action or fallback_action)
     primary_code = _string(primary_blocker.get("code"))
     primary_details = _string(
         primary_blocker.get("details")

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 
@@ -5538,3 +5539,98 @@ def test_review_summary_and_dashboard_share_canonical_decision() -> None:
     assert "- `review_and_decide`" in summary
     assert "| Review state | `ready` |" in dashboard
     assert "| Next reviewer action | `review_and_decide` |" in dashboard
+
+
+def test_review_model_affected_locals_are_assigned_once() -> None:
+    source = Path("src/sdetkit/pr_quality_action_report.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_pr_quality_review_model"
+    )
+
+    counts = {
+        "merge_assessment": 0,
+        "failed_count": 0,
+        "required_queued": 0,
+        "required_startup": 0,
+        "missing_required": 0,
+    }
+
+    def collect_names(target: ast.expr) -> list[str]:
+        if isinstance(target, ast.Name):
+            return [target.id]
+        if isinstance(target, (ast.Tuple, ast.List)):
+            names: list[str] = []
+            for element in target.elts:
+                names.extend(collect_names(element))
+            return names
+        return []
+
+    for node in ast.walk(function):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets.extend(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets.append(node.target)
+
+        for target in targets:
+            for name in collect_names(target):
+                if name in counts:
+                    counts[name] += 1
+
+    assert counts == {
+        "merge_assessment": 1,
+        "failed_count": 1,
+        "required_queued": 1,
+        "required_startup": 1,
+        "missing_required": 1,
+    }
+
+
+def test_review_model_fallback_action_preserves_blocker_selection() -> None:
+    assert (
+        report._review_model_fallback_action(
+            status="review_required",
+            action="review_security_alert",
+            evidence_review_required=True,
+            evidence_signal_lines=["- review"],
+            stale_only_security_signal=False,
+        )
+        == "review_security_alert"
+    )
+
+    assert (
+        report._review_model_fallback_action(
+            status="green",
+            action="",
+            evidence_review_required=True,
+            evidence_signal_lines=["- review"],
+            stale_only_security_signal=False,
+        )
+        == "review_listed_evidence"
+    )
+
+    assert (
+        report._review_model_fallback_action(
+            status="green",
+            action="",
+            evidence_review_required=False,
+            evidence_signal_lines=["- proof"],
+            stale_only_security_signal=False,
+        )
+        == "rerun_listed_proof"
+    )
+
+    assert (
+        report._review_model_fallback_action(
+            status="green",
+            action="",
+            evidence_review_required=False,
+            evidence_signal_lines=[],
+            stale_only_security_signal=True,
+        )
+        == report.WAIT_FOR_CODE_SCANNING_REFRESH
+    )


### PR DESCRIPTION
## Security remediation

The post-merge review for #1861 identified five current CodeQL
`py/multiple-definition` alerts in the canonical PR Quality model:

- `#1428` — `merge_assessment`
- `#1429` — `failed_count`
- `#1430` — `required_queued`
- `#1431` — `required_startup`
- `#1432` — `missing_required`

The affected values were computed twice during the state-model refactor. The
earlier values were overwritten before use.

## Roadmap action

```text
action:
  id=pr-review-state
  lane=Developer workflow
  title=Normalize PR Quality decision states
  sub_slice=Remove duplicate decision-state assignments
  priority=P1
  risk=low
  status=remediation_in_progress
```

## Change

- remove the four overwritten counter computations by AST-verified source
  ranges;
- replace the obsolete early merge-assessment block with a dedicated
  fallback-action helper;
- retain the existing blocker-action selection behavior;
- add an AST regression test requiring each affected local to be assigned
  exactly once;
- add focused fallback-action behavior tests;
- record the remediation sub-slice in the roadmap.

## Scope

Exactly three files:

- `docs/roadmap.md`
- `src/sdetkit/pr_quality_action_report.py`
- `tests/test_pr_quality_action_report.py`

## Preserved boundaries

- no alert dismissal;
- no canonical-state semantic change;
- no workflow or permission change;
- no trusted-publisher change;
- no issue mutation;
- no workflow rerun;
- no merge authorization.

## Proof

- focused PR Quality model, renderer, and workflow-contract tests;
- AST single-assignment regression proof;
- Python compilation;
- repository-standard mypy;
- exact three-file pre-commit;
- `make proof-after-format`;
- post-proof focused tests and mypy;
- protected-file hash and staged-scope verification.

## Review focus

1. Confirm the five affected locals are assigned once before use.
2. Confirm fallback blocker actions remain unchanged.
3. Confirm all six canonical review states remain behaviorally unchanged.
4. Confirm alerts `#1428–#1432` are absent on this PR head after CodeQL
   refreshes.
5. Confirm protected workflow and publisher files remain unchanged.

## Authority boundary

This is a code fix, not a security dismissal. The PR remains review-first and
does not authorize workflow reruns, issue mutation, automated patching, merge,
or semantic-equivalence claims.
