### PR TITLE
quality: establish machine-readable quality truth baseline

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,6 +7,16 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "30 4 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/quality.yml"
+      - "quality.sh"
+      - "pyproject.toml"
+      - "scripts/check_coverage_truth.py"
+      - "scripts/check_quality_truth_baseline.py"
+      - "docs/contracts/quality-truth-baseline.v1.json"
+      - "tests/test_coverage_truth.py"
+      - "tests/test_quality_truth_baseline.py"
 
 permissions:
   contents: read
@@ -29,23 +39,43 @@ jobs:
             pyproject.toml
             requirements-test.txt
             requirements-docs.txt
+            constraints-ci.txt
 
       - name: Install project + quality tooling
         run: |
           python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
+
       - name: Doctor (ASCII)
-        run: |
-          python -m sdetkit.doctor --ascii
+        run: python -m sdetkit.doctor --ascii
+
       - name: Lint
-        run: |
-          python -m pre_commit run -a
+        run: python -m pre_commit run -a
 
       - name: Feature registry maintenance lane
-        run: |
-          bash quality.sh registry
+        run: bash quality.sh registry
 
-      - name: Tests
+      - name: Whole-package coverage and critical-spine gate
         env:
-          COV_FAIL_UNDER: "95"
+          PYTEST_ADDOPTS: "-n auto"
         run: |
-          bash quality.sh cov
+          mkdir -p build/quality
+          python -m pytest \
+            --cov=sdetkit \
+            --cov-report=term-missing \
+            --cov-report=json:build/quality/coverage-full.json \
+            --cov-fail-under=0
+          python scripts/check_coverage_truth.py \
+            --coverage build/quality/coverage-full.json \
+            --contract docs/contracts/quality-truth-baseline.v1.json \
+            --out build/quality/coverage-truth-check.json
+          python scripts/check_quality_truth_baseline.py \
+            --out build/quality/quality-truth-check.json
+
+      - name: Upload quality truth evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: quality-truth-evidence
+          path: build/quality/
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,6 +41,9 @@ jobs:
             requirements-docs.txt
             constraints-ci.txt
 
+      - name: Prepare quality evidence directory
+        run: mkdir -p build/quality
+
       - name: Install project + quality tooling
         run: |
           python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
@@ -49,7 +52,14 @@ jobs:
         run: python -m sdetkit.doctor --ascii
 
       - name: Lint
-        run: python -m pre_commit run -a
+        shell: bash
+        run: |
+          set +e
+          python -m pre_commit run -a 2>&1 | tee build/quality/pre-commit.log
+          rc=${PIPESTATUS[0]}
+          git diff --binary > build/quality/pre-commit.diff
+          set -e
+          exit "$rc"
 
       - name: Feature registry maintenance lane
         run: bash quality.sh registry
@@ -58,7 +68,6 @@ jobs:
         env:
           PYTEST_ADDOPTS: "-n auto"
         run: |
-          mkdir -p build/quality
           python -m pytest \
             --cov=sdetkit \
             --cov-report=term-missing \

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -78,7 +78,8 @@ jobs:
             --contract docs/contracts/quality-truth-baseline.v1.json \
             --out build/quality/coverage-truth-check.json
           python scripts/check_quality_truth_baseline.py \
