### PR TITLE
typing: ratchet adoption bundle and external integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,13 @@ module = [
 ]
 ignore_errors = false
 
+[[tool.mypy.overrides]]
+module = [
+  "sdetkit.adoption_evidence_bundle",
+  "sdetkit.adoption_external_integration",
+]
+ignore_errors = false
+
 [tool.mutmut]
 paths_to_mutate = ["src/sdetkit"]
 tests_dir = ["tests"]

--- a/tests/test_mypy_adoption_bundle_external_ratchet_contract.py
+++ b/tests/test_mypy_adoption_bundle_external_ratchet_contract.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+ADOPTION_BUNDLE_EXTERNAL_RATCHET_MODULES = {
+    "sdetkit.adoption_evidence_bundle",
+    "sdetkit.adoption_external_integration",
+}
+
+
+def _module_names(override: dict[str, object]) -> set[str]:
+    raw = override.get("module", [])
+    if isinstance(raw, str):
+        return {raw}
+    if isinstance(raw, list):
+        return {str(item) for item in raw}
+    return set()
+
+
+def test_adoption_bundle_and_external_integration_are_type_checked() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    overrides = config["tool"]["mypy"]["overrides"]
+
+    ratchets = [
+        override
+        for override in overrides
+        if _module_names(override) == ADOPTION_BUNDLE_EXTERNAL_RATCHET_MODULES
+    ]
+    assert len(ratchets) == 1
+    assert ratchets[0].get("ignore_errors") is False


### PR DESCRIPTION
## Summary
- enable active mypy checking for `sdetkit.adoption_evidence_bundle`
- enable active mypy checking for `sdetkit.adoption_external_integration`
- add an isolated regression contract for this evidence-assembly and external-root boundary

## Why
These modules assemble reviewed adoption evidence and run the read-only artifact stack against external repository roots. Type-checking this boundary reduces schema and path-handling drift while preserving the existing no-execution, no-mutation, reporting-only authority contract.

## Verification
- `python -m pytest -q tests/test_mypy_adoption_bundle_external_ratchet_contract.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- full repository CI, coverage, wheel, docs, security, and governance gates

## Risk
- Low, configuration-first typing ratchet
- No target tests are executed and no dependencies are installed
- No target repository mutation, patch authority, automation authority, or merge authority change
- Any source fixes will remain limited to the two newly ratcheted modules and concrete mypy findings

## Rollback
Remove the dedicated two-module mypy override and its regression contract.
