### PR TITLE
feat(artifacts): register public trial matrix report

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -266,8 +266,10 @@ merge_authorized=false
 semantic_equivalence_proven=false
 ```
 
-This hidden maintainer report is not yet a separately registered artifact
-contract. Artifact-index registration remains an independent follow-up.
+The generated JSON artifact is registered as
+`public-repo-trial-matrix-report-json` at
+`build/sdetkit/public-repo-trial-matrix-report.json`. The Markdown file remains
+an operator-readable companion rather than a separate machine contract.
 
 ## Render the adoption learning dashboard
 

--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -981,6 +981,30 @@
       "stability": "advanced"
     },
     {
+      "id": "public-repo-trial-matrix-report-json",
+      "path": "build/sdetkit/public-repo-trial-matrix-report.json",
+      "produced_by": "python -m sdetkit adoption-public-trial-matrix-report --matrix-json tests/fixtures/adoption_public_trials/public_repo_trial_matrix.json --out build/sdetkit/public-repo-trial-matrix-report.json --format json",
+      "schema_version": "sdetkit.public_repo_trial_matrix_report.v1",
+      "required_fields": [
+        "schema_version",
+        "report_status",
+        "input_provenance",
+        "source_matrix",
+        "summary",
+        "trials",
+        "operator_summary",
+        "rules",
+        "reporting_only",
+        "repo_mutation",
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "authority_boundary"
+      ],
+      "stability": "advanced"
+    },
+    {
       "id": "adoption-learning-report-dashboard-json",
       "path": "build/sdetkit/adoption-learning-report-dashboard.json",
       "produced_by": "sdetkit-adoption-learning-report-dashboard --report-path build/sdetkit/adoption-learning-report.json --format json --out build/sdetkit/adoption-learning-report-dashboard.json",

--- a/src/sdetkit/artifact_contract_index.py
+++ b/src/sdetkit/artifact_contract_index.py
@@ -6,6 +6,7 @@ from typing import Any
 from . import (
     adoption_learning_report,
     adoption_learning_report_dashboard,
+    adoption_public_repo_trial_matrix_report,
     adoption_surface,
     automation_health,
     candidate_collision_checklist,
@@ -1103,6 +1104,37 @@ def build_index() -> dict[str, Any]:
                     "repo_memory_profile",
                     "operator_summary",
                     "rules",
+                    "automation_allowed",
+                    "patch_application_allowed",
+                    "merge_authorized",
+                    "semantic_equivalence_proven",
+                    "authority_boundary",
+                ],
+                "stability": "advanced",
+            },
+            {
+                "id": "public-repo-trial-matrix-report-json",
+                "path": adoption_public_repo_trial_matrix_report.DEFAULT_OUT.as_posix(),
+                "produced_by": (
+                    "python -m sdetkit adoption-public-trial-matrix-report "
+                    "--matrix-json "
+                    "tests/fixtures/adoption_public_trials/"
+                    "public_repo_trial_matrix.json "
+                    "--out build/sdetkit/public-repo-trial-matrix-report.json "
+                    "--format json"
+                ),
+                "schema_version": (adoption_public_repo_trial_matrix_report.SCHEMA_VERSION),
+                "required_fields": [
+                    "schema_version",
+                    "report_status",
+                    "input_provenance",
+                    "source_matrix",
+                    "summary",
+                    "trials",
+                    "operator_summary",
+                    "rules",
+                    "reporting_only",
+                    "repo_mutation",
                     "automation_allowed",
                     "patch_application_allowed",
                     "merge_authorized",

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from sdetkit import (
     adoption_learning_report,
     adoption_learning_report_dashboard,
+    adoption_public_repo_trial_matrix_report,
     adoption_surface,
     automation_health,
     candidate_collision_checklist,
@@ -461,6 +462,46 @@ def test_artifact_contract_index_includes_adoption_learning_report_json() -> Non
         "adoption-real-world-matrix.json" in entry["produced_by"]
     )
     assert "--out build/sdetkit/adoption-learning-report.json" in entry["produced_by"]
+    assert "--format json" in entry["produced_by"]
+
+
+def test_artifact_contract_index_includes_public_repo_trial_matrix_report_json() -> None:
+    payload = build_index()
+    entries = {item["id"]: item for item in payload["artifacts"]}
+
+    artifact_id = "public-repo-trial-matrix-report-json"
+    assert artifact_id in entries
+
+    entry = entries[artifact_id]
+    assert entry["schema_version"] == adoption_public_repo_trial_matrix_report.SCHEMA_VERSION
+    assert entry["path"] == (adoption_public_repo_trial_matrix_report.DEFAULT_OUT.as_posix())
+    assert entry["stability"] == "advanced"
+
+    assert {
+        "schema_version",
+        "report_status",
+        "input_provenance",
+        "source_matrix",
+        "summary",
+        "trials",
+        "operator_summary",
+        "rules",
+        "reporting_only",
+        "repo_mutation",
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "authority_boundary",
+    }.issubset(set(entry["required_fields"]))
+
+    assert entry["produced_by"].startswith("python -m sdetkit adoption-public-trial-matrix-report ")
+    assert (
+        "--matrix-json "
+        "tests/fixtures/adoption_public_trials/"
+        "public_repo_trial_matrix.json" in entry["produced_by"]
+    )
+    assert "--out build/sdetkit/public-repo-trial-matrix-report.json" in entry["produced_by"]
     assert "--format json" in entry["produced_by"]
 
 


### PR DESCRIPTION
## Summary
- Register the public repository trial matrix report in the canonical artifact-contract index.
- Bind the contract entry to the report module's schema version and default JSON output path.
- Add focused regression assertions for the artifact ID, path, producer command, required fields, and stability.
- Regenerate the checked-in artifact index.
- Update adoption documentation to reflect the completed registration.

## Why
PR #1897 introduced the reporting-only public trial matrix renderer but deliberately deferred artifact-index registration. Without this follow-up, operators and downstream tooling cannot discover the report through the repository's canonical artifact contract surface.

## Verification
- Focused artifact-index and report tests passed.
- Checked-in artifact index regenerated from the canonical generator.
- Generated index matches `build_index()` exactly.
- Scoped pre-commit passed.
- Focused tests passed after formatting.
- Full pre-commit passed.
- Exact four-file scope and `git diff --check` passed.

## Risk
- Low to medium.
- Metadata-only registration; no renderer, CLI, payload schema, dependency graph, or authority behavior changes.
- The artifact remains `advanced` stability.
- Rollback is a single focused revert.

## Notes
- Artifact ID: `public-repo-trial-matrix-report-json`
- Path: `build/sdetkit/public-repo-trial-matrix-report.json`
- Schema: `sdetkit.public_repo_trial_matrix_report.v1`
- Markdown remains an operator-readable companion, not a separate machine contract.
