### PR TITLE
chore(tooling): align Ruff pins across CI and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.20
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/tests/test_toolchain_pin_contract.py
+++ b/tests/test_toolchain_pin_contract.py
@@ -17,9 +17,7 @@ def _single_match(pattern: str, content: str, source: str) -> str:
 def test_ruff_version_is_aligned_across_toolchain_surfaces() -> None:
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     constraints = (ROOT / "constraints-ci.txt").read_text(encoding="utf-8")
-    pre_commit = yaml.safe_load(
-        (ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
-    )
+    pre_commit = yaml.safe_load((ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
 
     pyproject_version = _single_match(
         r'^\s*"ruff==([^"\s]+)"', pyproject, "pyproject.toml"

--- a/tests/test_toolchain_pin_contract.py
+++ b/tests/test_toolchain_pin_contract.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _single_match(pattern: str, content: str, source: str) -> str:
+    matches = re.findall(pattern, content, flags=re.MULTILINE)
+    assert len(matches) == 1, f"expected one Ruff pin in {source}, found {len(matches)}"
+    return matches[0]
+
+
+def test_ruff_version_is_aligned_across_toolchain_surfaces() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    constraints = (ROOT / "constraints-ci.txt").read_text(encoding="utf-8")
+    pre_commit = yaml.safe_load(
+        (ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    )
+
+    pyproject_version = _single_match(
+        r'^\s*"ruff==([^"\s]+)"', pyproject, "pyproject.toml"
+    )
+    constraints_version = _single_match(
+        r"^ruff==([^\s#]+)", constraints, "constraints-ci.txt"
+    )
+    ruff_repositories = [
+        repository
+        for repository in pre_commit["repos"]
+        if repository["repo"] == "https://github.com/astral-sh/ruff-pre-commit"
+    ]
+
+    assert len(ruff_repositories) == 1
+    pre_commit_version = str(ruff_repositories[0]["rev"]).removeprefix("v")
+    assert pre_commit_version == pyproject_version == constraints_version

--- a/tests/test_toolchain_pin_contract.py
+++ b/tests/test_toolchain_pin_contract.py
@@ -19,12 +19,8 @@ def test_ruff_version_is_aligned_across_toolchain_surfaces() -> None:
     constraints = (ROOT / "constraints-ci.txt").read_text(encoding="utf-8")
     pre_commit = yaml.safe_load((ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
 
-    pyproject_version = _single_match(
-        r'^\s*"ruff==([^"\s]+)"', pyproject, "pyproject.toml"
-    )
-    constraints_version = _single_match(
-        r"^ruff==([^\s#]+)", constraints, "constraints-ci.txt"
-    )
+    pyproject_version = _single_match(r'^\s*"ruff==([^"\s]+)"', pyproject, "pyproject.toml")
+    constraints_version = _single_match(r"^ruff==([^\s#]+)", constraints, "constraints-ci.txt")
     ruff_repositories = [
         repository
         for repository in pre_commit["repos"]


### PR DESCRIPTION
## Summary
- update `ruff-pre-commit` from `v0.15.18` to `v0.15.20`
- add a regression test that requires the Ruff version to match across `pyproject.toml`, `constraints-ci.txt`, and `.pre-commit-config.yaml`

## Why
The repository installed Ruff `0.15.20` in development and CI while pre-commit executed `0.15.18`. That allowed local hook behavior to diverge from the canonical CI baseline.

## Verification
- focused contract: `python -m pytest -q tests/test_toolchain_pin_contract.py -o addopts=`
- pre-commit: `python -m pre_commit run -a`
- full repository CI and coverage gates

## Risk
- Low tooling-only change
- No runtime, CLI, artifact schema, or workflow topology change
- Rollback: revert the pre-commit revision and remove the alignment contract
