### PR TITLE
fix(pr-quality): guarantee artifact link integrity

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1071,6 +1071,134 @@ jobs:
             .sdetkit/adaptive-sentinel/
           if-no-files-found: ignore
 
+      - name: Verify PR quality artifact bundle link integrity
+        if: always()
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          from html.parser import HTMLParser
+          from pathlib import Path
+          from urllib.parse import urlparse
+
+          root = Path("build/pr-quality")
+          manifest_path = root / "pr-review-artifacts-manifest.json"
+          index_path = root / "index.html"
+
+          if not manifest_path.is_file():
+              raise SystemExit(
+                  f"PR Quality artifact manifest is missing: {manifest_path}"
+              )
+          if not index_path.is_file():
+              raise SystemExit(
+                  f"PR Quality artifact index is missing: {index_path}"
+              )
+
+          manifest = json.loads(
+              manifest_path.read_text(encoding="utf-8")
+          )
+          artifacts = manifest.get("artifacts")
+          if not isinstance(artifacts, list) or not artifacts:
+              raise SystemExit(
+                  "PR Quality artifact manifest has no artifact entries"
+              )
+
+          local_manifest_paths: list[str] = []
+          for item in artifacts:
+              if not isinstance(item, dict):
+                  raise SystemExit(
+                      "PR Quality artifact manifest contains a non-object entry"
+                  )
+              artifact_path = str(item.get("path") or "").strip()
+              artifact_kind = str(
+                  item.get("kind") or item.get("format") or ""
+              ).strip()
+              if not artifact_path:
+                  raise SystemExit(
+                      "PR Quality artifact manifest contains an empty path"
+                  )
+              if artifact_kind == "github_artifact":
+                  continue
+
+              relative = Path(artifact_path)
+              if relative.is_absolute() or ".." in relative.parts:
+                  raise SystemExit(
+                      "PR Quality artifact manifest contains an unsafe "
+                      f"local path: {artifact_path}"
+                  )
+              local_manifest_paths.append(artifact_path)
+
+          missing_manifest_paths = [
+              artifact_path
+              for artifact_path in local_manifest_paths
+              if not (root / artifact_path).is_file()
+          ]
+          if missing_manifest_paths:
+              raise SystemExit(
+                  "PR Quality artifact manifest references missing files: "
+                  + ", ".join(missing_manifest_paths)
+              )
+
+          class LinkCollector(HTMLParser):
+              def __init__(self) -> None:
+                  super().__init__()
+                  self.hrefs: list[str] = []
+
+              def handle_starttag(
+                  self,
+                  tag: str,
+                  attrs: list[tuple[str, str | None]],
+              ) -> None:
+                  if tag != "a":
+                      return
+                  for name, value in attrs:
+                      if name == "href" and value:
+                          self.hrefs.append(value)
+
+          collector = LinkCollector()
+          collector.feed(index_path.read_text(encoding="utf-8"))
+
+          local_index_links: list[str] = []
+          for href in collector.hrefs:
+              parsed = urlparse(href)
+              if href.startswith("#") or parsed.scheme in {
+                  "http",
+                  "https",
+                  "mailto",
+              }:
+                  continue
+              relative = Path(parsed.path)
+              if relative.is_absolute() or ".." in relative.parts:
+                  raise SystemExit(
+                      "PR Quality artifact index contains an unsafe "
+                      f"local link: {href}"
+                  )
+              local_index_links.append(parsed.path)
+
+          missing_index_links = [
+              href
+              for href in local_index_links
+              if not (root / href).is_file()
+          ]
+          if missing_index_links:
+              raise SystemExit(
+                  "PR Quality artifact index contains dead local links: "
+                  + ", ".join(missing_index_links)
+              )
+
+          print(
+              "artifact_manifest_local_path_count="
+              f"{len(local_manifest_paths)}"
+          )
+          print(
+              "artifact_index_local_link_count="
+              f"{len(local_index_links)}"
+          )
+          integrity_marker = "artifact_bundle_" + "link_integrity=" + "passed"
+          print(integrity_marker)
+          PY
+
       - name: Upload PR quality evidence artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -1079,6 +1207,7 @@ jobs:
           name: pr-quality-comment
           path: |
             build/pr-quality/index.html
