### PR TITLE
feat(pr-quality): publish contributor-first review summary

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,7 +63,7 @@ When an enhancement is identified from customer or user feedback:
 
 This program connects contributor preparation, PR evidence, the canonical review model, trusted publication, human review, post-merge verification, and release-readiness handoff without expanding automation authority.
 
-### Active roadmap action
+### Completed roadmap action
 
 ```text
 action:
@@ -73,25 +73,40 @@ action:
   priority=P1
   risk=medium
   value=Give contributors one truthful verdict, one blocker, and one next action across every review surface.
+  status=done
+```
+
+**Closure evidence**
+
+- PRs `#1861` and `#1862` are merged.
+- The post-merge closure audit passed with `150` focused tests.
+- CodeQL alerts `#1428` through `#1432` are fixed without dismissal.
+- The six-state canonical review contract and reporting-only authority boundary remain intact.
+
+### Active roadmap action
+
+```text
+action:
+  id=pr-review-summary
+  lane=Developer workflow
+  title=Publish a contributor-first PR Quality summary
+  priority=P1
+  risk=medium
+  value=Put the contributor decision, blocker, next action, required checks, security posture, and merge posture before internal diagnostics.
   status=in_progress
 ```
 
 **Acceptance criteria**
 
-1. The canonical review state is one of `waiting`, `blocked`, `review`, `ready`, `stale`, or `invalid`.
-2. A `ready` review has no blocker and does not recommend rerunning proof.
-3. Required-check counts match the required-check names shown to contributors.
-4. The review summary, step summary, dashboard, and artifact manifest consume the same state and next action.
-5. Contradictory evidence produces `invalid` rather than a green verdict.
-6. The read-only evidence workflow and trusted publisher topology remain unchanged.
-
-**Current remediation sub-slice**
-
-- **Title:** Remove duplicate decision-state assignments.
-- **Reason:** Post-merge CodeQL alerts `#1428` through `#1432` identified five locals that were computed twice during the canonical-state refactor.
-- **Scope:** `src/sdetkit/pr_quality_action_report.py`, its focused regression tests, and this roadmap record.
-- **Completion gate:** The five alerts are absent on the remediation PR head, all canonical-state tests remain green, and the trusted publisher files remain unchanged.
-- **Status:** `remediation_in_progress`
+1. The first visible contributor panel contains exactly six decision rows.
+2. A `ready` review with no blocker does not show failure-vector language in the primary panel.
+3. Ready-state proof commands are labeled `Optional verification`, not `Proof to rerun`.
+4. Blocked, stale, and invalid reviews show one blocker and one next action before diagnostics.
+5. Failure-vector details remain available in collapsed details and the full artifact bundle.
+6. Product-artifact navigation appears once in the trusted PR comment.
+7. The summary, step summary, dashboard, model, and manifest retain one normalized decision.
+8. Reporting-only authority and security posture remain visible.
+9. The trusted evidence and publisher workflow files remain unchanged.
 
 ## Continuous maintenance hardening loop
 

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -2891,6 +2891,52 @@ def _normalized_review_decision(model: JsonObject) -> JsonObject:
     return decision
 
 
