### PR TITLE
feat(pr-quality): professionalize reviewer decision experience

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,6 +239,30 @@ action:
 - Security, proof commands, check evidence, and the full authority boundary remain available as focused collapsible sections.
 - The structured review model, trusted producer, trusted publisher, workflow permissions, exact-head verification, and reporting-only authority remain unchanged.
 
+### Completed roadmap action
+
+```text
+action:
+  id=sdet-quality-comment-professional-review-experience
+  lane=Reviewer experience and product surface
+  title=Professionalize the SDET Quality Gate decision surface across canonical states
+  priority=P1
+  risk=low
+  value=Reduce reviewer friction with human labels, state-aware commands, bounded disclosure, and canonical proof presentation without changing decision semantics or authority.
+  status=done
+```
+
+**Closure evidence**
+
+- A read-only accepted-main scenario laboratory rendered `13` meaningful reviewer states and passed `13/13` hard presentation and authority contracts.
+- The first screen now humanizes risk-surface identifiers while preserving raw machine values inside the auditable decision details.
+- Quick actions retain `/check`, `/quality`, `/doctor`, and `/hint`, but promote one state-relevant command and collapse the secondary command set.
+- Security and general verification commands are deduplicated into one canonical proof section.
+- Progressive disclosure preserves established blocked-state proof and current-GHAS visibility while collapsing secondary bot commands and deduplicating executable proof content.
+- Scenario regression tests cover all six canonical review states and preserve reporting-only authority.
+- Canonical review-state selection, merge assessment, evidence collection, workflow permissions, trusted publishing, exact-head verification, patch authority, security-dismissal authority, and merge authority remain unchanged.
+- Multi-blocker model expansion and security-unavailable decision policy remain explicitly out of scope for separate review.
+
 ### Roadmap selection status
 
 ```text

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -3098,11 +3098,24 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         }
         return executable in allowed_executables or executable.startswith("./")
 
-    proof_commands = [
-        str(command).strip()
-        for command in _as_list(model.get("proof_to_rerun"))
-        if isinstance(command, str) and _looks_like_shell_command(command)
-    ]
+    def _dedupe_commands(commands: list[str]) -> list[str]:
+        unique: list[str] = []
+        seen: set[str] = set()
+        for command in commands:
+            normalized = command.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            unique.append(normalized)
+        return unique
+
+    proof_commands = _dedupe_commands(
+        [
+            str(command).strip()
+            for command in _as_list(model.get("proof_to_rerun"))
+            if isinstance(command, str) and _looks_like_shell_command(command)
+        ]
+    )
     recommended_actions = [
         str(item)
         for item in _as_list(model.get("recommended_actions"))
@@ -3177,6 +3190,15 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "clear": "Clear",
             "none": "None",
             "unavailable": "Unavailable",
+            "diagnostic_engine": "Diagnostic engine",
+            "code_quality": "Code quality",
+            "workflow_permissions": "Workflow permissions",
+            "branch_protection": "Branch protection",
+            "review_model": "Review model",
+            "workflow": "Workflow",
+            "security": "Security",
+            "tests": "Tests",
+            "ci": "Continuous integration",
         }
         return labels.get(
             canonical_value,
@@ -3193,6 +3215,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     first_blocker = _review_model_scalar(decision.get("primary_blocker") or "none")
     merge_assessment = _review_model_scalar(decision.get("merge_assessment") or "unknown")
     risk_surface = _review_model_scalar(decision.get("risk_surface") or "unknown")
+    human_risk_surface = _human_token(risk_surface)
     signal_title = _review_model_scalar(decision.get("signal_title") or "none")
 
     panel_rows = dict(_contributor_review_panel_rows(model))
@@ -3217,6 +3240,23 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         "invalid": "The review evidence contract is inconsistent or incomplete.",
     }.get(review_state, "Review the evidence below before deciding.")
 
+    quick_action_catalog = {
+        "/check": "Re-run the standard validation checks",
+        "/quality": "Run the full quality and coverage gate",
+        "/doctor": "Diagnose the first concrete failure",
+        "/hint": "Show the compact reviewer checklist",
+    }
+    quick_action_order = {
+        "waiting": ["/check", "/hint", "/doctor", "/quality"],
+        "blocked": ["/doctor", "/check", "/quality", "/hint"],
+        "review": ["/hint", "/check", "/quality", "/doctor"],
+        "ready": ["/quality", "/check", "/hint", "/doctor"],
+        "stale": ["/check", "/hint", "/doctor", "/quality"],
+        "invalid": ["/doctor", "/check", "/hint", "/quality"],
+    }.get(review_state, ["/check", "/quality", "/doctor", "/hint"])
+    primary_quick_action = quick_action_order[0]
+    secondary_quick_actions = quick_action_order[1:]
+
     failure_actual = _review_model_scalar(failure_vector_signal.get("actual_failure") or "none")
     failure_source = _review_model_scalar(failure_vector_signal.get("source") or "none")
     failure_owner = _review_model_scalar(failure_vector_signal.get("owner_hint") or "none")
@@ -3234,6 +3274,16 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
     ghas_findings = [
         _as_dict(item) for item in _as_list(ghas_blocker_details.get("findings")) if _as_dict(item)
     ]
+    security_proof_commands = _dedupe_commands(
+        [
+            str(command).strip()
+            for finding in ghas_findings
+            for command in _as_list(finding.get("proof_commands"))
+            if isinstance(command, str) and _looks_like_shell_command(command)
+        ]
+    )
+    proof_commands = _dedupe_commands([*proof_commands, *security_proof_commands])
+
     if risk_surface == "security" and ghas_findings:
         primary_security_finding = ghas_findings[0]
         security_message = _review_model_scalar(primary_security_finding.get("message") or "")
@@ -3269,7 +3319,8 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             "or record a reviewed false-positive dismissal, then rerun the gate"
         )
 
-    active_blocker_open = review_state in {
+    decision_open = review_state in {
+        "waiting",
         "blocked",
         "review",
         "stale",
@@ -3282,7 +3333,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         failing_test,
     } - {"", "none", "unknown"}
     show_failure_vector = bool(
-        active_blocker_open
+        review_state in {"blocked", "stale", "invalid"}
         and (
             meaningful_failure_values
             or failed_total > 0
@@ -3290,8 +3341,14 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             or bool(failure_vector_signal.get("safe_fix_candidate"))
         )
     )
-    proof_open = active_blocker_open and bool(proof_commands)
-    ghas_open = bool(ghas_findings) and (active_blocker_open or stale_only_security_signal)
+    failure_open = show_failure_vector and review_state in {"blocked", "invalid"}
+
+    # Preserve established reviewer contracts for active blockers:
+    # focused proof and current GHAS evidence remain visible without a click.
+    proof_open = review_state in {"blocked", "review", "stale", "invalid"} and bool(proof_commands)
+    ghas_open = bool(ghas_findings) and (
+        review_state in {"blocked", "review", "stale", "invalid"} or stale_only_security_signal
+    )
 
     lines = [
         "# PR Quality Review Summary",
@@ -3306,18 +3363,29 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         f"| Required checks | **{_markdown_table_value(_human_token(required_summary))}** |",
         f"| Security | **{_markdown_table_value(_human_token(security_summary))}** |",
         f"| Merge guidance | {_markdown_table_value(_human_token(merge_assessment))} |",
-        f"| Risk focus | `{_markdown_table_value(risk_surface)}` — {_markdown_table_value(signal_title)} |",
+        f"| Risk focus | **{_markdown_table_value(human_risk_surface)}** — {_markdown_table_value(signal_title)} |",
         "",
         f"> **Do this now:** {human_first_action}.",
         "",
         "### Quick actions",
         "",
+        f"> **Recommended command:** `{primary_quick_action}` — {quick_action_catalog[primary_quick_action]}.",
+        "",
         "| Command | Purpose |",
         "|---|---|",
-        "| `/check` | Re-run the standard validation checks |",
-        "| `/quality` | Run the full quality and coverage gate |",
-        "| `/doctor` | Diagnose the first concrete failure |",
-        "| `/hint` | Show the compact reviewer checklist |",
+        f"| `{primary_quick_action}` | {quick_action_catalog[primary_quick_action]} |",
+        "",
+        "<details>",
+        "<summary>More bot commands</summary>",
+        "",
+        "| Command | Purpose |",
+        "|---|---|",
+        *[
+            f"| `{command}` | {quick_action_catalog[command]} |"
+            for command in secondary_quick_actions
+        ],
+        "",
+        "</details>",
         "",
         "<details>",
         "<summary>🧾 Machine decision contract</summary>",
@@ -3377,7 +3445,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
         _details(
             decision_detail_title,
             blocker_body,
-            open_by_default=active_blocker_open,
+            open_by_default=decision_open,
         )
     )
     lines.append("")
@@ -3404,7 +3472,7 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
             _details(
                 "🧭 Failure vector deep dive",
                 failure_body,
-                open_by_default=True,
+                open_by_default=failure_open,
             )
         )
         lines.append("")
@@ -3474,7 +3542,13 @@ def render_pr_quality_review_summary(model: JsonObject) -> str:
                 if isinstance(command, str) and command.strip()
             ]
             if commands:
-                ghas_body.extend(["", "Proof:", "", "```bash", *commands[:5], "```", ""])
+                ghas_body.extend(
+                    [
+                        "",
+                        "> Verification commands are consolidated in the Proof to rerun section.",
+                        "",
+                    ]
+                )
 
     security_title = (
         "🛡️ GHAS / CodeQL refresh details"

--- a/tests/test_pr_quality_comment_scenarios.py
+++ b/tests/test_pr_quality_comment_scenarios.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import pytest
+
+from sdetkit import pr_quality_action_report as report
+
+
+def _scenario_model(
+    state: str,
+    *,
+    risk_surface: str = "diagnostic_engine",
+    security_findings: list[dict] | None = None,
+    proof_commands: list[str] | None = None,
+) -> dict:
+    decision_by_state = {
+        "waiting": (
+            "none",
+            "wait_for_required_checks",
+            "wait_for_required_checks",
+        ),
+        "blocked": (
+            "Ruff lint failed",
+            "fix_lint",
+            "do_not_merge_until_blocker_resolved",
+        ),
+        "review": (
+            "none",
+            "review_listed_evidence",
+            "human_review_required_before_merge",
+        ),
+        "ready": (
+            "none",
+            "review_and_decide",
+            "automated_proof_complete_human_decision_required",
+        ),
+        "stale": (
+            "Evidence is stale for the current PR head",
+            report.WAIT_FOR_CODE_SCANNING_REFRESH,
+            report.WAIT_FOR_CODE_SCANNING_REFRESH,
+        ),
+        "invalid": (
+            "PR Quality review evidence is internally inconsistent",
+            "repair_review_evidence",
+            "do_not_merge_until_review_model_repaired",
+        ),
+    }
+    primary_blocker, next_action, merge_assessment = decision_by_state[state]
+
+    failed = 1 if state in {"blocked", "invalid"} else 0
+    queued = 1 if state == "waiting" else 0
+    stale_alerts = 1 if state == "stale" else 0
+    findings = security_findings or []
+
+    return {
+        "decision": {
+            "review_state": state,
+            "status": "green" if state in {"ready", "review", "stale"} else "failed",
+            "source_status": "green" if state in {"ready", "review", "stale"} else "failed",
+            "primary_blocker": primary_blocker,
+            "merge_assessment": merge_assessment,
+            "next_action": next_action,
+            "risk_surface": risk_surface,
+            "signal_title": "Scenario evidence changed",
+            "comment_signal": "Evidence proof signal",
+            "review_first_evidence": state == "review",
+            "failed_checks": failed,
+            "required_queued_checks": queued,
+            "required_startup_failures": 0,
+            "missing_required_contexts": 0,
+            "cleared_security_signal": state == "stale",
+            report.STALE_ONLY_SECURITY_SIGNAL: state == "stale",
+        },
+        "primary_blocker": {
+            "title": primary_blocker,
+            "surface": risk_surface,
+            "action": next_action,
+        },
+        "recommended_actions": [],
+        "failure_vector_signal": {
+            "source": "scenario_fixture",
+            "actual_failure": "F401 unused import" if failed else "none",
+            "failure_type": "lint" if failed else "none",
+            "failing_command": "python -m pre_commit run -a" if failed else "none",
+            "failing_test_or_check": "ruff" if failed else "none",
+            "owner_hint": "src/example.py" if failed else "none",
+            "affected_files": ["src/example.py"] if failed else [],
+            "safe_fix_candidate": False,
+            "safe_fix_allowed": False,
+            "reporting_only": True,
+        },
+        "ghas_blocker_details": {
+            "collected": True,
+            "collection_status": "collected",
+            "open_alerts": len(findings) + stale_alerts,
+            "current_alerts": len(findings),
+            "stale_alerts": stale_alerts,
+            "current_head_sha": "scenario-head",
+            "dismissal_allowed": False,
+            "findings": findings,
+        },
+        "failed_check_names": ["quality"] if failed else [],
+        "required_queued_check_names": ["CI / Python 3.13"] if queued else [],
+        "required_startup_failure_names": [],
+        "missing_required_context_names": [],
+        "proof_to_rerun": proof_commands or ["python -m pre_commit run -a"],
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_command"),
+    [
+        ("waiting", "/check"),
+        ("blocked", "/doctor"),
+        ("review", "/hint"),
+        ("ready", "/quality"),
+        ("stale", "/check"),
+        ("invalid", "/doctor"),
+    ],
+)
+def test_quick_actions_prioritize_the_current_review_state(
+    state: str,
+    expected_command: str,
+) -> None:
+    summary = report.render_pr_quality_review_summary(_scenario_model(state))
+    quick_actions = summary[
+        summary.index("### Quick actions") : summary.index(
+            "<summary>🧾 Machine decision contract</summary>"
+        )
+    ]
+
+    assert f"**Recommended command:** `{expected_command}`" in quick_actions
+    assert "<summary>More bot commands</summary>" in quick_actions
+    assert quick_actions.count("**Recommended command:**") == 1
+
+
+def test_first_screen_humanizes_risk_surface_but_retains_raw_contract() -> None:
+    summary = report.render_pr_quality_review_summary(
+        _scenario_model("ready", risk_surface="diagnostic_engine")
+    )
+    first_screen = summary.split(
+        "<summary>🧾 Machine decision contract</summary>",
+        maxsplit=1,
+    )[0]
+
+    assert "**Diagnostic engine**" in first_screen
+    assert "`diagnostic_engine`" not in first_screen
+    assert "| Risk surface | `diagnostic_engine` |" in summary
+
+
+def test_blocked_comment_keeps_decision_failure_and_proof_visible() -> None:
+    summary = report.render_pr_quality_review_summary(_scenario_model("blocked"))
+
+    assert ("<details open>\n<summary>🚨 Active blocker / decision details</summary>") in summary
+    assert ("<details open>\n<summary>🧭 Failure vector deep dive</summary>") in summary
+    assert ("<details open>\n<summary>🧪 Proof to rerun</summary>") in summary
+
+
+def test_current_security_comment_keeps_ghas_details_visible() -> None:
+    finding = {
+        "number": "9001",
+        "rule_id": "SEC_SECRET_PATTERN",
+        "severity": "error",
+        "location": "src/example.py:42",
+        "freshness": "current",
+        "message": "Potential hardcoded credential",
+        "proof_commands": [
+            "python -m sdetkit security check --root . --format json",
+        ],
+        "dismissal_allowed": False,
+    }
+    summary = report.render_pr_quality_review_summary(
+        _scenario_model(
+            "blocked",
+            risk_surface="security",
+            security_findings=[finding],
+        )
+    )
+
+    assert ("<details open>\n<summary>🛡️ GHAS / CodeQL blocker details</summary>") in summary
+
+
+def test_security_proof_commands_are_consolidated_and_deduplicated() -> None:
+    command = "python -m sdetkit security check --root . --format json"
+    pre_commit = "python -m pre_commit run -a"
+    finding = {
+        "number": "9001",
+        "rule_id": "SEC_SECRET_PATTERN",
+        "severity": "error",
+        "location": "src/example.py:42",
+        "freshness": "current",
+        "message": "Potential hardcoded credential",
+        "proof_commands": [command, pre_commit, command],
+        "dismissal_allowed": False,
+    }
+    model = _scenario_model(
+        "blocked",
+        risk_surface="security",
+        security_findings=[finding],
+        proof_commands=[command, pre_commit, command],
+    )
+
+    summary = report.render_pr_quality_review_summary(model)
+    bash_blocks: list[list[str]] = []
+    current: list[str] | None = None
+    for line in summary.splitlines():
+        if line == "```bash":
+            current = []
+            continue
+        if line == "```" and current is not None:
+            bash_blocks.append(current)
+            current = None
+            continue
+        if current is not None and line:
+            current.append(line)
+
+    commands = [item for block in bash_blocks for item in block]
+
+    assert commands.count(command) == 1
+    assert commands.count(pre_commit) == 1
+    assert "Verification commands are consolidated in the Proof to rerun section." in summary
+
+
+@pytest.mark.parametrize(
+    "state",
+    ["waiting", "blocked", "review", "ready", "stale", "invalid"],
+)
+def test_all_scenarios_preserve_reporting_only_authority(state: str) -> None:
+    summary = report.render_pr_quality_review_summary(_scenario_model(state))
+
+    assert "| Boundary mode | `reporting_only` |" in summary
+    assert "| Patch automation | `false` |" in summary
+    assert "| Security dismissal | `false` |" in summary
+    assert "| Merge authorization | `false` |" in summary
+    assert "| Semantic equivalence claim | `false` |" in summary


