### PR TITLE
feat(pr-quality): expose git-grounded proof profiles

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -194,7 +194,7 @@ action:
 - ProtectedVerifier review-first evidence propagation and verified network isolation already exist.
 - The first explicit unfinished, non-authority-expanding gap is PR Quality workflow visibility for Git-grounded proof profiles beyond the current narrow Ruff profile.
 
-### Active roadmap action
+### Completed roadmap action
 
 ```text
 action:
@@ -204,21 +204,32 @@ action:
   priority=P1
   risk=medium
   value=Expose multiple existing allowlisted current-head proof profiles as reporting-only reviewer evidence without claiming semantic equivalence or expanding automation authority.
-  status=in_progress
+  status=done
 ```
 
-**Acceptance criteria**
+**Closure evidence**
 
-1. Current-PR proof remains bound to exact Git-derived changed-file inventory and the current head.
-2. The implementation reuses existing allowlisted profiles instead of accepting arbitrary commands.
-3. PR Quality exposes at least one existing non-Ruff profile from `pre_commit_all` or `mypy_src` alongside `ruff_src_tests`.
-4. Every profile result reports the profile ID, canonical command, exit status, timeout state, workspace mutation state, inventory-claim match, and network-boundary state.
-5. Missing, mixed, timed-out, mutated, inventory-mismatched, or failed profile evidence remains review-first.
-6. ProtectedVerifier may consume the expanded evidence only as structural, reporting-only context.
-7. Patch application, automation, security dismissal, merge authorization, and semantic-equivalence claims remain false.
-8. Existing trusted-publisher exact-head verification and workflow permission boundaries remain unchanged.
-9. Focused tests cover positive, failed, unavailable, inventory-mismatch, and authority-expansion scenarios.
-10. Focused pre-commit and `proof-after-format` pass with a clean worktree.
+- PR Quality already executes the allowlisted `ruff_src_tests` and `pre_commit_all` profiles against the same exact Git-derived base/head inventory.
+- The runtime-proof summary now retains a bounded, sanitized result for each executed profile instead of collapsing evidence into counts only.
+- The contributor-facing PR Quality report shows each profile ID, canonical command, status, exit code, timeout state, workspace-mutation state, runtime-guard status, inventory-claim match, Git-inventory verification, network-boundary status, wrapping state, and review-first disposition.
+- Missing, incomplete, failed, timed-out, mutated, inventory-mismatched, or authority-expanding profile evidence remains review-first.
+- The runtime projection remains additive under the existing schema and grants no automation, patch application, security dismissal, merge, or semantic-equivalence authority.
+- The PR Quality producer and trusted publisher workflows remain unchanged.
+
+### Roadmap selection status
+
+```text
+roadmap_state:
+  patch_ready_action=none
+  next_recommended_pr=none
+  automation_expansion_allowed=false
+  merge_authority_expansion_allowed=false
+```
+
+The remaining partially aligned reliability-spine gaps require unavailable semantic-equivalence,
+external-filesystem-containment, process-escape-prevention, or explicit human authority evidence.
+They are capability/review blockers, not safe patch-ready roadmap work, and must not be converted
+into implementation PRs without new evidence.
 
 
 ## Continuous maintenance hardening loop

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -857,6 +857,9 @@ def _runtime_proof_artifact_lines(runtime_proof_artifacts: JsonObject | None) ->
         return []
 
     isolated = _as_dict(summary.get("isolated_proof"))
+    profile_results = [
+        _as_dict(item) for item in _as_list(isolated.get("profile_results")) if _as_dict(item)
+    ]
     benchmark = _as_dict(summary.get("live_benchmark"))
     memory = _as_dict(summary.get("repo_memory"))
     trusted_history = _as_dict(summary.get(TRUSTED_HISTORY))
@@ -894,7 +897,41 @@ def _runtime_proof_artifact_lines(runtime_proof_artifacts: JsonObject | None) ->
             f"`{_string(benchmark.get('collection_status') or 'not_collected')}`"
         ),
         f"- Live benchmark status: `{_string(benchmark.get('status') or 'not_collected')}`",
