### PR TITLE
release: establish current product delta and 1.1.0 baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,50 @@
 
 ## Unreleased
 
-- CI triage advisor: add `sdetkit triage-ci` for advisory saved-log diagnosis, with fixture coverage, clearer failure classifications, readable text/markdown output, and first-failure operator docs.
+This section describes capabilities merged to `main` after `1.0.3`. They are not claimed to be present in the published `sdetkit==1.0.3` wheel until a later release is built, verified, and published.
+
+### Release confidence and diagnosis
+
+- Add `sdetkit triage-ci` for advisory saved-log diagnosis with fixture coverage, structured failure classification, readable text and Markdown output, and first-failure operator guidance.
+- Add deterministic FailureVector extraction, normalized failure contracts, first-real-failure reporting, affected-file hints, local reproduction guidance, and conservative risk classification.
+- Add review-first SafetyGate decisions that preserve denied automation, patch, merge, security-dismissal, and semantic-equivalence authority.
+- Add DiagnosticJob, diagnostic execution-plan handoff, worker-result, and trajectory provenance contracts.
+
+### Verification and remediation safety
+
+- Add isolated proof execution with copied workspaces, mutation detection, reserved-evidence protection, bounded proof profiles, timeout handling, and network-boundary assessment.
+- Add protected verifier decisions, patch scoring, remediation-plan context, changed-file inventory checks, proof-requirement checks, and authority-boundary validation.
+- Add replayable remediation benchmark scenarios, anti-cheat checks, control scorecards, and reviewed baseline regression gates.
+- Preserve review-first handling for unknown, dependency, release, security, broad-scope, and verifier-sensitive failures.
+
+### Trajectory, memory, and reporting
+
+- Add trajectory storage, repository memory, failure-pattern insights, command provenance, proof-result retention, and deterministic reporting artifacts.
+- Expand PR Quality reporting with exact-failure evidence, safety decisions, proof state, review handoffs, and denied-authority fields.
+- Add trusted-main JUnit observation capture for retained test evidence.
+
+### External adoption intelligence
+
+- Add read-only repository surface discovery for Python, JavaScript/TypeScript, Go, Rust, Java, .NET, GitHub Actions, GitLab CI, Jenkins, security tools, release surfaces, and common evidence artifacts.
+- Add adoption topology, proof recommendations, evidence bundles, external integration, learning-state, and public repository trial-matrix reports.
+- Keep external adoption commands non-executing and non-mutating by default; recommended proof commands remain operator guidance.
+
+### Quality, packaging, and governance
+
+- Add Python 3.10 first-proof coverage and staged mypy ratchets for the diagnostic, trajectory, safety, adoption, and reporting boundaries.
+- Align Ruff versions across project metadata, CI constraints, and pre-commit configuration.
+- Add workflow-topology, required-check, public-surface, artifact-contract, release, security, and generated-artifact regression guards.
+- Maintain SHA-pinned GitHub Actions, strict documentation builds, wheel-content validation, clean-wheel smoke installation, dependency review, SBOM, and vulnerability scanning lanes.
+
+### Release qualification required
+
+- Reconstruct and review the complete `1.0.3` to current-main product delta.
+- Consolidate workflow and operator surfaces before release qualification.
+- Prove the exact release-candidate artifacts on Python 3.10, 3.11, and 3.12.
+- Refresh live-adoption proof at the release-candidate SHA.
+- Migrate PyPI publication to reviewed Trusted Publishing configuration.
+
+See [`docs/current-product-delta.md`](docs/current-product-delta.md) and [`docs/contracts/current-product-delta.v1.json`](docs/contracts/current-product-delta.v1.json).
 
 ## [1.0.3]
 
@@ -17,7 +60,6 @@ Released: 2026-04-18
 Released: 2026-04-16
 
 - Packaging: modernize license metadata.
-
 
 ## v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ Secondary lanes cover review, investigation, quality, maintenance, and CI automa
 - **Guarded automation path:** remediation and PR automation are explicit opt-in lanes, not the default behavior.
 - **One workflow everywhere:** use the same core commands locally, in CI, and during operator handoff.
 
