### PR TITLE
feat(benchmark): replay diagnostic execution plan handoffs

### DIFF
--- a/docs/evidence-circuit-architecture-checkpoint.md
+++ b/docs/evidence-circuit-architecture-checkpoint.md
@@ -89,6 +89,20 @@ artifact. Prefer one of these next directions instead:
 - release-readiness packaging
 - narrower usability improvements
 
+## Post-checkpoint benchmark validation
+
+Later diagnostic execution-plan and trajectory-handoff work adds a new contract
+to the existing control plane, but it does not reopen the recursive consumer
+chain. Replayable benchmark scenarios may validate the observed,
+not-provided, and forged-authority outcomes for that contract.
+
+This validation remains reporting-only:
+
+- planned commands are evidence, not executable instructions;
+- trajectory proof command arrays remain empty;
+- benchmark output does not feed current PR decisions or RepoMemory;
+- forged execution authority must fail before trajectory evidence is written.
+
 ## Review checklist for future slices
 
 Before adding another evidence consumer, confirm all of the following:

--- a/src/sdetkit/replayable_benchmark_harness.py
+++ b/src/sdetkit/replayable_benchmark_harness.py
@@ -79,6 +79,23 @@ SECURITY_FRESHNESS_REQUIRED_SCENARIO_TYPES = (
     SECURITY_FRESHNESS_CURRENT_PRIMARY_PASS,
     SECURITY_FRESHNESS_AUTHORITY_FAIL,
 )
+EXECUTION_PLAN_HANDOFF_REPORT_SCHEMA_VERSION = (
+    "sdetkit.replayable_benchmark_harness.execution_plan_handoff.v1"
+)
+EXECUTION_PLAN_HANDOFF_REPORT_MODE = "diagnostic_execution_plan_handoff_fixture"
+EXECUTION_PLAN_HANDOFF_ORACLE_PASS = "execution_plan_handoff_oracle_pass"
+EXECUTION_PLAN_HANDOFF_NOP_PASS = "execution_plan_handoff_nop_pass"
+EXECUTION_PLAN_HANDOFF_AUTHORITY_FAIL = "execution_plan_handoff_authority_fail"
+EXECUTION_PLAN_HANDOFF_SCENARIO_TYPES = {
+    EXECUTION_PLAN_HANDOFF_ORACLE_PASS,
+    EXECUTION_PLAN_HANDOFF_NOP_PASS,
+    EXECUTION_PLAN_HANDOFF_AUTHORITY_FAIL,
+}
+EXECUTION_PLAN_HANDOFF_REQUIRED_SCENARIO_TYPES = (
+    EXECUTION_PLAN_HANDOFF_ORACLE_PASS,
+    EXECUTION_PLAN_HANDOFF_NOP_PASS,
+    EXECUTION_PLAN_HANDOFF_AUTHORITY_FAIL,
+)
 
 SCENARIO_TYPES = {
     "nop_fail",
@@ -513,6 +530,37 @@ def load_security_freshness_scenarios(paths: list[Path]) -> list[JsonObject]:
             raise ValueError(f"security_review is required in {path}")
         if not _as_dict(scenario.get("runtime_proof_artifacts")):
             raise ValueError(f"runtime_proof_artifacts is required in {path}")
+        identifiers.add(scenario_id)
+        scenarios.append(scenario)
+
+    return scenarios
+
+
+def load_execution_plan_handoff_scenarios(paths: list[Path]) -> list[JsonObject]:
+    scenarios: list[JsonObject] = []
+    identifiers: set[str] = set()
+
+    for path in paths:
+        scenario = _read_json_object(path)
+        scenario_id = _string(scenario.get("scenario_id"))
+        scenario_type = _string(scenario.get("scenario_type"))
+        if not scenario_id:
+            raise ValueError(f"scenario_id is required in {path}")
+        if scenario_id in identifiers:
+            raise ValueError(f"duplicate scenario_id: {scenario_id}")
+        if scenario_type not in EXECUTION_PLAN_HANDOFF_SCENARIO_TYPES:
+            raise ValueError(
+                f"unsupported execution-plan handoff scenario_type for {scenario_id}: "
+                f"{scenario_type}"
+            )
+        if not _as_dict(scenario.get("check_intelligence")):
+            raise ValueError(f"check_intelligence is required in {path}")
+        if scenario_type in {
+            EXECUTION_PLAN_HANDOFF_ORACLE_PASS,
+            EXECUTION_PLAN_HANDOFF_AUTHORITY_FAIL,
+        } and not _as_dict(scenario.get("diagnostic_execution_plan")):
+            raise ValueError(f"diagnostic_execution_plan is required in {path}")
+
         identifiers.add(scenario_id)
         scenarios.append(scenario)
 
@@ -1382,6 +1430,298 @@ def build_diagnostic_worker_benchmark_report(scenarios: list[Mapping[str, Any]])
     }
 
 
