### PR TITLE
docs(readme): expose public stable operator lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Use these lanes when you need to evaluate repository readiness beyond the local 
 
 Authority boundary remains unchanged: `automation_allowed=false`, `patch_application_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false`.
 
-
 | Lane | Command | Start here when... |
 | --- | --- | --- |
 | Release gate | `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor` | You need a ship/no-ship decision. |
+| Readiness evidence | `python -m sdetkit repo audit . --format json --fail-on none` → `python -m sdetkit security scan --fail-on none --format sarif --output build/security.sarif --sbom-output build/sbom.cdx.json` → `python -m sdetkit evidence pack --output .sdetkit/out/evidence.zip` | You need local repository, security, and bundled evidence. See [Repo Audit](docs/repo-audit.md), [Security Gate](docs/security-gate.md), and [Artifact reference](docs/artifact-reference.md). |
 | Review | `python -m sdetkit review . --no-workspace --format operator-json` | You need operator-facing findings. |
 | Investigation | `python -m sdetkit investigate failure --log build/quality.log --format markdown` | A CI log or PR check needs triage before remediation. |
 | CI-ready | `./ci.sh quick --artifact-dir .sdetkit/out` and `make merge-ready` | You want a local CI-equivalent smoke path. |

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -234,6 +234,38 @@ def test_front_door_story_alignment_across_readme_docs_and_cli_contract() -> Non
     assert "one canonical command path" in contract
 
 
+def test_readme_exposes_secondary_public_stable_operator_lanes() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    canonical_index = readme.index("Canonical first path:")
+    secondary_index = readme.index("| Readiness evidence |")
+    assert canonical_index < secondary_index
+
+    expected_commands = (
+        "python -m sdetkit repo audit . --format json --fail-on none",
+        "python -m sdetkit security scan --fail-on none "
+        "--format sarif --output build/security.sarif "
+        "--sbom-output build/sbom.cdx.json",
+        "python -m sdetkit evidence pack --output .sdetkit/out/evidence.zip",
+    )
+    expected_docs = (
+        "docs/repo-audit.md",
+        "docs/security-gate.md",
+        "docs/artifact-reference.md",
+    )
+
+    assert "| Readiness evidence |" in readme
+    for command in expected_commands:
+        assert f"`{command}`" in readme
+    for docs_path in expected_docs:
+        assert f"]({docs_path})" in readme
+
+    assert (
+        "Secondary lanes cover review, investigation, quality, maintenance, "
+        "and CI automation once the primary gate decision is stable." in readme
+    )
+
+
 def test_cli_reference_keeps_current_surface_and_demotes_transition_appendix() -> None:
     cli_ref = Path("docs/cli.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- expose the supported `repo`, `security`, and `evidence` commands in one concise README operator lane;
- retain the canonical first-time path as `gate fast` → `gate release` → `doctor`;
- preserve the README's 160-line front-door budget;
- add a focused docs contract preventing the supported secondary commands from disappearing.

## Why

The clean-environment audit initially selected a missing quickstart, but repository reading showed that `README.md` already has a canonical **Start here** flow.

The first real gap is command discoverability: `repo`, `security`, and `evidence` are public/stable surfaces, but they were absent from the README operator table.

The first local patch used three rows and correctly exposed the commands, but the repository's front-door contract rejected the resulting 163-line README. This revision consolidates the commands into one `Readiness evidence` row and removes one redundant blank line, preserving discoverability at the existing concision budget.

Refs #1786.

## Verification

- isolated Python 3.11 virtual environment;
- pinned test and docs dependency installation;
- focused front-door, command-discovery, and 160-line concision tests;
- complete `tests/test_docs_qa.py` and `tests/test_public_command_surface_report.py`;
- strict MkDocs build;
- scoped and full pre-commit;
- post-format test and strict-docs rerun;
- `git diff --check`.

## Risk

- Low
- Rollback: easy

## Notes

- Documentation and regression-test scope only.
- No CLI behavior, workflow, package, security policy, artifact schema, automation authority, or merge authority changes.
- Existing open Dependabot PR #1864 touches workflow files only and does not overlap this change.

## PR card

```text
pr_card:
  title=Expose public stable operator lanes in the README
  branch=docs/public-stable-operator-lanes
  change_type=docs_quality
  problem=Supported secondary repo, security, and evidence commands are absent from the README operator table.
  user_value=New adopters can discover supported readiness, security, and evidence commands without bloating the front door.
  risk=low
  public_surface=yes
  compatibility=preserved
  files_expected=README.md, tests/test_docs_qa.py
  readme_line_budget=160
  rollback=easy
  split_needed=no
  verdict=fix_now
```