+        (
+            "- Profile visibility status: "
+            f"`{_string(isolated.get('profile_visibility_status') or 'not_collected')}`"
+        ),
+        (f"- Profile review-first results: `{_int(isolated.get('profile_review_first_count'))}`"),
+        (
+            "- Profile authority expansion detected: "
+            f"`{str(bool(isolated.get('profile_authority_expansion_detected', False))).lower()}`"
+        ),
     ]
+
+    if profile_results:
+        lines.append("- Proof profile results:")
+        for profile in profile_results:
+            claim_value = profile.get("inventory_claim_match")
+            claim_status = "not_checked" if claim_value is None else str(bool(claim_value)).lower()
+            lines.append(
+                f"  - `{_string(profile.get('profile_id') or 'unknown')}`: "
+                f"command=`{_string(profile.get('command') or 'unknown')}`, "
+                f"status=`{_string(profile.get('status') or 'unknown')}`, "
+                f"exit_code=`{_int(profile.get('exit_code'))}`, "
+                f"timed_out=`{str(bool(profile.get('timed_out', False))).lower()}`, "
+                "workspace_mutated=`"
+                f"{str(bool(profile.get('workspace_mutated', False))).lower()}`, "
+                f"runtime_guard=`{_string(profile.get('runtime_guard_status') or 'unknown')}`, "
+                f"inventory_claim_match=`{claim_status}`, "
+                "git_inventory_verified=`"
+                f"{str(bool(profile.get('git_inventory_verified', False))).lower()}`, "
+                f"network_boundary=`{_string(profile.get('network_boundary_status') or 'unknown')}`, "
+                "network_wrapped=`"
+                f"{str(bool(profile.get('network_backend_command_wrapped', False))).lower()}`, "
+                f"review_first=`{str(bool(profile.get('review_first', True))).lower()}`"
+            )
+    else:
+        lines.append("- Proof profile results: none")
 
     if benchmark.get("collection_status") == "collected":
         lines.extend(

--- a/src/sdetkit/pr_quality_runtime_proof_artifacts.py
+++ b/src/sdetkit/pr_quality_runtime_proof_artifacts.py
@@ -168,12 +168,112 @@ def _read_json(path: Path | None) -> JsonObject:
     return _as_dict(payload)
 
 
+def _isolated_profile_results(evidence: Mapping[str, Any]) -> list[JsonObject]:
+    payload = _as_dict(evidence)
+    if not payload:
+        return []
+
+    decision_boundary = _as_dict(payload.get("decision_boundary"))
+    isolation = _as_dict(payload.get("isolation"))
+    network_boundary = _as_dict(payload.get("network_boundary"))
+    claim_value = payload.get("inventory_claim_match")
+    inventory_claim_match = None if claim_value is None else _bool(claim_value)
+    git_inventory_verified = _bool(decision_boundary.get("git_inventory_verified"))
+
+    boundary_authority_expansion = any(
+        _bool(decision_boundary.get(field))
+        for field in (
+            "automation_allowed",
+            "patch_application_allowed",
+            "security_dismissal_allowed",
+            "merge_authorized",
+            "semantic_equivalence_proven",
+        )
+    )
+
+    profiles: list[JsonObject] = []
+    for raw in _as_list(payload.get("proof_results")):
+        item = _as_dict(raw)
+        if not item:
+            continue
+
+        runtime_guard = _as_dict(item.get("runtime_guard"))
+        authority_expansion = boundary_authority_expansion or any(
+            _bool(item.get(field))
+            for field in (
+                "automation_allowed",
+                "patch_application_allowed",
+                "security_dismissal_allowed",
+                "merge_authorized",
+                "semantic_equivalence_proven",
+            )
+        )
+        status = _string(item.get("status") or "unknown")
+        timed_out = _bool(item.get("timed_out"))
+        workspace_mutated = _bool(item.get("workspace_mutated_during_execution"))
+        runtime_guard_violation = _bool(runtime_guard.get("runtime_guard_violation"))
+        review_first = (
+            status != "passed"
+            or timed_out
+            or workspace_mutated
+            or runtime_guard_violation
+            or inventory_claim_match is False
+            or not git_inventory_verified
+            or authority_expansion
+        )
+
+        profiles.append(
+            {
+                "profile_id": _string(item.get("profile_id") or "unknown"),
+                "command": _string(item.get("command") or "unknown"),
+                "status": status,
+                "exit_code": _int(item.get("exit_code")),
+                "timed_out": timed_out,
+                "workspace_mutated": workspace_mutated,
+                "runtime_guard_status": _string(runtime_guard.get("status") or "unknown"),
+                "runtime_guard_violation": runtime_guard_violation,
+                "inventory_claim_match": inventory_claim_match,
+                "git_inventory_verified": git_inventory_verified,
+                "network_boundary_status": _string(
+                    network_boundary.get("status")
+                    or isolation.get("network_boundary_status")
+                    or "unknown"
+                ),
+                "network_isolation_required": _bool(isolation.get("network_isolation_required")),
+                "network_isolation_enforced": _bool(isolation.get("network_isolation_enforced")),
+                "network_backend": _string(
+                    item.get("network_backend") or network_boundary.get("backend") or "none"
+                ),
+                "network_backend_variant": _string(
+                    item.get("network_backend_variant")
+                    or network_boundary.get("backend_variant")
+                    or "none"
+                ),
+                "network_backend_command_wrapped": _bool(
+                    item.get("network_backend_command_wrapped")
+                ),
+                "review_first": review_first,
+                "reporting_only": True,
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "security_dismissal_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+                "authority_expansion_detected": authority_expansion,
+            }
+        )
+
+    return profiles
+
+
 def _isolated_proof_summary(evidence: Mapping[str, Any]) -> JsonObject:
     payload = _as_dict(evidence)
     if not payload:
         return {
             "collection_status": NOT_COLLECTED,
             "status": NOT_COLLECTED,
+            "profile_visibility_status": NOT_COLLECTED,
+            "profile_results": [],
         }
 
     proof_summary = _as_dict(payload.get("proof_summary"))
@@ -181,11 +281,32 @@ def _isolated_proof_summary(evidence: Mapping[str, Any]) -> JsonObject:
     network_boundary = _as_dict(payload.get("network_boundary"))
     isolation = _as_dict(payload.get("isolation"))
     decision_boundary = _as_dict(payload.get("decision_boundary"))
+    profile_results = _isolated_profile_results(payload)
+    executed_count = _int(proof_summary.get("executed_count"))
+    profile_review_first_count = sum(
+        1 for item in profile_results if _bool(item.get("review_first"))
+    )
+    profile_authority_expansion_detected = any(
+        _bool(item.get("authority_expansion_detected")) for item in profile_results
+    )
+
+    if not profile_results:
+        profile_visibility_status = NOT_COLLECTED if executed_count == 0 else "incomplete"
+    elif len(profile_results) != executed_count:
+        profile_visibility_status = "incomplete"
+    elif profile_review_first_count:
+        profile_visibility_status = "review_first"
+    else:
+        profile_visibility_status = COLLECTED
+
+    claim_value = payload.get("inventory_claim_match")
+    inventory_claim_match = None if claim_value is None else _bool(claim_value)
 
     return {
         "collection_status": COLLECTED,
         "status": _string(payload.get("status") or "unknown"),
         "git_inventory_verified": _bool(decision_boundary.get("git_inventory_verified")),
+        "inventory_claim_match": inventory_claim_match,
         "runtime_guard_checked": _bool(runtime_guard.get("checked")),
         "runtime_guard_passed": _bool(runtime_guard.get("passed")),
         "runtime_guard_violation_count": _int(runtime_guard.get("violation_count")),
@@ -197,10 +318,15 @@ def _isolated_proof_summary(evidence: Mapping[str, Any]) -> JsonObject:
         "network_isolation_enforced": _bool(isolation.get("network_isolation_enforced")),
         "proof_execution_blocked": _bool(isolation.get("proof_execution_blocked")),
         "profiles_requested": _int(proof_summary.get("requested_count")),
-        "profiles_executed": _int(proof_summary.get("executed_count")),
+        "profiles_executed": executed_count,
         "profiles_blocked": _int(proof_summary.get("blocked_count")),
         "profiles_passed": _int(proof_summary.get("passed_count")),
         "profiles_failed": _int(proof_summary.get("failed_count")),
+        "requested_profile_ids": _string_list(payload.get("requested_profiles")),
+        "profile_visibility_status": profile_visibility_status,
+        "profile_review_first_count": profile_review_first_count,
+        "profile_authority_expansion_detected": profile_authority_expansion_detected,
+        "profile_results": profile_results,
     }
 
 
@@ -602,6 +728,8 @@ def build_runtime_proof_artifacts(
             "reporting_only": True,
             "proof_commands_executed_by_renderer": False,
             "automation_allowed": False,
+            "patch_application_allowed": False,
+            "security_dismissal_allowed": False,
             "merge_authorized": False,
             "semantic_equivalence_proven": False,
         },
@@ -657,8 +785,50 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
                 ),
                 f"- Profiles executed: `{_int(isolated.get('profiles_executed'))}`",
                 f"- Profiles blocked: `{_int(isolated.get('profiles_blocked'))}`",
