### PR TITLE
typing: ratchet execution plan and trajectory store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,10 +125,12 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
+  "sdetkit.diagnostic_execution_plan",
   "sdetkit.diagnostic_job",
   "sdetkit.diagnostic_worker_trajectory",
   "sdetkit.failure_vector",
   "sdetkit.safety_gate",
+  "sdetkit.trajectory_store",
 ]
 ignore_errors = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,11 +125,16 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
-  "sdetkit.diagnostic_execution_plan",
   "sdetkit.diagnostic_job",
   "sdetkit.diagnostic_worker_trajectory",
   "sdetkit.failure_vector",
   "sdetkit.safety_gate",
+]
+ignore_errors = false
+
+[[tool.mypy.overrides]]
+module = [
+  "sdetkit.diagnostic_execution_plan",
   "sdetkit.trajectory_store",
 ]
 ignore_errors = false

--- a/src/sdetkit/trajectory_store.py
+++ b/src/sdetkit/trajectory_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -148,7 +148,7 @@ def _read_json(path: Path | None) -> JsonObject:
     return payload
 
 
-def _write_jsonl(path: Path, records: list[Mapping[str, Any]]) -> None:
+def _write_jsonl(path: Path, records: Sequence[Mapping[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = [json.dumps(record, sort_keys=True) for record in records]
     path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
@@ -618,7 +618,7 @@ def build_trajectory_records(
     return records
 
 
-def summarize_trajectory_records(records: list[Mapping[str, Any]]) -> JsonObject:
+def summarize_trajectory_records(records: Sequence[Mapping[str, Any]]) -> JsonObject:
     return {
         "schema_version": SCHEMA_VERSION,
         "record_count": len(records),
@@ -648,7 +648,7 @@ def summarize_trajectory_records(records: list[Mapping[str, Any]]) -> JsonObject
     }
 
 
-def write_trajectory_records(records: list[Mapping[str, Any]], out: Path) -> JsonObject:
+def write_trajectory_records(records: Sequence[Mapping[str, Any]], out: Path) -> JsonObject:
     _write_jsonl(out, records)
     summary = summarize_trajectory_records(records)
     summary["trajectory_jsonl"] = out.as_posix()

--- a/tests/test_mypy_provenance_ratchet_contract.py
+++ b/tests/test_mypy_provenance_ratchet_contract.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+PROVENANCE_RATCHET_MODULES = {
+    "sdetkit.diagnostic_execution_plan",
+    "sdetkit.trajectory_store",
+}
+
+
+def _module_names(override: dict[str, object]) -> set[str]:
+    raw = override.get("module", [])
+    if isinstance(raw, str):
+        return {raw}
+    if isinstance(raw, list):
+        return {str(item) for item in raw}
+    return set()
+
+
+def test_execution_plan_and_trajectory_store_are_type_checked() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    overrides = config["tool"]["mypy"]["overrides"]
+
+    ratchets = [
+        override
+        for override in overrides
+        if _module_names(override) == PROVENANCE_RATCHET_MODULES
+    ]
+    assert len(ratchets) == 1
+    assert ratchets[0].get("ignore_errors") is False

--- a/tests/test_mypy_provenance_ratchet_contract.py
+++ b/tests/test_mypy_provenance_ratchet_contract.py
@@ -28,9 +28,7 @@ def test_execution_plan_and_trajectory_store_are_type_checked() -> None:
     overrides = config["tool"]["mypy"]["overrides"]
 
     ratchets = [
-        override
-        for override in overrides
-        if _module_names(override) == PROVENANCE_RATCHET_MODULES
+        override for override in overrides if _module_names(override) == PROVENANCE_RATCHET_MODULES
     ]
     assert len(ratchets) == 1
     assert ratchets[0].get("ignore_errors") is False


### PR DESCRIPTION
## Summary
- enable active mypy checking for `sdetkit.diagnostic_execution_plan`
- enable active mypy checking for `sdetkit.trajectory_store`
- make trajectory record consumers accept covariant `Sequence[Mapping[...]]` inputs
- add an isolated regression contract for this provenance-boundary ratchet

## Why
These modules convert repository discovery evidence into a non-executing command plan and then persist diagnostic trajectories. Type-checking this boundary reduces schema and provenance drift without changing runtime authority.

## Verification
- `python -m pytest -q tests/test_mypy_provenance_ratchet_contract.py -o addopts=`
- `python -m mypy src` — success across 488 source files in the exact built source distribution
- `python -m pre_commit run -a`
- full repository CI, coverage, wheel, docs, security, and governance gates

## Risk
- Low, staged typing ratchet
- The `Sequence` annotations reflect existing read-only consumption and preserve list-producing APIs and serialized artifacts
- No runtime behavior, command execution, artifact authority, patching, or merge authorization change

## Rollback
Remove the dedicated two-module mypy override and regression contract, and restore the three trajectory consumer parameters to `list`.