+def _contributor_review_panel_rows(
+    model: JsonObject,
+) -> list[tuple[str, object]]:
+    decision = _normalized_review_decision(model)
+    ghas_details = _as_dict(model.get("ghas_blocker_details"))
+
+    required_counts = [
+        ("failed", _int(decision.get("failed_checks"))),
+        ("queued", _int(decision.get("required_queued_checks"))),
+        ("startup", _int(decision.get("required_startup_failures"))),
+        ("missing", _int(decision.get("missing_required_contexts"))),
+    ]
+    required_parts = [f"{count} {label}" for label, count in required_counts if count > 0]
+    required_summary = "; ".join(required_parts) if required_parts else "clear"
+
+    collected = bool(ghas_details.get("collected", False))
+    current_alerts = _int(ghas_details.get("current_alerts"))
+    stale_alerts = _int(ghas_details.get("stale_alerts"))
+    if not collected:
+        security_summary = "unavailable"
+    elif current_alerts > 0:
+        security_summary = f"{current_alerts} current alert(s)"
+    elif stale_alerts > 0:
+        security_summary = f"clear for current head; {stale_alerts} stale alert(s)"
+    else:
+        security_summary = "clear"
+
+    return [
+        ("Review state", _review_model_state(model)),
+        (
+            "First blocker",
+            _review_model_scalar(decision.get("primary_blocker") or "none"),
+        ),
+        (
+            "Next action",
+            _review_model_scalar(decision.get("next_action") or "none"),
+        ),
+        ("Required checks", required_summary),
+        ("Security posture", security_summary),
+        (
+            "Merge posture",
+            _review_model_scalar(decision.get("merge_assessment") or "unknown"),
+        ),
+    ]
+
+
 def render_pr_quality_review_summary(model: JsonObject) -> str:
     decision = _normalized_review_decision(model)
     authority = _as_dict(model.get("authority_boundary"))
@@ -2953,18 +2999,13 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "</details>",
         ]
 
-    status = _review_model_scalar(
-        decision.get("source_status") or decision.get("status") or "unknown"
-    )
     failed_total = _count(decision.get("failed_checks"))
     queued_total = _count(decision.get("required_queued_checks"))
     startup_total = _count(decision.get("required_startup_failures"))
     missing_total = _count(decision.get("missing_required_contexts"))
     stale_only_security_signal = bool(decision.get(STALE_ONLY_SECURITY_SIGNAL))
     review_state = _review_model_state(model)
-    first_blocker = _review_model_scalar(decision.get("primary_blocker") or "none")
     first_action = _review_model_scalar(decision.get("next_action") or "none")
-    first_recommended_action = first_action
 
     failure_actual = _review_model_scalar(failure_vector_signal.get("actual_failure") or "none")
     failure_source = _review_model_scalar(failure_vector_signal.get("source") or "none")
@@ -2979,22 +3020,6 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         for item in _as_list(failure_vector_signal.get("affected_files"))
         if isinstance(item, str) and item.strip()
     ]
-
-    artifact_entries = [
-        _as_dict(item)
-        for item in _as_list(model.get("artifact_index"))
-        if _string(_as_dict(item).get("path"))
-    ]
-    artifact_lines = [
-        f"- `{_string(item.get('path'))}` — {_string(item.get('description') or item.get('title') or item.get('surface'))}"
-        for item in artifact_entries
-    ]
-    if not artifact_lines:
-        artifact_lines = [
-            "- `index.html` — artifact landing page",
-            "- `pr-review-model.json` — machine-readable review model",
-            "- `pr-comment-body.md` — raw rendered comment body",
-        ]
 
     active_blocker_open = review_state in {
         "blocked",
@@ -3012,34 +3037,9 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     lines = [
         "# PR Quality Review Summary",
         "",
-        "## Mini triage",
+        "## Contributor decision",
         "",
-        *_markdown_table(
-            [
-                ("Review state", review_state),
-                ("Source status", status),
-                ("First blocker", first_blocker),
-                ("Recommended action", first_recommended_action),
-                ("Failed checks", failed_total),
-                ("Failed check names", _joined(failed_check_names)),
-                ("Queued required checks", queued_total),
-                ("Queued check names", _joined(queued_check_names)),
-                ("Startup failures", startup_total),
-                ("Startup failure names", _joined(startup_failure_names)),
-                ("Missing required contexts", missing_total),
-                ("Missing context names", _joined(missing_context_names)),
-                ("Failure vector source", failure_source),
-                ("Actual failure", failure_actual),
-                ("Failure type", failure_type),
-                ("Failing command", failing_command),
-                ("Failing test/check", failing_test),
-                ("Owner hint", failure_owner),
-                (
-                    "Failure-vector safe-fix allowed",
-                    _review_model_scalar(failure_vector_signal.get("safe_fix_allowed")),
-                ),
-            ]
-        ),
+        *_markdown_table(_contributor_review_panel_rows(model)),
         "",
     ]
 
@@ -3191,6 +3191,9 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     )
     lines.append("")
 
