### PR TITLE
product: consolidate first-run operator discovery

### DIFF
--- a/src/sdetkit/public_command_surface.json
+++ b/src/sdetkit/public_command_surface.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 1,
+  "contract_version": 2,
   "primary_outcome": "know if a change is ready to ship",
   "canonical_first_path": [
     "python -m sdetkit gate fast",
@@ -38,5 +38,38 @@
     "Public / stable",
     "Advanced but supported",
     "Experimental / incubator"
+  ],
+  "root_help_contract": {
+    "detailed_family_inventory": false,
+    "show_canonical_path": true,
+    "show_policy_tiers": true,
+    "show_compatibility_namespace": true,
+    "advanced_inventory_command": "python -m sdetkit kits list",
+    "experimental_inventory_location": "docs/command-surface.md"
+  },
+  "primary_make_targets": [
+    "install",
+    "merge-ready",
+    "first-proof",
+    "package-validate",
+    "release-preflight"
+  ],
+  "primary_documentation_journeys": [
+    {
+      "id": "install_and_decide",
+      "entry": "docs/start-here-5-minutes.md"
+    },
+    {
+      "id": "investigate_failure",
+      "entry": "docs/investigation-operator-guide.md"
+    },
+    {
+      "id": "adopt_ci",
+      "entry": "docs/recommended-ci-flow.md"
+    },
+    {
+      "id": "reference",
+      "entry": "docs/cli.md"
+    }
   ]
 }

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -101,53 +101,57 @@ def load_public_command_surface_contract() -> dict[str, object]:
     return cast(dict[str, object], loaded)
 
 
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
 def render_root_help_groups() -> str:
-    """Render concise command-family guidance for root CLI help text."""
+    """Render a concise, stability-aware root-help journey.
+
+    The complete command-family inventory remains available in the command-surface
+    documentation and machine-readable contract. Root help intentionally avoids
+    repeating every advanced or transition-era lane.
+    """
+
     contract = load_public_command_surface_contract()