### PR DESCRIPTION
## Product slice

`sdet-quality-comment-professional-review-experience`

## Evidence

A read-only accepted-main scenario laboratory rendered 13 meaningful Quality Gate scenarios:

- 13/13 hard presentation and authority contracts passed;
- 17 reviewer-experience warnings were identified;
- 10 scenarios showed presentation friction;
- no repository mutation, authority expansion, or decision-policy change occurred.

## Problem

The current reviewer-first comment is functionally correct, but scenario comparison exposed recurring product friction:

- raw risk-surface identifiers appear on the first screen;
- all bot commands have equal visual priority regardless of state;
- security and canonical proof sections can repeat commands;
- the same proof commands can appear in both security and canonical verification sections.

## Change

- humanize risk-surface labels on the reviewer-first screen;
- preserve raw machine values in the auditable decision details;
- promote one state-relevant quick action;
- collapse secondary bot commands without removing them;
- consolidate duplicate security/general proof commands;
- preserve established blocked-proof and current-GHAS visibility while reducing duplicated content;
- add scenario regression tests across all six canonical review states;
- record the scenario evidence and closure boundary in the roadmap.

## Explicitly out of scope

- no canonical review-state changes;
- no security-unavailable policy change;
- no multi-blocker schema/model expansion;
- no evidence-collection change;
- no workflow or workflow-permission change;
- no protected workflow change;
- no patch automation;
- no security dismissal;
- no merge authorization;
- no semantic-equivalence claim.

## Verification

- focused PR Quality, scenario, observability, intelligence, runtime-proof, and alignment tests;
- explicit repository security check;
- scoped pre-commit;
- `make proof-after-format` in an isolated exact-commit worktree;
- exact three-file scope;
- protected workflows unchanged;
- clean proof worktree.

## Human acceptance test

The PR's own trusted SDET Quality Gate comment is the live acceptance surface. Before merge, verify:

1. the risk focus is human-readable;
2. exactly one state-relevant command is recommended;
3. secondary bot commands are collapsed;
4. proof commands are not duplicated;
5. blocked proof and current GHAS evidence remain immediately visible;
6. machine fields and reporting-only authority remain available.
