### PR TITLE
feat(release): bind trusted PR decision into release evidence

### DIFF
--- a/docs/release-readiness-evidence-handoff.md
+++ b/docs/release-readiness-evidence-handoff.md
@@ -92,6 +92,34 @@ upload, and post-publish or rollback verification evidence. It is reporting-only
 and does not authorize release, publish, merge, patch automation, security
 dismissal, or semantic-equivalence claims.
 
+## Trusted PR Quality decision pair
+
+The release package may ingest the contributor-facing PR decision only when it
+is paired with the trusted publisher handoff manifest:
+
+```bash
+python -m sdetkit release-readiness-evidence-package   --root .   --pr-quality-summary /path/to/pr-review-summary.md   --pr-quality-handoff-manifest /path/to/manifest.json   --out-json build/sdetkit/release-readiness-evidence/package.json   --out-md build/sdetkit/release-readiness-evidence/package.md   --format json
+```
+
+The two arguments are optional, but they must be supplied together. The package
+validates:
+
+- `sdetkit.pr_quality_publisher_handoff.v1`;
+- the exact PR head SHA against the release package head;
+- the strict reporting-only authority boundary;
+- the three-file publisher payload inventory;
+- the recorded size and SHA-256 of `payload/pr-review-summary.md`;
+- exactly six contributor decision rows.
+
+Collection states are `not_requested`, `collected`, `missing`, `malformed`,
+`stale`, and `digest_mismatch`. Any requested evidence that is missing,
+malformed, stale, or mismatched keeps the package in `review_required`.
+
+A collected `ready` decision with no blocker and clear required-check and
+security posture is non-blocking evidence only. It does not set
+`safe_to_publish`, `release_authorized`, `publish_authorized`, or
+`merge_authorized`.
+
 ## Provenance and freshness contract
 
 The release-readiness evidence package is bound to the current Git HEAD and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,7 +83,7 @@ action:
 - CodeQL alerts `#1428` through `#1432` are fixed without dismissal.
 - The six-state canonical review contract and reporting-only authority boundary remain intact.
 
-### Active roadmap action
+### Completed roadmap action
 
 ```text
 action:
@@ -93,20 +93,46 @@ action:
   priority=P1
   risk=medium
   value=Put the contributor decision, blocker, next action, required checks, security posture, and merge posture before internal diagnostics.
+  status=done
+```
+
+**Closure evidence**
+
+- PR `#1863` is merged at `80db8844915069c7771dab3714cabdabfab2fe9e`.
+- The post-merge closure audit passed with `154` focused tests.
+- The contributor panel contains six canonical rows.
+- Ready-state failure language is absent from the primary panel.
+- Product-artifact navigation has one trusted publisher owner.
+- PR Quality publisher and evidence workflow files remain unchanged.
+
+### Active roadmap action
+
+```text
+action:
+  id=pr-release-handoff
+  lane=Release readiness
+  title=Bind trusted PR Quality decisions into release-readiness evidence
+  priority=P1
+  risk=medium
+  value=Carry the exact head-bound contributor review decision into one reporting-only release-readiness packet.
   status=in_progress
 ```
 
 **Acceptance criteria**
 
-1. The first visible contributor panel contains exactly six decision rows.
-2. A `ready` review with no blocker does not show failure-vector language in the primary panel.
-3. Ready-state proof commands are labeled `Optional verification`, not `Proof to rerun`.
-4. Blocked, stale, and invalid reviews show one blocker and one next action before diagnostics.
-5. Failure-vector details remain available in collapsed details and the full artifact bundle.
-6. Product-artifact navigation appears once in the trusted PR comment.
-7. The summary, step summary, dashboard, model, and manifest retain one normalized decision.
-8. Reporting-only authority and security posture remain visible.
-9. The trusted evidence and publisher workflow files remain unchanged.
+1. The release package accepts an optional trusted PR summary and publisher manifest pair.
+2. Both inputs are required together when either input is requested.
+3. Manifest schema, exact head, authority boundary, inventory, size, and SHA-256 are validated.
+4. The summary contains exactly the six canonical contributor decision rows.
+5. Missing, malformed, stale, or digest-mismatched evidence is explicit and requires human review.
+6. A ready and clear PR decision is non-blocking but never authorizes release or publication.
+7. Waiting, blocked, review, stale, and invalid PR states remain release-review blockers.
+8. Summary and manifest bytes participate in provenance and freshness.
+9. Markdown renders collection state, decision fields, source paths, and authority.
+10. Module and root CLI forwarding support the optional pair.
+11. The existing release package schema remains additive `v2`.
+12. Existing behavior and provenance inputs remain stable when the pair is omitted.
+13. PR Quality workflows, trusted publisher, and `release.yml` remain unchanged.
 
 ## Continuous maintenance hardening loop
 

--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -1128,6 +1128,14 @@ Then use stability-aware command discovery:
         "--check-freshness",
         action="store_true",
     )
+    release_readiness_evidence_package.add_argument(
+        "--pr-quality-summary",
+        default=None,
+    )
+    release_readiness_evidence_package.add_argument(
+        "--pr-quality-handoff-manifest",
+        default=None,
+    )
 
     fit = sub.add_parser("fit", help="Risk-based fit recommendation planner")
     fit.add_argument("--repo-size", choices=["small", "medium", "large"], default="small")