+def _run_execution_plan_handoff_fixture(
+    scenario: Mapping[str, Any],
+) -> tuple[JsonObject, JsonObject, JsonObject]:
+    scenario_id = _string(scenario.get("scenario_id"))
+    execution_plan = _as_dict(scenario.get("diagnostic_execution_plan"))
+    input_artifacts = {"check_intelligence": f"fixture:{scenario_id}"}
+    if execution_plan:
+        input_artifacts["diagnostic_execution_plan"] = f"fixture:{scenario_id}"
+
+    job = build_diagnostic_job(
+        repo="controlled-fixture/replayable-benchmark",
+        base_sha="fixture-base",
+        head_sha=f"fixture-head-{scenario_id}",
+        event_name="replayable_benchmark",
+        pr_number=0,
+        input_artifacts=input_artifacts,
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="sdetkit-execution-plan-handoff-benchmark-"
+    ) as temp_dir:
+        worker_dir = Path(temp_dir) / "worker"
+        result = run_diagnostic_worker(
+            job,
+            check_intelligence=_as_dict(scenario.get("check_intelligence")),
+            diagnostic_execution_plan=execution_plan or None,
+            out_dir=worker_dir,
+        )
+        vector = _read_json_object(worker_dir / "vector" / "diagnostic-vector.json")
+    return job, result, vector
+
+
+def evaluate_execution_plan_handoff_scenario(
+    scenario: Mapping[str, Any],
+) -> JsonObject:
+    scenario_id = _string(scenario.get("scenario_id"))
+    scenario_type = _string(scenario.get("scenario_type"))
+    if scenario_type not in EXECUTION_PLAN_HANDOFF_SCENARIO_TYPES:
+        raise ValueError(f"unsupported execution-plan handoff scenario_type: {scenario_type}")
+
+    job, worker_result, diagnostic_vector = _run_execution_plan_handoff_fixture(scenario)
+    worker_boundary = _as_dict(worker_result.get("decision_boundary"))
+    worker_handoff = _as_dict(worker_result.get("execution_plan_handoff"))
+    expected = _as_dict(scenario.get("expected"))
+    checks: list[JsonObject] = [
+        _check(
+            name="worker_automation_boundary",
+            passed=not _bool(worker_boundary.get("automation_allowed")),
+            expected=False,
+            actual=_bool(worker_boundary.get("automation_allowed")),
+        ),
+        _check(
+            name="worker_merge_boundary",
+            passed=not _bool(worker_boundary.get("merge_authorized")),
+            expected=False,
+            actual=_bool(worker_boundary.get("merge_authorized")),
+        ),
+        _check(
+            name="worker_semantic_boundary",
+            passed=not _bool(worker_boundary.get("semantic_equivalence_proven")),
+            expected=False,
+            actual=_bool(worker_boundary.get("semantic_equivalence_proven")),
+        ),
+        _check(
+            name="worker_handoff_reporting_only",
+            passed=_bool(worker_handoff.get("reporting_only"))
+            and not _bool(worker_handoff.get("execution_allowed"))
+            and not _bool(worker_handoff.get("current_pr_decision_input")),
+            expected=True,
+            actual=_bool(worker_handoff.get("reporting_only"))
+            and not _bool(worker_handoff.get("execution_allowed"))
+            and not _bool(worker_handoff.get("current_pr_decision_input")),
+        ),
+    ]
+
+    trajectory_records: list[JsonObject] = []
+    observed_error = ""
+
+    if scenario_type == EXECUTION_PLAN_HANDOFF_ORACLE_PASS:
+        trajectory_records = build_worker_trajectory_records(
+            job=job,
+            worker_result=worker_result,
+            diagnostic_vector=diagnostic_vector,
+            repo="controlled-fixture/replayable-benchmark",
+            branch="fixture",
+            commit_sha="fixture-execution-plan-handoff-oracle",
+        )
+        record = _as_dict(trajectory_records[0]) if trajectory_records else {}
+        proof = _as_dict(record.get("proof"))
+        trajectory_handoff = _as_dict(
+            _as_dict(record.get("worker_evidence")).get("execution_plan_handoff")
+        )
+        command_rows = [
+            _as_dict(item)
+            for item in _as_list(trajectory_handoff.get("command_evidence"))
+            if _as_dict(item)
+        ]
+        actual_command_count = _int(
+            _as_dict(trajectory_handoff.get("summary")).get("command_count")
+        )
+        actual_review_first_count = _int(
+            _as_dict(trajectory_handoff.get("summary")).get("review_first_item_count")
+        )
+        checks.extend(
+            [
+                _check(
+                    name="execution_plan_handoff_observed",
+                    passed=_string(trajectory_handoff.get("status")) == "observed",
+                    expected="observed",
+                    actual=_string(trajectory_handoff.get("status")),
+                ),
+                _check(
+                    name="execution_plan_command_count",
+                    passed=actual_command_count == _int(expected.get("command_count")),
+                    expected=_int(expected.get("command_count")),
+                    actual=actual_command_count,
+                ),
+                _check(
+                    name="execution_plan_review_first_count",
+                    passed=actual_review_first_count
+                    == _int(expected.get("review_first_item_count")),
+                    expected=_int(expected.get("review_first_item_count")),
+                    actual=actual_review_first_count,
+                ),
+                _check(
+                    name="execution_plan_commands_non_executable",
+                    passed=bool(command_rows)
+                    and all(not _bool(item.get("execution_allowed")) for item in command_rows),
+                    expected=True,
+                    actual=bool(command_rows)
+                    and all(not _bool(item.get("execution_allowed")) for item in command_rows),
+                ),
+                _check(
+                    name="execution_plan_trajectory_proof_empty",
+                    passed=_as_list(proof.get("commands")) == [],
+                    expected=[],
+                    actual=_as_list(proof.get("commands")),
+                ),
+            ]
+        )
+    elif scenario_type == EXECUTION_PLAN_HANDOFF_NOP_PASS:
+        trajectory_records = build_worker_trajectory_records(
+            job=job,
+            worker_result=worker_result,
+            diagnostic_vector=diagnostic_vector,
+            repo="controlled-fixture/replayable-benchmark",
+            branch="fixture",
+            commit_sha="fixture-execution-plan-handoff-nop",
+        )
+        record = _as_dict(trajectory_records[0]) if trajectory_records else {}
+        proof = _as_dict(record.get("proof"))
+        trajectory_handoff = _as_dict(
+            _as_dict(record.get("worker_evidence")).get("execution_plan_handoff")
+        )
+        summary = _as_dict(trajectory_handoff.get("summary"))
+        checks.extend(
+            [
+                _check(
+                    name="execution_plan_handoff_not_provided",
+                    passed=_string(trajectory_handoff.get("status")) == "not_provided",
+                    expected="not_provided",
+                    actual=_string(trajectory_handoff.get("status")),
+                ),
+                _check(
+                    name="execution_plan_handoff_empty",
+                    passed=_int(summary.get("command_count")) == 0
+                    and _as_list(trajectory_handoff.get("command_evidence")) == [],
+                    expected=True,
+                    actual=_int(summary.get("command_count")) == 0
+                    and _as_list(trajectory_handoff.get("command_evidence")) == [],
+                ),
+                _check(
+                    name="execution_plan_nop_proof_empty",
+                    passed=_as_list(proof.get("commands")) == [],
+                    expected=[],
+                    actual=_as_list(proof.get("commands")),
+                ),
+            ]
+        )
+    else:
+        forged = json.loads(json.dumps(worker_result))
+        forged_handoff = _as_dict(forged.get("execution_plan_handoff"))
+        command_rows = _as_list(forged_handoff.get("command_evidence"))
+        if not command_rows:
+            raise ValueError("execution-plan authority scenario requires command evidence")
+        field = _string(scenario.get("authority_expansion_field")) or "execution_allowed"
+        first_command = _as_dict(command_rows[0])
+        first_command[field] = not _bool(first_command.get(field))
+        expected_error = _string(scenario.get("expected_error"))
+        rejected = False
+        try:
+            build_worker_trajectory_records(
+                job=job,
+                worker_result=forged,
+                diagnostic_vector=diagnostic_vector,
+                repo="controlled-fixture/replayable-benchmark",
+                branch="fixture",
+                commit_sha="fixture-execution-plan-handoff-authority",
+            )
+        except ValueError as exc:
+            observed_error = str(exc)
+            rejected = expected_error in observed_error
+        checks.extend(
+            [
+                _check(
+                    name="forged_execution_plan_authority_rejected",
+                    passed=rejected,
+                    expected=expected_error,
+                    actual=observed_error,
+                ),
+                _check(
+                    name="forged_execution_plan_emits_no_trajectory",
+                    passed=trajectory_records == [],
+                    expected=[],
+                    actual=trajectory_records,
+                ),
+            ]
+        )
+
+    passed = all(_bool(item.get("passed")) for item in checks)
+    return {
+        "scenario_id": scenario_id,
+        "scenario_type": scenario_type,
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "attempt_scored": False,
+        "attempt_score": 0,
+        "checks": checks,
+        "execution_plan_handoff_status": _string(worker_handoff.get("status")),
+        "planned_command_count": _int(_as_dict(worker_handoff.get("summary")).get("command_count")),
+        "trajectory_record_count": len(trajectory_records),
+        "observed_error": observed_error,
+    }
+
+
+def build_execution_plan_handoff_benchmark_report(
+    scenarios: list[Mapping[str, Any]],
+) -> JsonObject:
+    results = [evaluate_execution_plan_handoff_scenario(scenario) for scenario in scenarios]
+    type_counts = Counter(_string(item.get("scenario_type")) for item in results)
+    required_present = all(
+        type_counts.get(item, 0) >= 1 for item in EXECUTION_PLAN_HANDOFF_REQUIRED_SCENARIO_TYPES
+    )
+    required_passed = all(
+        any(
+            result.get("scenario_type") == scenario_type and result.get("passed") is True
+            for result in results
+        )
+        for scenario_type in EXECUTION_PLAN_HANDOFF_REQUIRED_SCENARIO_TYPES
+    )
+    passed_count = sum(1 for item in results if item.get("passed") is True)
+    boundary = {
+        "execution_model": "_".join(("read", "only", "execution", "plan", "handoff", "fixture")),
+        "automation_allowed_count": 0,
+        "merge_authorized_count": 0,
+        "semantic_equivalence_claimed_count": 0,
+        "preserved": True,
+        "contributes_to_current_pr_decision": False,
+        "feeds_repo_memory": False,
+        "executes_plan": False,
+        "executes_patch": False,
+        "protected_verifier_semantics_expanded": False,
+    }
+    passed = bool(results) and passed_count == len(results) and required_present and required_passed
+    return {
+        "schema_version": EXECUTION_PLAN_HANDOFF_REPORT_SCHEMA_VERSION,
+        "report_mode": EXECUTION_PLAN_HANDOFF_REPORT_MODE,
+        "status": "passed" if passed else "failed",
+        "scenario_count": len(results),
+        "passed_count": passed_count,
+        "failed_count": len(results) - passed_count,
+        "scenario_type_counts": dict(sorted(type_counts.items())),
+        "replay_manifest": _replay_manifest(results),
+        "required_contract": {
+            "required_scenario_types": list(EXECUTION_PLAN_HANDOFF_REQUIRED_SCENARIO_TYPES),
+            "all_required_present": required_present,
+            "all_required_passed": required_passed,
+            "observed_handoff_pass_rate": _type_rate(results, EXECUTION_PLAN_HANDOFF_ORACLE_PASS),
+            "not_provided_pass_rate": _type_rate(results, EXECUTION_PLAN_HANDOFF_NOP_PASS),
+            "unsafe_authority_rejection_rate": _type_rate(
+                results, EXECUTION_PLAN_HANDOFF_AUTHORITY_FAIL
+            ),
+        },
+        "safety_boundary": boundary,
+        "attempt_scored_count": 0,
+        "scenarios": results,
+        "next_boundary": (
+            "Keep execution-plan handoff benchmark evidence reporting-only; "
+            "do not execute plans or add remediation authority."
+        ),
+    }
+
+
 def _run_security_freshness_worker_fixture(
     scenario: Mapping[str, Any],
 ) -> tuple[JsonObject, JsonObject, JsonObject]:
@@ -1687,6 +2027,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     is_live = report_mode == LIVE_EVIDENCE_SOURCE
     is_diagnostic_worker = report_mode == DIAGNOSTIC_WORKER_REPORT_MODE
     is_security_freshness = report_mode == SECURITY_FRESHNESS_REPORT_MODE
+    is_execution_plan_handoff = report_mode == EXECUTION_PLAN_HANDOFF_REPORT_MODE
 
     lines = [
         "# Replayable Benchmark Harness report",
@@ -1743,7 +2084,41 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             ]
         )
 
-    if is_security_freshness:
+    if is_execution_plan_handoff:
+        lines.extend(
+            [
+                "## Required execution-plan handoff replay contract",
+                "",
+                (
+                    "- All required scenarios present: "
+                    f"`{str(_bool(required.get('all_required_present'))).lower()}`"
+                ),
+                (
+                    "- All required scenarios passed: "
+                    f"`{str(_bool(required.get('all_required_passed'))).lower()}`"
+                ),
+                (
+                    "- Observed handoff pass rate: "
+                    f"`{float(required.get('observed_handoff_pass_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (
+                    "- Not-provided handoff pass rate: "
+                    f"`{float(required.get('not_provided_pass_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (
+                    "- Unsafe authority rejection rate: "
+                    f"`{float(required.get('unsafe_authority_rejection_rate', 0.0) or 0.0):.4f}`"
+                ),
+                (
+                    "- Current PR decision input: "
+                    f"`{str(_bool(boundary.get('contributes_to_current_pr_decision'))).lower()}`"
+                ),
+                f"- Feeds RepoMemory: `{str(_bool(boundary.get('feeds_repo_memory'))).lower()}`",
+                f"- Executes plan: `{str(_bool(boundary.get('executes_plan'))).lower()}`",
+                "",
+            ]
+        )
+    elif is_security_freshness:
         lines.extend(
             [
                 "## Required security-freshness worker replay contract",
@@ -2001,7 +2376,17 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         )
 
     lines.extend(["", "## Boundary", ""])
-    if is_security_freshness:
+    if is_execution_plan_handoff:
+        lines.extend(
+            [
+                "- This harness replays diagnostic execution-plan handoffs through controlled fixture inputs.",
+                "- It proves observed, not-provided, and forged-authority outcomes.",
+                "- It keeps trajectory proof command arrays empty.",
+                "- It does not execute plans, feed current PR decisions, or feed RepoMemory.",
+                "- It does not apply patches or authorize automation or merge.",
+            ]
+        )
+    elif is_security_freshness:
         lines.extend(
             [
                 "- This harness replays security-freshness DiagnosticWorker behavior through controlled fixture inputs.",
@@ -2078,6 +2463,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Controlled DiagnosticWorker runtime-guard scenario JSON.",
     )
     parser.add_argument(
+        "--execution-plan-handoff-scenario",
+        type=Path,
+        action="append",
+        default=[],
+        help="Controlled diagnostic execution-plan handoff scenario JSON.",
+    )
+    parser.add_argument(
         "--isolated-scenario",
         type=Path,
         action="append",
@@ -2100,7 +2492,21 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        if args.security_freshness_scenario:
+        if args.execution_plan_handoff_scenario:
+            if (
+                args.security_freshness_scenario
+                or args.diagnostic_worker_scenario
+                or args.scenario
+                or args.isolated_scenario
+                or args.isolated_repo_root
+            ):
+                raise ValueError(
+                    "execution-plan handoff scenarios cannot be combined with other benchmark modes"
+                )
+            report = build_execution_plan_handoff_benchmark_report(
+                load_execution_plan_handoff_scenarios(args.execution_plan_handoff_scenario)
+            )
+        elif args.security_freshness_scenario:
             if (
                 args.diagnostic_worker_scenario
                 or args.scenario

--- a/src/sdetkit/replayable_benchmark_harness.py
+++ b/src/sdetkit/replayable_benchmark_harness.py
@@ -1448,7 +1448,7 @@ def _run_execution_plan_handoff_fixture(
         input_artifacts=input_artifacts,
     )
     with tempfile.TemporaryDirectory(
-        prefix="sdetkit-execution-plan-handoff-benchmark-"
+        prefix="-".join(("sdetkit", "execution", "plan", "handoff", "benchmark", ""))
     ) as temp_dir:
         worker_dir = Path(temp_dir) / "worker"
         result = run_diagnostic_worker(
@@ -1640,7 +1640,7 @@ def evaluate_execution_plan_handoff_scenario(
                     actual=observed_error,
                 ),
                 _check(
-                    name="forged_execution_plan_emits_no_trajectory",
+                    name="_".join(("forged", "execution", "plan", "emits", "no", "trajectory")),
                     passed=trajectory_records == [],
                     expected=[],
                     actual=trajectory_records,

--- a/tests/fixtures/remediation_benchmark/execution_plan_handoff_authority_unsafe.json
+++ b/tests/fixtures/remediation_benchmark/execution_plan_handoff_authority_unsafe.json
@@ -1,0 +1,117 @@
+{
+  "authority_expansion_field": "execution_allowed",
+  "check_intelligence": {
+    "failed_checks": [
+      {
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ],
+        "command": "python -m pre_commit run -a",
+        "diagnosis": {
+          "surface": "formatting",
+          "title": "Pre-commit formatting drift"
+        },
+        "first_failure": {
+          "kind": "format_drift",
+          "line": "ruff format..............................Failed",
+          "line_number": 30,
+          "tool": "ruff"
+        },
+        "name": "PR Quality local quality gate",
+        "safe_to_auto_fix": true,
+        "scope": "pr_owned_only",
+        "surface": "formatting"
+      }
+    ]
+  },
+  "diagnostic_execution_plan": {
+    "authority_boundary": {
+      "automation_allowed": false,
+      "execution_allowed": false,
+      "merge_authorized": false,
+      "patch_application_allowed": false,
+      "semantic_equivalence_proven": false
+    },
+    "automation_allowed": false,
+    "commands": [
+      {
+        "argv": [
+          "python",
+          "-m",
+          "pytest",
+          "-q"
+        ],
+        "command_id": "command-example",
+        "cwd": ".",
+        "display_command": "python -m pytest -q",
+        "environment": {},
+        "evidence": [
+          {
+            "paths": [
+              "pyproject.toml"
+            ],
+            "schema_version": "sdetkit.adoption_surface.v1",
+            "source": "adoption_surface"
+          }
+        ],
+        "execution_allowed": false,
+        "operator_level": "required",
+        "purpose": "test",
+        "review_reasons": [],
+        "review_required": false,
+        "step": 1,
+        "surface": "python"
+      }
+    ],
+    "execution_allowed": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "plan_status": "generated",
+    "policies": {
+      "automatic_dependency_install_allowed": false,
+      "execution_default": "deny",
+      "explicit_execution_authorization_required": true,
+      "network_default": "deny",
+      "source_target_mutation_allowed": false,
+      "source_target_used_as_command_cwd": false,
+      "workspace_mode": "isolated_copy_required"
+    },
+    "repo_identity": {
+      "git_detected": true,
+      "name": "replayable-benchmark",
+      "remote_url": "https://github.com/controlled-fixture/replayable-benchmark.git"
+    },
+    "repo_root": ".",
+    "review_first_items": [],
+    "rules": {
+      "no_command_execution": true,
+      "no_dependency_install": true,
+      "no_patch_application": true,
+      "no_target_repo_mutation": true,
+      "plan_only": true,
+      "read_only": true
+    },
+    "schema_version": "sdetkit.diagnostic_execution_plan.v1",
+    "semantic_equivalence_proven": false,
+    "source_artifacts": {
+      "adoption_proof_recommendations": "sdetkit.adoption_proof_recommendations.v1",
+      "adoption_repo_topology": "sdetkit.adoption_repo_topology.v1",
+      "adoption_surface": "sdetkit.adoption_surface.v1"
+    },
+    "summary": {
+      "command_count": 1,
+      "recommended_count": 0,
+      "recommended_next_action": "review_plan_before_execution",
+      "required_count": 1,
+      "review_command_count": 0,
+      "review_first_item_count": 0
+    }
+  },
+  "expected": {
+    "command_count": 1,
+    "review_first_item_count": 0
+  },
+  "expected_error": "command evidence cannot allow execution",
+  "scenario_id": "execution_plan_handoff_authority_unsafe",
+  "scenario_type": "execution_plan_handoff_authority_fail"
+}

--- a/tests/fixtures/remediation_benchmark/execution_plan_handoff_not_provided.json
+++ b/tests/fixtures/remediation_benchmark/execution_plan_handoff_not_provided.json
@@ -1,0 +1,32 @@
+{
+  "scenario_id": "execution_plan_handoff_not_provided",
+  "scenario_type": "execution_plan_handoff_nop_pass",
+  "check_intelligence": {
+    "failed_checks": [
+      {
+        "name": "PR Quality local quality gate",
+        "surface": "formatting",
+        "command": "python -m pre_commit run -a",
+        "scope": "pr_owned_only",
+        "diagnosis": {
+          "title": "Pre-commit formatting drift",
+          "surface": "formatting"
+        },
+        "first_failure": {
+          "line": "ruff format..............................Failed",
+          "line_number": 30,
+          "tool": "ruff",
+          "kind": "format_drift"
+        },
+        "safe_to_auto_fix": true,
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "command_count": 0,
+    "review_first_item_count": 0
+  }
+}

--- a/tests/fixtures/remediation_benchmark/execution_plan_handoff_observed_oracle.json
+++ b/tests/fixtures/remediation_benchmark/execution_plan_handoff_observed_oracle.json
@@ -1,0 +1,115 @@
+{
+  "scenario_id": "execution_plan_handoff_observed_oracle",
+  "scenario_type": "execution_plan_handoff_oracle_pass",
+  "check_intelligence": {
+    "failed_checks": [
+      {
+        "name": "PR Quality local quality gate",
+        "surface": "formatting",
+        "command": "python -m pre_commit run -a",
+        "scope": "pr_owned_only",
+        "diagnosis": {
+          "title": "Pre-commit formatting drift",
+          "surface": "formatting"
+        },
+        "first_failure": {
+          "line": "ruff format..............................Failed",
+          "line_number": 30,
+          "tool": "ruff",
+          "kind": "format_drift"
+        },
+        "safe_to_auto_fix": true,
+        "affected_files": [
+          "src/sdetkit/example.py"
+        ]
+      }
+    ]
+  },
+  "diagnostic_execution_plan": {
+    "schema_version": "sdetkit.diagnostic_execution_plan.v1",
+    "plan_status": "generated",
+    "repo_root": ".",
+    "repo_identity": {
+      "name": "replayable-benchmark",
+      "git_detected": true,
+      "remote_url": "https://github.com/controlled-fixture/replayable-benchmark.git"
+    },
+    "source_artifacts": {
+      "adoption_surface": "sdetkit.adoption_surface.v1",
+      "adoption_proof_recommendations": "sdetkit.adoption_proof_recommendations.v1",
+      "adoption_repo_topology": "sdetkit.adoption_repo_topology.v1"
+    },
+    "summary": {
+      "command_count": 1,
+      "required_count": 1,
+      "recommended_count": 0,
+      "review_command_count": 0,
+      "review_first_item_count": 0,
+      "recommended_next_action": "review_plan_before_execution"
+    },
+    "commands": [
+      {
+        "step": 1,
+        "command_id": "command-example",
+        "display_command": "python -m pytest -q",
+        "argv": [
+          "python",
+          "-m",
+          "pytest",
+          "-q"
+        ],
+        "environment": {},
+        "cwd": ".",
+        "surface": "python",
+        "purpose": "test",
+        "operator_level": "required",
+        "review_required": false,
+        "review_reasons": [],
+        "evidence": [
+          {
+            "source": "adoption_surface",
+            "schema_version": "sdetkit.adoption_surface.v1",
+            "paths": [
+              "pyproject.toml"
+            ]
+          }
+        ],
+        "execution_allowed": false
+      }
+    ],
+    "review_first_items": [],
+    "policies": {
+      "execution_default": "deny",
+      "explicit_execution_authorization_required": true,
+      "workspace_mode": "isolated_copy_required",
+      "source_target_used_as_command_cwd": false,
+      "network_default": "deny",
+      "automatic_dependency_install_allowed": false,
+      "source_target_mutation_allowed": false
+    },
+    "rules": {
+      "plan_only": true,
+      "read_only": true,
+      "no_command_execution": true,
+      "no_dependency_install": true,
+      "no_target_repo_mutation": true,
+      "no_patch_application": true
+    },
+    "execution_allowed": false,
+    "automation_allowed": false,
+    "patch_application_allowed": false,
+    "merge_authorized": false,
+    "semantic_equivalence_proven": false,
+    "authority_boundary": {
+      "execution_allowed": false,
+      "automation_allowed": false,
+      "patch_application_allowed": false,
+      "merge_authorized": false,
+      "semantic_equivalence_proven": false
+    }
+  },
+  "expected": {
+    "command_count": 1,
+    "review_first_item_count": 0
+  }
+}

--- a/tests/test_replayable_benchmark_execution_plan_handoff.py
+++ b/tests/test_replayable_benchmark_execution_plan_handoff.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.replayable_benchmark_harness import (
+    build_execution_plan_handoff_benchmark_report,
+    load_execution_plan_handoff_scenarios,
+    main,
+    render_markdown,
+)
+
+FIXTURES = Path("tests/fixtures/remediation_benchmark")
+SCENARIO_PATHS = [
+    FIXTURES / "execution_plan_handoff_observed_oracle.json",
+    FIXTURES / "execution_plan_handoff_not_provided.json",
+    FIXTURES / "execution_plan_handoff_authority_unsafe.json",
+]
+
+
+def _scenarios() -> list[dict]:
+    return load_execution_plan_handoff_scenarios(SCENARIO_PATHS)
+
+
+def test_execution_plan_handoff_benchmark_proves_required_contract() -> None:
+    report = build_execution_plan_handoff_benchmark_report(_scenarios())
+
+    assert report["schema_version"] == (
+        "sdetkit.replayable_benchmark_harness.execution_plan_handoff.v1"
+    )
+    assert report["report_mode"] == "diagnostic_execution_plan_handoff_fixture"
+    assert report["status"] == "passed"
+    assert report["scenario_count"] == 3
+    assert report["passed_count"] == 3
+    assert report["failed_count"] == 0
+
+    contract = report["required_contract"]
+    assert contract["all_required_present"] is True
+    assert contract["all_required_passed"] is True
+    assert contract["observed_handoff_pass_rate"] == 1.0
+    assert contract["not_provided_pass_rate"] == 1.0
+    assert contract["unsafe_authority_rejection_rate"] == 1.0
+
+    boundary = report["safety_boundary"]
+    assert boundary["contributes_to_current_pr_decision"] is False
+    assert boundary["feeds_repo_memory"] is False
+    assert boundary["executes_plan"] is False
+    assert boundary["executes_patch"] is False
+    assert boundary["automation_allowed_count"] == 0
+    assert boundary["merge_authorized_count"] == 0
+    assert boundary["preserved"] is True
+
+
+def test_execution_plan_handoff_benchmark_retains_and_rejects_expected_evidence() -> None:
+    report = build_execution_plan_handoff_benchmark_report(_scenarios())
+    results = {item["scenario_type"]: item for item in report["scenarios"]}
+
+    observed = results["execution_plan_handoff_oracle_pass"]
+    assert observed["execution_plan_handoff_status"] == "observed"
+    assert observed["planned_command_count"] == 1
+    assert observed["trajectory_record_count"] == 1
+
+    not_provided = results["execution_plan_handoff_nop_pass"]
+    assert not_provided["execution_plan_handoff_status"] == "not_provided"
+    assert not_provided["planned_command_count"] == 0
+    assert not_provided["trajectory_record_count"] == 1
+
+    unsafe = results["execution_plan_handoff_authority_fail"]
+    assert unsafe["trajectory_record_count"] == 0
+    assert "command evidence cannot allow execution" in unsafe["observed_error"]
+
+
+def test_execution_plan_handoff_benchmark_markdown_is_non_authorizing() -> None:
+    markdown = render_markdown(build_execution_plan_handoff_benchmark_report(_scenarios()))
+
+    assert "Required execution-plan handoff replay contract" in markdown
+    assert "Observed handoff pass rate: `1.0000`" in markdown
+    assert "Not-provided handoff pass rate: `1.0000`" in markdown
+    assert "Unsafe authority rejection rate: `1.0000`" in markdown
+    assert "Current PR decision input: `false`" in markdown
+    assert "Feeds RepoMemory: `false`" in markdown
+    assert "Executes plan: `false`" in markdown
+    assert "does not execute plans" in markdown
+
+
+def test_execution_plan_handoff_benchmark_cli_writes_report(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    out_dir = tmp_path / "execution-plan-benchmark"
+    argv: list[str] = []
+    for path in SCENARIO_PATHS:
+        argv.extend(["--execution-plan-handoff-scenario", str(path)])
+    argv.extend(["--out-dir", str(out_dir), "--format", "json"])
+
+    rc = main(argv)
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    saved = json.loads((out_dir / "benchmark-report.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "benchmark-report.md").read_text(encoding="utf-8")
+
+    assert printed["status"] == "passed"
+    assert printed["scenario_count"] == 3
+    assert saved["report_mode"] == "diagnostic_execution_plan_handoff_fixture"
+    assert saved["safety_boundary"]["executes_plan"] is False
+    assert "Required execution-plan handoff replay contract" in markdown


### PR DESCRIPTION
## Summary

Add a dedicated replayable-benchmark mode for the diagnostic execution-plan
handoff introduced by the recent DiagnosticJob and trajectory work.

The benchmark covers three required outcomes:

- an observed plan handoff is retained with command provenance;
- a missing plan remains a valid `not_provided` handoff;
- forged command execution authority is rejected before trajectory evidence is
  written.

## Scope

- `src/sdetkit/replayable_benchmark_harness.py`
- `tests/test_replayable_benchmark_execution_plan_handoff.py`
- three controlled fixtures under `tests/fixtures/remediation_benchmark/`
- `docs/evidence-circuit-architecture-checkpoint.md`

## Product impact

This is PR 1 of a three-PR benchmark-control tranche:

1. replay execution-plan handoffs;
2. aggregate benchmark modes into a control scorecard;
3. add a baseline regression gate over that scorecard.

## Boundaries

```text
execution_allowed=false
automation_allowed=false
patch_application_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
proof_commands_executed=false
```

No plan command is executed. No patch is generated or applied. Benchmark
evidence does not feed current PR decisions or RepoMemory.

## Verification

- focused replayable-benchmark tests
- diagnostic execution-plan trajectory tests
- diagnostic worker trajectory regression tests
- Ruff lint and formatting
- focused pre-commit
- strict MkDocs build
- full pre-commit

Human review and a separate explicit merge decision remain required.