+    proof_section_title = (
+        "🧪 Optional verification" if review_state == "ready" else "🧪 Proof to rerun"
+    )
     proof_body: list[str] = []
     if proof_commands:
         proof_body.extend(["```bash", *proof_commands, "```"])
@@ -3198,7 +3201,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         proof_body.append("`none`")
     lines.extend(
         _details(
-            "🧪 Proof to rerun",
+            proof_section_title,
             proof_body,
             open_by_default=proof_open,
         )
@@ -3217,15 +3220,6 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         _details(
             "✅ Passing / queued / missing check evidence",
             check_body,
-            open_by_default=False,
-        )
-    )
-    lines.append("")
-
-    lines.extend(
-        _details(
-            "📦 PR Quality product artifacts",
-            artifact_lines,
             open_by_default=False,
         )
     )

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -3502,7 +3502,7 @@ def test_review_html_dashboard_visualizes_error_state() -> None:
     assert "false" in html
 
 
-def test_review_summary_includes_error_state_mini_triage() -> None:
+def test_review_summary_prioritizes_blocker_and_next_action() -> None:
     model = report.build_pr_quality_review_model(
         status="failed",
         evidence_signal_heading="Evidence review signal",
@@ -3518,7 +3518,10 @@ def test_review_summary_includes_error_state_mini_triage() -> None:
                 "path": "src/example.py",
                 "details": "unused import",
             },
-            "recommended_actions": ["Fix the lint finding.", "Run pre-commit."],
+            "recommended_actions": [
+                "Fix the lint finding.",
+                "Run pre-commit.",
+            ],
             "proof_commands": ["python -m pre_commit run -a"],
         },
         check_intelligence={
@@ -3546,22 +3549,33 @@ def test_review_summary_includes_error_state_mini_triage() -> None:
     )
 
     summary = report.render_pr_quality_review_summary(model)
+    decision_panel = summary[
+        summary.index("## Contributor decision") : summary.index("## Recommended actions")
+    ]
+    rows = [
+        line
+        for line in decision_panel.splitlines()
+        if line.startswith("| ") and line != "| Item | Value |" and line != "|---|---|"
+    ]
 
-    assert "## Mini triage" in summary
-    assert "| Review state | `blocked` |" in summary
-    assert "| First blocker | `Ruff check failed` |" in summary
-    assert "| Recommended action | `fix_lint` |" in summary
-    assert "| Failed checks | `1` |" in summary
-    assert "| Failed check names | `quality` |" in summary
-    assert "| Queued required checks | `1` |" in summary
-    assert "| Queued check names | `gate` |" in summary
-    assert "| Startup failures | `1` |" in summary
-    assert "| Startup failure names | `first-proof` |" in summary
-    assert "| Missing required contexts | `1` |" in summary
-    assert "| Missing context names | `ci` |" in summary
+    assert len(rows) == 6
+    assert "| Review state | `blocked` |" in decision_panel
+    assert "| First blocker | `Ruff check failed` |" in decision_panel
+    assert "| Next action | `fix_lint` |" in decision_panel
+    assert "| Required checks | `1 failed; 1 queued; 1 startup; 1 missing` |" in decision_panel
+    assert "| Security posture | `unavailable` |" in decision_panel
+    assert "| Merge posture | `do_not_merge_until_blocker_resolved` |" in decision_panel
+    assert "Failure vector source" not in decision_panel
+    assert "Actual failure" not in decision_panel
+    assert "Failure type" not in decision_panel
+    assert "Failing command" not in decision_panel
+    assert "Failing test/check" not in decision_panel
+    assert "Failure-vector safe-fix allowed" not in decision_panel
+
     assert "## Recommended actions" in summary
     assert "- Fix the lint finding." in summary
     assert "- Run pre-commit." in summary