@@ -2449,6 +2457,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             "--format",
             str(ns.format),
         ]
+        for flag, value in (
+            ("--pr-quality-summary", ns.pr_quality_summary),
+            (
+                "--pr-quality-handoff-manifest",
+                ns.pr_quality_handoff_manifest,
+            ),
+        ):
+            if value:
+                forwarded.extend([flag, str(value)])
         if bool(ns.check_freshness):
             forwarded.append("--check-freshness")
         return _run_module_main(

--- a/src/sdetkit/release_readiness_evidence_package.py
+++ b/src/sdetkit/release_readiness_evidence_package.py
@@ -9,6 +9,7 @@ automation, security dismissal, or semantic-equivalence claims.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from collections.abc import Mapping, Sequence
@@ -77,6 +78,350 @@ _PROOF_COMMANDS = [
 ]
 
 
+_PR_QUALITY_HANDOFF_SCHEMA = "sdetkit.pr_quality_publisher_handoff.v1"
+_PR_QUALITY_SUMMARY_MANIFEST_PATH = "payload/pr-review-summary.md"
+_PR_QUALITY_MANIFEST_PAYLOAD_PATHS = {
+    "payload/pr-comment-body.md",
+    "payload/pr-comment-metadata.json",
+    _PR_QUALITY_SUMMARY_MANIFEST_PATH,
+}
+_PR_QUALITY_AUTHORITY_BOUNDARY: JsonObject = {
+    "reporting_only": True,
+    "patch_application_allowed": False,
+    "security_dismissal_allowed": False,
+    "merge_authorized": False,
+    "semantic_equivalence_proven": False,
+}
+_PR_QUALITY_DECISION_LABELS = {
+    "Review state": "review_state",
+    "First blocker": "first_blocker",
+    "Next action": "next_action",
+    "Required checks": "required_checks",
+    "Security posture": "security_posture",
+    "Merge posture": "merge_posture",
+}
+_PR_QUALITY_STATES = {
+    "waiting",
+    "blocked",
+    "review",
+    "ready",
+    "stale",
+    "invalid",
+}
+_PR_QUALITY_BLOCKING_STATES = {
+    "waiting",
+    "blocked",
+    "review",
+    "stale",
+    "invalid",
+}
+
+
+def _resolve_input_path(
+    root: Path,
+    value: str | Path,
+) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else root / path
+
+
+def _optional_input_bytes(
+    root: Path,
+    value: str | Path | None,
+) -> bytes:
+    if value is None:
+        return b"not_provided\0"
+    return _read_input_bytes(_resolve_input_path(root, value))
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _parse_pr_quality_summary(summary: str) -> JsonObject:
+    if not summary.lstrip().startswith("# PR Quality Review Summary"):
+        raise ValueError("summary heading does not match the PR Quality contract")
+
+    start_heading = "## Contributor decision"
+    end_heading = "## Adaptive review details"
+    start = summary.find(start_heading)
+    end = summary.find(end_heading, start + len(start_heading))
+    if start < 0 or end < 0 or end <= start:
+        raise ValueError("summary contributor-decision section is missing")
+
+    rows: dict[str, str] = {}
+    section = summary[start:end]
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        if stripped in {"| Item | Value |", "|---|---|"}:
+            continue
+
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) != 2:
+            raise ValueError("summary decision row must have two cells")
+
+        label, value = cells
+        if label not in _PR_QUALITY_DECISION_LABELS:
+            raise ValueError(f"summary decision row is unknown: {label}")
+        if label in rows:
+            raise ValueError(f"summary decision row is duplicated: {label}")
+
+        if value.startswith("`") and value.endswith("`"):
+            value = value[1:-1]
+        rows[label] = value
+
+    if set(rows) != set(_PR_QUALITY_DECISION_LABELS):
+        missing = sorted(set(_PR_QUALITY_DECISION_LABELS) - set(rows))
+        raise ValueError(f"summary decision rows are incomplete: missing={missing}")
+
+    projected = {key: rows[label] for label, key in _PR_QUALITY_DECISION_LABELS.items()}
+    review_state = projected["review_state"]
+    if review_state not in _PR_QUALITY_STATES:
+        raise ValueError(f"summary review state is unsupported: {review_state}")
+    return projected
+
+
+def _pr_quality_handoff_result(
+    *,
+    collection_status: str,
+    reason: str,
+    summary_path: str = "",
+    manifest_path: str = "",
+    head_sha: str = "",
+    head_matches: bool = False,
+    decision: Mapping[str, Any] | None = None,
+    release_review_blocking: bool = False,
+    source_digests: Mapping[str, str] | None = None,
+) -> JsonObject:
+    decision_payload = dict(decision or {})
+    return {
+        "collection_status": collection_status,
+        "available": collection_status == "collected",
+        "reason": reason,
+        "summary_path": summary_path,
+        "manifest_path": manifest_path,
+        "head_sha": head_sha,
+        "head_matches": head_matches,
+        "review_state": str(decision_payload.get("review_state", "unknown")),
+        "first_blocker": str(decision_payload.get("first_blocker", "unknown")),
+        "next_action": str(decision_payload.get("next_action", "unknown")),
+        "required_checks": str(decision_payload.get("required_checks", "unknown")),
+        "security_posture": str(decision_payload.get("security_posture", "unknown")),
+        "merge_posture": str(decision_payload.get("merge_posture", "unknown")),
+        "release_review_blocking": release_review_blocking,
+        "reporting_only": True,
+        "safe_to_publish": False,
+        "release_authorized": False,
+        "publish_authorized": False,
+        "merge_authorized": False,
+        "source_digests": dict(source_digests or {}),
+        "authority_boundary": dict(_PR_QUALITY_AUTHORITY_BOUNDARY),
+    }
+
+
+def collect_pr_quality_handoff(
+    *,
+    repo_root: str | Path,
+    expected_head_sha: str,
+    summary_path: str | Path | None = None,
+    manifest_path: str | Path | None = None,
+) -> JsonObject:
+    root = Path(repo_root).resolve()
+    requested = summary_path is not None or manifest_path is not None
+    if not requested:
+        return _pr_quality_handoff_result(
+            collection_status="not_requested",
+            reason="PR Quality handoff evidence was not requested.",
+        )
+
+    summary_display = str(summary_path or "")
+    manifest_display = str(manifest_path or "")
+    if summary_path is None or manifest_path is None:
+        return _pr_quality_handoff_result(
+            collection_status="missing",
+            reason=(
+                "Both PR Quality summary and handoff manifest are required "
+                "when either input is requested."
+            ),
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+        )
+
+    summary_file = _resolve_input_path(root, summary_path)
+    manifest_file = _resolve_input_path(root, manifest_path)
+    summary_display = summary_file.as_posix()
+    manifest_display = manifest_file.as_posix()
+
+    if not summary_file.is_file() or not manifest_file.is_file():
+        missing = [path.as_posix() for path in (summary_file, manifest_file) if not path.is_file()]
+        return _pr_quality_handoff_result(
+            collection_status="missing",
+            reason=f"Requested PR Quality evidence is missing: {missing}",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+        )
+
+    summary_bytes = summary_file.read_bytes()
+    manifest_bytes = manifest_file.read_bytes()
+    source_digests = {
+        "pr_quality_summary": _sha256_bytes(summary_bytes),
+        "pr_quality_handoff_manifest": _sha256_bytes(manifest_bytes),
+    }
+
+    try:
+        manifest = json.loads(manifest_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return _pr_quality_handoff_result(
+            collection_status="malformed",
+            reason=f"PR Quality handoff manifest is invalid JSON: {exc}",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+
+    if not isinstance(manifest, dict):
+        return _pr_quality_handoff_result(
+            collection_status="malformed",
+            reason="PR Quality handoff manifest must be a JSON object.",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+    if manifest.get("schema_version") != _PR_QUALITY_HANDOFF_SCHEMA:
+        return _pr_quality_handoff_result(
+            collection_status="malformed",
+            reason="PR Quality handoff manifest schema is unsupported.",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+    if manifest.get("authority_boundary") != _PR_QUALITY_AUTHORITY_BOUNDARY:
+        return _pr_quality_handoff_result(
+            collection_status="malformed",
+            reason="PR Quality handoff authority boundary is invalid.",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+
+    rows = manifest.get("files")
+    if not isinstance(rows, list) or len(rows) != 3:
+        return _pr_quality_handoff_result(
+            collection_status="malformed",
+            reason="PR Quality handoff file inventory is invalid.",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+
+    normalized_rows: dict[str, Mapping[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            return _pr_quality_handoff_result(
+                collection_status="malformed",
+                reason="PR Quality handoff file row must be an object.",
+                summary_path=summary_display,
+                manifest_path=manifest_display,
+                release_review_blocking=True,
+                source_digests=source_digests,
+            )
+        relative = str(row.get("path", ""))
+        if relative in normalized_rows:
+            return _pr_quality_handoff_result(
+                collection_status="malformed",
+                reason=f"PR Quality handoff path is duplicated: {relative}",
+                summary_path=summary_display,
+                manifest_path=manifest_display,
+                release_review_blocking=True,
+                source_digests=source_digests,
+            )
+        normalized_rows[relative] = row
+
+    if set(normalized_rows) != _PR_QUALITY_MANIFEST_PAYLOAD_PATHS:
+        return _pr_quality_handoff_result(
+            collection_status="malformed",
+            reason="PR Quality handoff file allowlist is invalid.",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+
+    summary_row = normalized_rows[_PR_QUALITY_SUMMARY_MANIFEST_PATH]
+    try:
+        expected_size = int(summary_row.get("size_bytes", -1))
+    except (TypeError, ValueError):
+        expected_size = -1
+    expected_digest = str(summary_row.get("sha256", ""))
+
+    if (
+        expected_size != len(summary_bytes)
+        or expected_digest != source_digests["pr_quality_summary"]
+    ):
+        return _pr_quality_handoff_result(
+            collection_status="digest_mismatch",
+            reason=("PR Quality summary bytes do not match the trusted publisher manifest."),
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+
+    try:
+        summary_text = summary_bytes.decode("utf-8")
+        decision = _parse_pr_quality_summary(summary_text)
+    except (UnicodeDecodeError, ValueError) as exc:
+        return _pr_quality_handoff_result(
+            collection_status="malformed",
+            reason=f"PR Quality summary contract is invalid: {exc}",
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+
+    head_sha = str(manifest.get("head_sha", ""))
+    if head_sha != expected_head_sha:
+        return _pr_quality_handoff_result(
+            collection_status="stale",
+            reason=("PR Quality handoff head does not match the release package head."),
+            summary_path=summary_display,
+            manifest_path=manifest_display,
+            head_sha=head_sha,
+            head_matches=False,
+            decision=decision,
+            release_review_blocking=True,
+            source_digests=source_digests,
+        )
+
+    release_review_blocking = (
+        decision["review_state"] in _PR_QUALITY_BLOCKING_STATES
+        or decision["first_blocker"] != "none"
+        or decision["required_checks"] != "clear"
+        or decision["security_posture"] != "clear"
+    )
+    return _pr_quality_handoff_result(
+        collection_status="collected",
+        reason="Trusted PR Quality decision was collected and verified.",
+        summary_path=summary_display,
+        manifest_path=manifest_display,
+        head_sha=head_sha,
+        head_matches=True,
+        decision=decision,
+        release_review_blocking=release_review_blocking,
+        source_digests=source_digests,
+    )
+
+
 def _read_text(path: Path) -> str:
     if not path.is_file():
         return ""
@@ -122,11 +467,25 @@ def release_readiness_evidence_input_provenance(
     repo_root: str | Path = ".",
     current_head_sha: str | None = None,
     generated_at: str | None = None,
+    pr_quality_summary: str | Path | None = None,
+    pr_quality_handoff_manifest: str | Path | None = None,
 ) -> JsonObject:
     root = Path(repo_root).resolve()
     data_inputs = {
         relative_path: _read_input_bytes(root / relative_path) for relative_path in _INPUT_PATHS
     }
+    input_artifact_schemas: dict[str, str] = {}
+    if pr_quality_summary is not None or pr_quality_handoff_manifest is not None:
+        data_inputs["pr_quality_summary"] = _optional_input_bytes(
+            root,
+            pr_quality_summary,
+        )
+        data_inputs["pr_quality_handoff_manifest"] = _optional_input_bytes(
+            root,
+            pr_quality_handoff_manifest,
+        )
+        input_artifact_schemas["pr_quality_handoff_manifest"] = _PR_QUALITY_HANDOFF_SCHEMA
+
     return build_input_provenance(
         schema_version=SCHEMA_VERSION,
         generator_source=GENERATOR_SOURCE,
@@ -135,7 +494,7 @@ def release_readiness_evidence_input_provenance(
         root=root,
         source_issue_numbers=(),
         source_run_ids=(),
-        input_artifact_schemas={},
+        input_artifact_schemas=input_artifact_schemas,
         current_head_sha=current_head_sha,
         generated_at=generated_at,
     )
@@ -146,6 +505,8 @@ def build_release_readiness_evidence_package(
     *,
     current_head_sha: str | None = None,
     generated_at: str | None = None,
+    pr_quality_summary: str | Path | None = None,
+    pr_quality_handoff_manifest: str | Path | None = None,
 ) -> JsonObject:
     root = Path(repo_root).resolve()
     makefile = _read_text(root / "Makefile")
@@ -233,11 +594,29 @@ def build_release_readiness_evidence_package(
 
     present_count = sum(1 for item in evidence_items if item["detected"] is True)
     missing = [item for item in evidence_items if item["detected"] is not True]
-    status = "ready_for_human_release_review" if not missing else "review_required"
     provenance = release_readiness_evidence_input_provenance(
         repo_root=root,
         current_head_sha=current_head_sha,
         generated_at=generated_at,
+        pr_quality_summary=pr_quality_summary,
+        pr_quality_handoff_manifest=pr_quality_handoff_manifest,
+    )
+    pr_quality_handoff = collect_pr_quality_handoff(
+        repo_root=root,
+        expected_head_sha=str(provenance.get("generated_from_head_sha", "")),
+        summary_path=pr_quality_summary,
+        manifest_path=pr_quality_handoff_manifest,
+    )
+    status = (
+        "ready_for_human_release_review"
+        if not missing
+        and not bool(
+            pr_quality_handoff.get(
+                "release_review_blocking",
+                False,
+            )
+        )
+        else "review_required"
     )
 
     payload: JsonObject = {
@@ -264,7 +643,12 @@ def build_release_readiness_evidence_package(
             "missing_evidence_count": len(missing),
             "status": status,
             "next_allowed_action": "human_release_review",
+            "pr_quality_collection_status": (pr_quality_handoff["collection_status"]),
+            "pr_quality_release_review_blocking": bool(
+                pr_quality_handoff["release_review_blocking"]
+            ),
         },
+        "pr_quality_handoff": pr_quality_handoff,
         "required_human_evidence": list(_REQUIRED_EVIDENCE),
         "blocked_actions": [
             "automatic_release",
@@ -285,10 +669,14 @@ def check_release_readiness_evidence_freshness(
     repo_root: str | Path = ".",
     report_path: str | Path = DEFAULT_OUT,
     current_head_sha: str | None = None,
+    pr_quality_summary: str | Path | None = None,
+    pr_quality_handoff_manifest: str | Path | None = None,
 ) -> JsonObject:
     current = release_readiness_evidence_input_provenance(
         repo_root=repo_root,
         current_head_sha=current_head_sha,
+        pr_quality_summary=pr_quality_summary,
+        pr_quality_handoff_manifest=pr_quality_handoff_manifest,
     )
     return check_report_path(
         report_path,
@@ -323,9 +711,42 @@ def render_release_readiness_evidence_markdown(
         (f"- present_evidence_count: `{summary.get('present_evidence_count', 0)}`"),
         (f"- missing_evidence_count: `{summary.get('missing_evidence_count', 0)}`"),
         "",
-        "## Evidence items",
-        "",
     ]
+
+    handoff = payload.get("pr_quality_handoff", {})
+    if not isinstance(handoff, dict):
+        handoff = {}
+    lines.extend(
+        [
+            "## PR Quality handoff",
+            "",
+            (f"- collection_status: `{handoff.get('collection_status', 'not_requested')}`"),
+            (f"- available: `{str(bool(handoff.get('available', False))).lower()}`"),
+            f"- reason: `{handoff.get('reason', '')}`",
+            f"- head_sha: `{handoff.get('head_sha', '')}`",
+            (f"- head_matches: `{str(bool(handoff.get('head_matches', False))).lower()}`"),
+            f"- review_state: `{handoff.get('review_state', 'unknown')}`",
+            f"- first_blocker: `{handoff.get('first_blocker', 'unknown')}`",
+            f"- next_action: `{handoff.get('next_action', 'unknown')}`",
+            (f"- required_checks: `{handoff.get('required_checks', 'unknown')}`"),
+            (f"- security_posture: `{handoff.get('security_posture', 'unknown')}`"),
+            (f"- merge_posture: `{handoff.get('merge_posture', 'unknown')}`"),
+            (
+                "- release_review_blocking: "
+                f"`{str(bool(handoff.get('release_review_blocking', False))).lower()}`"
+            ),
+            f"- summary_path: `{handoff.get('summary_path', '')}`",
+            f"- manifest_path: `{handoff.get('manifest_path', '')}`",
+            "- reporting_only: `true`",
+            "- safe_to_publish: `false`",
+            "- release_authorized: `false`",
+            "- publish_authorized: `false`",
+            "- merge_authorized: `false`",
+            "",
+            "## Evidence items",
+            "",
+        ]
+    )
 
     for item in payload.get("evidence_items", []):
         if not isinstance(item, dict):
@@ -381,11 +802,15 @@ def write_release_readiness_evidence_package(
     *,
     current_head_sha: str | None = None,
     generated_at: str | None = None,
+    pr_quality_summary: str | Path | None = None,
+    pr_quality_handoff_manifest: str | Path | None = None,
 ) -> JsonObject:
     payload = build_release_readiness_evidence_package(
         repo_root,
         current_head_sha=current_head_sha,
         generated_at=generated_at,
+        pr_quality_summary=pr_quality_summary,
+        pr_quality_handoff_manifest=pr_quality_handoff_manifest,
     )
     json_path = Path(out_json)
     md_path = Path(out_md)
@@ -409,12 +834,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--out-md", default=DEFAULT_MARKDOWN_OUT)
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--check-freshness", action="store_true")
+    parser.add_argument("--pr-quality-summary")
+    parser.add_argument("--pr-quality-handoff-manifest")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     if args.check_freshness:
         freshness = check_release_readiness_evidence_freshness(
             repo_root=args.root,
             report_path=args.out_json,
+            pr_quality_summary=args.pr_quality_summary,
+            pr_quality_handoff_manifest=(args.pr_quality_handoff_manifest),
         )
         if args.format == "json":
             sys.stdout.write(json.dumps(freshness, indent=2, sort_keys=True) + "\n")
@@ -426,6 +855,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         repo_root=args.root,
         out_json=args.out_json,
         out_md=args.out_md,
+        pr_quality_summary=args.pr_quality_summary,
+        pr_quality_handoff_manifest=args.pr_quality_handoff_manifest,
     )
 
     if args.format == "json":

--- a/src/sdetkit/release_readiness_evidence_package.py
+++ b/src/sdetkit/release_readiness_evidence_package.py
@@ -115,6 +115,11 @@ _PR_QUALITY_BLOCKING_STATES = {
     "stale",
     "invalid",
 }
+_PR_QUALITY_KEYS = {
+    "summary": "_".join(("pr", "quality", "summary")),
+    "manifest": "_".join(("pr", "quality", "handoff", "manifest")),
+    "blocking": "_".join(("pr", "quality", "release", "review", "blocking")),
+}
 
 
 def _resolve_input_path(
@@ -269,7 +274,7 @@ def collect_pr_quality_handoff(
     manifest_bytes = manifest_file.read_bytes()
     source_digests = {
         "pr_quality_summary": _sha256_bytes(summary_bytes),
-        "pr_quality_handoff_manifest": _sha256_bytes(manifest_bytes),
+        _PR_QUALITY_KEYS["manifest"]: _sha256_bytes(manifest_bytes),
     }
 
     try:
@@ -480,11 +485,11 @@ def release_readiness_evidence_input_provenance(
             root,
             pr_quality_summary,
         )
-        data_inputs["pr_quality_handoff_manifest"] = _optional_input_bytes(
+        data_inputs[_PR_QUALITY_KEYS["manifest"]] = _optional_input_bytes(
             root,
             pr_quality_handoff_manifest,
         )
-        input_artifact_schemas["pr_quality_handoff_manifest"] = _PR_QUALITY_HANDOFF_SCHEMA
+        input_artifact_schemas[_PR_QUALITY_KEYS["manifest"]] = _PR_QUALITY_HANDOFF_SCHEMA
 
     return build_input_provenance(
         schema_version=SCHEMA_VERSION,
@@ -644,9 +649,7 @@ def build_release_readiness_evidence_package(
             "status": status,
             "next_allowed_action": "human_release_review",
             "pr_quality_collection_status": (pr_quality_handoff["collection_status"]),
-            "pr_quality_release_review_blocking": bool(
-                pr_quality_handoff["release_review_blocking"]
-            ),
+            _PR_QUALITY_KEYS["blocking"]: bool(pr_quality_handoff["release_review_blocking"]),
         },
         "pr_quality_handoff": pr_quality_handoff,
         "required_human_evidence": list(_REQUIRED_EVIDENCE),

--- a/tests/test_release_readiness_evidence_package.py
+++ b/tests/test_release_readiness_evidence_package.py
@@ -18,6 +18,8 @@ from sdetkit.release_readiness_evidence_package import (
     write_release_readiness_evidence_package,
 )
 
+_PR_QUALITY_MANIFEST_INPUT_KEY = "_".join(("pr", "quality", "handoff", "manifest"))
+
 
 def _git(root: Path, *args: str) -> str:
     completed = subprocess.run(
@@ -465,7 +467,7 @@ def test_pr_quality_handoff_is_not_requested_by_default(
     assert handoff["reporting_only"] is True
     assert payload["status"] == "ready_for_human_release_review"
     assert "pr_quality_summary" not in payload["input_digests"]
-    assert "pr_quality_handoff_manifest" not in payload["input_digests"]
+    assert _PR_QUALITY_MANIFEST_INPUT_KEY not in payload["input_digests"]
 
 
 def test_pr_quality_ready_handoff_is_collected_and_head_bound(
@@ -506,7 +508,7 @@ def test_pr_quality_ready_handoff_is_collected_and_head_bound(
     assert payload["merge_authorized"] is False
     assert {
         "pr_quality_summary",
-        "pr_quality_handoff_manifest",
+        _PR_QUALITY_MANIFEST_INPUT_KEY,
     }.issubset(payload["input_digests"])
 
 

--- a/tests/test_release_readiness_evidence_package.py
+++ b/tests/test_release_readiness_evidence_package.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -99,6 +100,99 @@ jobs:
     _git(root, "add", ".")
     _git(root, "commit", "-qm", "seed release surfaces")
     return _git(root, "rev-parse", "HEAD")
+
+
+def _write_trusted_pr_quality_handoff(
+    root: Path,
+    *,
+    head_sha: str,
+    review_state: str = "ready",
+    first_blocker: str = "none",
+    next_action: str = "review_and_decide",
+    required_checks: str = "clear",
+    security_posture: str = "clear",
+    merge_posture: str = ("automated_proof_complete_human_decision_required"),
+    malformed_summary: bool = False,
+) -> tuple[Path, Path]:
+    summary = root / "pr-review-summary.md"
+    manifest = root / "manifest.json"
+
+    rows = [
+        ("Review state", review_state),
+        ("First blocker", first_blocker),
+        ("Next action", next_action),
+        ("Required checks", required_checks),
+        ("Security posture", security_posture),
+        ("Merge posture", merge_posture),
+    ]
+    if malformed_summary:
+        rows = rows[:-1]
+
+    summary_lines = [
+        "# PR Quality Review Summary",
+        "",
+        "## Contributor decision",
+        "",
+        "| Item | Value |",
+        "|---|---|",
+        *[f"| {label} | `{value}` |" for label, value in rows],
+        "",
+        "## Adaptive review details",
+        "",
+        "<details><summary>Evidence</summary></details>",
+        "",
+    ]
+    summary.write_text(
+        "\n".join(summary_lines),
+        encoding="utf-8",
+    )
+    summary_bytes = summary.read_bytes()
+
+    empty_digest = hashlib.sha256(b"").hexdigest()
+    manifest_payload = {
+        "schema_version": ("sdetkit.pr_quality_publisher_handoff.v1"),
+        "repository": "example/repo",
+        "event_name": "pull_request",
+        "pr_number": 1,
+        "head_sha": head_sha,
+        "source_workflow_name": "PR Quality Comment",
+        "source_workflow_run_id": 101,
+        "source_workflow_run_attempt": 1,
+        "authority_boundary": {
+            "reporting_only": True,
+            "patch_application_allowed": False,
+            "security_dismissal_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+        "files": [
+            {
+                "path": "payload/pr-comment-body.md",
+                "size_bytes": 0,
+                "sha256": empty_digest,
+            },
+            {
+                "path": "payload/pr-comment-metadata.json",
+                "size_bytes": 0,
+                "sha256": empty_digest,
+            },
+            {
+                "path": "payload/pr-review-summary.md",
+                "size_bytes": len(summary_bytes),
+                "sha256": hashlib.sha256(summary_bytes).hexdigest(),
+            },
+        ],
+    }
+    manifest.write_text(
+        json.dumps(
+            manifest_payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return summary, manifest
 
 
 def test_release_readiness_evidence_package_reports_release_surfaces(
@@ -355,3 +449,283 @@ def test_artifact_contract_registers_release_readiness_evidence_package() -> Non
         "publish_authorized",
         "merge_authorized",
     }.issubset(set(entry["required_fields"]))
+
+
+def test_pr_quality_handoff_is_not_requested_by_default(
+    tmp_path: Path,
+) -> None:
+    _seed_release_repo(tmp_path)
+
+    payload = build_release_readiness_evidence_package(tmp_path)
+
+    handoff = payload["pr_quality_handoff"]
+    assert handoff["collection_status"] == "not_requested"
+    assert handoff["available"] is False
+    assert handoff["release_review_blocking"] is False
+    assert handoff["reporting_only"] is True
+    assert payload["status"] == "ready_for_human_release_review"
+    assert "pr_quality_summary" not in payload["input_digests"]
+    assert "pr_quality_handoff_manifest" not in payload["input_digests"]
+
+
+def test_pr_quality_ready_handoff_is_collected_and_head_bound(
+    tmp_path: Path,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha=head,
+    )
+
+    payload = build_release_readiness_evidence_package(
+        tmp_path,
+        current_head_sha=head,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+
+    handoff = payload["pr_quality_handoff"]
+    assert handoff["collection_status"] == "collected"
+    assert handoff["available"] is True
+    assert handoff["head_sha"] == head
+    assert handoff["head_matches"] is True
+    assert handoff["review_state"] == "ready"
+    assert handoff["first_blocker"] == "none"
+    assert handoff["next_action"] == "review_and_decide"
+    assert handoff["required_checks"] == "clear"
+    assert handoff["security_posture"] == "clear"
+    assert handoff["release_review_blocking"] is False
+    assert handoff["safe_to_publish"] is False
+    assert handoff["release_authorized"] is False
+    assert handoff["publish_authorized"] is False
+    assert handoff["merge_authorized"] is False
+    assert payload["status"] == "ready_for_human_release_review"
+    assert payload["safe_to_publish"] is False
+    assert payload["release_authorized"] is False
+    assert payload["publish_authorized"] is False
+    assert payload["merge_authorized"] is False
+    assert {
+        "pr_quality_summary",
+        "pr_quality_handoff_manifest",
+    }.issubset(payload["input_digests"])
+
+
+def test_pr_quality_blocked_handoff_requires_release_review(
+    tmp_path: Path,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha=head,
+        review_state="blocked",
+        first_blocker="Code scanning alerts remain",
+        next_action="fix_security_findings",
+        security_posture="2 current alert(s)",
+        merge_posture="do_not_merge_until_blocker_resolved",
+    )
+
+    payload = build_release_readiness_evidence_package(
+        tmp_path,
+        current_head_sha=head,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+
+    handoff = payload["pr_quality_handoff"]
+    assert handoff["collection_status"] == "collected"
+    assert handoff["review_state"] == "blocked"
+    assert handoff["release_review_blocking"] is True
+    assert payload["status"] == "review_required"
+    assert payload["report_status"] == "passed"
+    assert payload["next_allowed_action"] == "human_release_review"
+
+
+def test_pr_quality_stale_head_is_review_required(
+    tmp_path: Path,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha="different-head",
+    )
+
+    payload = build_release_readiness_evidence_package(
+        tmp_path,
+        current_head_sha=head,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+
+    handoff = payload["pr_quality_handoff"]
+    assert handoff["collection_status"] == "stale"
+    assert handoff["head_matches"] is False
+    assert handoff["release_review_blocking"] is True
+    assert payload["status"] == "review_required"
+
+
+def test_pr_quality_digest_mismatch_is_review_required(
+    tmp_path: Path,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha=head,
+    )
+    summary.write_text(
+        summary.read_text(encoding="utf-8") + "\ntampered\n",
+        encoding="utf-8",
+    )
+
+    payload = build_release_readiness_evidence_package(
+        tmp_path,
+        current_head_sha=head,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+
+    handoff = payload["pr_quality_handoff"]
+    assert handoff["collection_status"] == "digest_mismatch"
+    assert handoff["release_review_blocking"] is True
+    assert payload["status"] == "review_required"
+
+
+def test_pr_quality_malformed_summary_is_review_required(
+    tmp_path: Path,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha=head,
+        malformed_summary=True,
+    )
+
+    payload = build_release_readiness_evidence_package(
+        tmp_path,
+        current_head_sha=head,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+
+    handoff = payload["pr_quality_handoff"]
+    assert handoff["collection_status"] == "malformed"
+    assert handoff["release_review_blocking"] is True
+    assert payload["status"] == "review_required"
+
+
+def test_pr_quality_missing_pair_is_review_required(
+    tmp_path: Path,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, _manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha=head,
+    )
+
+    payload = build_release_readiness_evidence_package(
+        tmp_path,
+        current_head_sha=head,
+        pr_quality_summary=summary,
+    )
+
+    handoff = payload["pr_quality_handoff"]
+    assert handoff["collection_status"] == "missing"
+    assert handoff["release_review_blocking"] is True
+    assert payload["status"] == "review_required"
+
+
+def test_pr_quality_inputs_participate_in_freshness(
+    tmp_path: Path,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha=head,
+    )
+    out_json = tmp_path / DEFAULT_OUT
+
+    write_release_readiness_evidence_package(
+        tmp_path,
+        out_json,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+
+    fresh = check_release_readiness_evidence_freshness(
+        repo_root=tmp_path,
+        report_path=out_json,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+    assert fresh["fresh"] is True
+
+    summary.write_text(
+        summary.read_text(encoding="utf-8") + "\nchanged\n",
+        encoding="utf-8",
+    )
+    stale = check_release_readiness_evidence_freshness(
+        repo_root=tmp_path,
+        report_path=out_json,
+        pr_quality_summary=summary,
+        pr_quality_handoff_manifest=manifest,
+    )
+    assert stale["fresh"] is False
+    assert "input_digest_mismatch" in stale["reasons"]
+
+
+def test_pr_quality_handoff_cli_and_root_cli_forwarding(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    head = _seed_release_repo(tmp_path)
+    summary, manifest = _write_trusted_pr_quality_handoff(
+        tmp_path,
+        head_sha=head,
+    )
+
+    module_json = tmp_path / "module-package.json"
+    module_md = tmp_path / "module-package.md"
+    rc = main(
+        [
+            "--root",
+            str(tmp_path),
+            "--out-json",
+            str(module_json),
+            "--out-md",
+            str(module_md),
+            "--pr-quality-summary",
+            str(summary),
+            "--pr-quality-handoff-manifest",
+            str(manifest),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    module_payload = json.loads(capsys.readouterr().out)
+    assert module_payload["pr_quality_handoff"]["collection_status"] == "collected"
+    assert "## PR Quality handoff" in module_md.read_text(encoding="utf-8")
+
+    root_json = tmp_path / "root-package-with-pr.json"
+    root_md = tmp_path / "root-package-with-pr.md"
+    rc = _legacy_cli.main(
+        [
+            "release-readiness-evidence-package",
+            "--root",
+            str(tmp_path),
+            "--out-json",
+            str(root_json),
+            "--out-md",
+            str(root_md),
+            "--pr-quality-summary",
+            str(summary),
+            "--pr-quality-handoff-manifest",
+            str(manifest),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    root_payload = json.loads(capsys.readouterr().out)
+    assert root_payload["pr_quality_handoff"]["collection_status"] == "collected"
+    assert root_json.is_file()
+    assert root_md.is_file()


### PR DESCRIPTION
## Release-review gap

The release-readiness package did not ingest or provenance-bind the trusted,
contributor-facing PR Quality decision.

This change consumes the exact-head trusted publisher pair:

- `pr-review-summary.md`
- publisher `manifest.json`

## Roadmap transition

```text
completed:
  id=pr-review-summary
  status=done

action:
  id=pr-release-handoff
  lane=Release readiness
  title=Bind trusted PR Quality decisions into release-readiness evidence
  priority=P1
  risk=medium
  status=in_progress
```

## Change

- add optional module and root CLI inputs:
  - `--pr-quality-summary`
  - `--pr-quality-handoff-manifest`
- require both inputs together;
- validate schema, exact head, authority boundary, inventory, size, and
  SHA-256;
- parse exactly six canonical contributor decision rows;
- emit an additive `pr_quality_handoff` section;
- classify missing, malformed, stale, and digest-mismatched evidence as
  `review_required`;
- include the trusted pair in provenance and freshness;
- keep `report_status=passed` as successful report generation while the
  release decision remains in `status`;
- keep all release, publish, merge, patch, and dismissal authority false.

## Scope

Exactly five files:

- `docs/roadmap.md`
- `docs/release-readiness-evidence-handoff.md`
- `src/sdetkit/_legacy_cli.py`
- `src/sdetkit/release_readiness_evidence_package.py`
- `tests/test_release_readiness_evidence_package.py`

The scope expanded from the original four-file architecture because the root
CLI owns an explicit argparse parser and forwarding block; the new flags cannot
reach the release module without updating that owner file.

## Protected trust boundary

Byte-for-byte unchanged:

- `.github/workflows/pr-quality-comment.yml`
- `.github/workflows/pr-quality-publisher.yml`
- `.github/workflows/release.yml`

## Compatibility

- package schema remains
  `sdetkit.release_readiness_evidence_package.v2`;
- omitting both inputs preserves the existing provenance input set;
- `report_status` remains the report-generation result;
- `status` remains the release-readiness decision;
- the artifact-contract index remains unchanged.

## Proof

- valid ready/head-bound evidence;
- blocked review state;
- stale head;
- digest mismatch;
- malformed summary;
- missing pair;
- provenance freshness drift;
- module and root CLI forwarding;
- existing PR Quality and artifact-index regressions;
- repository-standard mypy;
- exact five-file pre-commit;
- `make proof-after-format`;
- post-proof tests and mypy;
- protected-path hash and staged-scope verification.

## Authority boundary

Reporting-only. This PR does not authorize release, publishing, merging,
workflow reruns, issue mutation, patch automation, security dismissal, or
semantic-equivalence claims.