+                (
+                    "- Profile visibility status: "
+                    f"`{_string(isolated.get('profile_visibility_status') or NOT_COLLECTED)}`"
+                ),
+                (
+                    "- Profile review-first results: "
+                    f"`{_int(isolated.get('profile_review_first_count'))}`"
+                ),
+                (
+                    "- Profile authority expansion detected: "
+                    f"`{str(_bool(isolated.get('profile_authority_expansion_detected'))).lower()}`"
+                ),
             ]
         )
+
+        profile_results = [
+            _as_dict(item) for item in _as_list(isolated.get("profile_results")) if _as_dict(item)
+        ]
+        if profile_results:
+            lines.append("- Profile results:")
+            for profile in profile_results:
+                claim_value = profile.get("inventory_claim_match")
+                claim_status = (
+                    "not_checked" if claim_value is None else str(_bool(claim_value)).lower()
+                )
+                lines.append(
+                    f"  - `{_string(profile.get('profile_id') or 'unknown')}`: "
+                    f"command=`{_string(profile.get('command') or 'unknown')}`, "
+                    f"status=`{_string(profile.get('status') or 'unknown')}`, "
+                    f"exit_code=`{_int(profile.get('exit_code'))}`, "
+                    f"timed_out=`{str(_bool(profile.get('timed_out'))).lower()}`, "
+                    "workspace_mutated=`"
+                    f"{str(_bool(profile.get('workspace_mutated'))).lower()}`, "
+                    f"runtime_guard=`{_string(profile.get('runtime_guard_status') or 'unknown')}`, "
+                    f"inventory_claim_match=`{claim_status}`, "
+                    "git_inventory_verified=`"
+                    f"{str(_bool(profile.get('git_inventory_verified'))).lower()}`, "
+                    f"network_boundary=`{_string(profile.get('network_boundary_status') or 'unknown')}`, "
+                    "network_wrapped=`"
+                    f"{str(_bool(profile.get('network_backend_command_wrapped'))).lower()}`, "
+                    f"review_first=`{str(_bool(profile.get('review_first'))).lower()}`"
+                )
+        else:
+            lines.append("- Profile results: none")
 
     lines.extend(
         [
@@ -1113,6 +1283,14 @@ def render_markdown(summary: Mapping[str, Any]) -> str:
                 f"`{str(_bool(boundary.get('proof_commands_executed_by_renderer'))).lower()}`"
             ),
             (f"- Automation allowed: `{str(_bool(boundary.get('automation_allowed'))).lower()}`"),
+            (
+                "- Patch application allowed: "
+                f"`{str(_bool(boundary.get('patch_application_allowed'))).lower()}`"
+            ),
+            (
+                "- Security dismissal allowed: "
+                f"`{str(_bool(boundary.get('security_dismissal_allowed'))).lower()}`"
+            ),
             (f"- Merge authorized: `{str(_bool(boundary.get('merge_authorized'))).lower()}`"),
             (
                 "- Semantic equivalence proven: "

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -27,12 +27,7 @@ SECURITY_FINDING_DIAGNOSIS_MODULE = "_".join(("security", "finding", "diagnosis"
 SECURITY_REVIEWED_DISPOSITION_HISTORY_MODULE = "_".join(
     ("security", "reviewed", "disposition", "history")
 )
-NEXT_RECOMMENDED_PR = "/".join(
-    (
-        "feature",
-        "-".join(("git", "proof", "profile", "visibility")),
-    )
-)
+NEXT_RECOMMENDED_PR = "none"
 
 SPINE_STAGES = (
     "evidence",
@@ -410,22 +405,23 @@ def build_alignment_components() -> list[AlignmentComponent]:
         ),
         _component(
             module="git_inventory_collector",
-            role="derive changed-file inventories from fixed read-only Git queries",
-            status="partially_aligned",
-            stages=("evidence", "proof", "verifier"),
+            role="derive changed-file inventories from fixed read-only Git queries and expose per-profile current-head proof context",
+            status="aligned",
+            stages=("evidence", "proof", "verifier", "reporting"),
             existing_artifacts=(
                 "git-inventory.json",
                 "git-inventory.md",
+                "runtime-proof-artifacts.json",
+                "runtime-proof-artifacts.md",
             ),
             integration_points=(
                 "isolated_proof_runner",
                 "protected_verifier",
                 "replayable_benchmark_harness",
+                "pr_quality_runtime_proof_artifacts",
+                "pr_quality_action_report",
             ),
-            gaps=(
-                "workflow visibility uses Git-derived inventory only for a narrow allowlisted Ruff proof profile",
-            ),
-            recommended_next_action="expand Git-grounded PR Quality visibility to existing non-Ruff allowlisted proof profiles without changing authority",
+            recommended_next_action="preserve bounded multi-profile visibility and keep proof, patch, and merge authority disabled",
         ),
         _component(
             module="network_boundary",

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -5835,3 +5835,81 @@ def test_failed_check_panel_renders_exact_failure_and_remediation_contract() -> 
     assert "Remediation affected files: `src/sdetkit/example.py`" in rendered
     assert "Remediation proof commands:" in rendered
     assert "python -m pre_commit run -a" in rendered
+
+
+def test_pr_quality_comment_renders_git_grounded_profile_visibility() -> None:
+    from sdetkit import pr_quality_action_report
+
+    lines = pr_quality_action_report._runtime_proof_artifact_lines(
+        {
+            "status": "collected",
+            "isolated_proof": {
+                "status": "passed",
+                "git_inventory_verified": True,
+                "runtime_guard_checked": True,
+                "runtime_guard_passed": True,
+                "runtime_guard_violation_count": 0,
+                "network_boundary_status": "not_requested",
+                "network_isolation_enforced": False,
+                "profiles_executed": 2,
+                "profiles_blocked": 0,
+                "profile_visibility_status": "collected",
+                "profile_review_first_count": 0,
+                "profile_authority_expansion_detected": False,
+                "profile_results": [
+                    {
+                        "profile_id": "ruff_src_tests",
+                        "command": "python -m ruff check src tests",
+                        "status": "passed",
+                        "exit_code": 0,
+                        "timed_out": False,
+                        "workspace_mutated": False,
+                        "runtime_guard_status": "clean",
+                        "inventory_claim_match": True,
+                        "git_inventory_verified": True,
+                        "network_boundary_status": "not_requested",
+                        "network_backend_command_wrapped": False,
+                        "review_first": False,
+                    },
+                    {
+                        "profile_id": "pre_commit_all",
+                        "command": "python -m pre_commit run -a",
+                        "status": "passed",
+                        "exit_code": 0,
+                        "timed_out": False,
+                        "workspace_mutated": False,
+                        "runtime_guard_status": "clean",
+                        "inventory_claim_match": True,
+                        "git_inventory_verified": True,
+                        "network_boundary_status": "not_requested",
+                        "network_backend_command_wrapped": False,
+                        "review_first": False,
+                    },
+                ],
+            },
+            "live_benchmark": {
+                "collection_status": "not_collected",
+                "status": "not_collected",
+            },
+            "repo_memory": {},
+            "trusted_history": {},
+            "trusted_diagnostic_signal_snapshot_history": {},
+            "decision_boundary": {
+                "reporting_only": True,
+                "automation_allowed": False,
+                "patch_application_allowed": False,
+                "security_dismissal_allowed": False,
+                "merge_authorized": False,
+                "semantic_equivalence_proven": False,
+            },
+        }
+    )
+
+    text = "\n".join(lines)
+    assert "Profile visibility status: `collected`" in text
+    assert "Proof profile results:" in text
+    assert "`ruff_src_tests`: command=`python -m ruff check src tests`" in text
+    assert "`pre_commit_all`: command=`python -m pre_commit run -a`" in text
+    assert "inventory_claim_match=`true`" in text
+    assert "git_inventory_verified=`true`" in text
+    assert "review_first=`false`" in text

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1331,3 +1331,21 @@ def test_pr_quality_contributor_summary_keeps_trusted_topology() -> None:
     assert 'cat build/pr-quality/pr-review-summary.md >> "$body_path"' in publisher
     assert "publisher handoff summary does not match the review contract" in publisher
     assert "Evidence is advisory and does not authorize merge." in publisher
+
+
+def test_pr_quality_workflow_runs_existing_non_ruff_git_grounded_profile() -> None:
+    text = _workflow_text()
+    start = text.index("python -m sdetkit.isolated_proof_runner")
+    end = text.index(
+        "--out-dir build/pr-quality/runtime-proof/isolated-proof",
+        start,
+    )
+    invocation = text[start:end]
+
+    assert "--inventory-mode base_head" in invocation
+    assert '--base-ref "origin/${{ github.event.pull_request.base.ref }}"' in invocation
+    assert "--head-ref HEAD" in invocation
+    assert "--profile ruff_src_tests" in invocation
+    assert "--profile pre_commit_all" in invocation
+    assert invocation.count("--profile ") == 2
+    assert "--command" not in invocation

--- a/tests/test_pr_quality_runtime_proof_artifacts.py
+++ b/tests/test_pr_quality_runtime_proof_artifacts.py
@@ -969,3 +969,117 @@ def test_runtime_proof_normalizes_missing_registry_history_to_not_collected() ->
     trusted = summary[runtime.TRUSTED_HISTORY]
     assert trusted[runtime.FLAKY_TEST_REGISTRY_COLLECTION_STATUS] == runtime.NOT_COLLECTED
     assert trusted[runtime.FLAKY_TEST_REGISTRY_ENTRY_COUNT] == 0
+
+
+def _multi_profile_isolated_proof() -> dict:
+    proof = _isolated_proof()
+    proof["inventory_claim_match"] = True
+    proof["requested_profiles"] = ["ruff_src_tests", "pre_commit_all"]
+    proof["proof_summary"] = {
+        "requested_count": 2,
+        "executed_count": 2,
+        "blocked_count": 0,
+        "passed_count": 2,
+        "failed_count": 0,
+    }
+    proof["proof_results"] = [
+        {
+            "profile_id": "ruff_src_tests",
+            "command": "python -m ruff check src tests",
+            "status": "passed",
+            "exit_code": 0,
+            "timed_out": False,
+            "workspace_mutated_during_execution": False,
+            "network_backend_command_wrapped": False,
+            "runtime_guard": {
+                "status": "clean",
+                "runtime_guard_violation": False,
+            },
+        },
+        {
+            "profile_id": "pre_commit_all",
+            "command": "python -m pre_commit run -a",
+            "status": "passed",
+            "exit_code": 0,
+            "timed_out": False,
+            "workspace_mutated_during_execution": False,
+            "network_backend_command_wrapped": False,
+            "runtime_guard": {
+                "status": "clean",
+                "runtime_guard_violation": False,
+            },
+        },
+    ]
+    return proof
+
+
+def test_runtime_proof_summary_preserves_bounded_multi_profile_visibility() -> None:
+    summary = build_runtime_proof_artifacts(isolated_proof=_multi_profile_isolated_proof())
+
+    isolated = summary["isolated_proof"]
+    assert isolated["profile_visibility_status"] == COLLECTED
+    assert isolated["requested_profile_ids"] == [
+        "ruff_src_tests",
+        "pre_commit_all",
+    ]
+    assert isolated["profile_review_first_count"] == 0
+    assert isolated["profile_authority_expansion_detected"] is False
+
+    profiles = isolated["profile_results"]
+    assert [item["profile_id"] for item in profiles] == [
+        "ruff_src_tests",
+        "pre_commit_all",
+    ]
+    assert all(item["inventory_claim_match"] is True for item in profiles)
+    assert all(item["git_inventory_verified"] is True for item in profiles)
+    assert all(item["review_first"] is False for item in profiles)
+    assert all(item["automation_allowed"] is False for item in profiles)
+    assert all(item["patch_application_allowed"] is False for item in profiles)
+    assert all(item["security_dismissal_allowed"] is False for item in profiles)
+    assert all(item["merge_authorized"] is False for item in profiles)
+    assert all(item["semantic_equivalence_proven"] is False for item in profiles)
+
+    markdown = render_markdown(summary)
+    assert "Profile visibility status: `collected`" in markdown
+    assert "`ruff_src_tests`: command=`python -m ruff check src tests`" in markdown
+    assert "`pre_commit_all`: command=`python -m pre_commit run -a`" in markdown
+    assert "inventory_claim_match=`true`" in markdown
+    assert "review_first=`false`" in markdown
+    assert "Patch application allowed: `false`" in markdown
+    assert "Security dismissal allowed: `false`" in markdown
+
+
+def test_runtime_proof_profile_visibility_fails_closed_on_untrusted_evidence() -> None:
+    proof = _multi_profile_isolated_proof()
+    proof["inventory_claim_match"] = False
+    proof["decision_boundary"]["git_inventory_verified"] = False
+    proof["proof_results"][1]["status"] = "failed"
+    proof["proof_results"][1]["exit_code"] = 1
+    proof["proof_results"][1]["timed_out"] = True
+    proof["proof_results"][1]["automation_allowed"] = True
+
+    summary = build_runtime_proof_artifacts(isolated_proof=proof)
+    isolated = summary["isolated_proof"]
+
+    assert isolated["profile_visibility_status"] == "review_first"
+    assert isolated["profile_review_first_count"] == 2
+    assert isolated["profile_authority_expansion_detected"] is True
+    assert all(item["review_first"] is True for item in isolated["profile_results"])
+
+    boundary = summary["decision_boundary"]
+    assert boundary["automation_allowed"] is False
+    assert boundary["patch_application_allowed"] is False
+    assert boundary["security_dismissal_allowed"] is False
+    assert boundary["merge_authorized"] is False
+    assert boundary["semantic_equivalence_proven"] is False
+
+
+def test_runtime_proof_profile_visibility_marks_missing_executed_results_incomplete() -> None:
+    proof = _isolated_proof()
+    proof["proof_summary"]["executed_count"] = 1
+    proof["proof_results"] = []
+
+    summary = build_runtime_proof_artifacts(isolated_proof=proof)
+
+    assert summary["isolated_proof"]["profile_visibility_status"] == "incomplete"
+    assert summary["isolated_proof"]["profile_results"] == []

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -61,7 +61,7 @@ def test_alignment_statuses_show_aligned_partial_and_planned_layers() -> None:
     status_counts = report["status_counts"]
 
     assert status_counts["aligned"] >= 13
-    assert status_counts["partially_aligned"] >= 7
+    assert status_counts["partially_aligned"] >= 6
     assert status_counts.get("planned", 0) == 0
     assert report["next_recommended_pr"] == NEXT_RECOMMENDED_PR
 
@@ -85,7 +85,7 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert "replayable_benchmark_harness" in gaps_by_module
     assert "repo_memory" not in gaps_by_module
     assert "isolated_proof_runner" in gaps_by_module
-    assert "git_inventory_collector" in gaps_by_module
+    assert "git_inventory_collector" not in gaps_by_module
     assert "network_boundary" not in gaps_by_module
     assert "proof_runtime_guard" in gaps_by_module
     assert "pr_quality_runtime_proof_artifacts" not in gaps_by_module
@@ -108,10 +108,6 @@ def test_alignment_identifies_safe_automation_gaps() -> None:
     assert any("semantic equivalence" in gap for gap in gaps_by_module["protected_verifier"])
     assert not any("network-isolated" in gap for gap in gaps_by_module["isolated_proof_runner"])
     assert any("external filesystem" in gap for gap in gaps_by_module["isolated_proof_runner"])
-    assert any(
-        "narrow allowlisted Ruff proof profile" in gap
-        for gap in gaps_by_module["git_inventory_collector"]
-    )
     assert any("containment" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert not any("PR Quality" in gap for gap in gaps_by_module["replayable_benchmark_harness"])
     assert "repo_memory" not in gaps_by_module
@@ -152,7 +148,7 @@ def test_alignment_closes_pr_quality_registry_visibility_without_authority() -> 
     assert "no-authority" in report.recommended_next_action
 
 
-def test_alignment_closes_exact_failure_gap_and_selects_git_proof_visibility() -> None:
+def test_alignment_closes_exact_failure_and_git_profile_visibility_gaps() -> None:
     components = {item.module: item for item in build_alignment_components()}
 
     adaptive = components["adaptive_diagnosis"]
@@ -168,10 +164,12 @@ def test_alignment_closes_exact_failure_gap_and_selects_git_proof_visibility() -
     assert "existing PR Quality candidate handoff" in scorer.recommended_next_action
     assert "unwired from automation" in scorer.recommended_next_action
 
-    assert inventory.status == "partially_aligned"
-    assert any("narrow allowlisted Ruff proof profile" in gap for gap in inventory.gaps)
-    assert "non-Ruff allowlisted proof profiles" in inventory.recommended_next_action
-    assert NEXT_RECOMMENDED_PR == "feature/git-proof-profile-visibility"
+    assert inventory.status == "aligned"
+    assert inventory.gaps == ()
+    assert "runtime-proof-artifacts.json" in inventory.existing_artifacts
+    assert "pr_quality_action_report" in inventory.integration_points
+    assert "multi-profile visibility" in inventory.recommended_next_action
+    assert NEXT_RECOMMENDED_PR == "none"
 
 
 def test_alignment_markdown_renders_operator_audit() -> None:
@@ -193,7 +191,7 @@ def test_alignment_markdown_renders_operator_audit() -> None:
     assert "`replayable_benchmark_harness`: `partially_aligned`" in markdown
     assert "`repo_memory`: `aligned`" in markdown
     assert "`isolated_proof_runner`: `partially_aligned`" in markdown
-    assert "`git_inventory_collector`: `partially_aligned`" in markdown
+    assert "`git_inventory_collector`: `aligned`" in markdown
     assert "`network_boundary`: `aligned`" in markdown
     assert "`proof_runtime_guard`: `partially_aligned`" in markdown
     assert "`pr_quality_runtime_proof_artifacts`: `aligned`" in markdown


### PR DESCRIPTION
## Roadmap action

`git-proof-profile-visibility`

## Problem

PR Quality already executes both `ruff_src_tests` and `pre_commit_all`
against exact Git-derived base/head inventory, but the runtime summary and
contributor comment collapse the profile results into counts.

## Change

- preserve a bounded sanitized result for each isolated proof profile;
- show profile ID, canonical command, status, exit code, timeout state,
  workspace mutation, runtime guard, inventory match, Git verification,
  network boundary, wrapping state, and review-first disposition;
- fail closed for missing, incomplete, failed, timed-out, mutated,
  inventory-mismatched, or authority-expanding profile evidence;
- keep the existing runtime summary schema additive;
- close the active roadmap action and record no safe patch-ready successor.

## Duplicate avoidance

- no new proof profile is introduced;
- no arbitrary command input is introduced;
- the existing `ruff_src_tests` and `pre_commit_all` invocation is reused;
- ProtectedVerifier already consumes the full verification evidence.

## Authority boundary

- workflow files changed: false
- workflow permissions changed: false
- automation allowed: false
- patch application allowed: false
- security dismissal allowed: false
- merge authorized: false
- semantic equivalence proven: false

## Verification

- focused runtime-proof, PR report, workflow-contract, verifier, and alignment tests;
- scoped pre-commit;
- `make proof-after-format` in an isolated exact-commit worktree;
- protected workflows unchanged;
- clean worktree.