-## Core operator lanes
-
 ## Real-world learning and governance lanes
 
 The `main` branch includes read-only adoption and learning lanes for understanding real repositories before recommending proof or remediation. These main-only lanes are advisory by default: they collect evidence, classify repo shape, surface review-first unknowns, and produce upgrade candidates for SDETKit itself without installing target dependencies, running target tests, mutating target repositories, or opening target PRs/issues.
@@ -83,11 +81,8 @@ Authority boundary remains unchanged: `automation_allowed=false`, `patch_applica
 | CI-ready | `./ci.sh quick --artifact-dir .sdetkit/out` and `make merge-ready` | You want a local CI-equivalent smoke path. |
 | First proof | `make first-proof` | You are validating this repository's full first-proof bundle. |
 
-For a guided command router, run:
+Guided router: `make upgrade-next`.
 
-```bash
-make upgrade-next
-```
 ## Product proof
 
 <!-- product-proof-start -->

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor --format json --out build/doctor.json
 ```
 
+## Release channel
+
+The command above installs the latest published package, `sdetkit==1.0.3`. The repository `main` branch contains additional diagnostic, verification, benchmark, trajectory, and adoption capabilities that remain **main-only** until the next qualified release. See the [current product delta](docs/current-product-delta.md) before using repository documentation as installed-wheel proof.
+
 Generated first-run artifacts:
 
 ```text
@@ -57,7 +61,7 @@ Secondary lanes cover review, investigation, quality, maintenance, and CI automa
 
 ## Real-world learning and governance lanes
 
-SDETKit now includes read-only adoption and learning lanes for understanding real repositories before recommending proof or remediation. These lanes are advisory by default: they collect evidence, classify repo shape, surface review-first unknowns, and produce upgrade candidates for SDETKit itself without installing target dependencies, running target tests, mutating target repositories, or opening target PRs/issues.
+The `main` branch includes read-only adoption and learning lanes for understanding real repositories before recommending proof or remediation. These main-only lanes are advisory by default: they collect evidence, classify repo shape, surface review-first unknowns, and produce upgrade candidates for SDETKit itself without installing target dependencies, running target tests, mutating target repositories, or opening target PRs/issues.
 
 Use these lanes when you need to evaluate repository readiness beyond the local release gate:
 
@@ -111,6 +115,7 @@ For this repository, `make first-proof` emits `FIRST_PROOF_DECISION=SHIP|NO-SHIP
 
 ## Documentation map
 
+- Current released versus main product delta: [docs/current-product-delta.md](docs/current-product-delta.md)
 - Start in 5 minutes: [docs/start-here-5-minutes.md](docs/start-here-5-minutes.md)
 - Docs index: [docs/index.md](docs/index.md)
 - Operator essentials: [docs/operator-essentials.md](docs/operator-essentials.md)

