### PR TITLE
feat(adoption): detect Sphinx documentation surface

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -301,6 +301,22 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             purpose="quality",
         )
 
+    sphinx_evidence = ["docs/conf.py"] if _file(root, "docs/conf.py") else []
+    if sphinx_evidence:
+        _add_named(
+            docs_tools,
+            "sphinx",
+            confidence="high",
+            evidence=sphinx_evidence,
+        )
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="docs",
+            command="python -m sphinx -W -b html docs docs/_build/html",
+            confidence="high",
+            purpose="docs",
+        )
+
     if _file(root, "mkdocs.yml"):
         _add_named(
             docs_tools,
@@ -315,7 +331,7 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             confidence="high",
             purpose="docs",
         )
-    elif _dir(root, "docs"):
+    elif _dir(root, "docs") and not sphinx_evidence:
         _add_named(
             docs_tools,
             "docs_directory",

--- a/tests/test_adoption_proof_recommendations.py
+++ b/tests/test_adoption_proof_recommendations.py
@@ -251,3 +251,41 @@ def test_proof_recommendations_classify_tox_as_required_manual_test(
     assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False
     assert payload["semantic_equivalence_proven"] is False
+
+
+def test_proof_recommendations_classify_sphinx_as_recommended_manual_docs(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "conf.py").write_text(
+        "project = 'Sphinx proof'\n",
+        encoding="utf-8",
+    )
+
+    surface = discover_adoption_surface(tmp_path)
+    payload = build_proof_recommendations_payload(
+        tmp_path,
+        surface_payload=surface,
+    )
+    commands = {str(item["command"]): item for item in payload["proof_recommendations"]}
+
+    assert commands["python -m sphinx -W -b html docs docs/_build/html"] == {
+        "index": 1,
+        "command": "python -m sphinx -W -b html docs docs/_build/html",
+        "surface": "docs",
+        "purpose": "docs",
+        "confidence": "high",
+        "operator_level": "recommended",
+        "execution_policy": "manual_only",
+        "executes_target_code": True,
+        "manual_execution_required": True,
+        "auto_run_allowed": False,
+        "reason": "documentation proof for detected docs surface",
+    }
+    assert payload["summary"]["required_count"] == 0
+    assert payload["summary"]["recommended_count"] == 1
+    assert payload["summary"]["review_first_count"] == 0
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False

--- a/tests/test_adoption_surface.py
+++ b/tests/test_adoption_surface.py
@@ -728,3 +728,72 @@ def test_adoption_surface_deduplicates_tox_proof_across_config_sources(
     assert len(commands) == 1
     python = {str(item["name"]): item for item in payload["detected_languages"]}["python"]
     assert {"tox.ini", "pyproject.toml"} <= set(python["evidence"])
+
+
+def test_adoption_surface_recommends_sphinx_from_docs_conf(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "docs" / "conf.py", "project = 'Example'\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    tools = {str(item["name"]): item for item in payload["docs_tools"]}
+    command = _proof_command(
+        payload,
+        "python -m sphinx -W -b html docs docs/_build/html",
+    )
+
+    assert tools["sphinx"] == {
+        "name": "sphinx",
+        "confidence": "high",
+        "evidence": ["docs/conf.py"],
+    }
+    assert "docs_directory" not in tools
+    assert command == {
+        "surface": "docs",
+        "command": "python -m sphinx -W -b html docs docs/_build/html",
+        "confidence": "high",
+        "purpose": "docs",
+        "executes_untrusted_code": True,
+        "auto_run_allowed": False,
+    }
+
+
+def test_adoption_surface_does_not_infer_sphinx_from_dependency_token_alone(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        "[project]\nname = 'sphinx-token-only'\ndependencies = ['sphinx']\n",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "sphinx" not in _names(payload["docs_tools"])
+    assert "python -m sphinx -W -b html docs docs/_build/html" not in _commands(payload)
+
+
+def test_adoption_surface_keeps_sphinx_and_mkdocs_as_distinct_surfaces(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "docs" / "conf.py", "project = 'Example'\n")
+    _write(tmp_path / "mkdocs.yml", "site_name: Example\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = payload["recommended_proof_commands"]
+
+    assert {"sphinx", "mkdocs"} <= _names(payload["docs_tools"])
+    assert "docs_directory" not in _names(payload["docs_tools"])
+    assert (
+        sum(
+            item["command"] == "python -m sphinx -W -b html docs docs/_build/html"
+            for item in commands
+        )
+        == 1
+    )
+    assert (
+        sum(
+            item["command"] == "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict"
+            for item in commands
+        )
+        == 1
+    )


### PR DESCRIPTION
## Summary

- detect Sphinx only from grounded `docs/conf.py` evidence
- classify Sphinx as a high-confidence documentation tool
- recommend one manual documentation proof:
  - `python -m sphinx -W -b html docs docs/_build/html`
- preserve existing MkDocs behavior
- permit distinct MkDocs and Sphinx surfaces to coexist
- add positive, negative, coexistence/deduplication, and downstream classification tests

## Why

A read-only external adoption trial against `pallets/click` at
`679a7a0eccbdded7a6e85680bdaaf08003765e01` found a real Sphinx configuration
and documentation proof surface. Before this change, SDETKit reduced that
repository to a generic documentation-directory signal.

The trigger is intentionally strict: dependency text alone does not establish
a Sphinx surface. `docs/conf.py` is required.

## Verification

- focused adoption tests
- complete adoption test suite
- scoped pre-commit and formatter convergence
- full pre-commit
- exact three-file scope verification
- SDETKit self-run against this repository:
  - MkDocs detected
  - no false Sphinx classification
  - all recommendations manual-only
  - all authority fields false
- updated read-only external integration against the preserved Click checkout:
  - Sphinx detected from `docs/conf.py`
  - Sphinx proof classified as recommended/manual-only
  - target HEAD, tree, detached state, and worktree unchanged
  - no dependency installation or target tests

## Risk

Low to medium. This is additive, reporting-only behavior. It does not execute
Sphinx, install dependencies, mutate a target repository, apply patches,
authorize automation, or authorize merge.

## Deferred

Python build-backend surface modeling remains deferred to a separate
evidence-backed change.
