### PR TITLE
feat(adoption): recommend tox proof from config evidence

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -162,6 +162,14 @@ def _quality_proof_command(root: Path) -> str:
     return "python -m pre_commit run -a"
 
 
+def _tox_config_evidence(root: Path) -> list[str]:
+    evidence = ["tox.ini"] if _file(root, "tox.ini") else []
+    pyproject_text = _read_text(root, "pyproject.toml")
+    if any(line.strip() == "[tool.tox]" for line in pyproject_text.splitlines()):
+        evidence.append("pyproject.toml")
+    return evidence
+
+
 def _sanitize_remote_url(url: str) -> str:
     if "://" not in url or "@" not in url:
         return url
@@ -230,10 +238,12 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     recommended_proof_commands: list[dict[str, Any]] = []
     review_first_unknowns: list[str] = []
 
+    tox_evidence = _tox_config_evidence(root)
     python_evidence = [
         path for path in ["pyproject.toml", "setup.cfg", "setup.py"] if _file(root, path)
     ]
     python_evidence.extend(requirements)
+    python_evidence.extend(tox_evidence)
     if _dir(root, "src"):
         python_evidence.append("src/")
     if python_evidence:
@@ -270,8 +280,17 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             confidence="high",
             purpose="test",
         )
-    elif python_evidence:
+    elif python_evidence and not tox_evidence:
         review_first_unknowns.append("Python project detected but test command is not proven")
+
+    if tox_evidence:
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="python",
+            command="python -m tox",
+            confidence="high",
+            purpose="test",
+        )
 
     if _file(root, ".pre-commit-config.yaml"):
         _add_proof_command(

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -214,3 +214,40 @@ def test_self_learning_advances_after_proof_recommendations_exist() -> None:
     assert "add public repo trial matrix report" not in payload["learning_gaps"]
     assert payload["authority_boundary"]["automation_allowed"] is False
     assert payload["authority_boundary"]["patch_application_allowed"] is False
+
+
+def test_proof_recommendations_classify_tox_as_required_manual_test(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        ("[project]\nname = 'tox-proof'\n\n[tool.tox]\nenv_list = ['py']\n"),
+        encoding="utf-8",
+    )
+
+    surface = discover_adoption_surface(tmp_path)
+    payload = build_proof_recommendations_payload(
+        tmp_path,
+        surface_payload=surface,
+    )
+    commands = {str(item["command"]): item for item in payload["proof_recommendations"]}
+
+    assert commands["python -m tox"] == {
+        "index": 1,
+        "command": "python -m tox",
+        "surface": "python",
+        "purpose": "test",
+        "confidence": "high",
+        "operator_level": "required",
+        "execution_policy": "manual_only",
+        "executes_target_code": True,
+        "manual_execution_required": True,
+        "auto_run_allowed": False,
+        "reason": "test proof for detected target repo surface",
+    }
+    assert payload["summary"]["first_manual_command"] == "python -m tox"
+    assert payload["summary"]["required_count"] == 1
+    assert payload["summary"]["review_first_count"] == 0
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -648,3 +648,83 @@ def test_adoption_surface_payload_validator_accepts_docs_and_release_surface_lis
     }
 
     assert validate_adoption_surface_payload(payload) == []
+
+
+@pytest.mark.parametrize(
+    ("files", "expected_evidence"),
+    [
+        (
+            {"tox.ini": "[tox]\nenvlist = py\n"},
+            {"tox.ini"},
+        ),
+        (
+            {
+                "pyproject.toml": (
+                    "[project]\nname = 'tox-project'\n\n[tool.tox]\nenv_list = ['py']\n"
+                )
+            },
+            {"pyproject.toml"},
+        ),
+    ],
+)
+def test_adoption_surface_recommends_tox_from_grounded_config(
+    tmp_path: Path,
+    files: dict[str, str],
+    expected_evidence: set[str],
+) -> None:
+    for relative_path, content in files.items():
+        _write(tmp_path / relative_path, content)
+
+    payload = discover_adoption_surface(tmp_path)
+    command = _proof_command(payload, "python -m tox")
+
+    assert "python" in _names(payload["detected_languages"])
+    assert command == {
+        "surface": "python",
+        "command": "python -m tox",
+        "confidence": "high",
+        "purpose": "test",
+        "executes_untrusted_code": True,
+        "auto_run_allowed": False,
+    }
+    python = {str(item["name"]): item for item in payload["detected_languages"]}["python"]
+    assert expected_evidence <= set(python["evidence"])
+    assert (
+        "Python project detected but test command is not proven"
+        not in payload["review_first_unknowns"]
+    )
+
+
+def test_adoption_surface_does_not_infer_tox_from_dependency_token_alone(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        ("[project]\nname = 'tox-dependency-only'\ndependencies = ['tox']\n"),
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "python -m tox" not in _commands(payload)
+    assert payload["review_first_unknowns"] == [
+        "Python project detected but test command is not proven"
+    ]
+
+
+def test_adoption_surface_deduplicates_tox_proof_across_config_sources(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "tox.ini", "[tox]\nenvlist = py\n")
+    _write(
+        tmp_path / "pyproject.toml",
+        "[project]\nname = 'dual-tox'\n\n[tool.tox]\nenv_list = ['py']\n",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = [
+        item for item in payload["recommended_proof_commands"] if item["command"] == "python -m tox"
+    ]
+
+    assert len(commands) == 1
+    python = {str(item["name"]): item for item in payload["detected_languages"]}["python"]
+    assert {"tox.ini", "pyproject.toml"} <= set(python["evidence"])


### PR DESCRIPTION
## Summary

- detect tox only from grounded configuration evidence:
  - `tox.ini`
  - a literal `[tool.tox]` section in `pyproject.toml`
- recommend one high-confidence manual `python -m tox` proof command
- preserve manual-only, non-authorizing execution boundaries
- add positive, negative, duplicate-source, and downstream classification tests

## Why

A read-only external trial against `pallets/click` at
`679a7a0eccbdded7a6e85680bdaaf08003765e01` found an explicit tox
environment matrix that SDETKit did not represent in its proof recommendations.

The change is intentionally narrow. Sphinx-specific documentation detection
and Flit build-backend representation remain deferred to separate evidence-backed
work.

## Verification

- focused adoption tests
- complete adoption test suite
- scoped pre-commit
- full pre-commit
- exact three-file scope verification
- positive, negative, duplicate-source, and downstream semantic assertions
- preserved Click target HEAD, tree, and clean worktree

## Risk

Low to medium. The change adds a reporting-only manual proof recommendation.
It does not execute tox, install dependencies, mutate a target repository, apply
patches, authorize merge, or change an artifact schema.
