### PR TITLE
ci: begin workflow consolidation with zero-signal issue policy

### DIFF
--- a/.github/workflows/ghas-campaign-bot.yml
+++ b/.github/workflows/ghas-campaign-bot.yml
@@ -49,6 +49,7 @@ jobs:
             };
 
             const notes = [];
+            const alertFetchFailures = [];
             const dayMs = 24 * 60 * 60 * 1000;
 
             async function fetchAlerts(path, label) {
@@ -62,7 +63,9 @@ jobs:
                 });
                 return Array.isArray(response.data) ? response.data : [];
               } catch (error) {
-                notes.push(`${label} unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`);
+                const message = `${label} unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`;
+                notes.push(message);
+                alertFetchFailures.push(message);
                 return [];
               }
             }
@@ -199,6 +202,18 @@ jobs:
               per_page: 100,
             });
             const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🧭 GHAS campaign planner'));
+            const actionableFindings = codeAlerts.length > 0
+              || secretAlerts.length > 0
+              || codeSummary.autofixHints > 0
+              || secretSummary.bypassed > 0;
+
+            if (!actionableFindings && alertFetchFailures.length === 0) {
+              for (const oldIssue of priorIssues) {
+                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
+              }
+              core.notice('GHAS campaign planner: no actionable open alerts; no issue created.');
+              return;
+            }
 
             for (const oldIssue of priorIssues) {
               if (oldIssue.title !== title) {

--- a/.github/workflows/ghas-campaign-bot.yml
+++ b/.github/workflows/ghas-campaign-bot.yml
@@ -26,6 +26,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const weekOf = new Date().toISOString().slice(0, 10);
+            const generatedBodyMarker = 'This issue is auto-generated to turn open GHAS alerts into actionable remediation campaigns.';
             const labels = [
               { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
               { name: 'security', color: 'b60205', description: 'Security operations and hardening work' },
@@ -61,7 +62,10 @@ jobs:
                   per_page: 100,
                   headers,
                 });
-                return Array.isArray(response.data) ? response.data : [];
+                if (!Array.isArray(response.data)) {
+                  throw new Error('unexpected non-array response');
+                }
+                return response.data;
               } catch (error) {
                 const message = `${label} unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`;
                 notes.push(message);
@@ -146,7 +150,7 @@ jobs:
             const ageOrder = ['0-6d', '7-13d', '14-29d', '30+d', 'unknown'];
 
             const body = [
-              'This issue is auto-generated to turn open GHAS alerts into actionable remediation campaigns.',
+              generatedBodyMarker,
               '',
               '## Why this exists',
               '- GitHub security campaigns help teams burn down alert backlogs in focused slices.',
@@ -201,7 +205,10 @@ jobs:
               labels: 'ghas',
               per_page: 100,
             });
-            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🧭 GHAS campaign planner'));
+            const priorIssues = openIssues.data.filter(
+              (issue) => issue.title.startsWith('🧭 GHAS campaign planner')
+                && issue.body?.startsWith(generatedBodyMarker),
+            );
             const actionableFindings = codeAlerts.length > 0
               || secretAlerts.length > 0
               || codeSummary.autofixHints > 0

--- a/docs/contracts/workflow-consolidation-plan.v1.json
+++ b/docs/contracts/workflow-consolidation-plan.v1.json
@@ -1,7 +1,7 @@
 {
   "plan_id": "sdetkit.workflow-consolidation.v1",
-  "generated_at_utc": "2026-04-16T00:00:00Z",
-  "current_workflow_count": 43,
+  "generated_at_utc": "2026-06-30T00:00:00Z",
+  "current_workflow_count": 56,
   "target_primary_workflow_count": 12,
   "keep_primary": [
     "ci.yml",
@@ -60,6 +60,19 @@
     "kpi-weekly.yml",
     "release-readiness-radar-bot.yml"
   ],
+  "execution_order": [
+    "record_current_topology_and_required_checks",
+    "stop_zero_signal_issue_creation",
+    "consume_canonical_ci_artifacts",
+    "introduce_reusable_workflow_bundles",
+    "retire_only_with_parity_evidence"
+  ],
+  "zero_signal_issue_policy": {
+    "create_issue_when_actionable_finding_count_is_zero": false,
+    "close_existing_tracker_when_findings_reach_zero": true,
+    "preserve_issue_when_source_evidence_is_unavailable": true,
+    "first_enforced_workflow": "ghas-campaign-bot.yml"
+  },
   "phases": [
     "phase1_baseline_and_parity",
     "phase2_bundle_introduction",
@@ -72,6 +85,8 @@
     "max_primary_workflows": 12,
     "duplicate_trigger_reduction_percent": 50,
     "ci_minutes_reduction_percent": 20,
-    "no_coverage_regression": true
+    "no_coverage_regression": true,
+    "zero_signal_generated_issues": 0,
+    "required_check_compatibility_preserved": true
   }
 }

--- a/tests/test_ghas_campaign_zero_signal_policy.py
+++ b/tests/test_ghas_campaign_zero_signal_policy.py
@@ -25,8 +25,19 @@ def test_ghas_campaign_does_not_create_zero_signal_issue() -> None:
 def test_ghas_campaign_preserves_unknown_evidence_for_review() -> None:
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
 
+    assert "if (!Array.isArray(response.data))" in workflow
+    assert "unexpected non-array response" in workflow
     assert "alertFetchFailures.push(message);" in workflow
     assert "alertFetchFailures.length === 0" in workflow
+
+
+def test_ghas_campaign_only_closes_workflow_managed_trackers() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "const generatedBodyMarker =" in workflow
+    assert "issue.title.startsWith('🧭 GHAS campaign planner')" in workflow
+    assert "issue.body?.startsWith(generatedBodyMarker)" in workflow
+    assert "const priorIssues = openIssues.data.filter(" in workflow
 
 
 def test_workflow_consolidation_contract_tracks_current_topology_and_policy() -> None:

--- a/tests/test_ghas_campaign_zero_signal_policy.py
+++ b/tests/test_ghas_campaign_zero_signal_policy.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "ghas-campaign-bot.yml"
+PLAN_PATH = ROOT / "docs" / "contracts" / "workflow-consolidation-plan.v1.json"
+
+
+def test_ghas_campaign_does_not_create_zero_signal_issue() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    guard = "if (!actionableFindings && alertFetchFailures.length === 0)"
+    notice = "no actionable open alerts; no issue created"
+    create_call = "await github.rest.issues.create({"
+
+    assert "const alertFetchFailures = [];" in workflow
+    assert guard in workflow
+    assert notice in workflow
+    assert workflow.index(guard) < workflow.rindex(create_call)
+    assert "return;" in workflow[workflow.index(guard) : workflow.rindex(create_call)]
+
+
+def test_ghas_campaign_preserves_unknown_evidence_for_review() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "alertFetchFailures.push(message);" in workflow
+    assert "alertFetchFailures.length === 0" in workflow
+
+
+def test_workflow_consolidation_contract_tracks_current_topology_and_policy() -> None:
+    plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+
+    assert plan["current_workflow_count"] == 56
+    assert plan["target_primary_workflow_count"] == 12
+    assert len(plan["keep_primary"]) == 12
+    assert plan["zero_signal_issue_policy"] == {
+        "create_issue_when_actionable_finding_count_is_zero": False,
+        "close_existing_tracker_when_findings_reach_zero": True,
+        "preserve_issue_when_source_evidence_is_unavailable": True,
+        "first_enforced_workflow": "ghas-campaign-bot.yml",
+    }
+    assert plan["success_targets"]["zero_signal_generated_issues"] == 0
+    assert plan["success_targets"]["required_check_compatibility_preserved"] is True


### PR DESCRIPTION
## Summary
- refresh the workflow-consolidation contract from the stale 43-workflow snapshot to the current 56-workflow topology
- define the evidence-first execution order for future consolidation
- add a zero-signal generated-issue policy
- enforce the first narrow policy slice in `ghas-campaign-bot.yml`
- close prior generated campaign trackers and skip new issue creation when alert APIs succeed and return no actionable findings
- preserve review visibility when code-scanning or secret-scanning evidence cannot be retrieved
- add focused workflow-policy regression tests

## Why
The scheduled GHAS campaign workflow can create recurring tracker issues even when successful alert queries return no findings. That creates operator noise without improving security posture. The narrow fix suppresses only proven zero-signal output and still creates a review-visible issue when source evidence is unavailable.

## Verification
- `python -m pytest -q tests/test_ghas_campaign_zero_signal_policy.py -o addopts=`
- `python scripts/check_workflow_contracts.py --root . --topology-contract docs/contracts/workflow-topology.v1.json --required-checks-contract docs/contracts/required-checks.v1.json`
- `python -m pre_commit run -a`
- affected workflow, security, governance, and full repository CI

## Risk
- Medium: scheduled issue-management behavior
- no security finding is dismissed, modified, or automatically remediated
- no required check or workflow is retired
- unavailable alert evidence remains review-first
- rollback: revert the workflow guard, contract additions, and focused test

## Rebase status
Rebuilt directly on merged `main` commit `c996a2b4a6d282e998e3237eb030601ab81d3075`; stale stacked commits were removed.

## Follow-up
This is the first workflow-control slice only. Reusable bundles and workflow retirement remain separate work and require parity evidence before any deletion or required-check change.
