### PR TITLE
feat(pr-quality): harden exact failure remediation guidance

### DIFF
--- a/docs/failure-vector-support-matrix.md
+++ b/docs/failure-vector-support-matrix.md
@@ -38,3 +38,25 @@ Do not repeat completed work:
 - unknown wrapper first meaningful line extraction is already covered.
 - CLI JSON/Markdown artifact coverage is already covered.
 - workflow permission evidence lane is already complete.
+
+
+## Exact-failure evidence quality and remediation eligibility
+
+The PR Quality check-intelligence path emits one canonical `first_failure` object.
+Its `evidence_quality` block is reporting-only and contains:
+
+- `confidence`: `high`, `medium`, or `low`;
+- `source`: the structured evidence source used to select the failure;
+- `actionable`: whether the evidence identifies a concrete operator starting point;
+- `uncertainty`: bounded reasons the evidence must remain review-first.
+
+Safe-remediation eligibility consumes that same object. Formatting-only evidence is
+a candidate only when the exact failure is high-confidence, actionable, has no
+unresolved uncertainty, and references approved repository-owned paths. Candidate
+status never means that automation, immediate auto-fix, patch application, merge,
+security dismissal, or semantic equivalence is authorized.
+
+The SDET Quality Gate PR comment renders the exact-failure evidence quality,
+remediation category and strategy, affected files, proof commands, and denied
+authority boundaries so contributors can distinguish a mechanical candidate from
+an approved mutation.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,7 +149,7 @@ action:
 - Local security reported informational findings separately with zero blocking, warning, or error findings.
 - PR Quality publisher, evidence, and release workflow files remain unchanged.
 
-### Active roadmap action
+### Completed roadmap action
 
 ```text
 action:
@@ -158,23 +158,40 @@ action:
   title=Publish release-evidence recipes and sanitized proof samples
   priority=P2
   risk=low
-  value=Turn mature release and post-merge evidence contracts into copy-ready operator recipes and trustworthy proof samples.
+  status=done
+```
+
+Closure evidence:
+
+- PR `#1874` is merged at `c93c360ae99470c33788b95ea3305bb38dcc74b1`.
+- The curated release-evidence recipes, sanitized proof samples, navigation, and focused drift contracts are present on `main`.
+- The selection-correction audit classified `diagnostic-job-local-runner` as already implemented and selected the next unfinished reliability-spine action.
+
+### Active roadmap action
+
+```text
+action:
+  id=exact-failure-extraction-safe-remediation
+  lane=Repo-native diagnosis and remediation control
+  title=Harden exact-failure extraction and safe-remediation visibility in the SDET Quality Gate PR comment
+  priority=P1
+  risk=medium
+  value=Give contributors one canonical, confidence-scored first failure and a truthful remediation eligibility decision without expanding automation authority.
   status=in_progress
 ```
 
 **Acceptance criteria**
 