-    canonical_obj = contract.get(
-        "canonical_first_path",
-        [
-            "python -m sdetkit gate fast",
-            "python -m sdetkit gate release",
-            "python -m sdetkit doctor",
-        ],
+    canonical = _string_list(contract.get("canonical_first_path"))
+    next_step = str(
+        contract.get("advanced_supported_next_step", "python -m sdetkit kits list")
     )
-    canonical = canonical_obj if isinstance(canonical_obj, list) else []
-    next_step = contract.get("advanced_supported_next_step", "python -m sdetkit kits list")
-    tier_a = contract.get("tier_a_contract_commands", [])
-    tier_b = contract.get("tier_b_contract_commands", [])
-    best_effort = contract.get("best_effort_compatibility_commands", [])
+    tier_a = _string_list(contract.get("tier_a_contract_commands"))
+    tier_b = _string_list(contract.get("tier_b_contract_commands"))
+    compatibility = _string_list(contract.get("best_effort_compatibility_commands"))
+
     canonical_summary = " -> ".join(
-        cmd.replace("python -m sdetkit ", "") if isinstance(cmd, str) else str(cmd)
-        for cmd in canonical
+        command.replace("python -m sdetkit ", "") for command in canonical
     )
-    lines = [
-        "Command discovery (stability-aware):",
-        "",
-        "  Canonical first-time path (public / stable):",
-        f"    {canonical_summary}",
-        "",
-        "  Frozen command contracts:",
-        f"    Tier A (public/stable): {', '.join(tier_a) if isinstance(tier_a, list) else ''}",
-        f"    Tier B (advanced/supported): {', '.join(tier_b) if isinstance(tier_b, list) else ''}",
-        "    Remaining lanes: best-effort compatibility (subject to change).",
-        (
-            f"      {', '.join(best_effort)}"
-            if isinstance(best_effort, list)
-            else "      legacy compatibility lanes"
-        ),
-        "",
-        "  Then expand deliberately:",
-    ]
-    for family in PUBLIC_SURFACE_CONTRACT:
-        name = family.name.replace("-", " ")
-        lines.append(
-            f"  {name} [{family.stability_tier}]"
-            f" (use first: {'yes' if family.first_time_recommended else 'no'};"
-            f" transition-era: {'yes' if family.transition_legacy_oriented else 'no'}):"
-        )
-        lines.append(f"    {family.role}")
-        lines.append(f"    {', '.join(family.top_level_commands)}")
-        lines.append("")
-    lines.append(f"Next step (advanced but supported): {next_step}")
-    return "\n".join(lines)
+    canonical_commands = " | ".join(canonical)
+
+    return "\n".join(
+        [
+            "Command discovery (stability-aware):",
+            "",
+            "  release confidence canonical path [Public / stable] (use first: yes; transition-era: no):",
+            "    Know if a change is ready to ship.",
+            f"    {canonical_summary}",
+            f"    {canonical_commands}",
+            "",
+            "  Frozen command contracts:",
+            f"    Tier A (public/stable): {', '.join(tier_a)}",
+            f"    Tier B (advanced/supported): {', '.join(tier_b)}",
+            "",
+            "  umbrella kits [Advanced but supported] (use first: no; transition-era: no):",
+            f"    Continue with: {next_step}",
+            "",
+            "  Experimental / incubator:",
+            "    Hidden from the first-run journey; see docs/command-surface.md.",
+            "",
+            "  Compatibility namespace:",
+            f"    {', '.join(compatibility)}",
+            "    Existing aliases remain available; new users should stay on the canonical path.",
+            "",
+            f"Next step (advanced but supported): {next_step}",
+        ]
+    )

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -117,9 +117,7 @@ def render_root_help_groups() -> str:
 
     contract = load_public_command_surface_contract()
     canonical = _string_list(contract.get("canonical_first_path"))
-    next_step = str(
-        contract.get("advanced_supported_next_step", "python -m sdetkit kits list")
-    )
+    next_step = str(contract.get("advanced_supported_next_step", "python -m sdetkit kits list"))
     tier_a = _string_list(contract.get("tier_a_contract_commands"))
     tier_b = _string_list(contract.get("tier_b_contract_commands"))
     compatibility = _string_list(contract.get("best_effort_compatibility_commands"))

--- a/tests/test_operator_surface_consolidation.py
+++ b/tests/test_operator_surface_consolidation.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.public_surface_contract import render_root_help_groups
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "src" / "sdetkit" / "public_command_surface.json"
+
+
+def test_root_help_keeps_canonical_path_and_hides_detailed_inventory() -> None:
+    rendered = render_root_help_groups()
+
+    assert "gate fast -> gate release -> doctor" in rendered
+    assert "python -m sdetkit gate fast" in rendered
+    assert "python -m sdetkit gate release" in rendered
+    assert "python -m sdetkit doctor" in rendered
+    assert "umbrella kits [Advanced but supported]" in rendered
+    assert "Experimental / incubator" in rendered
+    assert "legacy" in rendered
+    assert "supporting utilities and automation [" not in rendered
+    assert "weekly-review" not in rendered
+    assert "first-contribution" not in rendered
+    assert "demo" not in rendered
+
+
+def test_public_command_surface_declares_small_first_run_contract() -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    assert contract["contract_version"] == 2
+    assert contract["public_stable_front_door_commands"] == ["gate", "doctor", "release"]
+    assert len(contract["canonical_first_path"]) == 3
+    assert contract["root_help_contract"] == {
+        "detailed_family_inventory": False,
+        "show_canonical_path": True,
+        "show_policy_tiers": True,
+        "show_compatibility_namespace": True,
+        "advanced_inventory_command": "python -m sdetkit kits list",
+        "experimental_inventory_location": "docs/command-surface.md",
+    }
+
+
+def test_public_command_surface_limits_primary_make_and_docs_journeys() -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    assert contract["primary_make_targets"] == [
+        "install",
+        "merge-ready",
+        "first-proof",
+        "package-validate",
+        "release-preflight",
+    ]
+    journeys = contract["primary_documentation_journeys"]
+    assert [journey["id"] for journey in journeys] == [
+        "install_and_decide",
+        "investigate_failure",
+        "adopt_ci",
+        "reference",
+    ]
+    assert all((ROOT / journey["entry"]).is_file() for journey in journeys)

--- a/tests/test_public_surface_alignment.py
+++ b/tests/test_public_surface_alignment.py
@@ -36,7 +36,7 @@ def test_public_surface_alignment_script_passes() -> None:
 def test_public_command_surface_contract_is_machine_readable_and_stable() -> None:
     contract = load_public_command_surface_contract()
     assert contract == json.loads(PUBLIC_COMMAND_CONTRACT.read_text(encoding="utf-8"))
-    assert contract["contract_version"] == 1
+    assert contract["contract_version"] == 2
     assert contract["canonical_first_path"] == [
         "python -m sdetkit gate fast",
         "python -m sdetkit gate release",
@@ -47,6 +47,8 @@ def test_public_command_surface_contract_is_machine_readable_and_stable() -> Non
     assert contract["tier_a_contract_commands"] == ["gate", "doctor", "release"]
     assert "kits" in contract["tier_b_contract_commands"]
     assert "legacy" in contract["best_effort_compatibility_commands"]
+    assert contract["root_help_contract"]["detailed_family_inventory"] is False
+    assert len(contract["primary_documentation_journeys"]) == 4
 
 
 def test_root_help_groups_include_machine_readable_contract_commands() -> None:
@@ -56,7 +58,8 @@ def test_root_help_groups_include_machine_readable_contract_commands() -> None:
         assert command in help_groups
     assert "gate fast -> gate release -> doctor" in help_groups
     assert "Tier A (public/stable): gate, doctor, release" in help_groups
-    assert "Remaining lanes: best-effort compatibility" in help_groups
+    assert "Compatibility namespace:" in help_groups
+    assert "Existing aliases remain available" in help_groups
     assert contract["advanced_supported_next_step"] in help_groups
 
 


### PR DESCRIPTION
## Summary
- upgrade the machine-readable public command surface to contract version 2
- keep `gate`, `doctor`, and `release` as the only stable first-run front doors
- define five primary Make targets and four primary documentation journeys
- make root help concise instead of enumerating every advanced, supporting, playbook, and transition-era family
- preserve the advanced `kits list` route, policy-tier vocabulary, compatibility namespace, and every existing command implementation
- add focused contract tests for the smaller discovery surface

## Why
The CLI exposes a large compatible command inventory, but root help should lead new operators through one release-confidence journey. Existing users still retain aliases, advanced commands, and the detailed command-surface documentation.

## Verification
- `python -m pytest -q tests/test_operator_surface_consolidation.py tests/test_cli_help_discoverability_contract.py tests/test_public_surface_alignment.py -o addopts=`
- `python scripts/check_public_surface_alignment.py`
- `python -m pre_commit run -a`
- full CLI, docs, package, and repository CI

## Risk
- Medium-low: root-help rendering and machine-readable discovery contract
- no command deletion or rename
- no alias removal
- no parser or command-execution change
- rollback: revert the contract, help renderer, and focused tests

## Rebase status
Rebuilt independently on merged `main` commit `c996a2b4a6d282e998e3237eb030601ab81d3075`; stale stacked commits were removed.

## Follow-up
Physical Makefile and MkDocs navigation reduction remains separate work. This PR changes discovery guidance only and preserves compatibility.
