### PR TITLE
fix(release): keep informational security findings non-blocking

### DIFF
--- a/src/sdetkit/post_merge_verification.py
+++ b/src/sdetkit/post_merge_verification.py
@@ -332,17 +332,37 @@ def _security_summary(
 
     finding_rows = [row for row in findings if isinstance(row, dict)]
     try:
-        warnings = int(counts.get("warn", 0))
-        errors = int(counts.get("error", 0))
+        expected_counts = {
+            "info": int(counts.get("info", 0)),
+            "warn": int(counts.get("warn", 0)),
+            "error": int(counts.get("error", 0)),
+        }
     except (TypeError, ValueError):
         return None
+
+    if any(value < 0 for value in expected_counts.values()):
+        return None
+
+    observed_counts = {"info": 0, "warn": 0, "error": 0}
+    for row in finding_rows:
+        severity = str(row.get("severity", "")).strip().lower()
+        if severity not in observed_counts:
+            return None
+        observed_counts[severity] += 1
+
+    if observed_counts != expected_counts:
+        return None
+
+    blocking_findings = expected_counts["warn"] + expected_counts["error"]
 
     return {
         "collection_status": "collected",
         "available": True,
         "finding_count": len(finding_rows),
-        "warn_count": warnings,
-        "error_count": errors,
+        "info_count": expected_counts["info"],
+        "blocking_finding_count": blocking_findings,
+        "warn_count": expected_counts["warn"],
+        "error_count": expected_counts["error"],
     }
 
 
@@ -591,6 +611,8 @@ def build_post_merge_verification(
         "collection_status": artifacts["security"]["collection_status"],
         "available": False,
         "finding_count": 0,
+        "info_count": 0,
+        "blocking_finding_count": 0,
         "warn_count": 0,
         "error_count": 0,
     }
@@ -625,7 +647,7 @@ def build_post_merge_verification(
             canonical_merge_relation,
             ci_summary["state"] == "success",
             thread_summary["current_count"] == 0,
-            local_security["finding_count"] == 0,
+            local_security["blocking_finding_count"] == 0,
             local_security["warn_count"] == 0,
             local_security["error_count"] == 0,
             not protected_path_drift,
@@ -738,6 +760,8 @@ def render_post_merge_verification_markdown(
         (f"- outdated_ghas_threads: `{threads.get('outdated_count', 0)}`"),
         (f"- resolved_ghas_threads: `{threads.get('resolved_count', 0)}`"),
         (f"- local_security_findings: `{security.get('finding_count', 0)}`"),
+        (f"- local_security_info_findings: `{security.get('info_count', 0)}`"),
+        (f"- local_security_blocking_findings: `{security.get('blocking_finding_count', 0)}`"),
         "",
         "## Changed paths",
         "",

--- a/tests/test_post_merge_verification.py
+++ b/tests/test_post_merge_verification.py
@@ -131,11 +131,15 @@ def _write_evidence(
         }
     }
     finding_rows = findings or []
+    severity_counts = {"info": 0, "warn": 0, "error": 0}
+    for row in finding_rows:
+        severity = str(row.get("severity", "")).strip().lower()
+        if severity not in severity_counts:
+            raise ValueError(f"unsupported test severity: {severity}")
+        severity_counts[severity] += 1
+
     security_payload = {
-        "counts": {
-            "warn": len(finding_rows),
-            "error": 0,
-        },
+        "counts": severity_counts,
         "findings": finding_rows,
     }
 
@@ -370,6 +374,7 @@ def test_local_security_finding_requires_review(
         findings=[
             {
                 "rule_id": "TEST_RULE",
+                "severity": "warn",
                 "path": "src/example.py",
             }
         ],
@@ -384,6 +389,74 @@ def test_local_security_finding_requires_review(
 
     assert payload["status"] == "review_required"
     assert payload["local_security"]["finding_count"] == 1
+
+
+def test_info_only_security_finding_is_non_blocking(
+    tmp_path: Path,
+) -> None:
+    previous, merge_commit = _seed_repo(tmp_path)
+    evidence = _write_evidence(
+        tmp_path,
+        previous_main_sha=previous,
+        merge_commit_sha=merge_commit,
+        findings=[
+            {
+                "rule_id": "SEC_DEBUG_PRINT",
+                "severity": "info",
+                "path": "src/example.py",
+            }
+        ],
+    )
+
+    payload = build_post_merge_verification(
+        tmp_path,
+        evidence_dir=evidence,
+        previous_main_sha=previous,
+        current_head_sha=merge_commit,
+    )
+
+    assert payload["status"] == "verified"
+    assert payload["local_security"]["finding_count"] == 1
+    assert payload["local_security"]["info_count"] == 1
+    assert payload["local_security"]["blocking_finding_count"] == 0
+    assert payload["local_security"]["warn_count"] == 0
+    assert payload["local_security"]["error_count"] == 0
+
+
+def test_security_count_mismatch_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    previous, merge_commit = _seed_repo(tmp_path)
+    evidence = _write_evidence(
+        tmp_path,
+        previous_main_sha=previous,
+        merge_commit_sha=merge_commit,
+        findings=[
+            {
+                "rule_id": "SEC_DEBUG_PRINT",
+                "severity": "info",
+                "path": "src/example.py",
+            }
+        ],
+    )
+
+    security_path = evidence / "security-check.json"
+    security_payload = json.loads(security_path.read_text(encoding="utf-8"))
+    security_payload["counts"]["info"] = 0
+    security_path.write_text(
+        json.dumps(security_payload),
+        encoding="utf-8",
+    )
+
+    payload = build_post_merge_verification(
+        tmp_path,
+        evidence_dir=evidence,
+        previous_main_sha=previous,
+        current_head_sha=merge_commit,
+    )
+
+    assert payload["status"] == "unavailable"
+    assert payload["input_artifacts"]["security"]["collection_status"] == "unavailable"
 
 
 def test_freshness_detects_evidence_drift(tmp_path: Path) -> None:


### PR DESCRIPTION
## Defect

The repo-native post-merge reporter treated every security finding as blocking.
The security gate intentionally returns informational findings in `findings`
while keeping exit code `0`, `warn=0`, and `error=0`.

This caused a clean post-merge evidence packet to be classified as
`review_required`.

## Fix

- retain total finding visibility;
- add `info_count`;
- add `blocking_finding_count = warn + error`;
- validate that finding severities and declared counts agree;
- base the `verified` decision on blocking findings rather than total findings;
- render informational and blocking counts separately.

## Scope

Exactly two files:

- `src/sdetkit/post_merge_verification.py`
- `tests/test_post_merge_verification.py`

## Tests

- info-only security evidence remains visible and non-blocking;
- inconsistent security counts are unavailable rather than authoritative;
- existing warning evidence remains blocking;
- full post-merge and artifact-index tests;
- focused PR Quality and release-evidence tests;
- mypy, pre-commit, and `make proof-after-format`.

## Authority boundary

Reporting-only. No issue mutation, workflow rerun, security dismissal, release,
publication, or merge is authorized or performed.
