### PR TITLE
typing: ratchet diagnostic trajectory provenance modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,8 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
+  "sdetkit.diagnostic_job",
+  "sdetkit.diagnostic_worker_trajectory",
   "sdetkit.failure_vector",
   "sdetkit.safety_gate",
 ]

--- a/src/sdetkit/diagnostic_worker_trajectory.py
+++ b/src/sdetkit/diagnostic_worker_trajectory.py
@@ -305,7 +305,7 @@ def build_worker_trajectory_records(
     commit_sha: str = "",
     pr_number: int = 0,
     generated_at: str = DEFAULT_GENERATED_AT,
-) -> list[JsonObject]:
+) -> list[Mapping[str, Any]]:
     validate_worker_handoff(
         job=job,
         worker_result=worker_result,
@@ -322,7 +322,7 @@ def build_worker_trajectory_records(
 
     review_handoff = _review_handoff_projection(worker_result)
     execution_plan_handoff = _execution_plan_handoff_projection(worker_result)
-    records: list[JsonObject] = []
+    records: list[Mapping[str, Any]] = []
     for base_record in base_records:
         record = copy.deepcopy(base_record)
         observed_decision = _as_dict(record.get("decision"))

--- a/tests/test_mypy_ratchet_contract.py
+++ b/tests/test_mypy_ratchet_contract.py
@@ -8,7 +8,12 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
     import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[1]
-RATCHET_MODULES = {"sdetkit.failure_vector", "sdetkit.safety_gate"}
+RATCHET_MODULES = {
+    "sdetkit.diagnostic_job",
+    "sdetkit.diagnostic_worker_trajectory",
+    "sdetkit.failure_vector",
+    "sdetkit.safety_gate",
+}
 
 
 def _module_names(override: dict[str, object]) -> set[str]:
@@ -20,7 +25,7 @@ def _module_names(override: dict[str, object]) -> set[str]:
     return set()
 
 
-def test_failure_vector_and_safety_gate_are_removed_from_blanket_mypy_suppression() -> None:
+def test_selected_modules_are_removed_from_blanket_mypy_suppression() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     overrides = config["tool"]["mypy"]["overrides"]
 


### PR DESCRIPTION
## Summary
- extend the staged mypy ratchet to `sdetkit.diagnostic_job`
- extend the staged mypy ratchet to `sdetkit.diagnostic_worker_trajectory`
- express generated worker trajectory records through their read-only `Mapping` contract, resolving list invariance at the artifact handoff
- update the existing configuration contract so all four ratcheted modules must remain outside the blanket suppression

## Why
These modules preserve the reporting-only handoff from diagnostic execution-plan evidence into trajectory records. Type-checking this boundary reduces provenance drift risk without broadening runtime behavior or automation authority.

## Verification
- `python -m pytest -q tests/test_mypy_ratchet_contract.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- full repository CI, coverage, wheel, docs, security, and governance gates

## Risk
- Low, staged typing ratchet
- The return annotation now communicates that callers consume trajectory records read-only; produced values remain dictionaries and serialized artifacts are unchanged
- No artifact schema, command execution, patching, or merge authority change

## Rollback
Remove the two module names from the exact-module mypy override, restore the ratchet contract set, and restore the concrete trajectory-record return annotation.
