### PR TITLE
fix(adoption): preserve proof recommendation confidence

### DIFF
--- a/src/sdetkit/adoption_proof_recommendations.py
+++ b/src/sdetkit/adoption_proof_recommendations.py
@@ -35,6 +35,13 @@ def _purpose(item: dict[str, Any]) -> str:
     return str(item.get("purpose", "unknown")).strip() or "unknown"
 
 
+def _confidence(item: dict[str, Any]) -> str:
+    value = str(item.get("confidence", "unknown")).strip().lower()
+    if value in {"high", "medium", "low"}:
+        return value
+    return "unknown"
+
+
 def _operator_level(item: dict[str, Any]) -> str:
     purpose = _purpose(item)
     surface = _surface(item)
@@ -76,6 +83,7 @@ def _recommendation_from_command(item: dict[str, Any], index: int) -> dict[str, 
         "command": command,
         "surface": _surface(item),
         "purpose": _purpose(item),
+        "confidence": _confidence(item),
         "operator_level": level,
         "execution_policy": "manual_only",
         "executes_target_code": bool(command),
@@ -137,6 +145,10 @@ def build_proof_recommendations_payload(
     recommended_count = sum(
         1 for item in recommendations if item["operator_level"] == "recommended"
     )
+    confidence_counts = {
+        confidence: sum(1 for item in recommendations if item["confidence"] == confidence)
+        for confidence in ("high", "medium", "low", "unknown")
+    }
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -147,6 +159,7 @@ def build_proof_recommendations_payload(
             "required_count": required_count,
             "recommended_count": recommended_count,
             "review_first_count": len(review_first),
+            "confidence_counts": confidence_counts,
         },
         "proof_recommendations": recommendations,
         "review_first_items": review_first,
@@ -196,6 +209,11 @@ def render_proof_recommendations_text(payload: dict[str, Any]) -> str:
         f"required_count={summary['required_count']}",
         f"recommended_count={summary['recommended_count']}",
         f"review_first_count={summary['review_first_count']}",
+        "confidence_counts="
+        + ",".join(
+            f"{confidence}:{summary['confidence_counts'][confidence]}"
+            for confidence in ("high", "medium", "low", "unknown")
+        ),
         "proof_recommendations:",
     ]
 
@@ -205,6 +223,7 @@ def render_proof_recommendations_text(payload: dict[str, Any]) -> str:
             f"level={item['operator_level']}; "
             f"surface={item['surface']}; "
             f"purpose={item['purpose']}; "
+            f"confidence={item['confidence']}; "
             f"manual_only={str(item['manual_execution_required']).lower()}; "
             f"auto_run_allowed={str(item['auto_run_allowed']).lower()}; "
             f"command={item['command']}"

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -10,7 +10,10 @@ from sdetkit.adoption_proof_recommendations import (
     render_proof_recommendations_text,
     write_proof_recommendations_artifact,
 )
-from sdetkit.adoption_surface import write_adoption_surface_artifact
+from sdetkit.adoption_surface import (
+    discover_adoption_surface,
+    write_adoption_surface_artifact,
+)
 
 
 def test_proof_recommendations_classify_current_repo_commands() -> None:
@@ -28,9 +31,98 @@ def test_proof_recommendations_classify_current_repo_commands() -> None:
     commands = {item["command"]: item for item in payload["proof_recommendations"]}
     assert "python -m pytest -q -o addopts=" in commands
     assert commands["python -m pytest -q -o addopts="]["operator_level"] == "required"
+    assert commands["python -m pytest -q -o addopts="]["confidence"] == "high"
     assert commands["python -m pytest -q -o addopts="]["execution_policy"] == "manual_only"
+    assert payload["summary"]["confidence_counts"]["high"] >= 1
     assert commands["python -m pytest -q -o addopts="]["auto_run_allowed"] is False
     assert all(item["manual_execution_required"] is True for item in commands.values())
+
+
+def test_proof_recommendations_preserve_source_confidence(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["pytest"]\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "requirements-test.txt").write_text(
+        "pytest==9.1.1\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "confidence-fixture",
+                "scripts": {"test": "vitest run"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "package-lock.json").write_text("{}\n", encoding="utf-8")
+
+    surface = discover_adoption_surface(tmp_path)
+    payload = build_proof_recommendations_payload(
+        tmp_path,
+        surface_payload=surface,
+    )
+    commands = {item["command"]: item for item in payload["proof_recommendations"]}
+
+    assert commands["python -m pytest -q -o addopts="]["confidence"] == "high"
+    assert commands["npm test"]["confidence"] == "medium"
+    assert payload["summary"]["confidence_counts"] == {
+        "high": 1,
+        "medium": 1,
+        "low": 0,
+        "unknown": 0,
+    }
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_proof_recommendations_normalize_missing_or_invalid_confidence(
+    tmp_path: Path,
+) -> None:
+    surface = discover_adoption_surface(tmp_path)
+    surface["recommended_proof_commands"] = [
+        {
+            "surface": "custom",
+            "command": "custom proof",
+            "purpose": "test",
+            "executes_untrusted_code": True,
+            "auto_run_allowed": False,
+        },
+        {
+            "surface": "custom",
+            "command": "another proof",
+            "confidence": "UNTRUSTED",
+            "purpose": "quality",
+            "executes_untrusted_code": True,
+            "auto_run_allowed": False,
+        },
+    ]
+
+    payload = build_proof_recommendations_payload(
+        tmp_path,
+        surface_payload=surface,
+    )
+
+    assert [item["confidence"] for item in payload["proof_recommendations"]] == [
+        "unknown",
+        "unknown",
+    ]
+    assert payload["summary"]["confidence_counts"] == {
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "unknown": 2,
+    }
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
 
 
 def test_proof_recommendations_turn_unknowns_into_review_first_items() -> None:
@@ -82,6 +174,8 @@ def test_proof_recommendations_cli_dispatch_writes_text_summary(
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["schema_version"] == SCHEMA_VERSION
     assert "adoption_proof_recommendations_status=generated" in stdout
+    assert "confidence=high" in stdout
+    assert "confidence_counts=" in stdout
     assert "manual_only=true" in stdout
     assert "auto_run_allowed=false" in stdout
     assert "review_first_count=1" in stdout


### PR DESCRIPTION
## Summary

- preserve each adoption proof command's source confidence in the operator recommendation artifact;
- normalize missing or unsupported confidence values to `unknown`;
- add deterministic `confidence_counts` to the recommendation summary;
- expose confidence in text output;
- preserve manual-only execution and all reporting-only authority fields.

## Why

`adoption_surface` already classifies proof commands with `high` or `medium` confidence, but `adoption_proof_recommendations` currently drops that field.

The operator-facing recommendation therefore loses evidence strength when converting a detected command into its review contract. This PR preserves the existing source classification without changing command order, operator level, execution policy, or authority.

Refs #1786.

## Verification

- isolated Python 3.11 environment;
- focused high/medium confidence provenance tests;
- missing/invalid confidence normalization tests;
- complete proof-recommendation, topology, and adoption-surface test files;
- scoped and full pre-commit;
- post-format focused and regression rerun;
- `git diff --check`.

## Risk

- Low
- Additive recommendation metadata
- Existing schema version retained
- Rollback: easy

## Notes

- No proof commands are executed automatically.
- No command ranking or operator-level policy changes.
- No workflow, package, security-policy, or artifact discovery changes.
- No patch-application, security-dismissal, semantic-equivalence, or merge-authority expansion.
- Existing open Dependabot PR #1864 touches workflow files only and does not overlap this change.

## PR card

```text
pr_card:
  title=Preserve adoption proof recommendation confidence
  branch=fix/adoption-proof-confidence-provenance
  change_type=bugfix
  problem=Operator proof recommendations drop the confidence already assigned by adoption-surface discovery.
  user_value=Operators retain the evidence strength behind each recommended manual proof command.
  risk=low
  public_surface=additive_confidence_metadata
  compatibility=schema_version_preserved
  files_expected=src/sdetkit/adoption_proof_recommendations.py, tests/test_adoption_proof_recommendations.py
  rollback=easy
  split_needed=no
  verdict=fix_now
```