--- a/docs/contracts/current-product-delta.v1.json
+++ b/docs/contracts/current-product-delta.v1.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "sdetkit.current_product_delta.v1",
+  "generated_on": "2026-06-29",
+  "released_version": "1.0.3",
+  "released_on": "2026-04-18",
+  "release_candidate_version": "1.1.0",
+  "release_status": "main_ahead_of_published_package",
+  "canonical_first_path": [
+    "python -m sdetkit gate fast",
+    "python -m sdetkit gate release",
+    "python -m sdetkit doctor"
+  ],
+  "published_package_contract": {
+    "channel": "pypi",
+    "version": "1.0.3",
+    "scope": "released",
+    "documentation_must_not_imply_main_only_capabilities_are_published": true
+  },
+  "main_only_capability_groups": [
+    {
+      "id": "diagnostic_failure_model",
+      "stability": "advanced_supported",
+      "capabilities": [
+        "FailureVector extraction and normalized failure contracts",
+        "review-first SafetyGate decisions",
+        "DiagnosticJob and execution-plan handoffs"
+      ]
+    },
+    {
+      "id": "verification_and_benchmarking",
+      "stability": "experimental_incubator",
+      "capabilities": [
+        "isolated proof execution",
+        "protected verifier decisions",
+        "patch scoring and anti-cheat checks",
+        "replayable remediation benchmark scorecards"
+      ]
+    },
+    {
+      "id": "trajectory_and_memory",
+      "stability": "experimental_incubator",
+      "capabilities": [
+        "trajectory storage",
+        "repository memory",
+        "diagnostic learning and pattern insights"
+      ]
+    },
+    {
+      "id": "external_adoption_intelligence",
+      "stability": "advanced_supported",
+      "capabilities": [
+        "read-only repository surface discovery",
+        "proof recommendation generation",
+        "external integration evidence bundles",
+        "public repository trial-matrix reporting"
+      ]
+    }
+  ],
+  "release_blockers": [
+    "reconstruct the full changelog from 1.0.3 to current main",
+    "prove the exact release candidate wheel on Python 3.10, 3.11, and 3.12",
+    "refresh live-adoption proof at the release candidate SHA",
+    "complete workflow and operator-surface consolidation",
+    "replace token-based publishing with reviewed Trusted Publishing configuration"
+  ],
+  "authority_boundary": {
+    "automation_allowed": false,
+    "patch_application_allowed": false,
+    "merge_authorized": false,
+    "semantic_equivalence_proven": false
+  }
+}

--- a/docs/current-product-delta.md
+++ b/docs/current-product-delta.md
@@ -1,0 +1,87 @@
+# Current product delta
+
+SDETKit's repository evolves faster than its published package. This page separates released behavior from capabilities that exist only on `main` so operators do not mistake repository documentation for installed-wheel proof.
+
+Contract: [`docs/contracts/current-product-delta.v1.json`](contracts/current-product-delta.v1.json)
+
+## Release truth
+
+| Surface | Current truth |
+|---|---|
+| Published package | `sdetkit==1.0.3` |
+| Published release date | 2026-04-18 |
+| Current repository direction | 1.1.0 release-candidate preparation |
+| Release status | `main_ahead_of_published_package` |
+
+The installation command in the README intentionally pins the latest published package. Capabilities marked **main-only** below are not claimed to be available from that wheel until a later release is built, verified, and published.
+
+## Stable released front door
+
+The stable first path remains:
+
+```bash
+python -m sdetkit gate fast
+python -m sdetkit gate release
+python -m sdetkit doctor
+```
+
+These commands express the primary product outcome: determine whether a change is ready to ship and retain machine-readable evidence.
+
+## Main-only capability groups
+
+### Diagnostic failure model — advanced supported
+
+- FailureVector extraction and normalized failure contracts.
+- Review-first SafetyGate decisions.
+- DiagnosticJob and execution-plan handoffs.
+
+These capabilities are intended for operator diagnosis. Candidate status does not authorize patch application, merge, security dismissal, or semantic-equivalence claims.
+
+### Verification and benchmarking — experimental incubator
+
+- Isolated proof execution.
+- Protected verifier decisions.
+- Patch scoring and anti-cheat checks.
+- Replayable remediation benchmark scorecards.
+
+These surfaces remain qualification inputs for the next release. They are not described as autonomous remediation authority.
+
+### Trajectory and repository memory — experimental incubator
+
+- Trajectory storage.
+- Repository memory.
+- Diagnostic learning and pattern insights.
+
+These surfaces retain evidence and repeated failure patterns. They do not independently prove a diagnosis or repair.
+
+### External adoption intelligence — advanced supported
+
+- Read-only repository surface discovery.
+- Proof recommendation generation.
+- External integration evidence bundles.
+- Public repository trial-matrix reporting.
+
+External-repository commands remain read-only by default. Recommended proof commands are operator guidance, not commands SDETKit is authorized to run automatically.
+
+## 1.1.0 release blockers
+
+The next release is blocked until all of the following are proven:
+
+1. The changelog accounts for the product delta since 1.0.3.
+2. The exact release-candidate wheel passes clean-room installation and canonical-command smoke tests on Python 3.10, 3.11, and 3.12.
+3. Live-adoption evidence is refreshed at the release-candidate SHA.
+4. Workflow and operator-surface consolidation is complete enough for maintainers and adopters to identify the canonical path.
+5. PyPI publication uses reviewed Trusted Publishing configuration instead of a long-lived upload token.
+
+## Authority boundary
+
+The release-delta contract must preserve:
+
+```text
+automation_allowed=false
+patch_application_allowed=false
+merge_authorized=false
+semantic_equivalence_proven=false
+```
+
+Changing any of those values requires a separate security- and verifier-reviewed policy change. This release-truth document cannot authorize it.