-            --out build/quality/quality-truth-check.json
+            --out build/quality/quality-truth-check.json \
+            --typing-debt-out build/quality/typing-debt-inventory.json
 
       - name: Upload quality truth evidence
         if: always()

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -6,14 +6,26 @@
     "critical_spine": {
       "enforced": true,
       "minimum_percent": 95,
-      "scope_source": "quality.sh"
+      "scope_source": "quality.sh",
+      "files": [
+        "src/sdetkit/__main__.py",
+        "src/sdetkit/_entrypoints.py",
+        "src/sdetkit/_toml.py",
+        "src/sdetkit/atomicio.py",
+        "src/sdetkit/reliability_evidence_pack.py",
+        "src/sdetkit/report.py",
+        "src/sdetkit/roadmap_manifest.py",
+        "src/sdetkit/sqlite_scalar.py",
+        "src/sdetkit/textutil.py"
+      ]
     },
     "whole_package": {
       "measurement_required": true,
       "non_regression_required": true,
       "blocking_threshold_reviewed": false,
       "current_percent": null,
-      "artifact_path": "build/quality/coverage-full.json"
+      "artifact_path": "build/quality/coverage-full.json",
+      "check_artifact_path": "build/quality/coverage-truth-check.json"
     }
   },
   "typing": {

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -6,6 +6,8 @@
     "critical_spine": {
       "enforced": true,
       "minimum_percent": 95,
+      "observed_percent": 96.69,
+      "observed_statement_count": 966,
       "scope_source": "quality.sh",
       "files": [
         "src/sdetkit/__main__.py",
@@ -22,8 +24,9 @@
     "whole_package": {
       "measurement_required": true,
       "non_regression_required": true,
-      "blocking_threshold_reviewed": false,
-      "current_percent": null,
+      "blocking_threshold_reviewed": true,
+      "current_percent": 87.89,
+      "observed_statement_count": 66030,
       "artifact_path": "build/quality/coverage-full.json",
       "check_artifact_path": "build/quality/coverage-truth-check.json"
     }
@@ -32,6 +35,10 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
+    "source_module_count": 486,
+    "typing_debt_module_count": 474,
+    "typing_debt_inventory_sha256": "38e949d397eadffa94385375663b6ff2e9fc6ffe3cbdbac91ea5143565c01ad6",
+    "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "explicitly_type_checked_modules": [
       "sdetkit.adoption_evidence_bundle",
       "sdetkit.adoption_external_integration",

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "sdetkit.quality_truth_baseline.v1",
+  "generated_on": "2026-06-29",
+  "status": "staged_migration_visible",
+  "coverage": {
+    "critical_spine": {
+      "enforced": true,
+      "minimum_percent": 95,
+      "scope_source": "quality.sh"
+    },
+    "whole_package": {
+      "measurement_required": true,
+      "non_regression_required": true,
+      "blocking_threshold_reviewed": false,
+      "current_percent": null,
+      "artifact_path": "build/quality/coverage-full.json"
+    }
+  },
+  "typing": {
+    "blanket_package_suppression_present": true,
+    "blanket_module_pattern": "sdetkit.*",
+    "new_unrecorded_suppression_allowed": false,
+    "explicitly_type_checked_modules": [
+      "sdetkit.adoption_evidence_bundle",
+      "sdetkit.adoption_external_integration",
+      "sdetkit.adoption_learning",
+      "sdetkit.adoption_proof_recommendations",
+      "sdetkit.adoption_public_repo_trial_matrix_report",
+      "sdetkit.adoption_repo_topology",
+      "sdetkit.diagnostic_execution_plan",
+      "sdetkit.diagnostic_job",
+      "sdetkit.diagnostic_worker_trajectory",
+      "sdetkit.failure_vector",
+      "sdetkit.safety_gate",
+      "sdetkit.trajectory_store"
+    ],
+    "migration_complete": false
+  },
+  "runtime": {
+    "declared_python_versions": [
+      "3.10",
+      "3.11",
+      "3.12"
+    ],
+    "canonical_ci_matrix": [
+      "3.11",
+      "3.12"
+    ],
+    "python_310_full_ci_proven": false
+  },
+  "authority_boundary": {
+    "tests_may_be_weakened": false,
+    "quality_gates_may_be_hidden": false,
+    "unmeasured_quality_may_be_claimed": false
+  }
+}

--- a/docs/quality-truth-baseline.md
+++ b/docs/quality-truth-baseline.md
@@ -1,0 +1,55 @@
+# Quality truth baseline
+
+SDETKit uses staged quality gates. This page records what is enforced today, what is only measured, and what remains incomplete so a green check cannot be interpreted more broadly than the evidence supports.
+
+Contract: [`docs/contracts/quality-truth-baseline.v1.json`](contracts/quality-truth-baseline.v1.json)
+
+Validator:
+
+```bash
+python scripts/check_quality_truth_baseline.py \
+  --out build/quality/quality-truth-check.json
+```
+
+## Coverage truth
+
+- The critical reliability spine is currently enforced at 95% in canonical CI.
+- `quality.sh` supports whole-package coverage through `COV_SCOPE=full`.
+- A reviewed whole-package blocking threshold has not yet been established.
+- Until a full-package artifact and baseline are produced, the repository must not describe the whole package as 95% covered.
+
+The planned full-package artifact path is:
+
+```text
+build/quality/coverage-full.json
+```
+
+## Typing truth
+
+The repository still has a broad `sdetkit.*` mypy suppression. A reviewed group of diagnostic, safety, trajectory, and adoption modules explicitly opts back into error checking.
+
+The contract lists those modules exactly. The validator fails when the configured list and recorded list drift apart.
+
+This is a visible migration state, not a completion claim:
+
+```text
+blanket_package_suppression_present=true
+migration_complete=false
+new_unrecorded_suppression_allowed=false
+```
+
+## Runtime truth
+
+The package metadata declares Python 3.10, 3.11, and 3.12. Canonical fast and smoke CI currently cover Python 3.11 and 3.12. Python 3.10 appears in the first-proof route, but full CI and exact-wheel qualification across all three versions remain release work.
+
+## Required next steps
+
+1. Produce a deterministic whole-package coverage artifact from the existing full scope.
+2. Review and commit a non-regression baseline rather than inventing a target.
+3. Replace the broad mypy suppression with an explicit debt inventory or narrow per-module allowlist.
+4. Add Python 3.10 to the canonical exact-wheel qualification route.
+5. Update this contract only with fresh command or CI evidence.
+
+## Safety boundary
+
+Quality progress is invalid when it is achieved by weakening tests, hiding gates, reducing assertions, or presenting an unmeasured property as proven.

--- a/docs/quality-truth-baseline.md
+++ b/docs/quality-truth-baseline.md
@@ -1,6 +1,6 @@
 # Quality truth baseline
 
-SDETKit uses staged quality gates. This page records what is enforced today, what is only measured, and what remains incomplete so a green check cannot be interpreted more broadly than the evidence supports.
+SDETKit uses staged quality gates. This page records what is enforced today, what is measured, and what remains incomplete so a green check cannot be interpreted more broadly than the evidence supports.
 
 Contract: [`docs/contracts/quality-truth-baseline.v1.json`](contracts/quality-truth-baseline.v1.json)
 
@@ -8,29 +8,49 @@ Validator:
 
 ```bash
 python scripts/check_quality_truth_baseline.py \
-  --out build/quality/quality-truth-check.json
+  --out build/quality/quality-truth-check.json \
+  --typing-debt-out build/quality/typing-debt-inventory.json
 ```
 
 ## Coverage truth
 
-- The critical reliability spine is currently enforced at 95% in canonical CI.
-- `quality.sh` supports whole-package coverage through `COV_SCOPE=full`.
-- A reviewed whole-package blocking threshold has not yet been established.
-- Until a full-package artifact and baseline are produced, the repository must not describe the whole package as 95% covered.
+Fresh CI evidence at PR #1929 measured:
 
-The planned full-package artifact path is:
+- critical reliability spine: **96.69%** across **966** statements;
+- whole package: **87.89%** across **66,030** statements.
+
+The critical spine retains a 95% minimum. The whole-package result is now a reviewed non-regression baseline: future Quality runs fail when measured package coverage drops below 87.89%, while still reporting the exact current result.
+
+The workflow emits:
 
 ```text
 build/quality/coverage-full.json
+build/quality/coverage-truth-check.json
 ```
+
+The repository must not describe the whole package as 95% covered. The 95% statement applies only to the declared critical reliability spine.
 
 ## Typing truth
 
-The repository still has a broad `sdetkit.*` mypy suppression. A reviewed group of diagnostic, safety, trajectory, and adoption modules explicitly opts back into error checking.
+The repository still has a broad `sdetkit.*` mypy suppression. Twelve diagnostic, safety, trajectory, and adoption modules explicitly opt back into error checking.
 
-The contract lists those modules exactly. The validator fails when the configured list and recorded list drift apart.
+Fresh inventory evidence records:
 
-This is a visible migration state, not a completion claim:
+```text
+source_module_count=486
+explicitly_type_checked_module_count=12
+typing_debt_module_count=474
+```
+
+The complete debt module list is emitted to:
+
+```text
+build/quality/typing-debt-inventory.json
+```
+
+Its sorted module list is hash-bound in the contract. Adding, removing, or moving a source module changes the count or digest and requires an explicit baseline review. New production modules cannot inherit unrecorded typing debt without changing a reviewed contract.
+
+This remains a migration state, not a completion claim:
 
 ```text
 blanket_package_suppression_present=true
@@ -40,14 +60,14 @@ new_unrecorded_suppression_allowed=false
 
 ## Runtime truth
 
-The package metadata declares Python 3.10, 3.11, and 3.12. Canonical fast and smoke CI currently cover Python 3.11 and 3.12. Python 3.10 appears in the first-proof route, but full CI and exact-wheel qualification across all three versions remain release work.
+The package metadata declares Python 3.10, 3.11, and 3.12. Canonical fast and smoke CI currently cover Python 3.11 and 3.12. Python 3.10 appears in the first-proof route, but exact-wheel qualification across all three versions remains release work.
 
 ## Required next steps
 
-1. Produce a deterministic whole-package coverage artifact from the existing full scope.
-2. Review and commit a non-regression baseline rather than inventing a target.
-3. Replace the broad mypy suppression with an explicit debt inventory or narrow per-module allowlist.
-4. Add Python 3.10 to the canonical exact-wheel qualification route.
+1. Reduce the hashed 474-module typing-debt inventory through behavior-focused ratchets.
+2. Keep whole-package coverage at or above the reviewed 87.89% baseline.
+3. Keep the critical reliability spine at or above 95%.
+4. Add Python 3.10 to the exact-wheel qualification route.
 5. Update this contract only with fresh command or CI evidence.
 
 ## Safety boundary

--- a/scripts/check_coverage_truth.py
+++ b/scripts/check_coverage_truth.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _load_object(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _percentage(covered: int, statements: int) -> float:
+    return round((100.0 * covered / statements) if statements else 100.0, 2)
+
+
+def evaluate_coverage_truth(
+    coverage_path: Path,
+    contract_path: Path,
+) -> dict[str, object]:
+    coverage = _load_object(coverage_path)
+    contract = _load_object(contract_path)
+    coverage_contract = contract["coverage"]
+    critical_contract = coverage_contract["critical_spine"]
+    whole_contract = coverage_contract["whole_package"]
+
+    files = coverage.get("files")
+    totals = coverage.get("totals")
+    if not isinstance(files, dict) or not isinstance(totals, dict):
+        raise ValueError("coverage JSON is missing files or totals")
+
+    required_files = [str(item) for item in critical_contract["files"]]
+    missing_files = [path for path in required_files if path not in files]
+    critical_covered = 0
+    critical_statements = 0
+    for path in required_files:
+        entry = files.get(path)
+        if not isinstance(entry, dict):
+            continue
+        summary = entry.get("summary")
+        if not isinstance(summary, dict):
+            continue
+        critical_covered += int(summary.get("covered_lines", 0))
+        critical_statements += int(summary.get("num_statements", 0))
+
+    critical_percent = _percentage(critical_covered, critical_statements)
+    whole_percent = round(float(totals.get("percent_covered", 0.0)), 2)
+    critical_minimum = float(critical_contract["minimum_percent"])
+    baseline = whole_contract.get("current_percent")
+    baseline_reviewed = bool(whole_contract.get("blocking_threshold_reviewed"))
+    whole_non_regression = (
+        not baseline_reviewed
+        or baseline is None
+        or whole_percent >= float(baseline)
+    )
+
+    checks = {
+        "critical_files_present": not missing_files,
+        "critical_spine_meets_minimum": critical_percent >= critical_minimum,
+        "whole_package_non_regression": whole_non_regression,
+        "whole_package_measurement_present": float(totals.get("num_statements", 0)) > 0,
+    }
+    return {
+        "schema_version": "sdetkit.coverage_truth_check.v1",
+        "ok": all(checks.values()),
+        "checks": checks,
+        "critical_spine": {
+            "covered_lines": critical_covered,
+            "num_statements": critical_statements,
+            "percent": critical_percent,
+            "minimum_percent": critical_minimum,
+            "missing_files": missing_files,
+        },
+        "whole_package": {
+            "covered_lines": int(totals.get("covered_lines", 0)),
+            "num_statements": int(totals.get("num_statements", 0)),
+            "percent": whole_percent,
+            "reviewed_baseline_percent": baseline,
+            "baseline_enforced": baseline_reviewed,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate coverage truth evidence")
+    parser.add_argument("--coverage", type=Path, required=True)
+    parser.add_argument("--contract", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = evaluate_coverage_truth(args.coverage, args.contract)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, sort_keys=True))
+    return 0 if payload["ok"] is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_coverage_truth.py
+++ b/scripts/check_coverage_truth.py
@@ -51,9 +51,7 @@ def evaluate_coverage_truth(
     baseline = whole_contract.get("current_percent")
     baseline_reviewed = bool(whole_contract.get("blocking_threshold_reviewed"))
     whole_non_regression = (
-        not baseline_reviewed
-        or baseline is None
-        or whole_percent >= float(baseline)
+        not baseline_reviewed or baseline is None or whole_percent >= float(baseline)
     )
 
     checks = {

--- a/scripts/check_quality_truth_baseline.py
+++ b/scripts/check_quality_truth_baseline.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT = ROOT / "docs/contracts/quality-truth-baseline.v1.json"
+
+
+def _modules(value: object) -> set[str]:
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, list):
+        return {str(item) for item in value}
+    return set()
+
+
+def evaluate_quality_truth(root: Path, contract_path: Path) -> dict[str, object]:
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    pyproject_text = (root / "pyproject.toml").read_text(encoding="utf-8")
+    config = tomllib.loads(pyproject_text)
+    overrides = config["tool"]["mypy"]["overrides"]
+
+    blanket = False
+    checked: set[str] = set()
+    for override in overrides:
+        modules = _modules(override.get("module"))
+        if modules == {"sdetkit.*"} and override.get("ignore_errors") is True:
+            blanket = True
+        if override.get("ignore_errors") is False:
+            checked.update(name for name in modules if name.startswith("sdetkit."))
+
+    ci_text = (root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    quality_text = (root / "quality.sh").read_text(encoding="utf-8")
+    declared = sorted(set(re.findall(r"Python :: (3\.\d+)", pyproject_text)))
+    matrix_match = re.search(r"python-version:\s*\[([^\]]+)\]", ci_text)
+    matrix = sorted(set(re.findall(r'"(3\.\d+)"', matrix_match.group(1)))) if matrix_match else []
+
+    typing = contract["typing"]
+    runtime = contract["runtime"]
+    critical = contract["coverage"]["critical_spine"]
+    checks = {
+        "blanket_suppression_matches": blanket
+        is bool(typing["blanket_package_suppression_present"]),
+        "checked_modules_match": checked == set(typing["explicitly_type_checked_modules"]),
+        "declared_python_versions_match": declared == sorted(runtime["declared_python_versions"]),
+        "canonical_ci_versions_match": matrix == sorted(runtime["canonical_ci_matrix"]),
+        "critical_spine_threshold_present": f'COV_FAIL_UNDER: "{critical["minimum_percent"]}"'
+        in ci_text,
+        "whole_package_scope_exists": 'cov_scope="${COV_SCOPE:-core}"' in quality_text,
+        "authority_boundary_preserved": contract["authority_boundary"]
+        == {
+            "tests_may_be_weakened": False,
+            "quality_gates_may_be_hidden": False,
+            "unmeasured_quality_may_be_claimed": False,
+        },
+    }
+    return {
+        "schema_version": "sdetkit.quality_truth_check.v1",
+        "ok": all(checks.values()),
+        "checks": checks,
+        "observed": {
+            "blanket_package_suppression_present": blanket,
+            "explicitly_type_checked_modules": sorted(checked),
+            "declared_python_versions": declared,
+            "canonical_ci_matrix": matrix,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+    payload = evaluate_quality_truth(args.root.resolve(), args.contract.resolve())
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if payload["ok"] is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_quality_truth_baseline.py
+++ b/scripts/check_quality_truth_baseline.py
@@ -75,8 +75,7 @@ def evaluate_quality_truth(root: Path, contract_path: Path) -> dict[str, object]
         is bool(typing["blanket_package_suppression_present"]),
         "checked_modules_match": checked == set(typing["explicitly_type_checked_modules"]),
         "source_module_count_matches": len(source_modules) == int(typing["source_module_count"]),
-        "typing_debt_count_matches": len(debt_modules)
-        == int(typing["typing_debt_module_count"]),
+        "typing_debt_count_matches": len(debt_modules) == int(typing["typing_debt_module_count"]),
         "typing_debt_digest_matches": debt_digest == typing["typing_debt_inventory_sha256"],
         "declared_python_versions_match": declared == sorted(runtime["declared_python_versions"]),
         "canonical_ci_versions_match": matrix == sorted(runtime["canonical_ci_matrix"]),

--- a/scripts/check_quality_truth_baseline.py
+++ b/scripts/check_quality_truth_baseline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -22,6 +23,25 @@ def _modules(value: object) -> set[str]:
     return set()
 
 
+def _source_modules(root: Path) -> set[str]:
+    package_root = root / "src/sdetkit"
+    modules: set[str] = set()
+    for path in package_root.rglob("*.py"):
+        relative = path.relative_to(package_root).with_suffix("")
+        parts = list(relative.parts)
+        if parts[-1] == "__init__":
+            module = "sdetkit" if len(parts) == 1 else "sdetkit." + ".".join(parts[:-1])
+        else:
+            module = "sdetkit." + ".".join(parts)
+        modules.add(module)
+    return modules
+
+
+def _inventory_digest(modules: list[str]) -> str:
+    payload = ("\n".join(modules) + "\n").encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 def evaluate_quality_truth(root: Path, contract_path: Path) -> dict[str, object]:
     contract = json.loads(contract_path.read_text(encoding="utf-8"))
     pyproject_text = (root / "pyproject.toml").read_text(encoding="utf-8")
@@ -37,6 +57,10 @@ def evaluate_quality_truth(root: Path, contract_path: Path) -> dict[str, object]
         if override.get("ignore_errors") is False:
             checked.update(name for name in modules if name.startswith("sdetkit."))
 
+    source_modules = _source_modules(root)
+    debt_modules = sorted(source_modules - checked)
+    debt_digest = _inventory_digest(debt_modules)
+
     ci_text = (root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     quality_text = (root / "quality.sh").read_text(encoding="utf-8")
     declared = sorted(set(re.findall(r"Python :: (3\.\d+)", pyproject_text)))
@@ -50,6 +74,10 @@ def evaluate_quality_truth(root: Path, contract_path: Path) -> dict[str, object]
         "blanket_suppression_matches": blanket
         is bool(typing["blanket_package_suppression_present"]),
         "checked_modules_match": checked == set(typing["explicitly_type_checked_modules"]),
+        "source_module_count_matches": len(source_modules) == int(typing["source_module_count"]),
+        "typing_debt_count_matches": len(debt_modules)
+        == int(typing["typing_debt_module_count"]),
+        "typing_debt_digest_matches": debt_digest == typing["typing_debt_inventory_sha256"],
         "declared_python_versions_match": declared == sorted(runtime["declared_python_versions"]),
         "canonical_ci_versions_match": matrix == sorted(runtime["canonical_ci_matrix"]),
         "critical_spine_threshold_present": f'COV_FAIL_UNDER: "{critical["minimum_percent"]}"'
@@ -69,8 +97,17 @@ def evaluate_quality_truth(root: Path, contract_path: Path) -> dict[str, object]
         "observed": {
             "blanket_package_suppression_present": blanket,
             "explicitly_type_checked_modules": sorted(checked),
+            "source_module_count": len(source_modules),
+            "typing_debt_module_count": len(debt_modules),
+            "typing_debt_inventory_sha256": debt_digest,
             "declared_python_versions": declared,
             "canonical_ci_matrix": matrix,
+        },
+        "typing_debt_inventory": {
+            "schema_version": "sdetkit.typing_debt_inventory.v1",
+            "module_count": len(debt_modules),
+            "sha256": debt_digest,
+            "modules": debt_modules,
         },
     }
 
@@ -80,12 +117,19 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=ROOT)
     parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
     parser.add_argument("--out", type=Path)
+    parser.add_argument("--typing-debt-out", type=Path)
     args = parser.parse_args()
     payload = evaluate_quality_truth(args.root.resolve(), args.contract.resolve())
     rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(rendered, encoding="utf-8")
+    if args.typing_debt_out:
+        args.typing_debt_out.parent.mkdir(parents=True, exist_ok=True)
+        args.typing_debt_out.write_text(
+            json.dumps(payload["typing_debt_inventory"], indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     print(rendered, end="")
     return 0 if payload["ok"] is True else 1
 

--- a/tests/test_coverage_truth.py
+++ b/tests/test_coverage_truth.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-SCRIPT_PATH = ROOT / "scripts/check_coverage_truth.py"
+SCRIPT_PATH = ROOT / "scripts" / "check_coverage_truth.py"
 CONTRACT_PATH = ROOT / "docs/contracts/quality-truth-baseline.v1.json"
 
 
@@ -18,7 +18,12 @@ def _module():
     return module
 
 
-def _coverage(path: Path, *, critical_missing: int = 0, whole_percent: float = 70.0) -> None:
+def _coverage(
+    path: Path,
+    *,
+    critical_missing: int = 0,
+    whole_percent: float = 87.89,
+) -> None:
     contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
     files = {}
     for critical_path in contract["coverage"]["critical_spine"]["files"]:
@@ -34,8 +39,8 @@ def _coverage(path: Path, *, critical_missing: int = 0, whole_percent: float = 7
             {
                 "files": files,
                 "totals": {
-                    "covered_lines": 700,
-                    "num_statements": 1000,
+                    "covered_lines": 8789,
+                    "num_statements": 10000,
                     "percent_covered": whole_percent,
                 },
             }
@@ -44,7 +49,7 @@ def _coverage(path: Path, *, critical_missing: int = 0, whole_percent: float = 7
     )
 
 
-def test_coverage_truth_preserves_critical_threshold_and_records_whole_package(
+def test_coverage_truth_preserves_critical_and_whole_package_baselines(
     tmp_path: Path,
 ) -> None:
     coverage_path = tmp_path / "coverage.json"
@@ -55,8 +60,9 @@ def test_coverage_truth_preserves_critical_threshold_and_records_whole_package(
     assert payload["ok"] is True
     assert payload["critical_spine"]["percent"] == 100.0
     assert payload["critical_spine"]["minimum_percent"] == 95.0
-    assert payload["whole_package"]["percent"] == 70.0
-    assert payload["whole_package"]["baseline_enforced"] is False
+    assert payload["whole_package"]["percent"] == 87.89
+    assert payload["whole_package"]["baseline_enforced"] is True
+    assert payload["whole_package"]["reviewed_baseline_percent"] == 87.89
 
 
 def test_coverage_truth_rejects_critical_spine_regression(tmp_path: Path) -> None:
@@ -68,6 +74,16 @@ def test_coverage_truth_rejects_critical_spine_regression(tmp_path: Path) -> Non
     assert payload["ok"] is False
     assert payload["critical_spine"]["percent"] == 90.0
     assert payload["checks"]["critical_spine_meets_minimum"] is False
+
+
+def test_coverage_truth_rejects_whole_package_regression(tmp_path: Path) -> None:
+    coverage_path = tmp_path / "coverage.json"
+    _coverage(coverage_path, whole_percent=87.88)
+
+    payload = _module().evaluate_coverage_truth(coverage_path, CONTRACT_PATH)
+
+    assert payload["ok"] is False
+    assert payload["checks"]["whole_package_non_regression"] is False
 
 
 def test_coverage_truth_rejects_missing_critical_file(tmp_path: Path) -> None:

--- a/tests/test_coverage_truth.py
+++ b/tests/test_coverage_truth.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts/check_coverage_truth.py"
+CONTRACT_PATH = ROOT / "docs/contracts/quality-truth-baseline.v1.json"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("check_coverage_truth", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _coverage(path: Path, *, critical_missing: int = 0, whole_percent: float = 70.0) -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    files = {}
+    for critical_path in contract["coverage"]["critical_spine"]["files"]:
+        statements = 20
+        files[critical_path] = {
+            "summary": {
+                "covered_lines": statements - critical_missing,
+                "num_statements": statements,
+            }
+        }
+    path.write_text(
+        json.dumps(
+            {
+                "files": files,
+                "totals": {
+                    "covered_lines": 700,
+                    "num_statements": 1000,
+                    "percent_covered": whole_percent,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_coverage_truth_preserves_critical_threshold_and_records_whole_package(
+    tmp_path: Path,
+) -> None:
+    coverage_path = tmp_path / "coverage.json"
+    _coverage(coverage_path)
+
+    payload = _module().evaluate_coverage_truth(coverage_path, CONTRACT_PATH)
+
+    assert payload["ok"] is True
+    assert payload["critical_spine"]["percent"] == 100.0
+    assert payload["critical_spine"]["minimum_percent"] == 95.0
+    assert payload["whole_package"]["percent"] == 70.0
+    assert payload["whole_package"]["baseline_enforced"] is False
+
+
+def test_coverage_truth_rejects_critical_spine_regression(tmp_path: Path) -> None:
+    coverage_path = tmp_path / "coverage.json"
+    _coverage(coverage_path, critical_missing=2)
+
+    payload = _module().evaluate_coverage_truth(coverage_path, CONTRACT_PATH)
+
+    assert payload["ok"] is False
+    assert payload["critical_spine"]["percent"] == 90.0
+    assert payload["checks"]["critical_spine_meets_minimum"] is False
+
+
+def test_coverage_truth_rejects_missing_critical_file(tmp_path: Path) -> None:
+    coverage_path = tmp_path / "coverage.json"
+    _coverage(coverage_path)
+    coverage = json.loads(coverage_path.read_text(encoding="utf-8"))
+    removed = next(iter(coverage["files"]))
+    coverage["files"].pop(removed)
+    coverage_path.write_text(json.dumps(coverage), encoding="utf-8")
+
+    payload = _module().evaluate_coverage_truth(coverage_path, CONTRACT_PATH)
+
+    assert payload["ok"] is False
+    assert payload["critical_spine"]["missing_files"] == [removed]
+    assert payload["checks"]["critical_files_present"] is False

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "check_quality_truth_baseline.py"
+CONTRACT_PATH = ROOT / "docs" / "contracts" / "quality-truth-baseline.v1.json"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("check_quality_truth_baseline", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_quality_truth_baseline_matches_current_repository_configuration() -> None:
+    module = _load_script()
+    payload = module.evaluate_quality_truth(ROOT, CONTRACT_PATH)
+
+    assert payload["ok"] is True
+    assert all(payload["checks"].values())
+
+
+def test_quality_truth_baseline_keeps_unfinished_migrations_visible() -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    assert contract["status"] == "staged_migration_visible"
+    assert contract["typing"]["blanket_package_suppression_present"] is True
+    assert contract["typing"]["migration_complete"] is False
+    assert contract["coverage"]["whole_package"]["measurement_required"] is True
+    assert contract["coverage"]["whole_package"]["blocking_threshold_reviewed"] is False
+    assert contract["runtime"]["python_310_full_ci_proven"] is False
+
+
+def test_quality_truth_baseline_denies_false_green_shortcuts() -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    assert contract["authority_boundary"] == {
+        "tests_may_be_weakened": False,
+        "quality_gates_may_be_hidden": False,
+        "unmeasured_quality_may_be_claimed": False,
+    }

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,6 +24,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True
     assert all(payload["checks"].values())
+    assert payload["observed"]["source_module_count"] == 486
+    assert payload["observed"]["typing_debt_module_count"] == 474
+    assert payload["typing_debt_inventory"]["module_count"] == 474
+    assert len(payload["typing_debt_inventory"]["modules"]) == 474
 
 
 def test_quality_truth_baseline_keeps_unfinished_migrations_visible() -> None:
@@ -32,8 +36,11 @@ def test_quality_truth_baseline_keeps_unfinished_migrations_visible() -> None:
     assert contract["status"] == "staged_migration_visible"
     assert contract["typing"]["blanket_package_suppression_present"] is True
     assert contract["typing"]["migration_complete"] is False
+    assert contract["typing"]["new_unrecorded_suppression_allowed"] is False
     assert contract["coverage"]["whole_package"]["measurement_required"] is True
-    assert contract["coverage"]["whole_package"]["blocking_threshold_reviewed"] is False
+    assert contract["coverage"]["whole_package"]["blocking_threshold_reviewed"] is True
+    assert contract["coverage"]["whole_package"]["current_percent"] == 87.89
+    assert contract["coverage"]["critical_spine"]["observed_percent"] == 96.69
     assert contract["runtime"]["python_310_full_ci_proven"] is False
 
 


### PR DESCRIPTION
## Summary
- add a machine-readable quality-truth contract for coverage, typing debt, and runtime support
- measure whole-package coverage in the Quality workflow while independently preserving the 95% critical reliability-spine gate
- ratify an 87.89% whole-package non-regression baseline from 66,030 measured statements
- record a 96.69% critical-spine result across 966 statements
- generate and hash-bind a 474-module typing-debt inventory so new source modules cannot inherit invisible mypy debt
- retain pre-commit logs and generated diffs when Quality fails
- document what is proven, what remains incomplete, and the exact evidence artifacts

## Why
The repository had strong critical-path gates but no honest whole-package coverage floor and a broad mypy suppression whose debt could grow silently. This PR turns both into explicit, machine-readable, non-regressing contracts without claiming the typing migration is complete.

## Verified quality truth
- critical-spine minimum: 95%
- critical-spine measured: 96.69% across 966 statements
- whole-package measured and enforced floor: 87.89% across 66,030 statements
- source modules: 486
- explicitly type-checked modules: 12
- hash-bound typing-debt modules: 474
- Python 3.10 remains declared but exact-wheel release qualification is intentionally deferred to the release-readiness PR

## Evidence artifacts
- `build/quality/coverage-full.json`
- `build/quality/coverage-truth-check.json`
- `build/quality/quality-truth-check.json`
- `build/quality/typing-debt-inventory.json`
- `build/quality/pre-commit.log`
- `build/quality/pre-commit.diff`

## Verification
- `python -m pytest -q tests/test_quality_truth_baseline.py tests/test_coverage_truth.py -o addopts=`
- `python scripts/check_quality_truth_baseline.py --out build/quality/quality-truth-check.json --typing-debt-out build/quality/typing-debt-inventory.json`
- Quality workflow at exact head `f591412bd2b3f86522fb126f71b318a33ea99dfa`
- full canonical CI, package build and wheel smoke installs, strict docs, security, first-proof, premium gate, workflow governance, and advanced Linux/macOS matrix

## Risk
- Medium: workflow and quality-gate behavior
- no weakening of the existing critical-spine threshold
- no public CLI or runtime behavior change
- rollback: revert the Quality workflow, validators, contract, docs, and focused tests

## Remaining follow-up
- reduce the recorded typing-debt inventory through narrow ratchets
- qualify Python 3.10 through the exact-wheel release route