+    assert "🧪 Proof to rerun" in summary
     assert "python -m pytest -q tests/test_example.py -o addopts=" in summary
     assert "| Merge authorization | `false` |" in summary
 
@@ -4088,13 +4102,26 @@ def test_review_summary_renders_failure_vector_signal() -> None:
 
     summary = report.render_pr_quality_review_summary(model)
 
-    assert "| Failure vector source | `failed_check` |" in summary
+    decision_panel = summary[
+        summary.index("## Contributor decision") : summary.index("## Recommended actions")
+    ]
+
+    assert "Failure vector source" not in decision_panel
+    assert "Actual failure" not in decision_panel
+    assert "Failure type" not in decision_panel
+    assert "Failing command" not in decision_panel
+    assert "Failing test/check" not in decision_panel
+    assert "Owner hint" not in decision_panel
+    assert "Safe-fix" not in decision_panel
+
+    assert "<summary>🧭 Failure vector deep dive</summary>" in summary
+    assert "| Source | `failed_check` |" in summary
     assert "| Actual failure | `F821 Undefined name `JsonObject`` |" in summary
     assert "| Failure type | `lint` |" in summary
     assert "| Failing command | `python -m pre_commit run -a` |" in summary
     assert "| Failing test/check | `F821` |" in summary
     assert "| Owner hint | `tests/test_pr_quality_action_report.py` |" in summary
-    assert "| Failure-vector safe-fix allowed | `false` |" in summary
+    assert "| Safe-fix allowed | `false` |" in summary
     assert "does not authorize merge" in summary
 
 
@@ -4222,7 +4249,7 @@ def test_pr_quality_review_summary_opens_blocker_sections_and_collapses_noise() 
     assert "<details open>\n<summary>🧭 Failure vector deep dive</summary>" in body
     assert "<details open>\n<summary>🧪 Proof to rerun</summary>" in body
     assert "<details>\n<summary>✅ Passing / queued / missing check evidence</summary>" in body
-    assert "<details>\n<summary>📦 PR Quality product artifacts</summary>" in body
+    assert "📦 PR Quality product artifacts" not in body
     assert "Compare the alert commit SHA with the current PR head." in body
     assert "`src/sdetkit/release_anti_hijack_threat_model.py`" in body
     assert "does not authorize merge" in body
@@ -4277,12 +4304,13 @@ def test_pr_quality_review_summary_normalizes_legacy_green_decision() -> None:
 
     assert "| Review state | `ready` |" in body
     assert "| First blocker | `none` |" in body
-    assert "| Recommended action | `review_and_decide` |" in body
-    assert "| Merge assessment | `automated_proof_complete_human_decision_required` |" in body
+    assert "| Next action | `review_and_decide` |" in body
+    assert "| Merge posture | `automated_proof_complete_human_decision_required` |" in body
     assert "<details>\n<summary>✅ Ready for human decision</summary>" in body
     assert "<details>\n<summary>🧭 Failure vector deep dive</summary>" in body
-    assert "<details>\n<summary>🧪 Proof to rerun</summary>" in body
+    assert "<details>\n<summary>🧪 Optional verification</summary>" in body
     assert "<details open>" not in body
+    assert "🧪 Proof to rerun" not in body
     assert "rerun_proof" not in body
 
 
@@ -5534,7 +5562,7 @@ def test_review_summary_and_dashboard_share_canonical_decision() -> None:
 
     assert "| Review state | `ready` |" in summary
     assert "| First blocker | `none` |" in summary
-    assert "| Recommended action | `review_and_decide` |" in summary
+    assert "| Next action | `review_and_decide` |" in summary
     assert "### Canonical next action" in summary
     assert "- `review_and_decide`" in summary
     assert "| Review state | `ready` |" in dashboard
@@ -5634,3 +5662,116 @@ def test_review_model_fallback_action_preserves_blocker_selection() -> None:
         )
         == report.WAIT_FOR_CODE_SCANNING_REFRESH
     )
