### PR TITLE
test(ci): enforce declared Python 3.10 support

### DIFF
--- a/.github/workflows/first-proof.yml
+++ b/.github/workflows/first-proof.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     env:
       FIRST_PROOF_BRANCH: ${{ github.ref_name }}
 

--- a/tests/test_runtime_support_contract.py
+++ b/tests/test_runtime_support_contract.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _declared_python_floor() -> str:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'requires-python\s*=\s*">=(\d+\.\d+)"', pyproject)
+    assert match is not None, "pyproject.toml must declare an explicit minimum Python version"
+    return match.group(1)
+
+
+def test_declared_python_floor_is_covered_by_first_proof_matrix() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "first-proof.yml").read_text(encoding="utf-8")
+    )
+    versions = workflow["jobs"]["first-proof"]["strategy"]["matrix"]["python-version"]
+
+    assert _declared_python_floor() in {str(version) for version in versions}


### PR DESCRIPTION
## Summary
- add Python 3.10 to the canonical `first-proof` workflow matrix
- add a regression test that binds the declared `requires-python` floor to the first-proof matrix
- preserve the existing workflow inventory and authority boundaries

## Why
`pyproject.toml` declares Python 3.10+ support, but the canonical first-proof workflow previously started at Python 3.11. This PR makes the runtime support claim continuously verifiable.

## Verification
- branch diff: 2 files, 25 additions, 1 deletion
- focused test: `python -m pytest -q tests/test_runtime_support_contract.py -o addopts=`
- quality gate: `python -m pre_commit run -a`
- CI proof: Python 3.10 `first-proof` matrix job

## Risk
- Low
- Rollback: remove Python 3.10 from the matrix and the associated contract test

## Notes
- No new workflow was added because the repository workflow topology is already at its reviewed workflow-count budget.
- No public command, artifact schema, or compatibility surface changed.