+            build/pr-quality/pr-review-dashboard.html
             build/pr-quality/pr-review-artifacts-manifest.json
             build/pr-quality/pr-comment-body.md
             build/pr-quality/pr-comment-metadata.json

--- a/src/sdetkit/pr_quality_live_dashboard.py
+++ b/src/sdetkit/pr_quality_live_dashboard.py
@@ -636,18 +636,33 @@ def render_live_product_dashboard(model: JsonObject) -> str:
             "</div>"
         )
 
+    def artifact_link(item: JsonObject) -> str:
+        artifact_path = _text(item.get("path"))
+        artifact_kind = _text(item.get("kind") or item.get("format"))
+        if artifact_kind == "github_artifact":
+            artifacts_url = _text(provenance.get("artifacts_url"))
+            if artifacts_url:
+                return external_link(
+                    artifacts_url,
+                    "Open workflow artifacts",
+                    "button",
+                )
+            return '<span class="button">Artifact unavailable</span>'
+        return f'<a class="button" href="{safe(artifact_path)}">Open artifact</a>'
+
     artifact_cards = "\n".join(
-        (
-            '<article class="artifact-card">'
-            "<div>"
-            f'<div class="eyebrow">{safe(item.get("kind") or item.get("format") or "artifact")}</div>'
-            f"<h3>{safe(item.get('title') or item.get('path'))}</h3>"
-            f"<p>{safe(item.get('description') or item.get('surface') or 'Workflow artifact')}</p>"
-            "</div>"
-            f'<a class="button" href="{safe(item.get("path"))}">'
-            "Open artifact</a>"
-            f"<code>{safe(item.get('path'))}</code>"
-            "</article>"
+        "".join(
+            (
+                '<article class="artifact-card">',
+                "<div>",
+                f'<div class="eyebrow">{safe(item.get("kind") or item.get("format") or "artifact")}</div>',
+                f"<h3>{safe(item.get('title') or item.get('path'))}</h3>",
+                f"<p>{safe(item.get('description') or item.get('surface') or 'Workflow artifact')}</p>",
+                "</div>",
+                artifact_link(item),
+                f"<code>{safe(item.get('path'))}</code>",
+                "</article>",
+            )
         )
         for item in artifacts
     )

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1349,3 +1349,34 @@ def test_pr_quality_workflow_runs_existing_non_ruff_git_grounded_profile() -> No
     assert "--profile pre_commit_all" in invocation
     assert invocation.count("--profile ") == 2
     assert "--command" not in invocation
+
+
+def test_pr_quality_comment_workflow_uploads_visual_dashboard_file() -> None:
+    text = _workflow_text()
+    upload_start = text.index("- name: Upload PR quality evidence artifacts")
+    upload_end = text.index(
+        "- name: Build PR quality publisher handoff",
+        upload_start,
+    )
+    upload_step = text[upload_start:upload_end]
+
+    assert "build/pr-quality/index.html" in upload_step
+    assert "build/pr-quality/pr-review-dashboard.html" in upload_step
+    assert "build/pr-quality/pr-review-artifacts-manifest.json" in upload_step
+
+
+def test_pr_quality_comment_workflow_verifies_artifact_links_before_upload() -> None:
+    text = _workflow_text()
+    verify_step = text.index("- name: Verify PR quality artifact bundle link integrity")
+    upload_step = text.index("- name: Upload PR quality evidence artifacts")
+
+    assert verify_step < upload_step
+    verifier = text[verify_step:upload_step]
+    assert "pr-review-artifacts-manifest.json" in verifier
+    assert "index.html" in verifier
+    assert "HTMLParser" in verifier
+    assert 'artifact_kind == "github_artifact"' in verifier
+    assert "missing_manifest_paths" in verifier
+    assert "missing_index_links" in verifier
+    assert '"artifact_bundle_" + "link_integrity=" + "passed"' in verifier
+    assert "print(integrity_marker)" in verifier

--- a/tests/test_pr_quality_live_dashboard.py
+++ b/tests/test_pr_quality_live_dashboard.py
@@ -335,3 +335,49 @@ def test_product_dashboard_embeds_interactive_controls() -> None:
     assert "navigator.clipboard.writeText" in dashboard
     assert 'type="application/json" id="evidenceData"' in dashboard
     assert "No indicators match the current filter." in dashboard
+
+
+def test_product_dashboard_routes_bundle_to_workflow_artifacts_url() -> None:
+    model = _model()
+    model["live_evidence"] = _snapshot()
+    model["artifact_index"] = [
+        {
+            "path": "pr-review-dashboard.html",
+            "kind": "html",
+            "title": "Detailed review",
+            "description": "Detailed contributor review surface.",
+        },
+        {
+            "path": "pr-quality-comment",
+            "kind": "github_artifact",
+            "title": "Uploaded artifact bundle",
+            "description": "Full workflow artifact bundle.",
+        },
+    ]
+
+    dashboard = report.render_pr_quality_artifact_index_html(model)
+
+    assert 'href="pr-review-dashboard.html"' in dashboard
+    assert 'href="https://github.com/example/sdetkit/actions/runs/123456#artifacts"' in dashboard
+    assert 'href="pr-quality-comment"' not in dashboard
+    assert "Open workflow artifacts" in dashboard
+
+
+def test_product_dashboard_does_not_fabricate_bundle_file_link_without_run_url() -> None:
+    model = _model()
+    snapshot = _snapshot()
+    snapshot["provenance"]["artifacts_url"] = ""
+    model["live_evidence"] = snapshot
+    model["artifact_index"] = [
+        {
+            "path": "pr-quality-comment",
+            "kind": "github_artifact",
+            "title": "Uploaded artifact bundle",
+            "description": "Full workflow artifact bundle.",
+        }
+    ]
+
+    dashboard = report.render_pr_quality_artifact_index_html(model)
+
+    assert 'href="pr-quality-comment"' not in dashboard
+    assert "Artifact unavailable" in dashboard


### PR DESCRIPTION
## Defect

The merged PR Quality artifact center exposed two dead targets:

1. `pr-review-dashboard.html` was generated and advertised but omitted from the uploaded `pr-quality-comment` bundle.
2. `pr-quality-comment` is a GitHub Actions artifact name, but the dashboard rendered it as a relative file path.

## Correction

- upload `build/pr-quality/pr-review-dashboard.html`;
- route the artifact-bundle card to the exact workflow run artifacts URL;
- never fabricate a local bundle file link when workflow provenance is unavailable;
- verify manifest-declared local files exist before upload;
- parse `index.html` and fail the producer run if any relative link is unsafe or missing;
- add focused renderer and protected-workflow regression tests.

## Protected workflow review

```text
workflow_review:
  permissions_least_privilege=yes
  actions_pinned_to_sha=yes
  install_uses_constraints=yes
  cache_key_appropriate=yes
  job_names_unique=yes
  artifacts_have_retention=yes
  docs_build_strict=not_applicable
  no_secrets_in_pull_request_from_fork=yes
  local_equivalent_command_documented=yes
```

## Security review

```text
security_review:
  change=artifact upload completeness and pre-upload local-link verification
  secrets_touched=no
  workflow_permissions_changed=no
  dependency_surface_changed=no
  publish_or_release_changed=no
  user_input_handling_changed=no
  report_only_or_blocking=blocking only for malformed or incomplete artifact bundle
  patch_automation=false
  security_dismissal=false
  merge_authorization=false
```

## Scope

Exactly four files:

- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/pr_quality_live_dashboard.py`
- `tests/test_pr_quality_live_dashboard.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

No decision semantics, permissions, action pins, artifact retention, publisher authority, or merge authority change.

## Acceptance

A new PR run must produce a `pr-quality-comment` ZIP where:

- `pr-review-dashboard.html` exists;
- every relative link in `index.html` resolves;
- the artifact-bundle card opens the workflow artifacts page;
- `artifact_bundle_link_integrity=passed` appears in producer logs.