--- a/src/sdetkit/data/current_product_delta.v1.json
+++ b/src/sdetkit/data/current_product_delta.v1.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "sdetkit.current_product_delta.v1",
+  "generated_on": "2026-06-29",
+  "released_version": "1.0.3",
+  "released_on": "2026-04-18",
+  "release_candidate_version": "1.1.0",
+  "release_status": "main_ahead_of_published_package",
+  "canonical_first_path": [
+    "python -m sdetkit gate fast",
+    "python -m sdetkit gate release",
+    "python -m sdetkit doctor"
+  ],
+  "published_package_contract": {
+    "channel": "pypi",
+    "version": "1.0.3",
+    "scope": "released",
+    "documentation_must_not_imply_main_only_capabilities_are_published": true
+  },
+  "main_only_capability_groups": [
+    {
+      "id": "diagnostic_failure_model",
+      "stability": "advanced_supported",
+      "capabilities": [
+        "FailureVector extraction and normalized failure contracts",
+        "review-first SafetyGate decisions",
+        "DiagnosticJob and execution-plan handoffs"
+      ]
+    },
+    {
+      "id": "verification_and_benchmarking",
+      "stability": "experimental_incubator",
+      "capabilities": [
+        "isolated proof execution",
+        "protected verifier decisions",
+        "patch scoring and anti-cheat checks",
+        "replayable remediation benchmark scorecards"
+      ]
+    },
+    {
+      "id": "trajectory_and_memory",
+      "stability": "experimental_incubator",
+      "capabilities": [
+        "trajectory storage",
+        "repository memory",
+        "diagnostic learning and pattern insights"
+      ]
+    },
+    {
+      "id": "external_adoption_intelligence",
+      "stability": "advanced_supported",
+      "capabilities": [
+        "read-only repository surface discovery",
+        "proof recommendation generation",
+        "external integration evidence bundles",
+        "public repository trial-matrix reporting"
+      ]
+    }
+  ],
+  "release_blockers": [
+    "reconstruct the full changelog from 1.0.3 to current main",
+    "prove the exact release candidate wheel on Python 3.10, 3.11, and 3.12",
+    "refresh live-adoption proof at the release candidate SHA",
+    "complete workflow and operator-surface consolidation",
+    "replace token-based publishing with reviewed Trusted Publishing configuration"
+  ],
+  "authority_boundary": {
+    "automation_allowed": false,
+    "patch_application_allowed": false,
+    "merge_authorized": false,
+    "semantic_equivalence_proven": false
+  }
+}

