### PR TITLE
fix(adoption): ground Gradle proof commands in wrapper evidence

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -388,11 +388,12 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             )
         if _file(root, "build.gradle") or _file(root, "build.gradle.kts"):
             _add_named(package_managers, "gradle", files=java_files)
+            gradle_wrapper_detected = _file(root, "gradlew")
             _add_proof_command(
                 recommended_proof_commands,
                 surface="java",
-                command="./gradlew test",
-                confidence="medium",
+                command="./gradlew test" if gradle_wrapper_detected else "gradle test",
+                confidence="high" if gradle_wrapper_detected else "medium",
                 purpose="test",
             )
 

--- a/tests/fixtures/adoption_repos/java_gradle_no_wrapper/build.gradle
+++ b/tests/fixtures/adoption_repos/java_gradle_no_wrapper/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java'
+}

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -64,6 +64,48 @@ def test_adoption_surface_detects_remaining_package_manager_markers(
 
 
 @pytest.mark.parametrize(
+    ("files", "expected_command", "unexpected_command", "expected_confidence"),
+    [
+        (
+            {"build.gradle": "plugins { id 'java' }\n"},
+            "gradle test",
+            "./gradlew test",
+            "medium",
+        ),
+        (
+            {
+                "build.gradle.kts": "plugins { java }\n",
+                "gradlew": "#!/usr/bin/env sh\n",
+            },
+            "./gradlew test",
+            "gradle test",
+            "high",
+        ),
+    ],
+)
+def test_adoption_surface_grounds_gradle_proof_command_in_wrapper_evidence(
+    tmp_path: Path,
+    files: dict[str, str],
+    expected_command: str,
+    unexpected_command: str,
+    expected_confidence: str,
+) -> None:
+    for relative_path, content in files.items():
+        _write(tmp_path / relative_path, content)
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "gradle" in _names(payload["package_managers"])
+    assert expected_command in _commands(payload)
+    assert unexpected_command not in _commands(payload)
+    assert _proof_command(payload, expected_command)["confidence"] == expected_confidence
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+@pytest.mark.parametrize(
     ("relative_path", "content"),
     [
         ("pyproject.toml", "[project]\nname = 'manifest-only'\n"),

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -106,6 +106,15 @@ def _unknowns(payload: dict[str, object]) -> set[str]:
             set(),
         ),
         (
+            "java_gradle_no_wrapper",
+            {"java"},
+            {"gradle"},
+            set(),
+            set(),
+            {"gradle test"},
+            set(),
+        ),
+        (
             "dotnet_solution",
             {"dotnet"},
             {"nuget"},
@@ -172,6 +181,7 @@ def test_adoption_surface_fixture_matrix_detects_repo_shapes(
         "go_module",
         "rust_cargo",
         "java_maven",
+        "java_gradle_no_wrapper",
         "dotnet_solution",
         "gitlab_python",
         "jenkins_java",


### PR DESCRIPTION
## Summary
- Ground Gradle proof-command selection in detected wrapper evidence.
- Recommend `./gradlew test` with high confidence when `gradlew` exists.
- Recommend `gradle test` with medium confidence for Gradle manifests without a wrapper.
- Add direct and fixture-matrix regression coverage for both command paths.

## Why
Gradle package-manager detection already exists, but the adoption surface always recommended `./gradlew test` whenever a Gradle manifest was found. Repositories without a checked-in wrapper therefore received a command unsupported by their detected repository evidence.

## Verification
- `python -m pytest -q tests/test_adoption_surface.py tests/test_adoption_surface_fixture_matrix.py tests/test_adoption_proof_recommendations.py tests/test_adoption_repo_topology.py -o addopts=` — 66 passed before formatting
- `python -m pre_commit run --files src/sdetkit/adoption_surface.py tests/test_adoption_surface.py tests/test_adoption_surface_fixture_matrix.py tests/fixtures/adoption_repos/java_gradle_no_wrapper/build.gradle` — passed
- Focused pytest rerun after formatting — 66 passed
- `python -m pre_commit run -a` — passed
- Direct behavioral smoke verified wrapper-backed and wrapperless Gradle recommendations
- `git diff --check` — passed

## Risk
- Medium: this changes the public adoption recommendation selected for Gradle repositories.
- Compatibility is preserved: output schemas and authority fields are unchanged.
- Rollback: easy; revert this single focused commit.

## Notes
- Automation remains non-authorizing and `auto_run_allowed` behavior is unchanged.
- This PR does not execute Gradle or install tooling.
- Scope is limited to command selection and regression fixtures.
- Merge remains a human decision after exact-head CI is green.
