### PR TITLE
fix(adoption): preserve security tool evidence provenance

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -125,6 +125,11 @@ def _workflow_text(root: Path, files: list[str]) -> str:
     return "\n".join(_read_text(root, path).lower() for path in files)
 
 
+def _files_containing(root: Path, files: list[str], needle: str) -> list[str]:
+    normalized = needle.lower()
+    return sorted(path for path in files if normalized in _read_text(root, path).lower())
+
+
 def _package_json_has_test(root: Path) -> bool:
     payload = _read_json(root, "package.json")
     scripts = payload.get("scripts")
@@ -206,7 +211,6 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root)
     requirements = _glob_files(root, "requirements*.txt")
     workflows = _workflow_files(root)
-    workflow_text = _workflow_text(root, workflows)
 
     detected_languages: list[dict[str, Any]] = []
     package_managers: list[dict[str, Any]] = []
@@ -404,17 +408,44 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     if _file(root, "Jenkinsfile"):
         _add_named(ci_systems, "jenkins", files=["Jenkinsfile"])
 
-    if "codeql" in workflow_text:
-        _add_named(security_tools, "codeql", confidence="detected", evidence=workflows)
-    if "dependency-review" in workflow_text:
+    codeql_evidence = _files_containing(root, workflows, "codeql")
+    if codeql_evidence:
+        _add_named(
+            security_tools,
+            "codeql",
+            confidence="detected",
+            evidence=codeql_evidence,
+        )
+
+    dependency_review_evidence = _files_containing(
+        root,
+        workflows,
+        "dependency-review",
+    )
+    if dependency_review_evidence:
         _add_named(
             security_tools,
             "dependency_review",
             confidence="detected",
-            evidence=workflows,
+            evidence=dependency_review_evidence,
         )
-    if "pip-audit" in workflow_text or "pip-audit" in python_tool_text:
-        _add_named(security_tools, "pip_audit", confidence="detected", evidence=workflows)
+
+    python_tool_files = [
+        path for path in ["pyproject.toml", *requirements] if (root / path).is_file()
+    ]
+    pip_audit_evidence = sorted(
+        set(
+            _files_containing(root, workflows, "pip-audit")
+            + _files_containing(root, python_tool_files, "pip-audit")
+        )
+    )
+    if pip_audit_evidence:
+        _add_named(
+            security_tools,
+            "pip_audit",
+            confidence="detected",
+            evidence=pip_audit_evidence,
+        )
 
     release_workflows = [
         path

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -126,6 +126,84 @@ def test_adoption_surface_detects_python_github_security_and_proof_commands(
     )
 
 
+@pytest.mark.parametrize(
+    ("python_file", "python_content", "expected_pip_audit_evidence"),
+    [
+        (
+            "pyproject.toml",
+            "[project.optional-dependencies]\nsecurity = ['pip-audit']\n",
+            {"pyproject.toml"},
+        ),
+        (
+            "requirements-security.txt",
+            "pip-audit==2.9.0\n",
+            {"requirements-security.txt"},
+        ),
+    ],
+)
+def test_adoption_surface_security_tool_evidence_is_source_specific(
+    tmp_path: Path,
+    python_file: str,
+    python_content: str,
+    expected_pip_audit_evidence: set[str],
+) -> None:
+    _write(tmp_path / python_file, python_content)
+    _write(
+        tmp_path / ".github" / "workflows" / "codeql.yml",
+        "steps:\n  - uses: github/codeql-action/init@abc\n",
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "dependency-review.yml",
+        "steps:\n  - uses: actions/dependency-review-action@abc\n",
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "unrelated.yml",
+        "steps:\n  - run: echo unrelated\n",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    tools = {str(item["name"]): item for item in payload["security_tools"]}
+
+    assert set(tools) == {"codeql", "dependency_review", "pip_audit"}
+    assert set(tools["codeql"]["evidence"]) == {".github/workflows/codeql.yml"}
+    assert set(tools["dependency_review"]["evidence"]) == {
+        ".github/workflows/dependency-review.yml"
+    }
+    assert set(tools["pip_audit"]["evidence"]) == expected_pip_audit_evidence
+    assert ".github/workflows/unrelated.yml" not in {
+        evidence for tool in tools.values() for evidence in tool["evidence"]
+    }
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_adoption_surface_combines_pip_audit_workflow_and_python_evidence(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        "[project.optional-dependencies]\nsecurity = ['pip-audit']\n",
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "dependency-audit.yml",
+        "steps:\n  - run: python -m pip_audit\n  - run: pip-audit\n",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    tools = {str(item["name"]): item for item in payload["security_tools"]}
+
+    assert set(tools["pip_audit"]["evidence"]) == {
+        "pyproject.toml",
+        ".github/workflows/dependency-audit.yml",
+    }
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
 def test_adoption_surface_marks_unknown_javascript_test_command_review_first(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- preserve exact source provenance for CodeQL, Dependency Review, and pip-audit adoption detections;
- prevent unrelated workflow files from appearing as security-tool evidence;
- include `pyproject.toml` or matching requirements files when they trigger pip-audit detection;
- combine workflow and Python dependency evidence deterministically;
- preserve the existing schema and reporting-only authority fields.

## Why

The Stage 3 roadmap scan classified security-scanner detection as absent, but semantic reading showed that detection already exists.

The actual defect is evidence provenance: pip-audit can be detected from Python dependency files while the emitted evidence is the workflow list, which may be empty or unrelated. CodeQL and Dependency Review also currently cite every workflow rather than only the matching source.

This PR corrects the evidence contract without adding scanner execution, patching, dismissal, or merge authority.

Refs #1786.

## Verification

- isolated Python 3.11 environment;
- focused security provenance tests;
- complete adoption-surface, fixture-matrix, and real-world-learning-matrix suites;
- scoped and full pre-commit;
- post-format focused and regression rerun;
- `git diff --check`.

## Risk

- Low
- Additive evidence-accuracy correction
- Rollback: easy

## Notes

- No external tools are executed.
- No workflow or security policy changes.
- No artifact schema key changes.
- No automation, patch-application, security-dismissal, semantic-equivalence, or merge-authority expansion.
- Existing open Dependabot PR #1864 touches workflow files only and does not overlap this change.

## PR card

```text
pr_card:
  title=Preserve adoption security evidence provenance
  branch=fix/adoption-security-evidence-provenance
  change_type=bugfix
  problem=Security-tool detections can cite empty or unrelated workflow evidence, especially when pip-audit is detected from Python dependency files.
  user_value=Adoption reports identify the exact file that justified each security-tool classification.
  risk=low
  public_surface=evidence_values_only
  compatibility=schema_preserved
  files_expected=src/sdetkit/adoption_surface.py, tests/test_adoption_surface.py
  rollback=easy
  split_needed=no
  verdict=fix_now
```