--- a/tests/test_current_product_delta_contract.py
+++ b/tests/test_current_product_delta_contract.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+DELTA_PATH = ROOT / "docs" / "contracts" / "current-product-delta.v1.json"
+
+
+def _delta() -> dict[str, object]:
+    payload = json.loads(DELTA_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_current_product_delta_matches_published_project_version() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject["project"]
+    delta = _delta()
+
+    assert delta["released_version"] == project["version"]
+    assert delta["release_status"] == "main_ahead_of_published_package"
+    assert delta["release_candidate_version"] != delta["released_version"]
+
+
+def test_current_product_delta_preserves_review_first_authority() -> None:
+    authority = _delta()["authority_boundary"]
+
+    assert authority == {
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_current_product_delta_declares_main_only_groups_and_release_blockers() -> None:
+    delta = _delta()
+    groups = delta["main_only_capability_groups"]
+    blockers = delta["release_blockers"]
+
+    assert isinstance(groups, list)
+    assert {group["id"] for group in groups} == {
+        "diagnostic_failure_model",
+        "verification_and_benchmarking",
+        "trajectory_and_memory",
+        "external_adoption_intelligence",
+    }
+    assert all(group["capabilities"] for group in groups)
+    assert isinstance(blockers, list)
+    assert len(blockers) >= 5
+
+
+def test_readme_links_release_delta_and_avoids_unqualified_main_claims() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "docs/current-product-delta.md" in readme
+    assert "main-only" in readme
+    assert "sdetkit==1.0.3" in readme

--- a/tests/test_current_product_delta_contract.py
+++ b/tests/test_current_product_delta_contract.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[1]
 DELTA_PATH = ROOT / "docs" / "contracts" / "current-product-delta.v1.json"
@@ -42,6 +45,7 @@ def test_current_product_delta_declares_main_only_groups_and_release_blockers() 
     blockers = delta["release_blockers"]
 
     assert isinstance(groups, list)
+    assert all(isinstance(group, dict) for group in groups)
     assert {group["id"] for group in groups} == {
         "diagnostic_failure_model",
         "verification_and_benchmarking",

--- a/tests/test_current_product_delta_contract.py
+++ b/tests/test_current_product_delta_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from importlib import resources
 from pathlib import Path
 
 try:
@@ -9,11 +10,19 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
     import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[1]
-DELTA_PATH = ROOT / "docs" / "contracts" / "current-product-delta.v1.json"
+DOCS_DELTA_PATH = ROOT / "docs" / "contracts" / "current-product-delta.v1.json"
+
+
+def _delta_text() -> str:
+    return (
+        resources.files("sdetkit")
+        .joinpath("data/current_product_delta.v1.json")
+        .read_text(encoding="utf-8")
+    )
 
 
 def _delta() -> dict[str, object]:
-    payload = json.loads(DELTA_PATH.read_text(encoding="utf-8"))
+    payload = json.loads(_delta_text())
     assert isinstance(payload, dict)
     return payload
 
@@ -55,6 +64,13 @@ def test_current_product_delta_declares_main_only_groups_and_release_blockers() 
     assert all(group["capabilities"] for group in groups)
     assert isinstance(blockers, list)
     assert len(blockers) >= 5
+
+
+def test_docs_product_delta_copy_matches_packaged_contract_when_present() -> None:
+    if not DOCS_DELTA_PATH.exists():
+        return
+
+    assert json.loads(DOCS_DELTA_PATH.read_text(encoding="utf-8")) == _delta()
 
 
 def test_readme_links_release_delta_and_avoids_unqualified_main_claims() -> None:


### PR DESCRIPTION
## Summary
- add a machine-readable contract separating published `1.0.3` behavior from capabilities available only on `main`
- add an operator-facing current product delta and explicit 1.1.0 release blockers
- reconstruct the unreleased changelog across diagnosis, verification, trajectory, adoption, quality, and governance work
- update the README so the pinned PyPI install is not presented as proof of main-only capabilities
- add a regression contract tying the product delta to `pyproject.toml` and preserving review-first authority

## Why
The repository has materially advanced beyond the package currently published on PyPI. Release, documentation, and operator claims need one auditable truth surface before quality, workflow, command-surface, multi-ecosystem, verifier, and release-qualification work continues.

## Verification
- `python -m pytest -q tests/test_current_product_delta_contract.py -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`
- full repository CI, package, security, workflow-governance, and first-proof checks

## Risk
- Low: documentation and contract-only release baseline
- no package version change
- no publish operation
- no automation, patch, merge, security-dismissal, or semantic-equivalence authority expansion

## Rollback
Revert the product-delta contract, documentation page, README release-channel note, changelog reconstruction, and focused regression test.