-1. One curated page provides copy-ready release-package, trusted-handoff, post-merge, and freshness recipes.
-2. Every recipe declares required inputs, output paths, interpretation, and reporting-only authority.
-3. Two checked-in JSON samples are deterministic, schema-valid, and sanitized.
-4. The release sample grants no release, publish, merge, patch, or dismissal authority.
-5. The post-merge sample keeps informational findings visible and blocking findings at zero.
-6. A focused contract test owns canonical sample builders and rejects byte drift.
-7. The test rejects live identities, credentials, absolute user paths, and unsafe URLs.
-8. Artifact reference and evidence showcase link to the recipes and both samples.
-9. MkDocs navigation exposes the recipe page exactly once.
-10. Production report schemas, generators, artifact index, and protected workflows remain unchanged.
-11. Focused tests, strict docs build, mypy, pre-commit, and `proof-after-format` pass.
+1. Check intelligence emits one canonical exact-failure object with line, tool, kind, bounded context, evidence source, confidence, actionability, and uncertainty.
+2. Traceback failures retain the final owner file, line, function, exception type, and exception message.
+3. Pytest-node, formatter, linter, type-checker, dependency, and review-annotation evidence receive deterministic evidence-quality classifications.
+4. Generic, unknown, incomplete, or uncertain evidence remains review-first.
+5. Formatting-only safe-fix eligibility requires high-confidence actionable evidence, approved repo-owned paths, and no unresolved uncertainty.
+6. A safe-fix candidate still grants no immediate auto-fix, patch application, merge, dismissal, or semantic-equivalence authority.
+7. The contributor-facing SDET Quality Gate panel shows exact-failure confidence, source, actionability, uncertainty, remediation category, strategy, files, proof commands, and authority boundaries.
+8. The existing PR Quality producer and exact-head trusted publisher remain unchanged.
+9. Focused tests cover high-confidence formatting, uncertain formatting, runtime, pytest, protected-path, and unknown evidence.
+10. Focused pre-commit and `proof-after-format` pass with a clean worktree.
 
 ## Continuous maintenance hardening loop
 

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -790,6 +790,84 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
     return {}
 
 