+
+
+def test_ready_review_summary_is_contributor_first() -> None:
+    model = report.build_pr_quality_review_model(
+        status="green",
+        evidence_signal_heading="Evidence proof signal",
+        evidence_signal_lines=["- proof signal"],
+        evidence_review_required=False,
+        action_report={
+            "status": "green",
+            "primary_blocker": {},
+            "recommended_actions": [],
+            "proof_commands": [],
+        },
+        check_intelligence={
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+            "code_scanning_review": {
+                "collected": True,
+                "collection_status": "collected",
+                "open_alerts": 0,
+                "current_alerts": 0,
+                "stale_alerts": 0,
+                "current_head_sha": "abc123",
+                "dismissal_allowed": False,
+                "findings": [],
+            },
+        },
+        evidence_narrative={
+            "primary_signal": {
+                "kind": "review_signal",
+                "surface": "diagnostic_engine",
+                "title": "Diagnostic intelligence evidence changed",
+            },
+            "graph": {
+                "top_blocker": {
+                    "title": "Diagnostic intelligence evidence changed",
+                    "surface": "diagnostic_engine",
+                    "action": "rerun_proof",
+                    "review_first": False,
+                }
+            },
+            "next_proof": ["python -m pre_commit run -a"],
+        },
+    )
+
+    summary = report.render_pr_quality_review_summary(model)
+    decision_panel = summary[
+        summary.index("## Contributor decision") : summary.index("## Adaptive review details")
+    ]
+    rows = [
+        line
+        for line in decision_panel.splitlines()
+        if line.startswith("| ") and line != "| Item | Value |" and line != "|---|---|"
+    ]
+
+    assert len(rows) == 6
+    assert "| Review state | `ready` |" in decision_panel
+    assert "| First blocker | `none` |" in decision_panel
+    assert "| Next action | `review_and_decide` |" in decision_panel
+    assert "| Required checks | `clear` |" in decision_panel
+    assert "| Security posture | `clear` |" in decision_panel
+    assert (
+        "| Merge posture | `automated_proof_complete_human_decision_required` |" in decision_panel
+    )
+    assert "Source status" not in decision_panel
+    assert "Actual failure" not in decision_panel
+    assert "Failure type" not in decision_panel
+    assert "Failing command" not in decision_panel
+    assert "Failing test/check" not in decision_panel
+    assert "Safe-fix" not in decision_panel
+
+    assert "🧪 Optional verification" in summary
+    assert "🧪 Proof to rerun" not in summary
+    assert "python -m pre_commit run -a" in summary
+    assert "🧭 Failure vector deep dive" in summary
+    assert "📦 PR Quality product artifacts" not in summary
+    assert "| Merge authorization | `false` |" in summary
+
+
+def test_contributor_review_panel_summarizes_stale_security() -> None:
+    model = {
+        "decision": {
+            "review_state": "stale",
+            "status": "green",
+            "source_status": "green",
+            "primary_blocker": "Wait for Code Scanning refresh",
+            "next_action": report.WAIT_FOR_CODE_SCANNING_REFRESH,
+            "merge_assessment": report.WAIT_FOR_CODE_SCANNING_REFRESH,
+            "failed_checks": 0,
+            "required_queued_checks": 0,
+            "required_startup_failures": 0,
+            "missing_required_contexts": 0,
+        },
+        "primary_blocker": {
+            "title": "Wait for Code Scanning refresh",
+            "action": report.WAIT_FOR_CODE_SCANNING_REFRESH,
+        },
+        "ghas_blocker_details": {
+            "collected": True,
+            "current_alerts": 0,
+            "stale_alerts": 2,
+        },
+    }
+
+    rows = dict(report._contributor_review_panel_rows(model))
+
+    assert rows["Review state"] == "stale"
+    assert rows["Required checks"] == "clear"
+    assert rows["Security posture"] == ("clear for current head; 2 stale alert(s)")
+    assert rows["Merge posture"] == (report.WAIT_FOR_CODE_SCANNING_REFRESH)

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1306,3 +1306,28 @@ def test_pr_quality_decision_state_contract_is_canonical() -> None:
     assert "actions/checkout" not in publisher
     assert "issues: write" in publisher
     assert "pull-requests: write" in publisher
