### PR TITLE
feat(adoption): render public repo trial matrix report

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -154,8 +154,9 @@ default root help by design so adopter-facing discovery remains focused:
 
 - `adoption-real-world-learning-matrix`
 - `adoption-learning-report`
+- `adoption-public-trial-matrix-report`
 
-Maintainers can reveal both commands with `python -m sdetkit --show-hidden --help`. Direct
+Maintainers can reveal these commands with `python -m sdetkit --show-hidden --help`. Direct
 command help remains available through `python -m sdetkit <command> --help`.
 
 Hidden status is a discoverability contract, not action authority. Both commands remain
@@ -215,6 +216,58 @@ semantic_equivalence_proven=false
 ```
 
 The generated JSON artifact is registered as `adoption-learning-report-json` at `build/sdetkit/adoption-learning-report.json`. The Markdown file is an operator-readable companion, not a separate machine schema.
+
+## Render the recorded public trial matrix
+
+Use the dedicated reporting-only lane when the input is the recorded
+`sdetkit.public_repo_trial_matrix.v1` fixture contract rather than a live
+real-world learning matrix:
+
+```bash
+python -m sdetkit adoption-public-trial-matrix-report \
+  --matrix-json tests/fixtures/adoption_public_trials/public_repo_trial_matrix.json \
+  --out build/sdetkit/public-repo-trial-matrix-report.json \
+  --markdown-out build/sdetkit/public-repo-trial-matrix-report.md \
+  --format json
+```
+
+The command reads only the supplied matrix artifact. It does not revisit the
+listed repositories, install dependencies, execute target tests, mutate a
+target, open a target issue or pull request, claim endorsement, or authorize
+an implementation.
+
+Read these JSON fields first:
+
+- `report_status`
+- `input_provenance`
+- `source_matrix`
+- `summary`
+- `trials`
+- `operator_summary`
+- `rules`
+- `authority_boundary`
+
+The report binds the source matrix bytes and current Git head into a SHA-256
+input digest. Its trial list is sorted by repository name so JSON and Markdown
+remain deterministic for the same matrix and head.
+
+The authority boundary remains:
+
+```text
+target_repos_read=false
+install_dependencies=false
+target_tests_executed=false
+target_repo_mutation=false
+target_pr_or_issue_opened=false
+endorsement_claim=false
+automation_allowed=false
+patch_application_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+```
+
+This hidden maintainer report is not yet a separately registered artifact
+contract. Artifact-index registration remains an independent follow-up.
 
 ## Render the adoption learning dashboard
 

--- a/src/sdetkit/_legacy_cli.py
+++ b/src/sdetkit/_legacy_cli.py
@@ -797,6 +797,23 @@ Then use stability-aware command discovery:
     adoption_learning_report.add_argument("--format", choices=["json", "text"], default="json")
     adoption_learning_report.add_argument("--check-freshness", action="store_true")
 
+    adoption_public_trial_matrix_report = sub.add_parser(
+        "adoption-public-trial-matrix-report",
+        help=argparse.SUPPRESS,
+    )
+    adoption_public_trial_matrix_report.add_argument("--root", default=".")
+    adoption_public_trial_matrix_report.add_argument("--matrix-json", required=True)
+    adoption_public_trial_matrix_report.add_argument(
+        "--out",
+        default="build/sdetkit/public-repo-trial-matrix-report.json",
+    )
+    adoption_public_trial_matrix_report.add_argument("--markdown-out", default="")
+    adoption_public_trial_matrix_report.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="json",
+    )
+
     release_anti_hijack_threat_model = sub.add_parser(
         "release-anti-hijack-threat-model",
         help=argparse.SUPPRESS,
@@ -1884,6 +1901,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         if bool(ns.check_freshness):
             forwarded.append("--check-freshness")
         return _run_module_main("sdetkit.adoption_learning_report", forwarded)
+
+    if ns.cmd == "adoption-public-trial-matrix-report":
+        forwarded = [
+            "--root",
+            str(ns.root),
+            "--matrix-json",
+            str(ns.matrix_json),
+            "--out",
+            str(ns.out),
+            "--format",
+            str(ns.format),
+        ]
+        if str(ns.markdown_out):
+            forwarded.extend(["--markdown-out", str(ns.markdown_out)])
+        return _run_module_main(
+            "sdetkit.adoption_public_repo_trial_matrix_report",
+            forwarded,
+        )
 
     if ns.cmd == "release-anti-hijack-threat-model":
         forwarded = [

--- a/src/sdetkit/adoption_learning.py
+++ b/src/sdetkit/adoption_learning.py
@@ -107,6 +107,10 @@ def _public_repo_trial_matrix_present(repo_root: Path) -> bool:
     ).is_file()
 
 
+def _public_repo_trial_matrix_report_present(repo_root: Path) -> bool:
+    return (repo_root / "src" / "sdetkit" / "adoption_public_repo_trial_matrix_report.py").is_file()
+
+
 def _detected_strengths(surface: dict[str, Any]) -> list[str]:
     languages = set(_names(surface.get("detected_languages")))
     package_managers = set(_names(surface.get("package_managers")))
@@ -148,6 +152,7 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
     repo_topology_summary_present = _repo_topology_summary_present(repo_root)
     adoption_evidence_bundle_present = _adoption_evidence_bundle_present(repo_root)
     public_repo_trial_matrix_present = _public_repo_trial_matrix_present(repo_root)
+    public_repo_trial_matrix_report_present = _public_repo_trial_matrix_report_present(repo_root)
 
     gaps: list[str] = []
     if languages <= {"python"} and not fixture_matrix_present:
@@ -170,7 +175,7 @@ def _learning_gaps(surface: dict[str, Any], repo_root: Path) -> list[str]:
         gaps.append("add adoption evidence bundle")
     elif not public_repo_trial_matrix_present:
         gaps.append("add public repo trial matrix")
-    else:
+    elif not public_repo_trial_matrix_report_present:
         gaps.append("add public repo trial matrix report")
     return gaps
 

--- a/src/sdetkit/adoption_public_repo_trial_matrix_report.py
+++ b/src/sdetkit/adoption_public_repo_trial_matrix_report.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.public_repo_trial_matrix_report.v1"
+ACCEPTED_MATRIX_SCHEMA = "sdetkit.public_repo_trial_matrix.v1"
+DEFAULT_OUT = Path("build/sdetkit/public-repo-trial-matrix-report.json")
+GENERATOR_SOURCE = "src/sdetkit/adoption_public_repo_trial_matrix_report.py"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+SOURCE_SAFETY_FIELDS = (
+    "source_code_vendored",
+    "dependency_install_performed",
+    "target_tests_executed",
+    "target_repo_mutated",
+    "target_pr_or_issue_opened",
+    "endorsement_claimed",
+)
+
+
+def _authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _git_head_sha(root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _display_path(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _validate_matrix(matrix: dict[str, Any]) -> list[dict[str, Any]]:
+    schema = str(matrix.get("schema_version", "")).strip()
+    if schema != ACCEPTED_MATRIX_SCHEMA:
+        raise ValueError(
+            "unsupported public repo trial matrix schema: "
+            f"{schema or '<missing>'}; expected {ACCEPTED_MATRIX_SCHEMA}"
+        )
+
+    for field in SOURCE_SAFETY_FIELDS:
+        if matrix.get(field) is not False:
+            raise ValueError(f"source safety field must be false: {field}")
+
+    boundary = matrix.get("authority_boundary")
+    if not isinstance(boundary, dict):
+        raise ValueError("source matrix authority_boundary must be an object")
+    for field in AUTHORITY_FIELDS:
+        if boundary.get(field) is not False:
+            raise ValueError(f"source authority field must be false: {field}")
+
+    raw_trials = matrix.get("trials")
+    if not isinstance(raw_trials, list):
+        raise ValueError("source matrix trials must be a list")
+
+    trials: list[dict[str, Any]] = []
+    required_strings = (
+        "repo_full_name",
+        "repo_url",
+        "license_id",
+        "expected_primary_language",
+    )
+    required_bools = (
+        "eligibility_allowed_for_read_only_trial",
+        "prior_single_repo_trial",
+    )
+    for index, item in enumerate(raw_trials):
+        if not isinstance(item, dict):
+            raise ValueError(f"trial {index} must be an object")
+        for field in required_strings:
+            if not isinstance(item.get(field), str) or not str(item[field]).strip():
+                raise ValueError(f"trial {index} missing string field: {field}")
+        for field in required_bools:
+            if not isinstance(item.get(field), bool):
+                raise ValueError(f"trial {index} missing boolean field: {field}")
+        trials.append(
+            {
+                "repo_full_name": str(item["repo_full_name"]).strip(),
+                "repo_url": str(item["repo_url"]).strip(),
+                "license_id": str(item["license_id"]).strip(),
+                "expected_primary_language": str(item["expected_primary_language"]).strip(),
+                "eligibility_allowed_for_read_only_trial": bool(
+                    item["eligibility_allowed_for_read_only_trial"]
+                ),
+                "prior_single_repo_trial": bool(item["prior_single_repo_trial"]),
+            }
+        )
+    return sorted(trials, key=lambda trial: trial["repo_full_name"])
+
+
+def build_public_repo_trial_matrix_report(
+    matrix_json: str | Path,
+    *,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    root_path = Path(root).resolve()
+    matrix_path = Path(matrix_json).resolve()
+    matrix_bytes = matrix_path.read_bytes()
+    matrix = _load_json_object(matrix_path)
+    trials = _validate_matrix(matrix)
+    head_sha = (
+        _git_head_sha(root_path) if current_head_sha is None else str(current_head_sha).strip()
+    )
+
+    digest = hashlib.sha256()
+    digest.update(SCHEMA_VERSION.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(head_sha.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(matrix_bytes)
+
+    eligible_count = sum(1 for trial in trials if trial["eligibility_allowed_for_read_only_trial"])
+    prior_count = sum(1 for trial in trials if trial["prior_single_repo_trial"])
+    new_candidate_count = sum(
+        1
+        for trial in trials
+        if trial["eligibility_allowed_for_read_only_trial"] and not trial["prior_single_repo_trial"]
+    )
+    report_status = (
+        "ready_for_human_review" if trials and eligible_count == len(trials) else "review_required"
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_status": report_status,
+        "input_provenance": {
+            "input_digest_algorithm": "sha256",
+            "input_digest": digest.hexdigest(),
+            "matrix_path": _display_path(root_path, matrix_path),
+            "matrix_sha256": hashlib.sha256(matrix_bytes).hexdigest(),
+            "matrix_schema_version": str(matrix.get("schema_version", "")),
+            "generator_schema_version": SCHEMA_VERSION,
+            "generator_source": GENERATOR_SOURCE,
+            "current_head_sha": head_sha,
+            "current_head_bound": bool(head_sha),
+        },
+        "source_matrix": {
+            "matrix_name": str(matrix.get("matrix_name", "")).strip(),
+            "trial_mode": str(matrix.get("trial_mode", "")).strip(),
+            "schema_version": str(matrix.get("schema_version", "")).strip(),
+            "recommended_next_upgrade_after_matrix": str(
+                matrix.get("recommended_next_upgrade_after_matrix", "")
+            ).strip(),
+            "source_safety": {field: bool(matrix.get(field)) for field in SOURCE_SAFETY_FIELDS},
+        },
+        "summary": {
+            "trial_count": len(trials),
+            "eligible_trial_count": eligible_count,
+            "prior_single_repo_trial_count": prior_count,
+            "new_read_only_trial_candidate_count": new_candidate_count,
+            "all_trials_eligible": bool(trials) and eligible_count == len(trials),
+        },
+        "trials": trials,
+        "operator_summary": {
+            "status": report_status,
+            "headline": (
+                f"{len(trials)} recorded public repository trial candidates; "
+                f"{new_candidate_count} remain new read-only candidates."
+            ),
+            "recommended_next_action": (
+                "Review the recorded matrix evidence and select any next read-only trial manually."
+            ),
+        },
+        "rules": {
+            "source_matrix_only": True,
+            "target_repos_read": False,
+            "install_dependencies": False,
+            "target_tests_executed": False,
+            "target_repo_mutation": False,
+            "target_pr_or_issue_opened": False,
+            "endorsement_claim": False,
+            "review_first": True,
+        },
+        "reporting_only": True,
+        "repo_mutation": False,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+        "authority_boundary": _authority_boundary(),
+    }
+
+
+def render_public_repo_trial_matrix_report_markdown(payload: dict[str, Any]) -> str:
+    provenance = payload["input_provenance"]
+    summary = payload["summary"]
+    source = payload["source_matrix"]
+    lines = [
+        "# SDETKit public repository trial matrix report",
+        "",
+        f"- report_status: {payload['report_status']}",
+        f"- source_matrix_schema: {source['schema_version']}",
+        f"- source_matrix_name: {source['matrix_name']}",
+        f"- trial_mode: {source['trial_mode']}",
+        f"- trial_count: {summary['trial_count']}",
+        f"- eligible_trial_count: {summary['eligible_trial_count']}",
+        (
+            "- new_read_only_trial_candidate_count: "
+            f"{summary['new_read_only_trial_candidate_count']}"
+        ),
+        f"- input_digest: `{provenance['input_digest']}`",
+        f"- current_head_sha: `{provenance['current_head_sha']}`",
+        "- review_first: true",
+        "- reporting_only: true",
+        "",
+        "## Recorded trials",
+        "",
+    ]
+    trials = payload.get("trials")
+    if not isinstance(trials, list) or not trials:
+        lines.append("- none")
+    else:
+        for trial in trials:
+            lines.extend(
+                [
+                    f"- `{trial['repo_full_name']}`",
+                    f"  - license_id: {trial['license_id']}",
+                    (
+                        "  - eligibility_allowed_for_read_only_trial: "
+                        f"{str(trial['eligibility_allowed_for_read_only_trial']).lower()}"
+                    ),
+                    (
+                        "  - prior_single_repo_trial: "
+                        f"{str(trial['prior_single_repo_trial']).lower()}"
+                    ),
+                ]
+            )
+    lines.extend(
+        [
+            "",
+            "## Authority boundary",
+            "",
+            "- target_repos_read: false",
+            "- install_dependencies: false",
+            "- target_tests_executed: false",
+            "- target_repo_mutation: false",
+            "- target_pr_or_issue_opened: false",
+            "- endorsement_claim: false",
+            "- automation_allowed: false",
+            "- patch_application_allowed: false",
+            "- merge_authorized: false",
+            "- semantic_equivalence_proven: false",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_public_repo_trial_matrix_report_artifacts(
+    *,
+    matrix_json: str | Path,
+    out: str | Path = DEFAULT_OUT,
+    markdown_out: str | Path | None = None,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    payload = build_public_repo_trial_matrix_report(
+        matrix_json,
+        root=root,
+        current_head_sha=current_head_sha,
+    )
+    out_path = Path(out)
+    markdown_path = Path(markdown_out) if markdown_out else out_path.with_suffix(".md")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(
+        render_public_repo_trial_matrix_report_markdown(payload) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit adoption-public-trial-matrix-report",
+        description=(
+            "Render a reporting-only operator summary from a recorded "
+            "public repository trial matrix."
+        ),
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--matrix-json", required=True)
+    parser.add_argument("--out", default=DEFAULT_OUT.as_posix())
+    parser.add_argument("--markdown-out", default="")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+    payload = write_public_repo_trial_matrix_report_artifacts(
+        matrix_json=ns.matrix_json,
+        out=ns.out,
+        markdown_out=ns.markdown_out or None,
+        root=ns.root,
+    )
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_public_repo_trial_matrix_report_markdown(payload) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adoption_evidence_bundle.py
+++ b/tests/test_adoption_evidence_bundle.py
@@ -125,9 +125,9 @@ def test_evidence_bundle_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_evidence_bundle_exists() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_learning.py
+++ b/tests/test_adoption_learning.py
@@ -64,7 +64,8 @@ def test_adoption_learning_records_current_repo_self_baseline() -> None:
     assert "make proof-after-format" in payload["observed_surfaces"]["recommended_proof_commands"]
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
 
@@ -127,6 +128,6 @@ def test_adoption_learning_text_renderer_keeps_next_upgrade_visible() -> None:
 
     text = render_adoption_learning_text(payload)
 
-    assert "recommended_next_upgrade=public repo trial matrix report" in text
-    assert "learning_gaps:" in text
+    assert "recommended_next_upgrade=review learning gaps" in text
+    assert "learning_gaps:\nauthority_boundary:" in text
     assert "- semantic_equivalence_proven=false" in text

--- a/tests/test_adoption_local_external_root.py
+++ b/tests/test_adoption_local_external_root.py
@@ -119,7 +119,7 @@ def test_local_external_root_cli_dispatch_writes_artifact_outside_target(
 def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
     assert (
         "add public repo eligibility screen before using third-party repos"
@@ -130,6 +130,6 @@ def test_self_learning_advances_to_public_repo_eligibility_after_local_smoke() -
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -206,11 +206,11 @@ def test_proof_recommendations_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_proof_recommendations_exist() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_eligibility.py
+++ b/tests/test_adoption_public_repo_eligibility.py
@@ -139,7 +139,7 @@ def test_public_repo_eligibility_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert (
         "add public repo eligibility screen before using third-party repos"
         not in payload["learning_gaps"]
@@ -149,6 +149,6 @@ def test_self_learning_advances_to_public_repo_trial_after_eligibility_screen() 
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_readonly_trial.py
+++ b/tests/test_adoption_public_repo_readonly_trial.py
@@ -45,12 +45,12 @@ def test_first_public_readonly_trial_fixture_contains_no_source_tree() -> None:
 def test_self_learning_advances_after_first_public_readonly_trial() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "run first permissive public repo read-only trial" not in payload["learning_gaps"]
     assert "add proof command recommendation levels" not in payload["learning_gaps"]
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_trial_matrix.py
+++ b/tests/test_adoption_public_repo_trial_matrix.py
@@ -65,11 +65,11 @@ def test_public_repo_trial_matrix_fixture_contains_no_source_tree() -> None:
     assert all(not file_name.endswith(".py") for file_name in files)
 
 
-def test_self_learning_advances_after_public_repo_trial_matrix_exists() -> None:
+def test_self_learning_advances_after_public_repo_trial_matrix_report_exists() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_public_repo_trial_matrix_report.py
+++ b/tests/test_adoption_public_repo_trial_matrix_report.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_public_repo_trial_matrix_report import (
+    ACCEPTED_MATRIX_SCHEMA,
+    SCHEMA_VERSION,
+    build_public_repo_trial_matrix_report,
+    write_public_repo_trial_matrix_report_artifacts,
+)
+
+MATRIX_PATH = Path("tests/fixtures/adoption_public_trials/public_repo_trial_matrix.json")
+
+
+def test_public_repo_trial_matrix_report_summarizes_recorded_evidence() -> None:
+    payload = build_public_repo_trial_matrix_report(MATRIX_PATH, current_head_sha="head-a")
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["report_status"] == "ready_for_human_review"
+    assert payload["source_matrix"]["schema_version"] == ACCEPTED_MATRIX_SCHEMA
+    assert payload["summary"] == {
+        "trial_count": 3,
+        "eligible_trial_count": 3,
+        "prior_single_repo_trial_count": 1,
+        "new_read_only_trial_candidate_count": 2,
+        "all_trials_eligible": True,
+    }
+    assert [trial["repo_full_name"] for trial in payload["trials"]] == [
+        "pallets/click",
+        "pallets/itsdangerous",
+        "pallets/markupsafe",
+    ]
+    provenance = payload["input_provenance"]
+    assert provenance["input_digest_algorithm"] == "sha256"
+    assert len(provenance["input_digest"]) == 64
+    assert len(provenance["matrix_sha256"]) == 64
+    assert provenance["current_head_sha"] == "head-a"
+    assert provenance["current_head_bound"] is True
+    assert payload["rules"] == {
+        "source_matrix_only": True,
+        "target_repos_read": False,
+        "install_dependencies": False,
+        "target_tests_executed": False,
+        "target_repo_mutation": False,
+        "target_pr_or_issue_opened": False,
+        "endorsement_claim": False,
+        "review_first": True,
+    }
+    assert payload["reporting_only"] is True
+    assert payload["repo_mutation"] is False
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+    assert payload["authority_boundary"] == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_public_repo_trial_matrix_report_writes_json_and_markdown(tmp_path: Path) -> None:
+    out = tmp_path / "reports" / "public-trial-matrix-report.json"
+    payload = write_public_repo_trial_matrix_report_artifacts(
+        matrix_json=MATRIX_PATH,
+        out=out,
+        root=Path("."),
+        current_head_sha="head-a",
+    )
+    markdown = out.with_suffix(".md")
+    assert out.is_file()
+    assert markdown.is_file()
+    assert json.loads(out.read_text(encoding="utf-8")) == payload
+    rendered = markdown.read_text(encoding="utf-8")
+    assert "# SDETKit public repository trial matrix report" in rendered
+    assert "trial_count: 3" in rendered
+    assert "new_read_only_trial_candidate_count: 2" in rendered
+    assert "`pallets/click`" in rendered
+    assert "target_repos_read: false" in rendered
+    assert "merge_authorized: false" in rendered
+
+
+def test_public_repo_trial_matrix_report_cli_dispatch(tmp_path: Path, capsys) -> None:
+    from sdetkit.cli import main as cli_main
+
+    out = tmp_path / "report.json"
+    markdown = tmp_path / "report.md"
+    rc = cli_main(
+        [
+            "adoption-public-trial-matrix-report",
+            "--matrix-json",
+            str(MATRIX_PATH),
+            "--out",
+            str(out),
+            "--markdown-out",
+            str(markdown),
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "# SDETKit public repository trial matrix report" in stdout
+    assert "report_status: ready_for_human_review" in stdout
+    assert out.is_file()
+    assert markdown.is_file()
+
+
+def test_public_repo_trial_matrix_report_rejects_wrong_schema(tmp_path: Path) -> None:
+    matrix = tmp_path / "matrix.json"
+    matrix.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.public_repo_trial_matrix.v0",
+                "trials": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unsupported public repo trial matrix schema"):
+        build_public_repo_trial_matrix_report(matrix)

--- a/tests/test_adoption_repo_topology.py
+++ b/tests/test_adoption_repo_topology.py
@@ -112,10 +112,10 @@ def test_repo_topology_writer_records_json(tmp_path: Path) -> None:
 def test_self_learning_advances_after_repo_topology_exists() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False

--- a/tests/test_adoption_surface_fixture_matrix.py
+++ b/tests/test_adoption_surface_fixture_matrix.py
@@ -204,10 +204,10 @@ def test_adoption_surface_fixture_reports_remain_operator_readable(fixture: str)
 def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     payload = build_adoption_learning_payload(Path("."))
 
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "fixture repo matrix" in payload["upgrade_candidates"]
     assert "add fixture repo matrix for non-Python repo shapes" not in payload["learning_gaps"]
-    assert payload["recommended_next_upgrade"] == "public repo trial matrix report"
+    assert payload["recommended_next_upgrade"] == "review learning gaps"
     assert "add fixture coverage for non-GitHub CI providers" not in payload["learning_gaps"]
     assert "add fixtures that prove review-first unknown handling" not in payload["learning_gaps"]
     assert "add local external-root smoke before public repo trials" not in payload["learning_gaps"]
@@ -220,7 +220,7 @@ def test_adoption_learning_uses_fixture_matrix_as_next_upgrade_source() -> None:
     assert "add repo topology summary" not in payload["learning_gaps"]
     assert "add adoption evidence bundle" not in payload["learning_gaps"]
     assert "add public repo trial matrix" not in payload["learning_gaps"]
-    assert "add public repo trial matrix report" in payload["learning_gaps"]
+    assert "add public repo trial matrix report" not in payload["learning_gaps"]
 
 
 def test_fixture_matrix_proves_review_first_unknown_handling() -> None:


### PR DESCRIPTION
## Summary
- Add a dedicated reporting-only renderer for `sdetkit.public_repo_trial_matrix.v1`.
- Emit deterministic JSON and Markdown summaries with SHA-256 input provenance.
- Register a hidden maintainer CLI command: `adoption-public-trial-matrix-report`.
- Advance the self-learning roadmap once the report capability exists.
- Document the command and preserve all non-authorizing boundaries.

## Why
The repository already records a public repository trial matrix, but the existing adoption learning report accepts a different schema. Operators otherwise have to inspect the raw fixture JSON directly.

## Safety boundary
This report reads only the supplied matrix artifact. It does not:
- revisit target repositories;
- install dependencies;
- execute target tests;
- mutate target repositories;
- open target issues or pull requests;
- claim endorsement;
- authorize automation, patch application, or merge.

## Verification
- Focused pytest: 13 passed before formatting.
- Hidden CLI registration and default-help exclusion verified.
- Behavioral JSON/Markdown artifact smoke passed.
- Scoped pre-commit passed after formatter convergence.
- Focused pytest rerun: 13 passed.
- Full pre-commit passed.
- Final semantic contract and `git diff --check` passed.

## Risk
- Medium: adds a new hidden maintainer reporting surface and advances one internal roadmap signal.
- Compatibility is preserved for existing adoption schemas and public command discovery.
- Rollback is easy: revert this single focused commit.

## Deliberate non-goal
Artifact-contract-index registration is not included. It remains an independent follow-up rather than expanding this PR.