+_EXACT_FAILURE_HIGH_CONFIDENCE_KINDS = frozenset(
+    {
+        "check_run_annotation",
+        "dependency_resolution",
+        "dependency_vulnerability",
+        "format_drift",
+        "lint_failure",
+        "runtime_failure",
+        "test_failure",
+        "type_contract",
+    }
+)
+
+
+def _canonical_exact_failure(value: JsonObject) -> JsonObject:
+    failure = dict(_as_dict(value))
+    if not failure:
+        return {}
+
+    line = _string(failure.get("line"))
+    tool = _string(failure.get("tool")).lower()
+    kind = _string(failure.get("kind")).lower()
+    traceback = _as_dict(failure.get("traceback"))
+
+    uncertainty: list[str] = []
+    source = "missing"
+    confidence = "low"
+    actionable = False
+
+    if traceback:
+        source = "traceback_exception"
+        confidence = "high"
+        actionable = bool(
+            _string(traceback.get("exception_type")) and _string(traceback.get("exception_message"))
+        )
+        if not _string(traceback.get("owner_file")):
+            uncertainty.append("traceback owner file was not resolved")
+    elif line and kind in _EXACT_FAILURE_HIGH_CONFIDENCE_KINDS:
+        source = {
+            "check_run_annotation": "check_run_annotation",
+            "dependency_resolution": "dependency_log",
+            "dependency_vulnerability": "dependency_audit_summary",
+            "format_drift": "formatter_log",
+            "lint_failure": "linter_rule",
+            "runtime_failure": "runtime_log",
+            "test_failure": "pytest_node",
+            "type_contract": "type_checker_log",
+        }.get(kind, "structured_log")
+        confidence = "high"
+        actionable = True
+    elif line:
+        source = "generic_log_signal"
+        confidence = "medium"
+        actionable = False
+        uncertainty.append("failure kind is generic or unknown")
+    else:
+        uncertainty.append("no actionable failure line was extracted")
+
+    if not tool or tool == "unknown":
+        uncertainty.append("failure tool is unknown")
+        if confidence == "high":
+            confidence = "medium"
+            actionable = False
+
+    failure["evidence_quality"] = {
+        "confidence": confidence,
+        "actionable": actionable,
+        "source": source,
+        "uncertainty": sorted(set(uncertainty)),
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+    return failure
+
+
 def _looks_like_command(line: str) -> bool:
     lowered = line.strip().lower()
     return lowered.startswith(
@@ -1130,6 +1208,7 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
     dependency_audit = _extract_dependency_audit_evidence(log_text)
     if dependency_audit:
         first_failure = _dependency_audit_first_failure(log_text) or first_failure
+    first_failure = _canonical_exact_failure(first_failure)
     diagnostic_text = "\n".join(
         part
         for part in [

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -555,6 +555,95 @@ def _failed_step_evidence_lines(payload: JsonObject, *, prefix: str = "  - ") ->
     return lines
 
 
+def _exact_failure_quality_lines(
+    payload: JsonObject,
+    *,
+    prefix: str = "  - ",
+) -> list[str]:
+    first_failure = _as_dict(payload.get("first_failure"))
+    quality = _as_dict(first_failure.get("evidence_quality"))
+    if not quality:
+        return []
+
+    confidence = _string(quality.get("confidence") or "unknown")
+    source = _string(quality.get("source") or "unknown")
+    actionable = str(bool(quality.get("actionable", False))).lower()
+    uncertainty = [_string(item) for item in _as_list(quality.get("uncertainty")) if _string(item)]
+
+    lines = [
+        f"{prefix}Exact failure confidence: `{confidence}`",
+        f"{prefix}Exact failure source: `{source}`",
+        f"{prefix}Exact failure actionable: `{actionable}`",
+    ]
+    if uncertainty:
+        lines.append(
+            f"{prefix}Exact failure uncertainty: "
+            + "; ".join(f"`{item}`" for item in uncertainty[:5])
+        )
+    else:
+        lines.append(f"{prefix}Exact failure uncertainty: `none`")
+    return lines
+
+
+def _remediation_eligibility_lines(
+    payload: JsonObject,
+    *,
+    prefix: str = "  - ",
+) -> list[str]:
+    remediation = _as_dict(payload.get("safe_remediation"))
+    if not remediation:
+        return []
+
+    category = _string(remediation.get("category") or "unknown")
+    strategy = _string(remediation.get("strategy") or "unknown")
+    safe = str(bool(remediation.get("safe_to_auto_fix", False))).lower()
+    human_review = str(bool(remediation.get("requires_human_review", True))).lower()
+    auto_fix_now = str(bool(remediation.get("auto_fix_allowed_now", False))).lower()
+    patch_allowed = str(bool(remediation.get("patch_application_allowed", False))).lower()
+    merge_authorized = str(bool(remediation.get("merge_authorized", False))).lower()
+    reason = _string(remediation.get("reason") or "none")
+
+    lines = [
+        f"{prefix}Remediation eligibility: `{category}`",
+        f"{prefix}Remediation strategy: `{strategy}`",
+        f"{prefix}Safe-fix candidate: `{safe}`",
+        f"{prefix}Human review required: `{human_review}`",
+        f"{prefix}Auto-fix allowed now: `{auto_fix_now}`",
+        f"{prefix}Patch application allowed: `{patch_allowed}`",
+        f"{prefix}Merge authorized: `{merge_authorized}`",
+        f"{prefix}Remediation reason: {reason}",
+    ]
+    if bool(remediation.get("safe_to_auto_fix", False)):
+        lines.extend(
+            [
+                f"{prefix}Safe remediation: `{strategy}`",
+                f"{prefix}Safe reason: `{reason}`",
+            ]
+        )
+
+    affected_files = [
+        _string(item) for item in _as_list(remediation.get("affected_files")) if _string(item)
+    ]
+    if affected_files:
+        lines.append(
+            f"{prefix}Remediation affected files: "
+            + ", ".join(f"`{item}`" for item in affected_files[:8])
+        )
+    else:
+        lines.append(f"{prefix}Remediation affected files: `none`")
+
+    proof_commands = [
+        _string(item) for item in _as_list(remediation.get("proof_commands")) if _string(item)
+    ]
+    if proof_commands:
+        lines.append(f"{prefix}Remediation proof commands:")
+        lines.extend(f"{prefix}  - `{item}`" for item in proof_commands[:5])
+    else:
+        lines.append(f"{prefix}Remediation proof commands: `none`")
+
+    return lines
+
+
 def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
     failed = [_as_dict(item) for item in _as_list(check_intelligence.get("failed_checks"))]
     if not failed:
@@ -578,14 +667,10 @@ def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
             lines.append(f"  - First failure: `{first_line}`")
             lines.append(f"  - Failure location: `{location}`")
             lines.append(f"  - Failure tool/kind: `{tool}` / `{kind}`")
+        lines.extend(_exact_failure_quality_lines(item))
         lines.extend(_failed_step_evidence_lines(item))
         lines.extend(_artifact_evidence_lines(item))
-        safe_remediation = _as_dict(item.get("safe_remediation"))
-        if bool(safe_remediation.get("safe_to_auto_fix", False)):
-            strategy = _string(safe_remediation.get("strategy") or "unknown")
-            reason = _string(safe_remediation.get("reason") or "approved safe remediation")
-            lines.append(f"  - Safe remediation: `{strategy}`")
-            lines.append(f"  - Safe reason: `{reason}`")
+        lines.extend(_remediation_eligibility_lines(item))
         formatter_files = [
             _string(path) for path in _as_list(item.get("formatter_changed_files")) if _string(path)
         ]
@@ -641,14 +726,10 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
         lines.append(f"- First failure: `{first_line}`")
         lines.append(f"- Failure location: `{location}`")
         lines.append(f"- Failure tool/kind: `{tool}` / `{kind}`")
+    lines.extend(_exact_failure_quality_lines(primary, prefix="- "))
     lines.extend(_failed_step_evidence_lines(primary, prefix="- "))
     lines.extend(_artifact_evidence_lines(primary, prefix="- "))
-    safe_remediation = _as_dict(primary.get("safe_remediation"))
-    if bool(safe_remediation.get("safe_to_auto_fix", False)):
-        strategy = _string(safe_remediation.get("strategy") or "unknown")
-        reason = _string(safe_remediation.get("reason") or "approved safe remediation")
-        lines.append(f"- Safe remediation: `{strategy}`")
-        lines.append(f"- Safe reason: `{reason}`")
+    lines.extend(_remediation_eligibility_lines(primary, prefix="- "))
 
     formatter_files = [
         _string(path) for path in _as_list(primary.get("formatter_changed_files")) if _string(path)

--- a/src/sdetkit/safe_remediation_eligibility.py
+++ b/src/sdetkit/safe_remediation_eligibility.py
@@ -135,6 +135,69 @@ UNSAFE_REVIEW_MARKERS = (
 )
 
 
+_EXACT_FAILURE_HIGH_CONFIDENCE_KINDS = frozenset(
+    {
+        "check_run_annotation",
+        "dependency_resolution",
+        "dependency_vulnerability",
+        "format_drift",
+        "lint_failure",
+        "runtime_failure",
+        "test_failure",
+        "type_contract",
+    }
+)
+
+
+def _failure_evidence_quality(first_failure: JsonObject) -> JsonObject:
+    quality = _as_dict(first_failure.get("evidence_quality"))
+    line = _string(first_failure.get("line"))
+    kind = _lower(first_failure.get("kind"))
+
+    confidence = _lower(quality.get("confidence"))
+    if confidence not in {"high", "medium", "low"}:
+        if line and kind in _EXACT_FAILURE_HIGH_CONFIDENCE_KINDS:
+            confidence = "high"
+        elif line:
+            confidence = "medium"
+        else:
+            confidence = "low"
+
+    if "actionable" in quality:
+        actionable = bool(quality.get("actionable"))
+    else:
+        actionable = bool(line and confidence == "high")
+
+    raw_uncertainty = quality.get("uncertainty", [])
+    uncertainty = (
+        sorted({_string(item) for item in raw_uncertainty if _string(item)})
+        if isinstance(raw_uncertainty, list)
+        else []
+    )
+
+    source = _string(quality.get("source") or "legacy_inference")
+    return {
+        "confidence": confidence,
+        "actionable": actionable,
+        "source": source,
+        "uncertainty": uncertainty,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def _result_with_failure_evidence(
+    first_failure: JsonObject,
+    **kwargs: Any,
+) -> JsonObject:
+    result = _result(**kwargs)
+    result["exact_failure_evidence"] = _failure_evidence_quality(first_failure)
+    return result
+
+
 def classify_check_failure(
     *,
     name: str = "",
@@ -175,7 +238,8 @@ def classify_check_failure(
     )
 
     if kind == "check_run_annotation":
-        return _result(
+        return _result_with_failure_evidence(
+            first_failure,
             safe_to_auto_fix=False,
             strategy=REVIEW_FIRST_STRATEGY,
             category="review_first",
@@ -185,9 +249,11 @@ def classify_check_failure(
 
     unsafe_signal = _contains_any(combined, UNSAFE_REVIEW_MARKERS)
     formatting_signal = kind == "format_drift" or _contains_any(combined, SAFE_FORMAT_MARKERS)
+    failure_evidence = _failure_evidence_quality(first_failure)
 
     if unsafe_signal:
-        return _result(
+        return _result_with_failure_evidence(
+            first_failure,
             safe_to_auto_fix=False,
             strategy=REVIEW_FIRST_STRATEGY,
             category="review_first",
@@ -196,8 +262,26 @@ def classify_check_failure(
         )
 
     if formatting_signal:
+        if (
+            failure_evidence["confidence"] != "high"
+            or failure_evidence["actionable"] is not True
+            or failure_evidence["uncertainty"]
+        ):
+            return _result_with_failure_evidence(
+                first_failure,
+                safe_to_auto_fix=False,
+                strategy=REVIEW_FIRST_STRATEGY,
+                category="review_first",
+                affected_files=affected_files,
+                reason=(
+                    "Formatting evidence lacks a high-confidence, actionable exact-failure "
+                    "signal without unresolved uncertainty."
+                ),
+            )
+
         if not affected_files:
-            return _result(
+            return _result_with_failure_evidence(
+                first_failure,
                 safe_to_auto_fix=False,
                 strategy=REVIEW_FIRST_STRATEGY,
                 category="review_first",
@@ -206,7 +290,8 @@ def classify_check_failure(
 
         unsafe_files = [value for value in affected_files if not _is_safe_repo_owned_path(value)]
         if unsafe_files:
-            return _result(
+            return _result_with_failure_evidence(
+                first_failure,
                 safe_to_auto_fix=False,
                 strategy=REVIEW_FIRST_STRATEGY,
                 category="review_first",
@@ -214,7 +299,8 @@ def classify_check_failure(
                 reason="Formatting evidence includes files outside approved safe-fix paths.",
             )
 
-        return _result(
+        return _result_with_failure_evidence(
+            first_failure,
             safe_to_auto_fix=True,
             strategy=FORMAT_SAFE_STRATEGY,
             category="formatting_only",
@@ -227,7 +313,8 @@ def classify_check_failure(
             ],
         )
 
-    return _result(
+    return _result_with_failure_evidence(
+        first_failure,
         safe_to_auto_fix=False,
         strategy=REVIEW_FIRST_STRATEGY,
         category="unknown",

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -1032,3 +1032,47 @@ def test_check_intelligence_routes_ruff_b011_advice_to_ruff_not_pytest(
     assert report["primary_blocker"]["title"] == "Ruff lint contract failed"
     assert all("unknown test" not in command for command in report["proof_commands"])
     assert report["automation"]["allowed"] is False
+
+
+def test_canonical_exact_failure_adds_confidence_and_uncertainty_contract() -> None:
+    from sdetkit import check_intelligence
+
+    traceback_log = (
+        "Run python -m pytest -q\n"
+        "Traceback (most recent call last):\n"
+        '  File "/workspace/src/sdetkit/example.py", line 42, in execute\n'
+        '    raise AssertionError("expected stable output")\n'
+        "AssertionError: expected stable output\n"
+    )
+    exact = check_intelligence._canonical_exact_failure(
+        check_intelligence._first_failure_summary(traceback_log)
+    )
+
+    assert exact["line"] == "AssertionError: expected stable output"
+    assert exact["evidence_quality"] == {
+        "confidence": "high",
+        "actionable": True,
+        "source": "traceback_exception",
+        "uncertainty": [],
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+    generic = check_intelligence._canonical_exact_failure(
+        {
+            "line_number": 1,
+            "line": "Step failed",
+            "tool": "unknown",
+            "kind": "failed_step",
+            "context": [],
+        }
+    )
+    assert generic["evidence_quality"]["confidence"] == "medium"
+    assert generic["evidence_quality"]["actionable"] is False
+    assert generic["evidence_quality"]["uncertainty"] == [
+        "failure kind is generic or unknown",
+        "failure tool is unknown",
+    ]

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -5775,3 +5775,63 @@ def test_contributor_review_panel_summarizes_stale_security() -> None:
     assert rows["Required checks"] == "clear"
     assert rows["Security posture"] == ("clear for current head; 2 stale alert(s)")
     assert rows["Merge posture"] == (report.WAIT_FOR_CODE_SCANNING_REFRESH)
+
+
+def test_failed_check_panel_renders_exact_failure_and_remediation_contract() -> None:
+    from sdetkit.pr_quality_action_report import _failed_check_lines
+
+    lines = _failed_check_lines(
+        {
+            "failed_checks": [
+                {
+                    "name": "PR Quality local quality gate",
+                    "diagnosis": {
+                        "code": "PRE_COMMIT_FORMAT_DRIFT",
+                        "title": "Formatting drift",
+                    },
+                    "safe_to_auto_fix": True,
+                    "first_failure": {
+                        "line_number": 14,
+                        "line": "Would reformat: src/sdetkit/example.py",
+                        "tool": "ruff",
+                        "kind": "format_drift",
+                        "context": [],
+                        "evidence_quality": {
+                            "confidence": "high",
+                            "actionable": True,
+                            "source": "formatter_log",
+                            "uncertainty": [],
+                        },
+                    },
+                    "safe_remediation": {
+                        "safe_to_auto_fix": True,
+                        "strategy": "run_pre_commit",
+                        "category": "formatting_only",
+                        "affected_files": ["src/sdetkit/example.py"],
+                        "reason": "Failure is limited to deterministic formatting.",
+                        "proof_commands": ["python -m pre_commit run -a"],
+                        "requires_human_review": True,
+                        "auto_fix_allowed_now": False,
+                        "patch_application_allowed": False,
+                        "merge_authorized": False,
+                    },
+                }
+            ]
+        }
+    )
+    rendered = "\n".join(lines)
+
+    assert "Exact failure confidence: `high`" in rendered
+    assert "Exact failure source: `formatter_log`" in rendered
+    assert "Exact failure actionable: `true`" in rendered
+    assert "Exact failure uncertainty: `none`" in rendered
+    assert "Remediation eligibility: `formatting_only`" in rendered
+    assert "Remediation strategy: `run_pre_commit`" in rendered
+    assert "Safe-fix candidate: `true`" in rendered
+    assert "Human review required: `true`" in rendered
+    assert "Auto-fix allowed now: `false`" in rendered
+    assert "Patch application allowed: `false`" in rendered
+    assert "Merge authorized: `false`" in rendered
+    assert "Remediation affected files: `src/sdetkit/example.py`" in rendered
+    assert "Remediation proof commands:" in rendered
+    assert "python -m pre_commit run -a" in rendered

--- a/tests/test_safe_remediation_eligibility.py
+++ b/tests/test_safe_remediation_eligibility.py
@@ -195,3 +195,55 @@ def test_safe_remediation_review_first_preserves_no_automation_boundary() -> Non
     assert result["safe_to_auto_fix"] is False
     assert result["strategy"] == "review_first"
     _assert_no_automation_boundary(result)
+
+
+def test_formatting_safe_fix_requires_high_confidence_exact_failure() -> None:
+    from sdetkit.safe_remediation_eligibility import classify_check_failure
+
+    uncertain = classify_check_failure(
+        name="ruff format",
+        diagnosis={"code": "PRE_COMMIT_FORMAT_DRIFT"},
+        first_failure={
+            "line": "Would reformat: src/sdetkit/example.py",
+            "tool": "ruff",
+            "kind": "format_drift",
+            "evidence_quality": {
+                "confidence": "medium",
+                "actionable": False,
+                "source": "generic_log_signal",
+                "uncertainty": ["formatter owner file is uncertain"],
+            },
+        },
+        log_text="Would reformat: src/sdetkit/example.py",
+    )
+
+    assert uncertain["safe_to_auto_fix"] is False
+    assert uncertain["strategy"] == "review_first"
+    assert uncertain["category"] == "review_first"
+    assert uncertain["exact_failure_evidence"]["confidence"] == "medium"
+    assert uncertain["exact_failure_evidence"]["actionable"] is False
+    assert "high-confidence" in uncertain["reason"]
+
+    exact = classify_check_failure(
+        name="ruff format",
+        diagnosis={"code": "PRE_COMMIT_FORMAT_DRIFT"},
+        first_failure={
+            "line": "Would reformat: src/sdetkit/example.py",
+            "tool": "ruff",
+            "kind": "format_drift",
+            "evidence_quality": {
+                "confidence": "high",
+                "actionable": True,
+                "source": "formatter_log",
+                "uncertainty": [],
+            },
+        },
+        log_text="Would reformat: src/sdetkit/example.py",
+    )
+
+    assert exact["safe_to_auto_fix"] is True
+    assert exact["category"] == "formatting_only"
+    assert exact["exact_failure_evidence"]["confidence"] == "high"
+    assert exact["auto_fix_allowed_now"] is False
+    assert exact["patch_application_allowed"] is False
+    assert exact["merge_authorized"] is False


### PR DESCRIPTION
## Roadmap action

`exact-failure-extraction-safe-remediation` — harden the existing SDET Quality Gate PR comment instead of adding a parallel diagnostic path.

## Contributor problem

PR Quality already extracts a first failure and computes safe-remediation eligibility, but the evidence quality is implicit. Contributors cannot consistently tell whether the selected line is high-confidence and actionable, what uncertainty remains, or why a formatting candidate is still denied immediate mutation authority.

## Change

- add deterministic evidence quality to the canonical `first_failure` object: confidence, source, actionability, and bounded uncertainty;
- require high-confidence actionable exact-failure evidence with no unresolved uncertainty before formatting-only eligibility can be a safe-fix candidate;
- render the complete exact-failure and remediation decision in the existing SDET Quality Gate panel;
- keep runtime, tests, unknown, protected-path, dependency, release, and security cases review-first;
- close `release-evidence-recipes` and activate this roadmap action;
- document the evidence-quality and authority contract.

## Authority boundaries

- producer workflow changed: false
- trusted publisher changed: false
- workflow permissions expanded: false
- automation allowed: false
- auto-fix allowed now: false
- patch application allowed: false
- security dismissal allowed: false
- merge authorized: false
- semantic equivalence proven: false
- human review required: true

## Proof

- focused PR Quality contract suite passed;
- scoped pre-commit passed;
- `make proof-after-format` passed in an isolated exact-commit worktree;
- protected workflow files are unchanged;
- worktree is clean.

## Scope

- `docs/roadmap.md`
- `docs/failure-vector-support-matrix.md`
- `src/sdetkit/check_intelligence.py`
- `src/sdetkit/safe_remediation_eligibility.py`
- `src/sdetkit/pr_quality_action_report.py`
- `tests/test_check_intelligence.py`
- `tests/test_safe_remediation_eligibility.py`
- `tests/test_pr_quality_action_report.py`
