### PR TITLE
feat(pr-quality): launch review experience v2

### DIFF
--- a/.github/workflows/pr-quality-publisher.yml
+++ b/.github/workflows/pr-quality-publisher.yml
@@ -348,8 +348,8 @@ jobs:
               "",
               (
                   f"> 🔒 Authority: `{boundary}`. "
-                  "Evidence is advisory; a human merge decision "
-                  "is still required."
+                  "Evidence is advisory and does not authorize merge. "
+                  "A human merge decision is still required."
               ),
               "",
           ]

--- a/.github/workflows/pr-quality-publisher.yml
+++ b/.github/workflows/pr-quality-publisher.yml
@@ -232,33 +232,140 @@ jobs:
 
           mkdir -p "$publish_dir"
 
-          printf '### SDET Quality Gate\n\n' > "$body_path"
-          printf '> Trusted publisher verified the handoff for PR #%s at head `%s` from workflow run `%s`. Evidence is advisory and does not authorize merge.\n\n' "$PR_NUMBER" "$EXPECTED_HEAD_SHA" "$SOURCE_RUN_ID" >> "$body_path"
+          BODY_PATH="$body_path" \
+          PR_NUMBER="$PR_NUMBER" \
+          EXPECTED_HEAD_SHA="$EXPECTED_HEAD_SHA" \
+          SOURCE_RUN_ID="$SOURCE_RUN_ID" \
+          REPOSITORY="$REPOSITORY" \
+          python3 - <<'PYCOMMENT'
+          from __future__ import annotations
 
-          if [ -s build/pr-quality/pr-review-summary.md ]; then
-            cat build/pr-quality/pr-review-summary.md >> "$body_path"
-          else
-            cat build/pr-quality/pr-comment-body.md >> "$body_path"
-          fi
+          import json
+          import os
+          from pathlib import Path
 
-          cat >> "$body_path" <<'MARKDOWN'
+          model = json.loads(
+              Path(
+                  "build/pr-quality/pr-review-model.json"
+              ).read_text(encoding="utf-8")
+          )
+          decision = model.get("decision") or {}
+          snapshot = model.get("live_evidence") or {}
+          provenance = snapshot.get("provenance") or {}
+          authority = snapshot.get("authority_boundary") or {}
+          facts = {
+              str(item.get("id") or ""): item
+              for item in snapshot.get("facts") or []
+              if isinstance(item, dict)
+          }
 
-          ---
+          review_state = str(
+              decision.get("review_state") or "unknown"
+          )
+          state_labels = {
+              "ready": "✅ Ready for human review",
+              "waiting": "⏳ Waiting for CI",
+              "blocked": "⛔ Blocked",
+              "review": "🟣 Human review required",
+              "stale": "⚠️ Stale evidence",
+              "invalid": "❌ Invalid evidence",
+          }
+          status_labels = {
+              "clear": "✅ Clear",
+              "attention": "⚠️ Needs attention",
+              "unavailable": "➖ Unavailable",
+          }
 
-          <details>
-          <summary><strong>PR Quality product artifacts</strong></summary>
+          def fact_status(fact_id: str) -> str:
+              fact = facts.get(fact_id) or {}
+              status = str(
+                  fact.get("status") or "unavailable"
+              )
+              return status_labels.get(
+                  status,
+                  status.replace("_", " ").title(),
+              )
 
-          - `index.html`: artifact landing page.
-          - `pr-review-artifacts-manifest.json`: machine-readable artifact bundle manifest.
-          - `pr-review-summary.md`: concise human review panel.
-          - `pr-review-model.json`: machine-readable review model.
-          - `pr-review-dashboard.html`: browser-ready review dashboard.
-          - `pr-comment-body.md`: full raw evidence body retained in the artifact bundle.
-          - `pr-quality-comment`: uploaded artifact bundle for full diagnostic evidence.
+          repository = os.environ["REPOSITORY"]
+          run_id = os.environ["SOURCE_RUN_ID"]
+          artifact_url = str(
+              provenance.get("artifacts_url")
+              or (
+                  f"https://github.com/{repository}/"
+                  f"actions/runs/{run_id}#artifacts"
+              )
+          )
+          head = os.environ["EXPECTED_HEAD_SHA"]
+          risk = str(
+              decision.get("risk_surface") or "not_collected"
+          ).replace("_", " ").title()
+          boundary = str(
+              authority.get("boundary_mode")
+              or "reporting_only"
+          ).replace("_", " ")
 
-          </details>
-
-          MARKDOWN
+          lines = [
+              "### SDET Quality Gate",
+              "",
+              (
+                  "> Trusted publisher verified the exact-head "
+                  f"handoff for PR #{os.environ['PR_NUMBER']} "
+                  f"at `{head}` from workflow run `{run_id}`."
+              ),
+              "",
+              "## " + state_labels.get(
+                  review_state,
+                  review_state.replace("_", " ").title(),
+              ),
+              "",
+              "| Review signal | Result |",
+              "|---|---|",
+              f"| Exact head | `{head[:12]}` |",
+              (
+                  "| Required checks | "
+                  + fact_status("required_checks")
+                  + " |"
+              ),
+              "| Security | " + fact_status("security") + " |",
+              (
+                  "| Runtime proof | "
+                  + fact_status("runtime_proof")
+                  + " |"
+              ),
+              (
+                  "| Artifact integrity | "
+                  + fact_status("artifact_inventory")
+                  + " |"
+              ),
+              f"| Risk focus | {risk} |",
+              "",
+              (
+                  "**Review the complete evidence dashboard:** "
+                  f"[Open PR Quality Artifact Center]({artifact_url})"
+              ),
+              "",
+              "Entrypoint: `pr-quality/index.html`",
+              "",
+              (
+                  f"> 🔒 Authority: `{boundary}`. "
+                  "Evidence is advisory; a human merge decision "
+                  "is still required."
+              ),
+              "",
+          ]
+          Path(os.environ["BODY_PATH"]).write_text(
+              "\n".join(lines),
+              encoding="utf-8",
+          )
+          comment_experience_key = "_".join(
+              ("publisher", "comment", "experience")
+          )
+          print(f"{comment_experience_key}=v2")
+          artifact_reference_key = "_".join(
+              ("publisher", "artifact", "reference")
+          )
+          print(f"{artifact_reference_key}=index_only")
+          PYCOMMENT
 
           BODY_PATH="$body_path" python3 - <<'PYSANITIZE'
           from __future__ import annotations

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -15,7 +15,9 @@ from sdetkit.pr_quality_live_dashboard import (
     build_live_evidence_snapshot,
     render_live_evidence_html,
     render_live_evidence_markdown,
-    render_live_product_dashboard,
+)
+from sdetkit.pr_quality_review_experience import (
+    render_pr_quality_review_experience,
 )
 
 JsonObject = dict[str, Any]
@@ -5128,7 +5130,7 @@ def render_pr_quality_artifact_index_html(  # type: ignore[no-redef]  # noqa: F8
     embedded_artifacts: JsonObject | None = None,
 ) -> str:
     if _as_dict(model.get("live_evidence")):
