### PR TITLE
fix(pr-quality): synchronize final embedded artifacts

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1071,6 +1071,18 @@ jobs:
             .sdetkit/adaptive-sentinel/
           if-no-files-found: ignore
 
+
+      - name: Refresh self-contained PR quality artifact index
+        if: always()
+        run: |
+          PYTHONPATH=src python -m sdetkit.pr_quality_artifact_index \
+            --review-model build/pr-quality/pr-review-model.json \
+            --review-summary build/pr-quality/pr-review-summary.md \
+            --review-html build/pr-quality/pr-review-dashboard.html \
+            --review-manifest build/pr-quality/pr-review-artifacts-manifest.json \
+            --comment-body build/pr-quality/pr-comment-body.md \
+            --out build/pr-quality/index.html
+
       - name: Verify PR quality artifact bundle link integrity
         if: always()
         run: |

--- a/src/sdetkit/pr_quality_artifact_index.py
+++ b/src/sdetkit/pr_quality_artifact_index.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from sdetkit.pr_quality_action_report import (
+    render_pr_quality_artifact_index_html,
+)
+
+JsonObject = dict[str, Any]
+
+_EMBEDDED_ARTIFACT_SPECS = (
+    (
+        "pr-review-dashboard.html",
+        "text/html;charset=utf-8",
+        "review_html_path",
+    ),
+    (
+        "pr-review-summary.md",
+        "text/markdown;charset=utf-8",
+        "review_summary_path",
+    ),
+    (
+        "pr-review-model.json",
+        "application/json;charset=utf-8",
+        "review_model_path",
+    ),
+    (
+        "pr-review-artifacts-manifest.json",
+        "application/json;charset=utf-8",
+        "review_manifest_path",
+    ),
+    (
+        "pr-comment-body.md",
+        "text/markdown;charset=utf-8",
+        "comment_body_path",
+    ),
+)
+
+
+class _EvidencePayloadParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._inside_payload = False
+        self.parts: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        if tag != "script":
+            return
+        attributes = dict(attrs)
+        self._inside_payload = (
+            attributes.get("id") == "evidenceData" and attributes.get("type") == "application/json"
+        )
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self._inside_payload:
+            self._inside_payload = False
+
+    def handle_data(self, data: str) -> None:
+        if self._inside_payload:
+            self.parts.append(data)
+
+
+class _LinkCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        if tag != "a":
+            return
+        attributes = dict(attrs)
+        href = attributes.get("href")
+        if href:
+            self.hrefs.append(href)
+
+
+def _read_json_object(path: Path) -> JsonObject:
+    if not path.is_file():
+        raise ValueError(f"required JSON file is missing: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError(f"required artifact file is missing: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _embedded_sources(
+    *,
+    review_model_path: Path,
+    review_summary_path: Path,
+    review_html_path: Path,
+    review_manifest_path: Path,
+    comment_body_path: Path,
+) -> JsonObject:
+    paths = {
+        "review_model_path": review_model_path,
+        "review_summary_path": review_summary_path,
+        "review_html_path": review_html_path,
+        "review_manifest_path": review_manifest_path,
+        "comment_body_path": comment_body_path,
+    }
+    return {
+        artifact_path: {
+            "mime_type": mime_type,
+            "content": _read_text(paths[path_key]),
+        }
+        for artifact_path, mime_type, path_key in _EMBEDDED_ARTIFACT_SPECS
+    }
+
+
+def _extract_evidence_payload(html: str) -> JsonObject:
+    parser = _EvidencePayloadParser()
+    parser.feed(html)
+    if not parser.parts:
+        raise ValueError("generated index has no evidenceData JSON payload")
+    payload = json.loads("".join(parser.parts))
+    if not isinstance(payload, dict):
+        raise ValueError("generated evidenceData payload is not an object")
+    return payload
+
+
+def _relative_links(html: str) -> list[str]:
+    parser = _LinkCollector()
+    parser.feed(html)
+    relative: list[str] = []
+    for href in parser.hrefs:
+        parsed = urlparse(href)
+        if href.startswith("#"):
+            continue
+        if parsed.scheme in {"http", "https", "mailto"}:
+            continue
+        relative.append(href)
+    return relative
+
+
+def refresh_pr_quality_artifact_index(
+    *,
+    review_model_path: Path,
+    review_summary_path: Path,
+    review_html_path: Path,
+    review_manifest_path: Path,
+    comment_body_path: Path,
+    out: Path,
+) -> JsonObject:
+    model = _read_json_object(review_model_path)
+    sources = _embedded_sources(
+        review_model_path=review_model_path,
+        review_summary_path=review_summary_path,
+        review_html_path=review_html_path,
+        review_manifest_path=review_manifest_path,
+        comment_body_path=comment_body_path,
+    )
+    html = render_pr_quality_artifact_index_html(
+        model,
+        embedded_artifacts=sources,
+    )
+
+    payload = _extract_evidence_payload(html)
+    embedded = payload.get("embedded_artifacts")
+    if not isinstance(embedded, dict):
+        raise ValueError("generated index has no embedded_artifacts object")
+
+    expected_paths = set(sources)
+    observed_paths = set(embedded)
+    if observed_paths != expected_paths:
+        raise ValueError(
+            "embedded artifact path mismatch: "
+            f"expected={sorted(expected_paths)} "
+            f"observed={sorted(observed_paths)}"
+        )
+
+    verified: list[JsonObject] = []
+    for artifact_path in sorted(expected_paths):
+        source = sources[artifact_path]
+        item = embedded.get(artifact_path)
+        if not isinstance(item, dict):
+            raise ValueError(f"embedded artifact entry is invalid: {artifact_path}")
+
+        content = str(source["content"])
+        source_bytes = content.encode("utf-8")
+        encoded = item.get("content_base64")
+        if not isinstance(encoded, str):
+            raise ValueError(f"embedded artifact has no Base64 content: {artifact_path}")
+        decoded = base64.b64decode(encoded, validate=True)
+        digest = hashlib.sha256(source_bytes).hexdigest()
+
+        if decoded != source_bytes:
+            raise ValueError(f"embedded artifact bytes differ from source: {artifact_path}")
+        if item.get("sha256") != digest:
+            raise ValueError(f"embedded artifact digest differs from source: {artifact_path}")
+        if item.get("size_bytes") != len(source_bytes):
+            raise ValueError(f"embedded artifact size differs from source: {artifact_path}")
+        if item.get("mime_type") != source["mime_type"]:
+            raise ValueError(f"embedded artifact MIME type differs from source: {artifact_path}")
+
+        verified.append(
+            {
+                "path": artifact_path,
+                "size_bytes": len(source_bytes),
+                "sha256": digest,
+                "mime_type": source["mime_type"],
+                "source_match": True,
+            }
+        )
+
+    relative_links = _relative_links(html)
+    if relative_links:
+        raise ValueError(
+            "generated standalone index contains relative links: " + ", ".join(relative_links)
+        )
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html, encoding="utf-8", newline="\n")
+
+    return {
+        "schema_version": ("sdetkit.pr_quality.artifact_index_refresh.v1"),
+        "status": "passed",
+        "out": out.as_posix(),
+        "embedded_artifact_count": len(verified),
+        "embedded_artifact_mismatch_count": 0,
+        "relative_artifact_link_count": 0,
+        "artifacts": verified,
+        "reporting_only": True,
+        "patch_automation": False,
+        "security_dismissal": False,
+        "merge_authorization": False,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.pr_quality_artifact_index")
+    parser.add_argument("--review-model", type=Path, required=True)
+    parser.add_argument("--review-summary", type=Path, required=True)
+    parser.add_argument("--review-html", type=Path, required=True)
+    parser.add_argument("--review-manifest", type=Path, required=True)
+    parser.add_argument("--comment-body", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = refresh_pr_quality_artifact_index(
+        review_model_path=args.review_model,
+        review_summary_path=args.review_summary,
+        review_html_path=args.review_html,
+        review_manifest_path=args.review_manifest,
+        comment_body_path=args.comment_body,
+        out=args.out,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    print("self_contained_index_refresh=passed")
+    print(f"embedded_artifact_match_count={result['embedded_artifact_count']}")
+    print("relative_artifact_link_count=0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_quality_artifact_index.py
+++ b/tests/test_pr_quality_artifact_index.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import base64
+import json
+from html.parser import HTMLParser
+from pathlib import Path
+
+import pytest
+
+from sdetkit.pr_quality_artifact_index import (
+    refresh_pr_quality_artifact_index,
+)
+
+
+class _PayloadParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.inside = False
+        self.parts: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        attributes = dict(attrs)
+        self.inside = tag == "script" and attributes.get("id") == "evidenceData"
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script":
+            self.inside = False
+
+    def handle_data(self, data: str) -> None:
+        if self.inside:
+            self.parts.append(data)
+
+
+def _model() -> dict:
+    return {
+        "schema_version": "sdetkit.pr_quality.review_model.v2",
+        "decision": {
+            "review_state": "ready",
+            "status": "green",
+            "merge_assessment": ("automated_proof_complete_human_decision_required"),
+            "next_action": "review_and_decide",
+            "risk_surface": "diagnostic_engine",
+        },
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "artifact_index": [
+            {
+                "path": "pr-review-dashboard.html",
+                "kind": "html",
+                "title": "Detailed review",
+            },
+            {
+                "path": "pr-review-summary.md",
+                "kind": "markdown",
+                "title": "Review summary",
+            },
+            {
+                "path": "pr-review-model.json",
+                "kind": "json",
+                "title": "Review model",
+            },
+            {
+                "path": "pr-review-artifacts-manifest.json",
+                "kind": "json",
+                "title": "Artifact manifest",
+            },
+            {
+                "path": "pr-comment-body.md",
+                "kind": "markdown",
+                "title": "Comment body",
+            },
+        ],
+        "live_evidence": {
+            "schema_version": "sdetkit.pr_quality.live_evidence.v1",
+            "snapshot_status": "complete",
+            "generated_at_utc": "2026-06-26T08:00:00+00:00",
+            "provenance": {
+                "pr_number": 1883,
+                "head_sha": "head-sha",
+                "workflow_run_id": "123",
+                "head_binding_status": "verified",
+                "artifact_entrypoint": "pr-quality/index.html",
+                "artifacts_url": ("https://github.com/example/repo/actions/runs/123#artifacts"),
+            },
+            "authority_boundary": {
+                "boundary_mode": "reporting_only",
+                "patch_automation": False,
+                "security_dismissal": False,
+                "merge_authorization": False,
+                "semantic_equivalence_claim": False,
+            },
+            "facts": [],
+            "lineage": [],
+        },
+    }
+
+
+def _payload(html: str) -> dict:
+    parser = _PayloadParser()
+    parser.feed(html)
+    return json.loads("".join(parser.parts))
+
+
+def test_refresh_embeds_final_files_byte_for_byte(
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "pr-review-model.json"
+    summary_path = tmp_path / "pr-review-summary.md"
+    html_path = tmp_path / "pr-review-dashboard.html"
+    manifest_path = tmp_path / "pr-review-artifacts-manifest.json"
+    comment_path = tmp_path / "pr-comment-body.md"
+    out = tmp_path / "index.html"
+
+    model_path.write_text(
+        json.dumps(_model(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    summary_path.write_text("# Final summary\n", encoding="utf-8")
+    html_path.write_text(
+        "<!doctype html><title>Final review</title>\n",
+        encoding="utf-8",
+    )
+    manifest_path.write_text(
+        '{"status":"final"}\n',
+        encoding="utf-8",
+    )
+    comment_path.write_text(
+        "# Initial body\n\n## Final appendix\n",
+        encoding="utf-8",
+    )
+
+    result = refresh_pr_quality_artifact_index(
+        review_model_path=model_path,
+        review_summary_path=summary_path,
+        review_html_path=html_path,
+        review_manifest_path=manifest_path,
+        comment_body_path=comment_path,
+        out=out,
+    )
+
+    assert result["status"] == "passed"
+    assert result["embedded_artifact_count"] == 5
+    assert result["embedded_artifact_mismatch_count"] == 0
+    assert result["relative_artifact_link_count"] == 0
+
+    rendered = out.read_text(encoding="utf-8")
+    payload = _payload(rendered)
+    embedded = payload["embedded_artifacts"]
+
+    expected = {
+        "pr-review-dashboard.html": html_path.read_bytes(),
+        "pr-review-summary.md": summary_path.read_bytes(),
+        "pr-review-model.json": model_path.read_bytes(),
+        "pr-review-artifacts-manifest.json": manifest_path.read_bytes(),
+        "pr-comment-body.md": comment_path.read_bytes(),
+    }
+    for artifact_path, expected_bytes in expected.items():
+        actual = base64.b64decode(
+            embedded[artifact_path]["content_base64"],
+            validate=True,
+        )
+        assert actual == expected_bytes
+
+    assert "## Final appendix" not in rendered
+    assert 'href="pr-comment-body.md"' not in rendered
+    assert 'data-open-artifact="pr-comment-body.md"' in rendered
+
+
+def test_refresh_fails_closed_when_final_file_is_missing(
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "pr-review-model.json"
+    model_path.write_text(
+        json.dumps(_model()),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="required artifact file is missing",
+    ):
+        refresh_pr_quality_artifact_index(
+            review_model_path=model_path,
+            review_summary_path=tmp_path / "missing-summary.md",
+            review_html_path=tmp_path / "missing-dashboard.html",
+            review_manifest_path=tmp_path / "missing-manifest.json",
+            comment_body_path=tmp_path / "missing-comment.md",
+            out=tmp_path / "index.html",
+        )

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1380,3 +1380,23 @@ def test_pr_quality_comment_workflow_verifies_artifact_links_before_upload() -> 
     assert "missing_index_links" in verifier
     assert '"artifact_bundle_" + "link_integrity=" + "passed"' in verifier
     assert "print(integrity_marker)" in verifier
+
+
+def test_pr_quality_comment_workflow_refreshes_standalone_index_after_appendices() -> None:
+    text = _workflow_text()
+    appendices = text.index("- name: Build PR comment body diagnostic appendices")
+    refresh = text.index("- name: Refresh self-contained PR quality artifact index")
+    verify = text.index("- name: Verify PR quality artifact bundle link integrity")
+    upload = text.index("- name: Upload PR quality evidence artifacts")
+
+    assert appendices < refresh < verify < upload
+
+    refresh_step = text[refresh:verify]
+    assert "if: always()" in refresh_step
+    assert "python -m sdetkit.pr_quality_artifact_index" in refresh_step
+    assert "--review-model build/pr-quality/pr-review-model.json" in refresh_step
+    assert "--review-summary build/pr-quality/pr-review-summary.md" in refresh_step
+    assert "--review-html build/pr-quality/pr-review-dashboard.html" in refresh_step
+    assert "--review-manifest build/pr-quality/pr-review-artifacts-manifest.json" in refresh_step
+    assert "--comment-body build/pr-quality/pr-comment-body.md" in refresh_step
+    assert "--out build/pr-quality/index.html" in refresh_step


### PR DESCRIPTION
## Post-merge consistency defect

PR #1883 made `index.html` browser-safe and self-contained. Production
artifact verification found that four embedded files matched their uploaded
siblings byte-for-byte, but embedded `pr-comment-body.md` represented the
pre-appendix body.

The workflow generates the index first, then appends diagnostic, history,
candidate-validation, and benchmark sections to the comment body. The final
uploaded comment therefore differed from the embedded copy.

## Correction

- add a dedicated read-only artifact-index refresh command;
- run it after all comment-body appendices and immediately before the existing
  artifact-integrity verifier;
- read the five final files from disk;
- regenerate the standalone index from those final bytes;
- decode the generated Base64 payload and compare every artifact byte-for-byte;
- verify MIME type, byte size, and SHA-256 metadata;
- reject any relative artifact link;
- fail closed on missing or inconsistent files.

## Scope

Exactly four files:

- `.github/workflows/pr-quality-comment.yml`
- `src/sdetkit/pr_quality_artifact_index.py`
- `tests/test_pr_quality_artifact_index.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

## Preserved boundaries

- workflow permissions unchanged;
- action pins unchanged;
- retention unchanged;
- decision logic unchanged;
- patch automation denied;
- security dismissal denied;
- merge authorization denied;
- reporting-only authority preserved.

## Acceptance

A new run must report:

```text
self_contained_index_refresh=passed
embedded_artifact_match_count=5
relative_artifact_link_count=0
```

The embedded `pr-comment-body.md` SHA-256 and bytes must exactly match the
final uploaded `pr-comment-body.md`.