+
+
+def test_pr_quality_comment_has_single_artifact_navigation_owner() -> None:
+    source = Path("src/sdetkit/pr_quality_action_report.py").read_text(encoding="utf-8")
+    publisher = _publisher_text()
+
+    summary_start = source.index("def render_pr_quality_review_summary")
+    summary_end = source.index(
+        "\ndef ",
+        summary_start + len("def render_pr_quality_review_summary"),
+    )
+    summary_renderer = source[summary_start:summary_end]
+
+    assert "PR Quality product artifacts" not in summary_renderer
+    assert publisher.count("<summary><strong>PR Quality product artifacts</strong></summary>") == 1
+
+
+def test_pr_quality_contributor_summary_keeps_trusted_topology() -> None:
+    evidence = _workflow_text()
+    publisher = _publisher_text()
+
+    assert 'cat build/pr-quality/pr-review-summary.md >> "$GITHUB_STEP_SUMMARY"' in evidence
+    assert 'cat build/pr-quality/pr-review-summary.md >> "$body_path"' in publisher
+    assert "publisher handoff summary does not match the review contract" in publisher
+    assert "Evidence is advisory and does not authorize merge." in publisher


### PR DESCRIPTION
## Contributor problem

The canonical review model is truthful, but the trusted PR comment still makes
contributors scan a 19-row diagnostic table before reaching the decision.
A ready review can also display `Actual failure`, use `Proof to rerun`
wording, and repeat artifact navigation.

## Roadmap transition

```text
completed:
  id=pr-review-state
  status=done

action:
  id=pr-review-summary
  lane=Developer workflow
  title=Publish a contributor-first PR Quality summary
  priority=P1
  risk=medium
  status=in_progress
```

## Change

- replace the 19-row Mini triage table with one six-row Contributor decision
  panel;
- show review state, first blocker, next action, required checks, security
  posture, and merge posture first;
- keep failure-vector diagnostics in collapsed details and the full artifact
  bundle;
- label ready-state commands as Optional verification;
- keep Proof to rerun for non-ready states;
- remove the duplicate artifact-navigation block from the generated summary,
  leaving the trusted publisher as the single PR-comment navigation owner;
- migrate legacy presentation guardrails to the contributor-first contract;
- record `pr-review-state` as done and activate `pr-review-summary`.

## Scope

Exactly four files:

- `docs/roadmap.md`
- `src/sdetkit/pr_quality_action_report.py`
- `tests/test_pr_quality_action_report.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

## Preserved trust boundary

The following workflow files remain byte-for-byte unchanged:

- `.github/workflows/pr-quality-comment.yml`
- `.github/workflows/pr-quality-publisher.yml`

This PR does not change workflow permissions, publisher handoff validation,
artifact allowlists, issue state, security dismissal, or merge authority.

## Proof

- ready, blocked, and stale contributor-panel regression tests;
- failure-vector detail-retention regression;
- single artifact-navigation ownership contract;
- trusted workflow topology contract;
- Python compilation;
- focused PR Quality and workflow-contract tests;
- repository-standard mypy;
- exact four-file pre-commit;
- `make proof-after-format`;
- post-proof focused tests and mypy;
- protected-workflow and staged-scope verification.

## Review focus

1. Confirm the first visible panel has exactly six rows.
2. Confirm a ready/no-blocker summary contains no primary failure language.
3. Confirm ready proof is labeled Optional verification.
4. Confirm blocked reviews still show blocker and action first.
5. Confirm diagnostics remain available in collapsed details.
6. Confirm artifact navigation appears once in the trusted PR comment.
7. Confirm both protected workflow files are unchanged.
8. Confirm reporting-only authority remains explicit.

## Authority boundary

Review-first and reporting-only. This PR does not authorize workflow reruns,
issue mutation, patch automation, security dismissal, merge, or
semantic-equivalence claims.
