### PR TITLE
feat(adoption): detect standard evidence artifacts

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -74,6 +74,13 @@ def _recursive_files(root: Path, pattern: str) -> list[str]:
     return sorted(files)
 
 
+def _recursive_files_for_patterns(
+    root: Path,
+    patterns: Sequence[str],
+) -> list[str]:
+    return sorted({path for pattern in patterns for path in _recursive_files(root, pattern)})
+
+
 def _read_text(root: Path, path: str) -> str:
     try:
         return (root / path).read_text(encoding="utf-8", errors="ignore")
@@ -470,8 +477,57 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             evidence=["CHANGELOG.md"],
         )
 
-    if _file(root, "coverage.xml"):
-        _add_named(artifact_surfaces, "coverage", paths=["coverage.xml"])
+    coverage_artifacts = _recursive_files_for_patterns(
+        root,
+        ("coverage.xml", "coverage.json", "lcov.info"),
+    )
+    if coverage_artifacts:
+        _add_named(
+            artifact_surfaces,
+            "coverage",
+            paths=coverage_artifacts,
+        )
+
+    junit_artifacts = _recursive_files_for_patterns(
+        root,
+        ("junit.xml", "junit-*.xml", "junit_*.xml"),
+    )
+    if junit_artifacts:
+        _add_named(
+            artifact_surfaces,
+            "junit_xml",
+            paths=junit_artifacts,
+        )
+
+    sarif_artifacts = _recursive_files_for_patterns(
+        root,
+        ("*.sarif", "*.sarif.json"),
+    )
+    if sarif_artifacts:
+        _add_named(
+            artifact_surfaces,
+            "sarif",
+            paths=sarif_artifacts,
+        )
+
+    sbom_artifacts = _recursive_files_for_patterns(
+        root,
+        (
+            "*.cdx.json",
+            "*.spdx.json",
+            "sbom.json",
+            "sbom.xml",
+            "bom.json",
+            "bom.xml",
+        ),
+    )
+    if sbom_artifacts:
+        _add_named(
+            artifact_surfaces,
+            "sbom",
+            paths=sbom_artifacts,
+        )
+
     if _dir(root, "dist"):
         _add_named(artifact_surfaces, "python_distribution", paths=["dist/"])
     if _dir(root, "build"):

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -284,6 +284,72 @@ def test_adoption_surface_detects_multi_language_evidence_without_running_comman
     assert payload["artifact_surfaces"] == [{"name": "coverage", "paths": ["coverage.xml"]}]
 
 
+def test_adoption_surface_detects_standard_evidence_artifacts(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "reports" / "coverage.xml", "<coverage />\n")
+    _write(tmp_path / "reports" / "coverage.json", "{}\n")
+    _write(tmp_path / "reports" / "lcov.info", "TN:\n")
+    _write(tmp_path / "reports" / "junit.xml", "<testsuite />\n")
+    _write(tmp_path / "reports" / "junit-unit.xml", "<testsuite />\n")
+    _write(tmp_path / "reports" / "junit_integration.xml", "<testsuite />\n")
+    _write(tmp_path / "security" / "security.sarif", "{}\n")
+    _write(tmp_path / "security" / "codeql.sarif.json", "{}\n")
+    _write(tmp_path / "sbom" / "application.cdx.json", "{}\n")
+    _write(tmp_path / "sbom" / "application.spdx.json", "{}\n")
+    _write(tmp_path / "sbom" / "sbom.xml", "<bom />\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    surfaces = {str(item["name"]): item for item in payload["artifact_surfaces"]}
+
+    assert set(surfaces) == {
+        "coverage",
+        "junit_xml",
+        "sarif",
+        "sbom",
+    }
+    assert surfaces["coverage"]["paths"] == [
+        "reports/coverage.json",
+        "reports/coverage.xml",
+        "reports/lcov.info",
+    ]
+    assert surfaces["junit_xml"]["paths"] == [
+        "reports/junit-unit.xml",
+        "reports/junit.xml",
+        "reports/junit_integration.xml",
+    ]
+    assert surfaces["sarif"]["paths"] == [
+        "security/codeql.sarif.json",
+        "security/security.sarif",
+    ]
+    assert surfaces["sbom"]["paths"] == [
+        "sbom/application.cdx.json",
+        "sbom/application.spdx.json",
+        "sbom/sbom.xml",
+    ]
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_adoption_surface_ignores_non_artifacts_and_ignored_tree_artifacts(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "docs" / "example.xml", "<example />\n")
+    _write(tmp_path / "data" / "report.json", "{}\n")
+    _write(tmp_path / "site" / "junit.xml", "<testsuite />\n")
+    _write(tmp_path / "node_modules" / "security.sarif", "{}\n")
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert payload["artifact_surfaces"] == []
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
 def test_adoption_surface_profiles_external_repo_readiness_without_authority(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- discover existing coverage, JUnit XML, SARIF, and SBOM evidence artifacts recursively;
- report exact deterministic paths in the existing `artifact_surfaces` field;
- ignore non-artifact files and artifacts under ignored generated/vendor trees;
- preserve existing `dist/` and `build/` surface detection;
- preserve the existing schema and reporting-only authority boundary.

## Why

The adoption preflight promises artifact-surface discovery, but currently recognizes only root `coverage.xml`, `dist/`, and `build/`.

Common CI evidence already used throughout SDETKit—JUnit XML, SARIF, and CycloneDX/SPDX SBOM files—can therefore exist in a target repository without appearing in its adoption profile.

This PR adds read-only file discovery only. It does not execute tools, parse untrusted artifact contents, mutate target repositories, or authorize automation.

Refs #1786.

## Verification

- isolated Python 3.11 environment;
- focused artifact-discovery and ignored-tree tests;
- complete adoption-surface, fixture-matrix, and real-world-learning-matrix suites;
- scoped and full pre-commit;
- post-format focused and regression rerun;
- `git diff --check`.

## Risk

- Low
- Additive artifact classification
- Schema preserved
- Rollback: easy

## Notes

- No artifact contents are executed.
- No workflow, package, or security-policy changes.
- No artifact schema key changes.
- No automation, patch-application, security-dismissal, semantic-equivalence, or merge-authority expansion.
- Existing open Dependabot PR #1864 touches workflow files only and does not overlap this change.

## PR card

```text
pr_card:
  title=Detect standard evidence artifacts in adoption profiles
  branch=feat/adoption-standard-artifact-discovery
  change_type=feature
  problem=Adoption profiles omit existing JUnit, SARIF, SBOM, and nested coverage evidence artifacts.
  user_value=Operators see the evidence files already available before choosing proof and rollout depth.
  risk=low
  public_surface=additive_artifact_surface_values
  compatibility=schema_preserved
  files_expected=src/sdetkit/adoption_surface.py, tests/test_adoption_surface.py
  rollback=easy
  split_needed=no
  verdict=fix_now
```