### PR TITLE
feat(pr-quality): add reviewer-first SDET gate console

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -216,6 +216,29 @@ action:
 - The runtime projection remains additive under the existing schema and grants no automation, patch application, security dismissal, merge, or semantic-equivalence authority.
 - The PR Quality producer and trusted publisher workflows remain unchanged.
 
+### Completed roadmap action
+
+```text
+action:
+  id=sdet-quality-comment-review-console
+  lane=Reviewer experience and product surface
+  title=Turn the SDET Quality Gate PR comment into a reviewer-first interactive console
+  priority=P1
+  risk=medium
+  value=Make the gate immediately understandable and actionable without changing evidence collection, trusted publishing, or authority.
+  status=done
+```
+
+**Closure evidence**
+
+- The decision is presented first in human language with a visible gate state, required-check summary, security posture, merge guidance, risk focus, and one canonical reviewer action.
+- Bot commands `/check`, `/quality`, `/doctor`, and `/hint` are integrated into the comment as quick actions.
+- The raw machine decision contract remains available under progressive disclosure for compatibility and auditability.
+- Green PRs retain the collapsed failure-vector compatibility panel, but it now states that no active actionable failure exists and emits no unknown failure fields.
+- Blocked, review-first, stale, and invalid states automatically open the relevant decision and failure evidence.
+- Security, proof commands, check evidence, and the full authority boundary remain available as focused collapsible sections.
+- The structured review model, trusted producer, trusted publisher, workflow permissions, exact-head verification, and reporting-only authority remain unchanged.
+
 ### Roadmap selection status
 
 ```text

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -3060,10 +3060,48 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     authority = _as_dict(model.get("authority_boundary"))
     failure_vector_signal = _as_dict(model.get("failure_vector_signal"))
     ghas_blocker_details = _as_dict(model.get("ghas_blocker_details"))
+
+    def _looks_like_shell_command(value: str) -> bool:
+        parts = value.strip().split()
+        if not parts:
+            return False
+
+        while parts and "=" in parts[0]:
+            name, separator, _assigned_value = parts[0].partition("=")
+            if not separator or not name or not name.replace("_", "").isalnum():
+                break
+            parts = parts[1:]
+
+        if not parts:
+            return False
+
+        executable = parts[0]
+        allowed_executables = {
+            "bash",
+            "gh",
+            "make",
+            "mkdocs",
+            "mypy",
+            "nox",
+            "npm",
+            "pnpm",
+            "poetry",
+            "pre-commit",
+            "pytest",
+            "python",
+            "python3",
+            "ruff",
+            "sh",
+            "tox",
+            "uv",
+            "yarn",
+        }
+        return executable in allowed_executables or executable.startswith("./")
+
     proof_commands = [
-        str(command)
+        str(command).strip()
         for command in _as_list(model.get("proof_to_rerun"))
-        if isinstance(command, str) and command.strip()
+        if isinstance(command, str) and _looks_like_shell_command(command)
     ]
     recommended_actions = [
         str(item)
@@ -3118,7 +3156,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         ]
 
     def _human_token(value: object) -> str:
-        token = _review_model_scalar(value or "none")
+        canonical_value = _review_model_scalar(value or "none")
         labels = {
             "review_and_decide": "Review the changed evidence and make the final merge decision",
             "do_not_merge_until_blocker_resolved": "Do not merge until the named blocker is resolved",
@@ -3140,7 +3178,10 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "none": "None",
             "unavailable": "Unavailable",
         }
-        return labels.get(token, token.replace("_", " ").strip().capitalize())
+        return labels.get(
+            canonical_value,
+            canonical_value.replace("_", " ").strip().capitalize(),
+        )
 
     failed_total = _count(decision.get("failed_checks"))
     queued_total = _count(decision.get("required_queued_checks"))
@@ -3190,6 +3231,44 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         if isinstance(item, str) and item.strip()
     ]
 
+    ghas_findings = [
+        _as_dict(item) for item in _as_list(ghas_blocker_details.get("findings")) if _as_dict(item)
+    ]
+    if risk_surface == "security" and ghas_findings:
+        primary_security_finding = ghas_findings[0]
+        security_message = _review_model_scalar(primary_security_finding.get("message") or "")
+        security_rule = _review_model_scalar(primary_security_finding.get("rule_id") or "security")
+        security_location = _review_model_scalar(
+            primary_security_finding.get("location") or "unknown"
+        )
+        security_proof = [
+            str(command).strip()
+            for command in _as_list(primary_security_finding.get("proof_commands"))
+            if isinstance(command, str) and _looks_like_shell_command(command)
+        ]
+
+        if security_message:
+            failure_actual = security_message
+        if failure_type in {"", "none", "unknown"}:
+            failure_type = security_rule
+        if failing_command in {"", "none", "unknown"} and security_proof:
+            failing_command = security_proof[0]
+        if failing_test in {"", "none", "unknown"}:
+            failing_test = "sdetkit-security-gate"
+        if failure_owner in {"", "none", "unknown"}:
+            failure_owner = security_location
+
+        security_path = security_location.split(":", 1)[0]
+        if security_path and security_path != "unknown" and security_path not in affected_files:
+            affected_files.insert(0, security_path)
+
+    human_first_action = _human_token(first_action)
+    if first_action == "review" and risk_surface == "security":
+        human_first_action = (
+            "Review the current security finding, decide whether to fix it "
+            "or record a reviewed false-positive dismissal, then rerun the gate"
+        )
+
     active_blocker_open = review_state in {
         "blocked",
         "review",
@@ -3212,9 +3291,6 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         )
     )
     proof_open = active_blocker_open and bool(proof_commands)
-    ghas_findings = [
-        _as_dict(item) for item in _as_list(ghas_blocker_details.get("findings")) if _as_dict(item)
-    ]
     ghas_open = bool(ghas_findings) and (active_blocker_open or stale_only_security_signal)
 
     lines = [
@@ -3232,7 +3308,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         f"| Merge guidance | {_markdown_table_value(_human_token(merge_assessment))} |",
         f"| Risk focus | `{_markdown_table_value(risk_surface)}` — {_markdown_table_value(signal_title)} |",
         "",
-        f"> **Do this now:** {_human_token(first_action)}.",
+        f"> **Do this now:** {human_first_action}.",
         "",
         "### Quick actions",
         "",
@@ -3265,7 +3341,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         "| Item | Value |",
         "|---|---|",
         f"| Human merge guidance | {_markdown_table_value(_human_token(merge_assessment))} |",
-        f"| Human next action | {_markdown_table_value(_human_token(first_action))} |",
+        f"| Human next action | {_markdown_table_value(human_first_action)} |",
         f"| Merge assessment | `{_markdown_table_value(merge_assessment)}` |",
         f"| Next action | `{_markdown_table_value(first_action)}` |",
         f"| First blocker | `{_markdown_table_value(first_blocker)}` |",

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -3117,6 +3117,31 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "</details>",
         ]
 
+    def _human_token(value: object) -> str:
+        token = _review_model_scalar(value or "none")
+        labels = {
+            "review_and_decide": "Review the changed evidence and make the final merge decision",
+            "do_not_merge_until_blocker_resolved": "Do not merge until the named blocker is resolved",
+            "wait_for_required_checks": "Wait for required checks to finish",
+            "review_listed_evidence": "Review the listed evidence before merging",
+            "rerun_listed_proof": "Run the focused verification commands",
+            "refresh_stale_evidence": "Refresh stale evidence and rerun the gate",
+            "repair_invalid_evidence": "Repair the invalid evidence contract",
+            "automated_proof_complete_human_decision_required": (
+                "Automated proof is complete; a human merge decision is still required"
+            ),
+            "merge_blocked_required_checks_incomplete": (
+                "Merge is blocked while required checks are incomplete"
+            ),
+            "do_not_merge_until_evidence_reviewed": (
+                "Do not merge until the review-first evidence is resolved"
+            ),
+            "clear": "Clear",
+            "none": "None",
+            "unavailable": "Unavailable",
+        }
+        return labels.get(token, token.replace("_", " ").strip().capitalize())
+
     failed_total = _count(decision.get("failed_checks"))
     queued_total = _count(decision.get("required_queued_checks"))
     startup_total = _count(decision.get("required_startup_failures"))
@@ -3124,6 +3149,32 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     stale_only_security_signal = bool(decision.get(STALE_ONLY_SECURITY_SIGNAL))
     review_state = _review_model_state(model)
     first_action = _review_model_scalar(decision.get("next_action") or "none")
+    first_blocker = _review_model_scalar(decision.get("primary_blocker") or "none")
+    merge_assessment = _review_model_scalar(decision.get("merge_assessment") or "unknown")
+    risk_surface = _review_model_scalar(decision.get("risk_surface") or "unknown")
+    signal_title = _review_model_scalar(decision.get("signal_title") or "none")
+
+    panel_rows = dict(_contributor_review_panel_rows(model))
+    required_summary = _review_model_scalar(panel_rows.get("Required checks") or "unknown")
+    security_summary = _review_model_scalar(panel_rows.get("Security posture") or "unknown")
+
+    state_icon = {
+        "waiting": "⏳",
+        "blocked": "🚨",
+        "review": "👀",
+        "ready": "✅",
+        "stale": "🟡",
+        "invalid": "❌",
+    }.get(review_state, "ℹ️")
+    state_label = _review_model_state_label(review_state).capitalize()
+    state_explanation = {
+        "waiting": "Required checks are still running; no merge decision should be made yet.",
+        "blocked": "A required proof contract is failing and blocks merge.",
+        "review": "Automated checks may be green, but named evidence still requires human review.",
+        "ready": "Required checks and security evidence are clear for the current head.",
+        "stale": "The evidence does not match the current head and must be refreshed.",
+        "invalid": "The review evidence contract is inconsistent or incomplete.",
+    }.get(review_state, "Review the evidence below before deciding.")
 
     failure_actual = _review_model_scalar(failure_vector_signal.get("actual_failure") or "none")
     failure_source = _review_model_scalar(failure_vector_signal.get("source") or "none")
@@ -3145,7 +3196,21 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         "stale",
         "invalid",
     }
-    failure_vector_open = active_blocker_open and failure_actual not in {"", "none"}
+    meaningful_failure_values = {
+        failure_actual,
+        failure_type,
+        failing_command,
+        failing_test,
+    } - {"", "none", "unknown"}
+    show_failure_vector = bool(
+        active_blocker_open
+        and (
+            meaningful_failure_values
+            or failed_total > 0
+            or bool(affected_files)
+            or bool(failure_vector_signal.get("safe_fix_candidate"))
+        )
+    )
     proof_open = active_blocker_open and bool(proof_commands)
     ghas_findings = [
         _as_dict(item) for item in _as_list(ghas_blocker_details.get("findings")) if _as_dict(item)
@@ -3155,15 +3220,43 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     lines = [
         "# PR Quality Review Summary",
         "",
+        f"> {state_icon} **{state_label}** — {state_explanation}",
+        "",
+        "## Review at a glance",
+        "",
+        "| Area | Result |",
+        "|---|---|",
+        f"| Gate | {state_icon} **{state_label}** |",
+        f"| Required checks | **{_markdown_table_value(_human_token(required_summary))}** |",
+        f"| Security | **{_markdown_table_value(_human_token(security_summary))}** |",
+        f"| Merge guidance | {_markdown_table_value(_human_token(merge_assessment))} |",
+        f"| Risk focus | `{_markdown_table_value(risk_surface)}` — {_markdown_table_value(signal_title)} |",
+        "",
+        f"> **Do this now:** {_human_token(first_action)}.",
+        "",
+        "### Quick actions",
+        "",
+        "| Command | Purpose |",
+        "|---|---|",
+        "| `/check` | Re-run the standard validation checks |",
+        "| `/quality` | Run the full quality and coverage gate |",
+        "| `/doctor` | Diagnose the first concrete failure |",
+        "| `/hint` | Show the compact reviewer checklist |",
+        "",
+        "<details>",
+        "<summary>🧾 Machine decision contract</summary>",
+        "",
         "## Contributor decision",
         "",
         *_markdown_table(_contributor_review_panel_rows(model)),
+        "",
+        "</details>",
         "",
     ]
 
     if recommended_actions:
         lines.extend(["## Recommended actions", ""])
-        lines.extend(f"- {action}" for action in recommended_actions[:10])
+        lines.extend(f"- {action}" for action in recommended_actions[:5])
         lines.append("")
 
     lines.extend(["## Adaptive review details", ""])
@@ -3171,23 +3264,23 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     blocker_body = [
         "| Item | Value |",
         "|---|---|",
-        f"| Merge assessment | `{_review_model_scalar(decision.get('merge_assessment'))}` |",
-        f"| Next action | `{_review_model_scalar(decision.get('next_action'))}` |",
-        f"| Risk surface | `{_markdown_table_value(decision.get('risk_surface'))}` |",
-        f"| Signal title | `{_markdown_table_value(decision.get('signal_title'))}` |",
+        f"| Human merge guidance | {_markdown_table_value(_human_token(merge_assessment))} |",
+        f"| Human next action | {_markdown_table_value(_human_token(first_action))} |",
+        f"| Merge assessment | `{_markdown_table_value(merge_assessment)}` |",
+        f"| Next action | `{_markdown_table_value(first_action)}` |",
+        f"| First blocker | `{_markdown_table_value(first_blocker)}` |",
+        f"| Risk surface | `{_markdown_table_value(risk_surface)}` |",
+        f"| Signal title | `{_markdown_table_value(signal_title)}` |",
         f"| Signal | `{_markdown_table_value(decision.get('comment_signal'))}` |",
         f"| Review-first evidence | `{_review_model_scalar(decision.get('review_first_evidence'))}` |",
         f"| Cleared security signal | `{_review_model_scalar(decision.get('cleared_security_signal'))}` |",
         f"| Stale-only security signal | `{str(stale_only_security_signal).lower()}` |",
         "",
+        "### Canonical next action",
+        "",
+        f"- `{first_action}`",
     ]
-    blocker_body.extend(
-        [
-            "### Canonical next action",
-            "",
-            f"- `{first_action}`",
-        ]
-    )
+
     additional_guidance = [
         action for action in recommended_actions if action and action != first_action
     ]
@@ -3202,7 +3295,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         "ready": "✅ Ready for human decision",
         "stale": "🟡 Stale evidence / refresh required",
         "invalid": "❌ Invalid review evidence",
-    }.get(review_state, "Decision details")
+    }.get(review_state, "Decision evidence")
 
     lines.extend(
         _details(
@@ -3213,31 +3306,46 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     )
     lines.append("")
 
-    failure_body = [
-        "| Failure field | Value |",
-        "|---|---|",
-        f"| Source | `{_markdown_table_value(failure_source)}` |",
-        f"| Actual failure | `{_markdown_table_value(failure_actual)}` |",
-        f"| Failure type | `{_markdown_table_value(failure_type)}` |",
-        f"| Failing command | `{_markdown_table_value(failing_command)}` |",
-        f"| Failing test/check | `{_markdown_table_value(failing_test)}` |",
-        f"| Owner hint | `{_markdown_table_value(failure_owner)}` |",
-        f"| Safe-fix candidate | `{_review_model_scalar(failure_vector_signal.get('safe_fix_candidate'))}` |",
-        f"| Safe-fix allowed | `{_review_model_scalar(failure_vector_signal.get('safe_fix_allowed'))}` |",
-        f"| Reporting only | `{_review_model_scalar(failure_vector_signal.get('reporting_only'))}` |",
-    ]
-    if affected_files:
-        failure_body.extend(["", "### Affected files", ""])
-        failure_body.extend(f"- `{item}`" for item in affected_files[:10])
+    if show_failure_vector:
+        failure_body = [
+            "| Failure field | Value |",
+            "|---|---|",
+            f"| Source | `{_markdown_table_value(failure_source)}` |",
+            f"| Actual failure | `{_markdown_table_value(failure_actual)}` |",
+            f"| Failure type | `{_markdown_table_value(failure_type)}` |",
+            f"| Failing command | `{_markdown_table_value(failing_command)}` |",
+            f"| Failing test/check | `{_markdown_table_value(failing_test)}` |",
+            f"| Owner hint | `{_markdown_table_value(failure_owner)}` |",
+            f"| Safe-fix candidate | `{_review_model_scalar(failure_vector_signal.get('safe_fix_candidate'))}` |",
+            f"| Safe-fix allowed | `{_review_model_scalar(failure_vector_signal.get('safe_fix_allowed'))}` |",
+            f"| Reporting only | `{_review_model_scalar(failure_vector_signal.get('reporting_only'))}` |",
+        ]
+        if affected_files:
+            failure_body.extend(["", "### Affected files", ""])
+            failure_body.extend(f"- `{item}`" for item in affected_files[:10])
 
-    lines.extend(
-        _details(
-            "🧭 Failure vector deep dive",
-            failure_body,
-            open_by_default=failure_vector_open,
+        lines.extend(
+            _details(
+                "🧭 Failure vector deep dive",
+                failure_body,
+                open_by_default=True,
+            )
         )
-    )
-    lines.append("")
+        lines.append("")
+    else:
+        no_failure_body = [
+            "> No active actionable failure exists for the current PR head.",
+            "",
+            "The compatibility panel is retained for audit consumers, but no unknown failure fields are emitted.",
+        ]
+        lines.extend(
+            _details(
+                "🧭 Failure vector deep dive",
+                no_failure_body,
+                open_by_default=False,
+            )
+        )
+        lines.append("")
 
     ghas_body = [
         "| Item | Value |",
@@ -3250,11 +3358,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         f"| Current head SHA | `{_markdown_table_value(ghas_blocker_details.get('current_head_sha') or 'unknown')}` |",
         f"| Dismissal allowed | `{_review_model_scalar(ghas_blocker_details.get('dismissal_allowed'))}` |",
     ]
-    if (
-        _int(ghas_blocker_details.get("open_alerts")) > 0
-        and _int(ghas_blocker_details.get("current_alerts")) == 0
-        and _int(ghas_blocker_details.get("stale_alerts")) > 0
-    ):
+    if stale_only_security_signal:
         ghas_body.extend(
             [
                 "",
@@ -3296,13 +3400,18 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             if commands:
                 ghas_body.extend(["", "Proof:", "", "```bash", *commands[:5], "```", ""])
 
+    security_title = (
+        "🛡️ GHAS / CodeQL refresh details"
+        if stale_only_security_signal
+        else (
+            "🛡️ GHAS / CodeQL blocker details"
+            if _int(ghas_blocker_details.get("current_alerts")) > 0
+            else "🛡️ Security evidence"
+        )
+    )
     lines.extend(
         _details(
-            (
-                "🛡️ GHAS / CodeQL refresh details"
-                if stale_only_security_signal
-                else "🛡️ GHAS / CodeQL blocker details"
-            ),
+            security_title,
             ghas_body,
             open_by_default=ghas_open,
         )
@@ -3312,11 +3421,14 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     proof_section_title = (
         "🧪 Optional verification" if review_state == "ready" else "🧪 Proof to rerun"
     )
-    proof_body: list[str] = []
+    proof_body: list[str] = [
+        "> Copy and run the focused commands below when verification is needed.",
+        "",
+    ]
     if proof_commands:
-        proof_body.extend(["```bash", *proof_commands, "```"])
+        proof_body.extend(["```bash", *proof_commands[:5], "```"])
     else:
-        proof_body.append("`none`")
+        proof_body.append("`No additional command is required.`")
     lines.extend(
         _details(
             proof_section_title,
@@ -3343,19 +3455,26 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     )
     lines.append("")
 
+    authority_body = [
+        "| Authority | Value |",
+        "|---|---|",
+        f"| Boundary mode | `{_review_model_scalar(authority.get('boundary_mode'))}` |",
+        f"| Patch automation | `{_review_model_scalar(authority.get('patch_automation'))}` |",
+        f"| Security dismissal | `{_review_model_scalar(authority.get('security_dismissal'))}` |",
+        f"| Merge authorization | `{_review_model_scalar(authority.get('merge_authorization'))}` |",
+        f"| Semantic equivalence claim | `{_review_model_scalar(authority.get('semantic_equivalence_claim'))}` |",
+    ]
     lines.extend(
         [
-            "## Authority boundary",
+            "> 🔒 **Authority boundary:** reporting only. This gate does not authorize merge, patch code, or dismiss security findings.",
             "",
-            "| Authority | Value |",
-            "|---|---|",
-            f"| Boundary mode | `{_review_model_scalar(authority.get('boundary_mode'))}` |",
-            f"| Patch automation | `{_review_model_scalar(authority.get('patch_automation'))}` |",
-            f"| Security dismissal | `{_review_model_scalar(authority.get('security_dismissal'))}` |",
-            f"| Merge authorization | `{_review_model_scalar(authority.get('merge_authorization'))}` |",
-            f"| Semantic equivalence claim | `{_review_model_scalar(authority.get('semantic_equivalence_claim'))}` |",
+            *_details(
+                "🔒 Full authority boundary",
+                authority_body,
+                open_by_default=False,
+            ),
             "",
-            "> This summary is generated from the structured PR Quality review model. It is reporting-only and does not authorize merge, patch automation, security dismissal, or semantic-equivalence claims.",
+            "> This summary is generated from the structured PR Quality review model and preserves the existing trusted-publisher contract.",
         ]
     )
 

--- a/src/sdetkit/reliability_spine_alignment.py
+++ b/src/sdetkit/reliability_spine_alignment.py
@@ -190,16 +190,21 @@ def build_alignment_components() -> list[AlignmentComponent]:
         ),
         _component(
             module="pr_quality_action_report",
-            role="render operator-facing PR Quality status, evidence, trajectory, runtime-proof, trusted-history, and aggregate producer-vetted registry summaries",
+            role="render a reviewer-first interactive PR Quality console over status, evidence, trajectory, runtime proof, trusted history, and aggregate producer-vetted registry summaries",
             status="aligned",
             stages=("reporting", "trajectory", "proof", "history"),
-            existing_artifacts=("pr-comment-body.md", "pr-comment-metadata.json"),
+            existing_artifacts=(
+                "pr-comment-body.md",
+                "pr-comment-metadata.json",
+                "pr-review-summary.md",
+                "pr-review-dashboard.html",
+            ),
             integration_points=(
                 "check_intelligence",
                 "trajectory_store",
                 "pr_quality_runtime_proof_artifacts",
             ),
-            recommended_next_action="keep accepted-main registry context aggregate-only, advisory-only, and no-authority",
+            recommended_next_action="preserve human-readable decisions, conditional evidence disclosure, bot quick-actions, reporting-only authority, and the existing no-authority contract",
         ),
         _component(
             module="pr_quality_runtime_proof_artifacts",

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -6075,3 +6075,108 @@ def test_review_summary_opens_blocker_evidence_and_keeps_authority_false() -> No
     assert "| Patch automation | `false` |" in summary
     assert "| Security dismissal | `false` |" in summary
     assert "reporting only" in summary.lower()
+
+
+def test_review_summary_filters_non_commands_from_proof_block() -> None:
+    model = _review_console_ready_model()
+    model["proof_to_rerun"] = [
+        "python -m pre_commit run -a",
+        "Review the current security check annotations for the PR.",
+        "Fix the flagged surface or dismiss a reviewed false positive with a reason.",
+    ]
+
+    summary = report.render_pr_quality_review_summary(model)
+    proof_start = summary.index("<summary>🧪 Optional verification</summary>")
+    proof_section = summary[proof_start : summary.index("</details>", proof_start)]
+
+    assert "python -m pre_commit run -a" in proof_section
+    assert "Review the current security check annotations" not in proof_section
+    assert "Fix the flagged surface" not in proof_section
+
+
+def test_review_summary_enriches_security_failure_from_ghas() -> None:
+    model = {
+        "decision": {
+            "status": "review_required",
+            "merge_assessment": "do_not_merge_until_blocker_resolved",
+            "next_action": "review",
+            "risk_surface": "security",
+            "signal_title": "Security check annotation requires review",
+            "comment_signal": "Evidence review signal",
+            "review_first_evidence": True,
+            "cleared_security_signal": False,
+            "failed_checks": 1,
+            "required_queued_checks": 0,
+            "required_startup_failures": 0,
+            "missing_required_contexts": 0,
+        },
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "primary_blocker": {
+            "title": "Security check annotation requires review",
+            "action": "review",
+        },
+        "failure_vector_signal": {
+            "source": "evidence_top_blocker",
+            "actual_failure": "Security check annotation requires review",
+            "failure_type": "unknown",
+            "failing_command": "unknown",
+            "failing_test_or_check": "unknown",
+            "owner_hint": "unknown",
+            "affected_files": [],
+            "safe_fix_candidate": False,
+            "safe_fix_allowed": False,
+            "reporting_only": True,
+        },
+        "ghas_blocker_details": {
+            "collected": True,
+            "collection_status": "collected",
+            "open_alerts": 1,
+            "current_alerts": 1,
+            "stale_alerts": 0,
+            "current_head_sha": "head-sha",
+            "dismissal_allowed": False,
+            "findings": [
+                {
+                    "number": "1448",
+                    "rule_id": "SEC_SECRET_PATTERN",
+                    "severity": "error",
+                    "location": "src/sdetkit/pr_quality_action_report.py:3121",
+                    "freshness": "current",
+                    "message": "Potential hardcoded credential",
+                    "proof_commands": [
+                        "python -m sdetkit security check --root . --format json",
+                        "Review the annotation.",
+                    ],
+                }
+            ],
+        },
+        "recommended_actions": [],
+        "proof_to_rerun": [
+            "python -m sdetkit security check --root . --format json",
+        ],
+        "failed_check_names": ["sdetkit-security-gate"],
+        "required_queued_check_names": [],
+        "required_startup_failure_names": [],
+        "missing_required_context_names": [],
+    }
+
+    summary = report.render_pr_quality_review_summary(model)
+
+    assert (
+        "**Do this now:** Review the current security finding, decide whether "
+        "to fix it or record a reviewed false-positive dismissal, then rerun "
+        "the gate." in summary
+    )
+    assert "| Actual failure | `Potential hardcoded credential` |" in summary
+    assert "| Failure type | `SEC_SECRET_PATTERN` |" in summary
+    assert (
+        "| Failing command | `python -m sdetkit security check --root . --format json` |" in summary
+    )
+    assert "| Failing test/check | `sdetkit-security-gate` |" in summary
+    assert "| Owner hint | `src/sdetkit/pr_quality_action_report.py:3121` |" in summary

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -5913,3 +5913,165 @@ def test_pr_quality_comment_renders_git_grounded_profile_visibility() -> None:
     assert "inventory_claim_match=`true`" in text
     assert "git_inventory_verified=`true`" in text
     assert "review_first=`false`" in text
+
+
+def _review_console_ready_model() -> dict:
+    return report.build_pr_quality_review_model(
+        status="green",
+        evidence_signal_heading="Evidence proof signal",
+        evidence_signal_lines=[],
+        evidence_review_required=False,
+        action_report={
+            "status": "green",
+            "primary_blocker": {},
+            "recommended_actions": [],
+            "proof_commands": ["python -m pre_commit run -a"],
+        },
+        check_intelligence={
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+            "security_review": {
+                "collected": True,
+                "unresolved_findings": 0,
+            },
+            "code_scanning_review": {
+                "collected": True,
+                "collection_status": "collected",
+                "open_alerts": 0,
+                "current_alerts": 0,
+                "stale_alerts": 0,
+                "current_head_sha": "head-sha",
+                "findings": [],
+            },
+        },
+        evidence_narrative={
+            "primary_signal": {
+                "kind": "integration_proof",
+                "surface": "workflow",
+                "title": "Workflow evidence changed",
+            },
+            "graph": {
+                "node_count": 1,
+                "review_first_count": 0,
+                "critical_count": 0,
+                "top_blocker": {
+                    "title": "Workflow evidence changed",
+                    "surface": "workflow",
+                    "action": "rerun_proof",
+                    "review_first": False,
+                },
+            },
+            "next_proof": ["python -m pre_commit run -a"],
+        },
+    )
+
+
+def test_review_summary_is_reviewer_first_and_human_readable() -> None:
+    summary = report.render_pr_quality_review_summary(_review_console_ready_model())
+
+    assert "## Review at a glance" in summary
+    assert "✅ **Ready for human decision**" in summary
+    assert (
+        "**Do this now:** Review the changed evidence and make the final merge decision." in summary
+    )
+    assert "| `/check` | Re-run the standard validation checks |" in summary
+    assert "| `/quality` | Run the full quality and coverage gate |" in summary
+    assert "| `/doctor` | Diagnose the first concrete failure |" in summary
+    assert "| `/hint` | Show the compact reviewer checklist |" in summary
+    assert "<summary>🧾 Machine decision contract</summary>" in summary
+
+    glance = summary[summary.index("## Review at a glance") : summary.index("<details>")]
+    assert "review_and_decide" not in glance
+    assert "automated_proof_complete_human_decision_required" not in glance
+
+
+def test_review_summary_hides_false_failure_panel_on_ready_pr() -> None:
+    summary = report.render_pr_quality_review_summary(_review_console_ready_model())
+
+    assert "<details>\n<summary>🧭 Failure vector deep dive</summary>" in summary
+    assert "No active actionable failure exists for the current PR head." in summary
+    assert "no unknown failure fields are emitted" in summary
+    assert "<summary>🛡️ Security evidence</summary>" in summary
+    assert "GHAS / CodeQL blocker details" not in summary
+
+
+def test_review_summary_opens_blocker_evidence_and_keeps_authority_false() -> None:
+    model = report.build_pr_quality_review_model(
+        status="failed",
+        evidence_signal_heading="Evidence review signal",
+        evidence_signal_lines=[],
+        evidence_review_required=True,
+        action_report={
+            "status": "failed",
+            "primary_blocker": {
+                "title": "Ruff check failed",
+                "surface": "workflow",
+                "action": "fix_lint",
+                "code": "ruff",
+                "path": "src/example.py",
+                "details": "unused import",
+            },
+            "recommended_actions": ["Fix the lint finding."],
+            "proof_commands": ["python -m pre_commit run -a"],
+        },
+        check_intelligence={
+            "failed_checks": [
+                {
+                    "name": "quality",
+                    "command": "python -m pre_commit run -a",
+                    "actual_failure": "unused import",
+                    "failure_type": "lint",
+                    "failing_test_or_check": "F401",
+                    "owner_hint": "src/example.py",
+                    "affected_files": ["src/example.py"],
+                    "first_failure": {
+                        "line": "F401 unused import",
+                        "line_number": 4,
+                        "tool": "ruff",
+                        "kind": "lint",
+                    },
+                    "diagnosis": {
+                        "code": "RUFF_LINT_FAILURE",
+                        "title": "Ruff lint failed",
+                    },
+                }
+            ],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+        evidence_narrative={
+            "primary_signal": {
+                "kind": "review_signal",
+                "surface": "workflow",
+                "title": "Workflow evidence changed",
+            },
+            "graph": {
+                "node_count": 1,
+                "review_first_count": 1,
+                "critical_count": 1,
+                "top_blocker": {
+                    "title": "Ruff check failed",
+                    "actual_failure": "unused import",
+                    "surface": "workflow",
+                    "action": "fix_lint",
+                    "review_first": True,
+                },
+            },
+            "next_proof": ["python -m pre_commit run -a"],
+        },
+    )
+
+    summary = report.render_pr_quality_review_summary(model)
+
+    assert "🚨 **Blocked**" in summary
+    assert "<details open>" in summary
+    assert "<summary>🧭 Failure vector deep dive</summary>" in summary
+    assert "| Actual failure | `unused import` |" in summary
+    assert "Do not merge until the named blocker is resolved" in summary
+    assert "| Merge authorization | `false` |" in summary
+    assert "| Patch automation | `false` |" in summary
+    assert "| Security dismissal | `false` |" in summary
+    assert "reporting only" in summary.lower()

--- a/tests/test_reliability_spine_alignment.py
+++ b/tests/test_reliability_spine_alignment.py
@@ -500,3 +500,15 @@ def test_alignment_closes_verified_network_backend_contract_without_overclaim() 
     assert memory.status == "aligned"
     assert memory.gaps == ()
     assert "runtime-verified network-boundary evidence" in memory.recommended_next_action
+
+
+def test_alignment_records_reviewer_first_pr_quality_console() -> None:
+    components = {item.module: item for item in build_alignment_components()}
+    report_component = components["pr_quality_action_report"]
+
+    assert report_component.status == "aligned"
+    assert "reviewer-first interactive PR Quality console" in report_component.role
+    assert "pr-review-summary.md" in report_component.existing_artifacts
+    assert "pr-review-dashboard.html" in report_component.existing_artifacts
+    assert "human-readable decisions" in report_component.recommended_next_action
+    assert "reporting-only authority" in report_component.recommended_next_action


### PR DESCRIPTION
## Product slice

`sdet-quality-comment-review-console`

## Problem

The SDET Quality Gate comment is structurally correct but still reads like an
internal schema dump. Green PRs can display an unknown failure panel, raw
snake_case actions dominate the first screen, and reviewer commands are
separated from the decision.

## Change

- add a human-readable review-at-a-glance panel;
- show one canonical action in plain language;
- integrate `/check`, `/quality`, `/doctor`, and `/hint`;
- retain the raw machine decision contract under progressive disclosure;
- retain the collapsed failure-vector compatibility panel while replacing unknown fields with an explicit no-active-failure message;
- open decision/failure evidence automatically only for blocked, review-first,
  stale, or invalid states;
- rename clear security evidence so it is not presented as a blocker;
- make verification commands copy-ready;
- keep the full authority boundary visible but compact.

## Compatibility

- structured review model unchanged;
- evidence collection unchanged;
- canonical decision logic unchanged;
- trusted producer and publisher unchanged;
- workflow permissions unchanged;
- exact-head verification unchanged;
- existing raw decision fields retained for audit and compatibility.

## Authority boundary

- workflow files changed: false
- workflow permissions changed: false
- patch automation: false
- security dismissal: false
- merge authorization: false
- semantic equivalence claim: false

## Verification

- focused PR comment, workflow-observability, alignment, intelligence, and
  runtime-proof tests;
- scoped pre-commit;
- `make proof-after-format` in an isolated exact-commit worktree;
- protected workflows unchanged;
- clean worktree.