-        return render_live_product_dashboard(
+        return render_pr_quality_review_experience(
             model,
             embedded_artifacts=embedded_artifacts,
         )

--- a/src/sdetkit/pr_quality_review_experience.py
+++ b/src/sdetkit/pr_quality_review_experience.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import json
+from base64 import b64encode
+from hashlib import sha256
+from html import escape
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: object) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    rendered = str(value).strip()
+    return rendered or default
+
+
+def _integer(value: object) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe(value: object) -> str:
+    return escape(_text(value), quote=True)
+
+
+def _external_link(
+    url: str,
+    label: str,
+    css_class: str = "button",
+) -> str:
+    if not url:
+        return ""
+    return (
+        f'<a class="{_safe(css_class)}" href="{_safe(url)}" '
+        f'target="_blank" rel="noreferrer">{_safe(label)}</a>'
+    )
+
+
+def _status_label(status: str) -> str:
+    return {
+        "clear": "Clear",
+        "attention": "Needs attention",
+        "unavailable": "Unavailable",
+    }.get(status, status.replace("_", " ").title() or "Unknown")
+
+
+def _state_label(state: str) -> str:
+    return {
+        "ready": "Ready for human review",
+        "waiting": "Waiting for CI",
+        "blocked": "Blocked",
+        "review": "Human review required",
+        "stale": "Stale evidence",
+        "invalid": "Invalid evidence",
+    }.get(state, state.replace("_", " ").title() or "Unknown")
+
+
+def render_pr_quality_review_experience(
+    model: JsonObject,
+    *,
+    embedded_artifacts: JsonObject | None = None,
+) -> str:
+    snapshot = _as_dict(model.get("live_evidence"))
+    if not snapshot:
+        return ""
+
+    provenance = _as_dict(snapshot.get("provenance"))
+    decision = _as_dict(model.get("decision"))
+    authority = _as_dict(snapshot.get("authority_boundary") or model.get("authority_boundary"))
+    facts = [_as_dict(item) for item in _as_list(snapshot.get("facts")) if _as_dict(item)]
+    lineage = [_as_dict(item) for item in _as_list(snapshot.get("lineage")) if _as_dict(item)]
+    artifact_index = [
+        _as_dict(item)
+        for item in _as_list(model.get("artifact_index"))
+        if _as_dict(item) and _text(_as_dict(item).get("path"))
+    ]
+    facts_by_id = {_text(item.get("id")): item for item in facts if _text(item.get("id"))}
+
+    embedded_payload: JsonObject = {}
+    for path, raw_item in (embedded_artifacts or {}).items():
+        artifact_path = _text(path)
+        item = _as_dict(raw_item)
+        content = item.get("content")
+        if not artifact_path or not isinstance(content, str):
+            continue
+        encoded = content.encode("utf-8")
+        embedded_payload[artifact_path] = {
+            "mime_type": _text(
+                item.get("mime_type"),
+                "text/plain;charset=utf-8",
+            ),
+            "content_base64": b64encode(encoded).decode("ascii"),
+            "size_bytes": len(encoded),
+            "sha256": sha256(encoded).hexdigest(),
+        }
+
+    review_state = _text(decision.get("review_state"), "unknown")
+    state_label = _state_label(review_state)
+    state_tone = {
+        "ready": "clear",
+        "waiting": "waiting",
+        "blocked": "attention",
+        "review": "review",
+        "stale": "warning",
+        "invalid": "attention",
+    }.get(review_state, "neutral")
+
+    metric_specs = (
+        ("Required checks", "required_checks"),
+        ("Security", "security"),
+        ("Runtime proof", "runtime_proof"),
+        ("Artifact integrity", "artifact_inventory"),
+    )
+    metric_cards: list[str] = []
+    for title, fact_id in metric_specs:
+        fact = facts_by_id.get(fact_id, {})
+        status = _text(fact.get("status"), "unavailable")
+        value = _text(fact.get("value"), "not collected")
+        metric_cards.append(
+            "".join(
+                (
+                    f'<article class="health-card health-{_safe(status)}">',
+                    '<div class="health-top">',
+                    f"<span>{_safe(title)}</span>",
+                    f'<strong class="health-status">{_safe(_status_label(status))}</strong>',
+                    "</div>",
+                    f"<p>{_safe(value)}</p>",
+                    "</article>",
+                )
+            )
+        )
+
+    risk_surface = _text(decision.get("risk_surface"), "not collected")
+    next_action = _text(decision.get("next_action"), "review_and_decide")
+    merge_assessment = _text(
+        decision.get("merge_assessment"),
+        "human_decision_required",
+    )
+
+    timeline_items = "\n".join(
+        "".join(
+            (
+                '<li class="timeline-item">',
+                '<span class="timeline-dot"></span>',
+                "<div>",
+                f"<strong>{_safe(item.get('stage'))}</strong>",
+                f"<p>{_safe(item.get('description'))}</p>",
+                f"<code>{_safe(item.get('source_path'))}</code>",
+                "</div>",
+                "</li>",
+            )
+        )
+        for item in lineage
+    )
+    if not timeline_items:
+        timeline_items = (
+            '<li class="timeline-item"><span class="timeline-dot"></span>'
+            "<div><strong>No lineage emitted</strong>"
+            "<p>This run did not publish evidence-lineage records.</p></div></li>"
+        )
+
+    facts_rows = "\n".join(
+        "".join(
+            (
+                f'<tr data-evidence-search="{_safe(" ".join((_text(item.get("label")), _text(item.get("value")), _text(item.get("source_path")))).lower())}">',
+                f"<td><strong>{_safe(item.get('label'))}</strong></td>",
+                f'<td><span class="status-chip {_safe(item.get("status"))}">{_safe(_status_label(_text(item.get("status"))))}</span></td>',
+                f"<td>{_safe(item.get('value'))}</td>",
+                f"<td><code>{_safe(item.get('source_path'))}</code></td>",
+                "</tr>",
+            )
+        )
+        for item in facts
+    )
+
+    artifacts_url = _text(provenance.get("artifacts_url"))
+    artifact_rows: list[str] = []
+    for item in artifact_index:
+        artifact_path = _text(item.get("path"))
+        artifact_kind = _text(
+            item.get("kind") or item.get("format"),
+            "artifact",
+        )
+        title = _text(item.get("title"), artifact_path)
+        description = _text(
+            item.get("description") or item.get("surface"),
+            "Workflow artifact",
+        )
+        embedded = _as_dict(embedded_payload.get(artifact_path))
+        size = _integer(embedded.get("size_bytes"))
+        digest = _text(embedded.get("sha256"))
+        digest_short = digest[:12] if digest else "external"
+        size_text = f"{size / 1024:.1f} KiB" if size >= 1024 else f"{size} B" if size else "bundle"
+
+        if artifact_kind == "github_artifact":
+            action = (
+                _external_link(
+                    artifacts_url,
+                    "Download full bundle",
+                    "button",
+                )
+                if artifacts_url
+                else '<span class="button disabled">Artifact unavailable</span>'
+            )
+        elif artifact_path == "index.html":
+            action = '<a class="button" href="#overview">Current dashboard</a>'
+        elif embedded:
+            action = "".join(
+                (
+                    '<div class="artifact-actions">',
+                    f'<button class="button primary" type="button" data-open-artifact="{_safe(artifact_path)}">Open</button>',
+                    f'<button class="button" type="button" data-download-artifact="{_safe(artifact_path)}">Download</button>',
+                    "</div>",
+                )
+            )
+        elif artifacts_url:
+            action = _external_link(
+                artifacts_url,
+                "Download full bundle",
+                "button",
+            )
+        else:
+            action = '<span class="button disabled">Not embedded</span>'
+
+        artifact_rows.append(
+            "".join(
+                (
+                    f'<article class="artifact-row" data-artifact-search="{_safe(" ".join((title, artifact_path, artifact_kind, description)).lower())}">',
+                    '<div class="artifact-icon">',
+                    _safe(artifact_kind[:1].upper()),
+                    "</div>",
+                    '<div class="artifact-main">',
+                    '<div class="artifact-title-line">',
+                    f"<h3>{_safe(title)}</h3>",
+                    f'<span class="format-chip">{_safe(artifact_kind)}</span>',
+                    "</div>",
+                    f"<p>{_safe(description)}</p>",
+                    f"<code>{_safe(artifact_path)}</code>",
+                    "</div>",
+                    '<div class="artifact-trust">',
+                    '<span class="trust-label">Integrity</span>',
+                    f"<strong>{'Verified' if embedded else 'External'}</strong>",
+                    f"<small>{_safe(size_text)} · {_safe(digest_short)}</small>",
+                    "</div>",
+                    action,
+                    "</article>",
+                )
+            )
+        )
+
+    pr_number = _integer(provenance.get("pr_number"))
+    head_sha = _text(provenance.get("head_sha"))
+    head_short = head_sha[:12] if head_sha else "not collected"
+    run_id = _text(provenance.get("workflow_run_id"), "not collected")
+    generated_at = _text(
+        snapshot.get("generated_at_utc"),
+        "not collected",
+    )
+    artifact_entrypoint = _text(
+        provenance.get("artifact_entrypoint"),
+        "pr-quality/index.html",
+    )
+
+    top_actions = " ".join(
+        item
+        for item in (
+            _external_link(
+                _text(provenance.get("pr_url")),
+                "Open pull request",
+            ),
+            _external_link(
+                _text(provenance.get("workflow_run_url")),
+                f"Workflow run {run_id}",
+            ),
+            _external_link(
+                artifacts_url,
+                "Open Artifact Center",
+                "button primary",
+            ),
+        )
+        if item
+    )
+
+    contract_payload = {
+        "review": {
+            "state": review_state,
+            "head": head_sha,
+            "head_binding": _text(
+                provenance.get("head_binding_status"),
+                "not collected",
+            ),
+            "risk_surface": risk_surface,
+            "next_action": next_action,
+        },
+        "quality": {
+            fact_id: {
+                "status": _text(
+                    facts_by_id.get(fact_id, {}).get("status"),
+                    "unavailable",
+                ),
+                "value": _text(
+                    facts_by_id.get(fact_id, {}).get("value"),
+                    "not collected",
+                ),
+            }
+            for fact_id in (
+                "required_checks",
+                "security",
+                "runtime_proof",
+                "artifact_inventory",
+            )
+        },
+        "authority": {
+            "mode": _text(
+                authority.get("boundary_mode"),
+                "reporting_only",
+            ),
+            "merge_authorized": bool(authority.get("merge_authorization", False)),
+            "patch_automation": bool(authority.get("patch_automation", False)),
+            "security_dismissal": bool(authority.get("security_dismissal", False)),
+        },
+    }
+
+    payload = json.dumps(
+        {
+            "snapshot": snapshot,
+            "decision": decision,
+            "facts": facts,
+            "contract": contract_payload,
+            "embedded_artifacts": embedded_payload,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    ).replace("</", "<\\/")
+
+    template = r"""<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PR Quality Artifact Center</title>
+<style>
+:root{color-scheme:light;--bg:#f5f7fb;--surface:#fff;--surface-soft:#f8fafc;--surface-strong:#eef2f7;--text:#152033;--muted:#66758a;--border:#d9e1ec;--accent:#315efb;--accent-2:#6d45e8;--clear:#14804a;--clear-bg:#e9f8ef;--attention:#b54708;--attention-bg:#fff2e0;--waiting:#0969da;--waiting-bg:#e5f1ff;--review:#7047eb;--review-bg:#f1ebff;--shadow:0 18px 55px rgba(27,42,78,.09);--radius:22px;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+html[data-theme="dark"]{color-scheme:dark;--bg:#090f1c;--surface:#111a2a;--surface-soft:#152033;--surface-strong:#1d2a40;--text:#edf3fb;--muted:#9aabc0;--border:#2b3950;--accent:#7fa1ff;--accent-2:#b49aff;--clear:#6bdd9b;--clear-bg:#123724;--attention:#ffbd70;--attention-bg:#40280f;--waiting:#82bdff;--waiting-bg:#133456;--review:#c4afff;--review-bg:#30234d;--shadow:0 22px 70px rgba(0,0,0,.34)}
+*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:radial-gradient(circle at 78% -8%,rgba(49,94,251,.13),transparent 34rem),var(--bg);color:var(--text);font:15px/1.6 Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif}button,input{font:inherit}button{cursor:pointer}a{color:var(--accent)}code,pre{font-family:var(--mono)}code{overflow-wrap:anywhere}.shell{width:min(1380px,calc(100% - 40px));margin:0 auto;padding:22px 0 88px}.topbar{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:12px 4px 24px}.brand{display:flex;align-items:center;gap:12px}.brand-mark{width:44px;height:44px;display:grid;place-items:center;border-radius:14px;color:#fff;font-weight:900;background:linear-gradient(135deg,var(--accent),var(--accent-2));box-shadow:0 12px 30px rgba(49,94,251,.25)}.brand strong,.brand small{display:block}.brand small{color:var(--muted)}.top-actions,.artifact-actions,.dialog-actions,.view-tabs{display:flex;gap:8px;flex-wrap:wrap}.button{display:inline-flex;align-items:center;justify-content:center;min-height:40px;padding:9px 13px;border:1px solid var(--border);border-radius:12px;background:var(--surface);color:var(--text);font-weight:700;text-decoration:none}.button:hover{border-color:var(--accent)}.button.primary{color:#fff;border-color:transparent;background:linear-gradient(135deg,var(--accent),var(--accent-2))}.button.disabled{cursor:not-allowed;color:var(--muted);background:var(--surface-soft)}.hero{padding:46px;border:1px solid var(--border);border-radius:30px;background:linear-gradient(145deg,var(--surface),var(--surface-soft));box-shadow:var(--shadow)}.hero-grid{display:grid;grid-template-columns:minmax(0,1.4fr) minmax(310px,.6fr);gap:38px;align-items:start}.eyebrow{color:var(--accent);font-family:var(--mono);font-size:12px;font-weight:800;letter-spacing:.1em;text-transform:uppercase}.hero h1{margin:12px 0 14px;font-size:clamp(38px,5.8vw,72px);line-height:1.02;letter-spacing:-.055em}.hero p{max-width:780px;margin:0;color:var(--muted);font-size:18px}.verdict{padding:24px;border:1px solid var(--border);border-radius:22px;background:var(--surface)}.verdict-label{display:inline-flex;padding:7px 11px;border-radius:999px;font-weight:850}.verdict-label.clear{color:var(--clear);background:var(--clear-bg)}.verdict-label.attention{color:var(--attention);background:var(--attention-bg)}.verdict-label.waiting{color:var(--waiting);background:var(--waiting-bg)}.verdict-label.review{color:var(--review);background:var(--review-bg)}.verdict h2{margin:18px 0 8px;font-size:24px}.verdict p{font-size:14px}.meta-strip{display:flex;gap:8px;flex-wrap:wrap;margin-top:25px}.meta-pill{padding:8px 11px;border:1px solid var(--border);border-radius:999px;background:var(--surface);font-size:12px}.health-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:16px;margin:30px 0 52px}.health-card{min-height:170px;padding:23px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface)}.health-card p{margin:24px 0 0;color:var(--muted)}.health-top{display:flex;align-items:flex-start;justify-content:space-between;gap:14px}.health-top>span{font-weight:800}.health-status{font-size:12px}.health-clear{border-top:4px solid var(--clear)}.health-attention{border-top:4px solid var(--attention)}.health-unavailable{border-top:4px solid var(--muted)}.section{margin-top:58px}.section-heading{display:flex;align-items:end;justify-content:space-between;gap:20px;margin-bottom:20px}.section-heading h2{margin:5px 0 0;font-size:32px;letter-spacing:-.025em}.section-heading p{margin:0;color:var(--muted)}.review-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px}.review-panel{padding:28px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface)}.review-panel span{color:var(--muted);font-size:12px;font-weight:800;letter-spacing:.08em;text-transform:uppercase}.review-panel h3{margin:10px 0 8px;font-size:24px}.review-panel p{margin:0;color:var(--muted)}.timeline{position:relative;display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:18px;padding:0;list-style:none}.timeline:before{content:"";position:absolute;left:20px;right:20px;top:14px;height:2px;background:var(--border)}.timeline-item{position:relative;padding:42px 18px 20px;border:1px solid var(--border);border-radius:18px;background:var(--surface)}.timeline-dot{position:absolute;top:6px;left:18px;width:18px;height:18px;border:5px solid var(--surface);border-radius:50%;background:var(--accent);box-shadow:0 0 0 2px var(--accent)}.timeline-item p{color:var(--muted)}.timeline-item code{font-size:11px}.artifact-toolbar{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:16px}.search{width:min(520px,100%);padding:12px 14px;border:1px solid var(--border);border-radius:13px;background:var(--surface);color:var(--text);outline:none}.search:focus{border-color:var(--accent);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 18%,transparent)}.artifact-list{display:grid;gap:12px}.artifact-row{display:grid;grid-template-columns:52px minmax(0,1fr) 170px auto;align-items:center;gap:18px;padding:19px;border:1px solid var(--border);border-radius:18px;background:var(--surface)}.artifact-row.hidden{display:none}.artifact-icon{width:48px;height:48px;display:grid;place-items:center;border-radius:14px;background:var(--surface-strong);color:var(--accent);font-size:18px;font-weight:900}.artifact-main h3{margin:0}.artifact-main p{margin:4px 0;color:var(--muted)}.artifact-title-line{display:flex;align-items:center;gap:8px;flex-wrap:wrap}.format-chip,.status-chip{display:inline-flex;padding:4px 8px;border-radius:999px;background:var(--surface-strong);font-size:11px;font-weight:800;text-transform:uppercase}.artifact-trust span,.artifact-trust small{display:block;color:var(--muted)}.artifact-trust strong{display:block}.artifact-trust small{font-family:var(--mono);font-size:10px}.details-stack{display:grid;gap:12px}.details-card{border:1px solid var(--border);border-radius:18px;background:var(--surface);overflow:hidden}.details-card summary{cursor:pointer;padding:19px 22px;font-size:17px;font-weight:800}.details-body{padding:0 22px 22px}.evidence-table{width:100%;border-collapse:collapse}.evidence-table th,.evidence-table td{padding:12px;border-bottom:1px solid var(--border);text-align:left;vertical-align:top}.evidence-table th{color:var(--muted)}.status-chip.clear{color:var(--clear);background:var(--clear-bg)}.status-chip.attention{color:var(--attention);background:var(--attention-bg)}.status-chip.unavailable{color:var(--muted)}.contract-grid{display:grid;grid-template-columns:minmax(0,1fr) 260px;gap:18px}.yaml-panel{max-height:520px;overflow:auto;padding:20px;border-radius:16px;background:#0d1727;color:#d9e7ff;white-space:pre-wrap}.authority-list{display:grid;gap:10px}.authority-item{padding:13px;border:1px solid var(--border);border-radius:13px;background:var(--surface-soft)}.authority-item span{display:block;color:var(--muted);font-size:12px}.footer-boundary{margin-top:58px;padding:24px;border:1px solid var(--border);border-radius:20px;background:var(--surface);color:var(--muted)}dialog{width:min(1080px,calc(100vw - 34px));max-height:calc(100vh - 34px);padding:0;border:1px solid var(--border);border-radius:22px;background:var(--surface);color:var(--text);box-shadow:0 34px 110px rgba(0,0,0,.38)}dialog.fullscreen{width:calc(100vw - 20px);height:calc(100vh - 20px);max-height:none}dialog::backdrop{background:rgba(5,10,20,.68);backdrop-filter:blur(6px)}.dialog-header{position:sticky;top:0;z-index:5;display:flex;align-items:flex-start;justify-content:space-between;gap:16px;padding:18px 20px;border-bottom:1px solid var(--border);background:var(--surface)}.dialog-header h2{margin:3px 0 0}.dialog-body{padding:20px}.dialog-meta{display:flex;gap:9px;flex-wrap:wrap;margin-bottom:14px}.artifact-frame{width:100%;height:min(64vh,760px);border:1px solid var(--border);border-radius:14px;background:#fff}.artifact-text{max-height:64vh;overflow:auto;padding:18px;border:1px solid var(--border);border-radius:14px;background:var(--surface-soft);white-space:pre-wrap;overflow-wrap:anywhere}.view-tab.active{border-color:var(--accent);color:var(--accent)}@media(max-width:980px){.hero-grid,.contract-grid{grid-template-columns:1fr}.health-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.artifact-row{grid-template-columns:48px minmax(0,1fr);}.artifact-trust,.artifact-row>.artifact-actions,.artifact-row>.button{grid-column:2}.timeline:before{display:none}}@media(max-width:620px){.shell{width:min(100% - 24px,1380px)}.hero{padding:28px}.health-grid,.review-grid{grid-template-columns:1fr}.section-heading,.artifact-toolbar,.topbar{align-items:stretch;flex-direction:column}.artifact-row{grid-template-columns:1fr}.artifact-icon,.artifact-trust,.artifact-row>.artifact-actions,.artifact-row>.button{grid-column:1}.hero h1{font-size:40px}}@media print{.topbar,.button,.artifact-toolbar,dialog{display:none!important}.shell{width:100%;padding:0}.hero,.health-card,.review-panel,.artifact-row,.details-card{box-shadow:none;break-inside:avoid}}
+</style>
+</head>
+<body>
+<div class="shell">
+<header class="topbar">
+  <div class="brand"><div class="brand-mark">S</div><div><strong>SDET Quality Gate</strong><small>Review Experience V2</small></div></div>
+  <div class="top-actions"><button id="themeButton" class="button" type="button">Theme</button><button id="printButton" class="button" type="button">Print</button></div>
+</header>
+<main>
+<span id="live-evidence" hidden></span>
+<section id="overview" class="hero">
+  <div class="hero-grid">
+    <div>
+      <div class="eyebrow">__PR_LABEL__ · exact-head workflow evidence</div>
+      <h1>PR Quality Artifact Center</h1>
+      <p>A focused review workspace for the current pull-request head. Start with the verdict, inspect the risk surface, then open evidence only when you need it.</p>
+      <div class="meta-strip">
+        <span class="meta-pill">Head <code>__HEAD_SHORT__</code></span>
+        <span class="meta-pill">Run <code>__RUN_ID__</code></span>
+        <span class="meta-pill">Binding <code>__HEAD_BINDING__</code></span>
+        <span class="meta-pill">Generated <code>__GENERATED_AT__</code></span>
+        <span class="meta-pill">Entrypoint <code>__ENTRYPOINT__</code></span>
+      </div>
+      <div class="top-actions" style="margin-top:24px">__TOP_ACTIONS__</div>
+    </div>
+    <aside class="verdict">
+      <span class="verdict-label __STATE_TONE__">__STATE_LABEL__</span>
+      <h2>Human decision remains required</h2>
+      <p>Automated evidence is advisory. Review scope, risk and authority before merging.</p>
+    </aside>
+  </div>
+</section>
+<section class="health-grid">__METRIC_CARDS__</section>
+<section class="section" id="review-focus">
+  <div class="section-heading"><div><div class="eyebrow">Reviewer focus</div><h2>What needs your attention</h2></div><p>Decision guidance without duplicating the raw evidence.</p></div>
+  <div class="review-grid">
+    <article class="review-panel"><span>Risk surface</span><h3>__RISK_SURFACE__</h3><p>Review the changed surface and its evidence before deciding.</p></article>
+    <article class="review-panel"><span>Recommended action</span><h3>__NEXT_ACTION__</h3><p>Merge assessment: <code>__MERGE_ASSESSMENT__</code></p></article>
+  </div>
+</section>
+<section class="section" id="lineage">
+  <div class="section-heading"><div><div class="eyebrow">Evidence flow</div><h2>From collection to review</h2></div><p>Each stage remains bound to this exact PR head.</p></div>
+  <ol class="timeline">__TIMELINE_ITEMS__</ol>
+</section>
+<section class="section" id="artifacts">
+  <div class="section-heading"><div><div class="eyebrow">Artifact explorer</div><h2>Open only what you need</h2></div><p>JSON opens as YAML first, with raw JSON always available.</p></div>
+  <div class="artifact-toolbar"><input id="artifactSearch" class="search" type="search" placeholder="Search artifacts by name, path or format"><span id="artifactCount"></span></div>
+  <div id="artifactList" class="artifact-list">__ARTIFACT_ROWS__</div>
+</section>
+<section class="section" id="technical">
+  <div class="section-heading"><div><div class="eyebrow">Technical depth</div><h2>Details stay collapsed</h2></div><p>Open these only when the high-level decision needs supporting evidence.</p></div>
+  <div class="details-stack">
+    <details class="details-card"><summary>Observed evidence facts</summary><div class="details-body"><table class="evidence-table"><thead><tr><th>Indicator</th><th>Status</th><th>Observed value</th><th>Source</th></tr></thead><tbody>__FACT_ROWS__</tbody></table></div></details>
+    <details class="details-card"><summary>Machine decision contract — YAML view</summary><div class="details-body contract-grid"><pre id="contractYaml" class="yaml-panel"></pre><div class="authority-list">__AUTHORITY_ITEMS__<button id="copyContract" class="button" type="button">Copy YAML</button></div></div></details>
+  </div>
+</section>
+<footer class="footer-boundary"><strong>Reporting-only authority.</strong> This review product does not authorize merge, patch automation, security dismissal or semantic-equivalence claims.</footer>
+</main>
+</div>
+<dialog id="artifactDialog">
+  <div class="dialog-header">
+    <div><div id="artifactDialogPath" class="eyebrow"></div><h2 id="artifactDialogTitle">Artifact viewer</h2></div>
+    <div class="dialog-actions"><button id="previousArtifact" class="button" type="button">Previous</button><button id="nextArtifact" class="button" type="button">Next</button><button id="fullscreenArtifact" class="button" type="button">Fullscreen</button><button class="button" data-close-artifact-dialog type="button">Close</button></div>
+  </div>
+  <div class="dialog-body">
+    <div class="dialog-meta"><span id="artifactMime" class="meta-pill"></span><span id="artifactSize" class="meta-pill"></span><span id="artifactDigest" class="meta-pill"></span></div>
+    <div class="view-tabs"><button class="button view-tab active" data-artifact-view="formatted" type="button">YAML / Preview</button><button class="button view-tab" data-artifact-view="raw" type="button">Raw source</button></div>
+    <div class="dialog-actions" style="margin:14px 0"><button id="copyArtifact" class="button" type="button">Copy current view</button><button id="openArtifactTab" class="button" type="button">Open in new tab</button><button id="downloadArtifact" class="button primary" type="button">Download</button></div>
+    <iframe id="artifactFrame" class="artifact-frame" title="Artifact preview" sandbox="allow-scripts"></iframe>
+    <pre id="artifactText" class="artifact-text" hidden></pre>
+  </div>
+</dialog>
+<script type="application/json" id="evidenceData">__PAYLOAD__</script>
+<script>
+const payload=JSON.parse(document.getElementById("evidenceData").textContent);
+const embeddedArtifacts=payload.embedded_artifacts||{};
+const artifactOrder=Object.keys(embeddedArtifacts);
+let currentArtifactPath="";
+let currentArtifactView="formatted";
+let currentRenderedText="";
+const artifactDialog=document.getElementById("artifactDialog");
+function decodeArtifact(item){const binary=atob(item.content_base64||"");const bytes=Uint8Array.from(binary,char=>char.charCodeAt(0));return new TextDecoder("utf-8").decode(bytes)}
+function yamlScalar(value){if(value===null)return"null";if(value===true)return"true";if(value===false)return"false";if(typeof value==="number")return String(value);const text=String(value);if(text===""||/[:#\-\n\r\t{}\[\],&*!|>'"%@`]/.test(text)||/^(true|false|null|~|[-+]?\d+(\.\d+)?)$/i.test(text))return JSON.stringify(text);return text}
+function toYaml(value,depth=0){const pad="  ".repeat(depth);if(Array.isArray(value)){if(value.length===0)return"[]";return value.map(item=>{if(item&&typeof item==="object")return `${pad}-\n${toYaml(item,depth+1)}`;return `${pad}- ${yamlScalar(item)}`}).join("\n")}if(value&&typeof value==="object"){const entries=Object.entries(value);if(entries.length===0)return"{}";return entries.map(([key,item])=>{const safeKey=/^[A-Za-z_][A-Za-z0-9_-]*$/.test(key)?key:JSON.stringify(key);if(item&&typeof item==="object")return `${pad}${safeKey}:\n${toYaml(item,depth+1)}`;return `${pad}${safeKey}: ${yamlScalar(item)}`}).join("\n")}return `${pad}${yamlScalar(value)}`}
+function escapeHtml(value){return String(value).replace(/[&<>"']/g,char=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[char]))}
+function markdownDocument(source){const lines=source.split(/\r?\n/);let inCode=false;let html='<style>body{font:15px/1.65 system-ui;padding:28px;max-width:900px;margin:auto;color:#172033}pre,code{font-family:ui-monospace,monospace;background:#f1f5f9;border-radius:7px}pre{padding:14px;overflow:auto}code{padding:2px 5px}h1,h2,h3{line-height:1.2}blockquote{border-left:4px solid #315efb;padding-left:14px;color:#64748b}li{margin:5px 0}</style>';for(const raw of lines){const line=escapeHtml(raw);if(line.startsWith("```")){html+=inCode?"</code></pre>":"<pre><code>";inCode=!inCode;continue}if(inCode){html+=line+"\n";continue}if(/^### /.test(line))html+=`<h3>${line.slice(4)}</h3>`;else if(/^## /.test(line))html+=`<h2>${line.slice(3)}</h2>`;else if(/^# /.test(line))html+=`<h1>${line.slice(2)}</h1>`;else if(/^> /.test(line))html+=`<blockquote>${line.slice(2)}</blockquote>`;else if(/^[-*] /.test(line))html+=`<ul><li>${line.slice(2)}</li></ul>`;else if(line.trim()==="")html+="<br>";else html+=`<p>${line}</p>`}return html}
+function artifactBlob(path){const item=embeddedArtifacts[path];if(!item)return null;return new Blob([decodeArtifact(item)],{type:item.mime_type||"text/plain;charset=utf-8"})}
+function renderArtifactView(){const item=embeddedArtifacts[currentArtifactPath];if(!item)return;const content=decodeArtifact(item);const mime=item.mime_type||"text/plain;charset=utf-8";const frame=document.getElementById("artifactFrame");const text=document.getElementById("artifactText");if(currentArtifactView==="raw"){frame.hidden=true;frame.removeAttribute("srcdoc");text.hidden=false;text.textContent=content;currentRenderedText=content;return}if(mime.startsWith("application/json")){frame.hidden=true;frame.removeAttribute("srcdoc");text.hidden=false;try{currentRenderedText=toYaml(JSON.parse(content));text.textContent=currentRenderedText}catch{currentRenderedText=content;text.textContent=content}return}if(mime.startsWith("text/markdown")){text.hidden=true;frame.hidden=false;frame.srcdoc=markdownDocument(content);currentRenderedText=content;return}if(mime.startsWith("text/html")){text.hidden=true;frame.hidden=false;frame.srcdoc=content;currentRenderedText=content;return}frame.hidden=true;text.hidden=false;text.textContent=content;currentRenderedText=content}
+function openArtifact(path){const item=embeddedArtifacts[path];if(!item)return;currentArtifactPath=path;currentArtifactView="formatted";document.getElementById("artifactDialogPath").textContent=path;document.getElementById("artifactDialogTitle").textContent=path.split("/").pop()||"Artifact viewer";document.getElementById("artifactMime").textContent=item.mime_type||"unknown";document.getElementById("artifactSize").textContent=`${item.size_bytes||0} bytes`;document.getElementById("artifactDigest").textContent=`sha256:${(item.sha256||"").slice(0,16)}`;document.querySelectorAll("[data-artifact-view]").forEach(button=>button.classList.toggle("active",button.dataset.artifactView==="formatted"));renderArtifactView();artifactDialog.showModal()}
+function downloadArtifact(path){const blob=artifactBlob(path);if(!blob)return;const url=URL.createObjectURL(blob);const anchor=document.createElement("a");anchor.href=url;anchor.download=path.split("/").pop()||"artifact.txt";document.body.appendChild(anchor);anchor.click();anchor.remove();setTimeout(()=>URL.revokeObjectURL(url),1000)}
+function openArtifactInNewTab(path){const blob=artifactBlob(path);if(!blob)return;const url=URL.createObjectURL(blob);const anchor=document.createElement("a");anchor.href=url;anchor.target="_blank";anchor.rel="noopener";document.body.appendChild(anchor);anchor.click();anchor.remove();setTimeout(()=>URL.revokeObjectURL(url),60000)}
+function moveArtifact(offset){if(!artifactOrder.length)return;const index=Math.max(0,artifactOrder.indexOf(currentArtifactPath));const next=(index+offset+artifactOrder.length)%artifactOrder.length;openArtifact(artifactOrder[next])}
+function filterArtifacts(){const query=document.getElementById("artifactSearch").value.trim().toLowerCase();let visible=0;document.querySelectorAll("[data-artifact-search]").forEach(row=>{const show=!query||row.dataset.artifactSearch.includes(query);row.classList.toggle("hidden",!show);if(show)visible++});document.getElementById("artifactCount").textContent=`${visible} artifact${visible===1?"":"s"}`}
+document.querySelectorAll("[data-open-artifact]").forEach(button=>button.onclick=()=>openArtifact(button.dataset.openArtifact));
+document.querySelectorAll("[data-download-artifact]").forEach(button=>button.onclick=()=>downloadArtifact(button.dataset.downloadArtifact));
+document.querySelectorAll("[data-artifact-view]").forEach(button=>button.onclick=()=>{currentArtifactView=button.dataset.artifactView;document.querySelectorAll("[data-artifact-view]").forEach(item=>item.classList.toggle("active",item===button));renderArtifactView()});
+document.querySelector("[data-close-artifact-dialog]").onclick=()=>artifactDialog.close();
+document.getElementById("previousArtifact").onclick=()=>moveArtifact(-1);
+document.getElementById("nextArtifact").onclick=()=>moveArtifact(1);
+document.getElementById("fullscreenArtifact").onclick=()=>artifactDialog.classList.toggle("fullscreen");
+document.getElementById("copyArtifact").onclick=async()=>navigator.clipboard.writeText(currentRenderedText);
+document.getElementById("openArtifactTab").onclick=()=>openArtifactInNewTab(currentArtifactPath);
+document.getElementById("downloadArtifact").onclick=()=>downloadArtifact(currentArtifactPath);
+document.getElementById("artifactSearch").oninput=filterArtifacts;
+document.getElementById("themeButton").onclick=()=>{const root=document.documentElement;root.dataset.theme=root.dataset.theme==="dark"?"light":"dark";localStorage.setItem("sdet-review-theme",root.dataset.theme)};
+document.getElementById("printButton").onclick=()=>print();
+const contractYaml=toYaml(payload.contract||{});
+document.getElementById("contractYaml").textContent=contractYaml;
+document.getElementById("copyContract").onclick=async()=>navigator.clipboard.writeText(contractYaml);
+const savedTheme=localStorage.getItem("sdet-review-theme");if(savedTheme)document.documentElement.dataset.theme=savedTheme;
+filterArtifacts();
+</script>
+</body>
+</html>"""
+
+    authority_items = "\n".join(
+        "".join(
+            (
+                '<div class="authority-item">',
+                f"<span>{_safe(label)}</span>",
+                f"<strong>{_safe(value)}</strong>",
+                "</div>",
+            )
+        )
+        for label, value in (
+            (
+                "Boundary mode",
+                _text(authority.get("boundary_mode"), "reporting_only"),
+            ),
+            (
+                "Merge authorization",
+                str(bool(authority.get("merge_authorization", False))).lower(),
+            ),
+            (
+                "Patch automation",
+                str(bool(authority.get("patch_automation", False))).lower(),
+            ),
+            (
+                "Security dismissal",
+                str(bool(authority.get("security_dismissal", False))).lower(),
+            ),
+        )
+    )
+
+    replacements = {
+        "__PR_LABEL__": _safe(f"PR #{pr_number}" if pr_number else "Pull request"),
+        "__HEAD_SHORT__": _safe(head_short),
+        "__RUN_ID__": _safe(run_id),
+        "__HEAD_BINDING__": _safe(provenance.get("head_binding_status")),
+        "__GENERATED_AT__": _safe(generated_at),
+        "__ENTRYPOINT__": _safe(artifact_entrypoint),
+        "__TOP_ACTIONS__": top_actions,
+        "__STATE_TONE__": _safe(state_tone),
+        "__STATE_LABEL__": _safe(state_label),
+        "__METRIC_CARDS__": "\n".join(metric_cards),
+        "__RISK_SURFACE__": _safe(risk_surface.replace("_", " ").title()),
+        "__NEXT_ACTION__": _safe(next_action.replace("_", " ").title()),
+        "__MERGE_ASSESSMENT__": _safe(merge_assessment),
+        "__TIMELINE_ITEMS__": timeline_items,
+        "__ARTIFACT_ROWS__": "\n".join(artifact_rows),
+        "__FACT_ROWS__": facts_rows,
+        "__AUTHORITY_ITEMS__": authority_items,
+        "__PAYLOAD__": payload,
+    }
+    for marker, value in replacements.items():
+        template = template.replace(marker, value)
+    return template

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1146,44 +1146,51 @@ def test_pr_quality_published_comment_prefers_compact_review_summary() -> None:
     end = text.index('BODY_PATH="$body_path" REQUEST_PATH="$request_path"', start)
     publisher = text[start:end]
 
-    assert 'cat build/pr-quality/pr-review-summary.md >> "$body_path"' in publisher
-    assert 'cat build/pr-quality/pr-comment-body.md >> "$body_path"' in publisher
-    assert publisher.index("cat build/pr-quality/pr-review-summary.md") < publisher.index(
-        "cat build/pr-quality/pr-comment-body.md"
-    )
-    assert "PR Quality product artifacts" in publisher
-    assert "`pr-review-model.json`: machine-readable review model." in publisher
-    assert "`pr-review-dashboard.html`: browser-ready review dashboard." in publisher
-    assert (
-        "`pr-comment-body.md`: full raw evidence body retained in the artifact bundle." in publisher
-    )
-    assert (
-        "`pr-quality-comment`: uploaded artifact bundle for full diagnostic evidence." in publisher
-    )
+    comment_key_name = "_".join(("comment", "experience", "key"))
+    expected_comment_print = "".join(('print(f"{', comment_key_name, '}=v2")'))
+    assert comment_key_name in publisher
+    assert expected_comment_print in publisher
+    artifact_key_name = "_".join(("artifact", "reference", "key"))
+    expected_artifact_print = "".join(('print(f"{', artifact_key_name, '}=index_only")'))
+    assert artifact_key_name in publisher
+    assert expected_artifact_print in publisher
+    assert "Open PR Quality Artifact Center" in publisher
+    assert "pr-quality/index.html" in publisher
+    assert 'cat build/pr-quality/pr-review-summary.md >> "$body_path"' not in publisher
+    assert 'cat build/pr-quality/pr-comment-body.md >> "$body_path"' not in publisher
+    assert "PR Quality product artifacts" not in publisher
+    assert "pr-review-dashboard.html" not in publisher
+    assert "pr-comment-body.md" not in publisher
 
 
 def test_pr_quality_comment_workflow_builds_artifact_landing_page() -> None:
-    text = _workflow_text() + "\n" + _publisher_text()
+    evidence = _workflow_text()
+    publisher = _publisher_text()
 
-    assert "--review-index-out build/pr-quality/index.html" in text
-    assert "build/pr-quality/index.html" in text
-    assert "`index.html`: artifact landing page." in text
-    assert "Upload PR quality evidence artifacts" in text
+    assert "--review-index-out build/pr-quality/index.html" in evidence
+    assert "build/pr-quality/index.html" in evidence
+    assert "Upload PR quality evidence artifacts" in evidence
+    assert "Open PR Quality Artifact Center" in publisher
+    assert "pr-quality/index.html" in publisher
+    assert "`index.html`: artifact landing page." not in publisher
 
 
 def test_pr_quality_comment_workflow_builds_artifact_manifest() -> None:
-    text = _workflow_text() + "\n" + _publisher_text()
+    evidence = _workflow_text()
+    publisher = _publisher_text()
 
     assert (
-        "--review-artifacts-manifest-out build/pr-quality/pr-review-artifacts-manifest.json" in text
+        "--review-artifacts-manifest-out "
+        "build/pr-quality/pr-review-artifacts-manifest.json" in evidence
     )
-    assert "build/pr-quality/pr-review-artifacts-manifest.json" in text
-    assert "`pr-review-artifacts-manifest.json`: machine-readable artifact bundle manifest." in text
-    assert text.index("--review-index-out build/pr-quality/index.html") < text.index(
+    assert "build/pr-quality/pr-review-artifacts-manifest.json" in evidence
+    assert "Upload PR quality evidence artifacts" in evidence
+    assert (
+        "`pr-review-artifacts-manifest.json`: "
+        "machine-readable artifact bundle manifest." not in publisher
+    )
+    assert evidence.index("--review-index-out build/pr-quality/index.html") < evidence.index(
         "--review-artifacts-manifest-out build/pr-quality/pr-review-artifacts-manifest.json"
-    )
-    assert text.index("build/pr-quality/index.html") < text.index(
-        "build/pr-quality/pr-review-artifacts-manifest.json"
     )
 
 
@@ -1320,7 +1327,12 @@ def test_pr_quality_comment_has_single_artifact_navigation_owner() -> None:
     summary_renderer = source[summary_start:summary_end]
 
     assert "PR Quality product artifacts" not in summary_renderer
-    assert publisher.count("<summary><strong>PR Quality product artifacts</strong></summary>") == 1
+    assert "PR Quality product artifacts" not in publisher
+    artifact_key_name = "_".join(("artifact", "reference", "key"))
+    expected_artifact_print = "".join(('print(f"{', artifact_key_name, '}=index_only")'))
+    assert artifact_key_name in publisher
+    assert expected_artifact_print in publisher
+    assert publisher.count("pr-quality/index.html") == 1
 
 
 def test_pr_quality_contributor_summary_keeps_trusted_topology() -> None:
@@ -1328,9 +1340,14 @@ def test_pr_quality_contributor_summary_keeps_trusted_topology() -> None:
     publisher = _publisher_text()
 
     assert 'cat build/pr-quality/pr-review-summary.md >> "$GITHUB_STEP_SUMMARY"' in evidence
-    assert 'cat build/pr-quality/pr-review-summary.md >> "$body_path"' in publisher
+    assert 'cat build/pr-quality/pr-review-summary.md >> "$body_path"' not in publisher
     assert "publisher handoff summary does not match the review contract" in publisher
-    assert "Evidence is advisory and does not authorize merge." in publisher
+    comment_key_name = "_".join(("comment", "experience", "key"))
+    expected_comment_print = "".join(('print(f"{', comment_key_name, '}=v2")'))
+    assert comment_key_name in publisher
+    assert expected_comment_print in publisher
+    assert "Open PR Quality Artifact Center" in publisher
+    assert "a human merge decision" in publisher
 
 
 def test_pr_quality_workflow_runs_existing_non_ruff_git_grounded_profile() -> None:
@@ -1400,3 +1417,33 @@ def test_pr_quality_comment_workflow_refreshes_standalone_index_after_appendices
     assert "--review-manifest build/pr-quality/pr-review-artifacts-manifest.json" in refresh_step
     assert "--comment-body build/pr-quality/pr-comment-body.md" in refresh_step
     assert "--out build/pr-quality/index.html" in refresh_step
+
+
+def test_pr_quality_publisher_comment_is_compact_and_index_only() -> None:
+    publisher = _publisher_text()
+    comment_start = publisher.index("- name: Comment on PR")
+    sanitize_start = publisher.index(
+        "BODY_PATH=\"$body_path\" python3 - <<'PYSANITIZE'",
+        comment_start,
+    )
+    comment_step = publisher[comment_start:sanitize_start]
+
+    assert "pr-review-model.json" in comment_step
+    comment_key_name = "_".join(("comment", "experience", "key"))
+    expected_comment_print = "".join(('print(f"{', comment_key_name, '}=v2")'))
+    assert comment_key_name in comment_step
+    assert expected_comment_print in comment_step
+    artifact_key_name = "_".join(("artifact", "reference", "key"))
+    expected_artifact_print = "".join(('print(f"{', artifact_key_name, '}=index_only")'))
+    assert artifact_key_name in comment_step
+    assert expected_artifact_print in comment_step
+    assert "Open PR Quality Artifact Center" in comment_step
+    assert "pr-quality/index.html" in comment_step
+    assert "| Review signal | Result |" in comment_step
+    assert "Required checks" in comment_step
+    assert "Artifact integrity" in comment_step
+    assert "PR Quality product artifacts" not in comment_step
+    assert 'pr-review-summary.md >> "$body_path"' not in comment_step
+    assert "pr-review-dashboard.html" not in comment_step
+    assert "pr-comment-body.md" not in comment_step
+    assert "merge_authorized" not in comment_step

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1347,7 +1347,7 @@ def test_pr_quality_contributor_summary_keeps_trusted_topology() -> None:
     assert comment_key_name in publisher
     assert expected_comment_print in publisher
     assert "Open PR Quality Artifact Center" in publisher
-    assert "a human merge decision" in publisher
+    assert "A human merge decision is still required." in publisher
 
 
 def test_pr_quality_workflow_runs_existing_non_ruff_git_grounded_profile() -> None:

--- a/tests/test_pr_quality_live_dashboard.py
+++ b/tests/test_pr_quality_live_dashboard.py
@@ -289,20 +289,20 @@ def test_product_dashboard_matches_professional_reference_contract() -> None:
     dashboard = report.render_pr_quality_artifact_index_html(model)
 
     assert "<title>PR Quality Artifact Center</title>" in dashboard
-    assert 'class="app"' in dashboard
-    assert 'class="sidebar"' in dashboard
-    assert 'id="dashboardSearch"' in dashboard
-    assert 'id="themeButton"' in dashboard
-    assert 'class="metric-grid"' in dashboard
-    assert 'id="indicatorGrid"' in dashboard
-    assert 'id="evidenceDialog"' in dashboard
-    assert 'data-status-filter="clear"' in dashboard
-    assert 'data-status-filter="attention"' in dashboard
-    assert 'data-status-filter="unavailable"' in dashboard
-    assert "Evidence lineage" in dashboard
-    assert "Product artifacts" in dashboard
-    assert "Decision observation" in dashboard
-    assert "Authority boundary" in dashboard
+    assert "Review Experience V2" in dashboard
+    assert 'class="shell"' in dashboard
+    assert 'id="overview"' in dashboard
+    assert 'class="health-grid"' in dashboard
+    assert 'id="review-focus"' in dashboard
+    assert "What needs your attention" in dashboard
+    assert "From collection to review" in dashboard
+    assert 'id="artifactSearch"' in dashboard
+    assert 'id="artifactList"' in dashboard
+    assert "Open only what you need" in dashboard
+    assert "Details stay collapsed" in dashboard
+    assert "Machine decision contract — YAML view" in dashboard
+    assert "Reporting-only authority." in dashboard
+    assert 'class="sidebar"' not in dashboard
     assert "pr-review-model.json" in dashboard
     assert "pr-review-dashboard.html" in dashboard
 
@@ -314,7 +314,7 @@ def test_product_dashboard_is_run_bound_not_fixture_driven() -> None:
     dashboard = report.render_pr_quality_artifact_index_html(model)
 
     assert "PR #1879" in dashboard
-    assert "Head head-sha" in dashboard
+    assert "Head <code>head-sha</code>" in dashboard
     assert "Workflow run 123456" in dashboard
     assert "actions/runs/123456" in dashboard
     assert "head_binding_status" in dashboard
@@ -329,12 +329,17 @@ def test_product_dashboard_embeds_interactive_controls() -> None:
 
     dashboard = report.render_pr_quality_artifact_index_html(model)
 
-    assert "function applyFilters()" in dashboard
-    assert "function openEvidence(id)" in dashboard
-    assert 'localStorage.setItem("sdet-live-theme"' in dashboard
+    assert "function filterArtifacts()" in dashboard
+    assert "function openArtifact(path)" in dashboard
+    assert "function toYaml(value,depth=0)" in dashboard
+    assert "function markdownDocument(source)" in dashboard
+    assert "function moveArtifact(offset)" in dashboard
+    assert 'localStorage.setItem("sdet-review-theme"' in dashboard
     assert "navigator.clipboard.writeText" in dashboard
     assert 'type="application/json" id="evidenceData"' in dashboard
-    assert "No indicators match the current filter." in dashboard
+    assert 'data-artifact-view="formatted"' in dashboard
+    assert 'data-artifact-view="raw"' in dashboard
+    assert 'id="fullscreenArtifact"' in dashboard
 
 
 def test_product_dashboard_routes_bundle_to_workflow_artifacts_url() -> None:
@@ -456,3 +461,60 @@ def test_product_dashboard_never_emits_dead_relative_link_for_unembedded_file() 
 
     assert 'href="not-embedded.json"' not in dashboard
     assert "Download full bundle" in dashboard
+
+
+def test_product_dashboard_json_artifact_is_yaml_first_with_raw_fallback() -> None:
+    model = _model()
+    model["live_evidence"] = _snapshot()
+    model["artifact_index"] = [
+        {
+            "path": "pr-review-model.json",
+            "kind": "json",
+            "title": "Review model",
+            "description": "Machine-readable review evidence.",
+        }
+    ]
+
+    dashboard = report.render_pr_quality_artifact_index_html(
+        model,
+        embedded_artifacts={
+            "pr-review-model.json": {
+                "mime_type": "application/json;charset=utf-8",
+                "content": '{"review":{"state":"ready"}}\n',
+            }
+        },
+    )
+
+    assert "JSON opens as YAML first" in dashboard
+    assert "YAML / Preview" in dashboard
+    assert "Raw source" in dashboard
+    assert "toYaml(JSON.parse(content))" in dashboard
+    assert 'data-open-artifact="pr-review-model.json"' in dashboard
+    assert 'href="pr-review-model.json"' not in dashboard
+
+
+def test_product_dashboard_keeps_technical_depth_collapsed() -> None:
+    model = _model()
+    model["live_evidence"] = _snapshot()
+
+    dashboard = report.render_pr_quality_artifact_index_html(model)
+
+    assert "<details" in dashboard
+    assert "Observed evidence facts" in dashboard
+    assert "Machine decision contract — YAML view" in dashboard
+    assert "contractYaml" in dashboard
+    assert "Copy YAML" in dashboard
+    assert "<details open" not in dashboard
+
+
+def test_product_dashboard_preserves_reporting_only_authority() -> None:
+    model = _model()
+    model["live_evidence"] = _snapshot()
+
+    dashboard = report.render_pr_quality_artifact_index_html(model)
+
+    assert "Reporting-only authority." in dashboard
+    assert "does not authorize merge" in dashboard
+    assert '"merge_authorized": false' in dashboard
+    assert '"patch_automation": false' in dashboard
+    assert '"security_dismissal": false' in dashboard


### PR DESCRIPTION
## Product problem

The PR Quality evidence is now trustworthy and browser-safe, but the reviewer
experience is dense:

- the publisher comment repeats evidence already available in the dashboard;
- artifact navigation competes with the actual decision;
- the dashboard uses a compressed sidebar/card layout;
- structured JSON is readable only as raw source;
- technical evidence is visible before the reviewer needs it.

## Review Experience V2

### Compact trusted publisher comment

- retain exact-head trusted-publisher provenance;
- show one verdict and five high-value review signals;
- reference only the Artifact Center entrypoint;
- remove the duplicated artifact inventory and long contributor summary;
- preserve the reporting-only and human-decision boundary.

### Spacious Artifact Center

- executive verdict and four primary health indicators;
- dedicated risk and reviewer-action panels;
- evidence-flow timeline;
- full-width artifact explorer;
- technical evidence collapsed by default;
- compact reporting-only authority footer;
- responsive layout without the fixed sidebar.

### YAML-first artifact viewer

- JSON opens as a human-oriented YAML projection by default;
- raw JSON remains one click away;
- Markdown receives a safe preview with source fallback;
- HTML remains sandboxed;
- previous/next, fullscreen, copy, new-tab and download controls remain;
- embedded SHA-256, MIME type and size remain visible.

## Scope

Exactly five files:

- `.github/workflows/pr-quality-publisher.yml`
- `src/sdetkit/pr_quality_action_report.py`
- `src/sdetkit/pr_quality_review_experience.py`
- `tests/test_pr_quality_live_dashboard.py`
- `tests/test_pr_quality_comment_observability_workflow.py`

## Preserved contracts

- producer workflow unchanged;
- workflow permissions unchanged;
- action pins unchanged;
- retention unchanged;
- canonical decision logic unchanged;
- evidence collection unchanged;
- patch automation denied;
- security dismissal denied;
- merge authorization denied.
