### PR TITLE
feature: add JavaScript and Go failure-vector adapters

### DIFF
--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "sdetkit.quality_truth_baseline.v1",
-  "generated_on": "2026-06-29",
+  "generated_on": "2026-06-30",
   "status": "staged_migration_visible",
   "coverage": {
     "critical_spine": {
@@ -35,7 +35,7 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 486,
+    "source_module_count": 487,
     "typing_debt_module_count": 474,
     "typing_debt_inventory_sha256": "38e949d397eadffa94385375663b6ff2e9fc6ffe3cbdbac91ea5143565c01ad6",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
@@ -50,6 +50,7 @@
       "sdetkit.diagnostic_job",
       "sdetkit.diagnostic_worker_trajectory",
       "sdetkit.failure_vector",
+      "sdetkit.failure_vector_adapters",
       "sdetkit.safety_gate",
       "sdetkit.trajectory_store"
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,10 @@ module = [
 ignore_errors = false
 
 [[tool.mypy.overrides]]
+module = "sdetkit.failure_vector_adapters"
+ignore_errors = false
+
+[[tool.mypy.overrides]]
 module = [
   "sdetkit.diagnostic_execution_plan",
   "sdetkit.trajectory_store",

--- a/src/sdetkit/failure_vector_adapters.py
+++ b/src/sdetkit/failure_vector_adapters.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from sdetkit.failure_vector import FailureVector, extract_failure_vector
+
+TS_ERROR = re.compile(r"(?P<path>[\w./-]+\.(?:ts|tsx|js|jsx))\(\d+,\d+\): error (?P<check>TS\d+):")
+JS_LOCATION = re.compile(r"(?P<path>[\w./-]+\.(?:ts|tsx|js|jsx)):\d+:\d+\s+error\s+(?P<check>.+)")
+JS_TEST = re.compile(
+    r"^(?:FAIL|❯)\s+(?P<path>[\w./-]+\.(?:test|spec)\.(?:ts|tsx|js|jsx))",
+    re.MULTILINE,
+)
+GO_LOCATION = re.compile(r"(?P<path>[\w./-]+\.go):\d+(?::\d+)?:\s*(?P<check>.+)")
+GO_TEST = re.compile(r"---\s+FAIL:\s+(?P<check>[\w./-]+)")
+COMMAND = re.compile(r"^(?:Run|\$)\s+(?P<command>.+)$", re.MULTILINE)
+EXIT_CODE = re.compile(r"Process completed with exit code (?P<code>\d+)")
+SUPPORTED = frozenset({"auto", "python", "javascript_typescript", "go"})
+
+
+@dataclass(frozen=True)
+class FailureVectorAdapterResult:
+    vector: FailureVector
+    ecosystem: str
+    tool: str
+    confidence: str
+    uncertainty: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        payload = self.vector.to_dict()
+        payload["adapter"] = {
+            "ecosystem": self.ecosystem,
+            "tool": self.tool,
+            "confidence": self.confidence,
+            "uncertainty": list(self.uncertainty),
+            "target_code_execution": False,
+        }
+        return payload
+
+
+def extract_ecosystem_failure_vector(
+    log_text: str,
+    *,
+    ecosystem: str = "auto",
+    check: str = "unknown",
+    log_url: str | None = None,
+    environment: str = "unknown",
+) -> FailureVectorAdapterResult:
+    """Extract advisory evidence without executing target-repository commands."""
+
+    if ecosystem not in SUPPORTED:
+        raise ValueError(f"unsupported ecosystem: {ecosystem}")
+    selected = _detect(log_text) if ecosystem == "auto" else ecosystem
+    if selected == "python":
+        vector = extract_failure_vector(
+            log_text,
+            check=check,
+            log_url=log_url,
+            environment=environment,
+        )
+        known = vector.failure_class != "unknown"
+        return FailureVectorAdapterResult(
+            vector=vector,
+            ecosystem="python",
+            tool={"test": "pytest", "type": "mypy", "lint": "ruff"}.get(
+                vector.failure_class, "unknown"
+            ),
+            confidence="high" if known else "low",
+            uncertainty=() if known else ("python_tool_not_identified",),
+        )
+    if selected == "javascript_typescript":
+        return _javascript_result(log_text, check, log_url, environment)
+    if selected == "go":
+        return _go_result(log_text, check, log_url, environment)
+    return _unknown(log_text, "unknown", check, log_url, environment, "ecosystem_not_identified")
+
+
+def _detect(log_text: str) -> str:
+    lower = log_text.lower()
+    if TS_ERROR.search(log_text) or JS_LOCATION.search(log_text) or JS_TEST.search(log_text):
+        return "javascript_typescript"
+    if any(token in lower for token in ("jest", "vitest", "eslint", "tsc --noemit")):
+        return "javascript_typescript"
+    if GO_LOCATION.search(log_text) or GO_TEST.search(log_text):
+        return "go"
+    if any(token in lower for token in ("go test", "go vet")):
+        return "go"
+    if any(token in lower for token in ("pytest", "mypy", "ruff", ".py:")):
+        return "python"
+    return "unknown"
+
+
+def _javascript_result(
+    log_text: str,
+    check: str,
+    log_url: str | None,
+    environment: str,
+) -> FailureVectorAdapterResult:
+    lower = log_text.lower()
+    match = TS_ERROR.search(log_text)
+    if match:
+        return _result(
+            log_text, check, log_url, environment, match, "type", "typescript", "npx tsc --noEmit"
+        )
+    match = JS_LOCATION.search(log_text)
+    if match:
+        return _result(
+            log_text, check, log_url, environment, match, "lint", "eslint", "npx eslint ."
+        )
+    match = JS_TEST.search(log_text)
+    if match or "assertionerror" in lower or "test failed" in lower:
+        tool = "vitest" if "vitest" in lower else "jest" if "jest" in lower else "node_test"
+        return _result(log_text, check, log_url, environment, match, "test", tool, "npm test")
+    return _unknown(
+        log_text,
+        "javascript_typescript",
+        check,
+        log_url,
+        environment,
+        "javascript_failure_not_classified",
+    )
+
+
+def _go_result(
+    log_text: str,
+    check: str,
+    log_url: str | None,
+    environment: str,
+) -> FailureVectorAdapterResult:
+    lower = log_text.lower()
+    location = GO_LOCATION.search(log_text)
+    if "go vet" in lower and location:
+        return _result(
+            log_text, check, log_url, environment, location, "lint", "go_vet", "go vet ./..."
+        )
+    test = GO_TEST.search(log_text)
+    if test or "go test" in lower or "--- fail:" in lower:
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location or test,
+            "test",
+            "go_test",
+            "go test ./...",
+        )
+    if location:
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location,
+            "unknown",
+            "go_toolchain",
+            "go test ./...",
+            ("go_failure_class_not_proven",),
+        )
+    return _unknown(log_text, "go", check, log_url, environment, "go_failure_not_classified")
+
+
+def _result(
+    log_text: str,
+    check: str,
+    log_url: str | None,
+    environment: str,
+    match: re.Match[str] | None,
+    failure_class: str,
+    tool: str,
+    repro: str,
+    uncertainty: tuple[str, ...] = (),
+) -> FailureVectorAdapterResult:
+    path = match.groupdict().get("path", "") if match else ""
+    detail = match.groupdict().get("check", "") if match else ""
+    line = match.group(0).strip() if match else _first_failure_line(log_text)
+    command_match = COMMAND.search(log_text)
+    exit_match = EXIT_CODE.search(log_text)
+    command = command_match.group("command").strip() if command_match else repro
+    vector = FailureVector(
+        check=check,
+        command=command,
+        exit_code=int(exit_match.group("code")) if exit_match else None,
+        failure_class=failure_class,
+        risk="high" if failure_class == "unknown" else "medium",
+        scope="unknown",
+        reproducible_locally="not_run",
+        safe_fix_candidate=False,
+        first_failing_line=line,
+        affected_files=(path,) if path else (),
+        log_url=log_url,
+        local_repro_command=repro,
+        environment=environment,
+        headline_signal=f"{check}: {failure_class}",
+        actual_failure=line,
+        failure_type=failure_class,
+        failing_command=command,
+        failing_test_or_check=detail or check,
+        owner_hint=path or check,
+        safe_fix_allowed=False,
+    )
+    return FailureVectorAdapterResult(
+        vector=vector,
+        ecosystem="go" if tool.startswith("go_") else "javascript_typescript",
+        tool=tool,
+        confidence="medium" if uncertainty else "high",
+        uncertainty=uncertainty,
+    )
+
+
+def _unknown(
+    log_text: str,
+    ecosystem: str,
+    check: str,
+    log_url: str | None,
+    environment: str,
+    uncertainty: str,
+) -> FailureVectorAdapterResult:
+    vector = extract_failure_vector(
+        log_text,
+        check=check,
+        log_url=log_url,
+        environment=environment,
+    )
+    return FailureVectorAdapterResult(vector, ecosystem, "unknown", "low", (uncertainty,))
+
+
+def _first_failure_line(log_text: str) -> str:
+    lines = [line.strip() for line in log_text.splitlines() if line.strip()]
+    for line in lines:
+        if any(token in line for token in ("FAIL", "AssertionError", "panic:")):
+            return line
+    return lines[0] if lines else "unknown failure"

--- a/tests/fixtures/ci_failures/eslint/ci_log.txt
+++ b/tests/fixtures/ci_failures/eslint/ci_log.txt
@@ -1,0 +1,3 @@
+$ npx eslint .
+src/util.ts:8:5 error 'result' is assigned a value but never used no-unused-vars
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/go_test/ci_log.txt
+++ b/tests/fixtures/ci_failures/go_test/ci_log.txt
@@ -1,0 +1,5 @@
+Run go test ./...
+--- FAIL: TestTotal (0.00s)
+    calculator/calculator_test.go:18: expected 4, got 3
+FAIL	example.com/project/calculator	0.003s
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/go_vet/ci_log.txt
+++ b/tests/fixtures/ci_failures/go_vet/ci_log.txt
@@ -1,0 +1,3 @@
+$ go vet ./...
+internal/logging/logging.go:27:2: fmt.Printf call has arguments but no formatting directives
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/jest/ci_log.txt
+++ b/tests/fixtures/ci_failures/jest/ci_log.txt
@@ -1,0 +1,8 @@
+Run npm test
+> jest --runInBand
+FAIL src/math.test.ts
+  add
+    ✕ returns the expected total (5 ms)
+
+AssertionError: expected 3 to be 4
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/typescript_tsc/ci_log.txt
+++ b/tests/fixtures/ci_failures/typescript_tsc/ci_log.txt
@@ -1,0 +1,3 @@
+Run npx tsc --noEmit
+src/app.ts(14,7): error TS2322: Type 'string' is not assignable to type 'number'.
+Process completed with exit code 2

--- a/tests/test_cross_ecosystem_failure_vector_adapters.py
+++ b/tests/test_cross_ecosystem_failure_vector_adapters.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sdetkit.failure_vector_adapters import extract_ecosystem_failure_vector
+from sdetkit.safety_gate import evaluate_failure_vector
+
+FIXTURES = Path(__file__).parent / "fixtures" / "ci_failures"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name / "ci_log.txt").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("fixture", "tool", "failure_class", "affected_file", "repro", "exit_code"),
+    [
+        ("typescript_tsc", "typescript", "type", "src/app.ts", "npx tsc --noEmit", 2),
+        ("eslint", "eslint", "lint", "src/util.ts", "npx eslint .", 1),
+        ("jest", "jest", "test", "src/math.test.ts", "npm test", 1),
+        (
+            "go_test",
+            "go_test",
+            "test",
+            "calculator/calculator_test.go",
+            "go test ./...",
+            1,
+        ),
+        ("go_vet", "go_vet", "lint", "internal/logging/logging.go", "go vet ./...", 1),
+    ],
+)
+def test_cross_ecosystem_adapter_extracts_review_first_failure_vectors(
+    fixture: str,
+    tool: str,
+    failure_class: str,
+    affected_file: str,
+    repro: str,
+    exit_code: int,
+) -> None:
+    result = extract_ecosystem_failure_vector(_fixture(fixture), check=fixture)
+
+    assert result.tool == tool
+    assert result.vector.failure_class == failure_class
+    assert result.vector.affected_files == (affected_file,)
+    assert result.vector.local_repro_command == repro
+    assert result.vector.exit_code == exit_code
+    assert result.vector.scope == "unknown"
+    assert result.vector.safe_fix_candidate is False
+    assert result.vector.safe_fix_allowed is False
+    assert result.confidence in {"high", "medium"}
+    assert result.to_dict()["adapter"]["target_code_execution"] is False
+
+    decision = evaluate_failure_vector(result.vector)
+    assert decision.safe_fix_allowed is False
+    assert decision.review_first is True
+    assert decision.automation_allowed is False
+    assert decision.patch_application_allowed is False
+    assert decision.merge_authorized is False
+
+
+def test_adapter_preserves_existing_python_failure_vector_behavior() -> None:
+    log = """Run python -m pytest -q
+FAILED tests/test_math.py::test_add - assert 3 == 4
+Process completed with exit code 1
+"""
+
+    result = extract_ecosystem_failure_vector(log, check="pytest")
+
+    assert result.ecosystem == "python"
+    assert result.tool == "pytest"
+    assert result.vector.failure_class == "test"
+    assert result.vector.affected_files == ("tests/test_math.py",)
+    assert result.vector.safe_fix_allowed is False
+
+
+def test_unknown_cross_ecosystem_signal_remains_review_first() -> None:
+    result = extract_ecosystem_failure_vector(
+        "Build stopped without a structured failure line",
+        ecosystem="javascript_typescript",
+        check="node-build",
+    )
+
+    assert result.tool == "unknown"
+    assert result.confidence == "low"
+    assert result.uncertainty == ("javascript_failure_not_classified",)
+    assert result.vector.failure_class == "unknown"
+    assert evaluate_failure_vector(result.vector).review_first is True
+
+
+def test_adapter_rejects_unsupported_ecosystem() -> None:
+    with pytest.raises(ValueError, match="unsupported ecosystem"):
+        extract_ecosystem_failure_vector("failure", ecosystem="ruby")

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,8 +24,11 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 486
+    assert payload["observed"]["source_module_count"] == 487
     assert payload["observed"]["typing_debt_module_count"] == 474
+    assert (
+        "sdetkit.failure_vector_adapters" in payload["observed"]["explicitly_type_checked_modules"]
+    )
     assert payload["typing_debt_inventory"]["module_count"] == 474
     assert len(payload["typing_debt_inventory"]["modules"]) == 474
 


### PR DESCRIPTION
## Summary
- add fixture-driven failure adapters for TypeScript compiler, ESLint, Jest, `go test`, and `go vet` output
- emit the existing `FailureVector` schema while preserving the current Python extractor
- capture ecosystem, tool, confidence, uncertainty, exit code, owner hint, and recommended local proof command
- record `scope=unknown` because a log path does not prove PR ownership
- keep target execution, safe-fix, patch, merge, security-dismissal, and semantic-equivalence authority disabled
- add the new production module to a dedicated mypy ratchet while keeping the hash-bound typing-debt count flat at 474
- add five realistic fixture logs plus compatibility, safety, and unsupported-ecosystem tests

## Why
SDETKit already discovers JavaScript/TypeScript and Go repositories, but detailed failure extraction was Python-centric. This PR adds the first read-only multi-ecosystem diagnosis slice without executing target repository commands or implying remediation authority.

## Verification
- `python -m pytest -q tests/test_cross_ecosystem_failure_vector_adapters.py tests/test_failure_vector_extraction.py tests/test_safety_gate.py tests/test_quality_truth_baseline.py tests/test_mypy_ratchet_contract.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- dedicated Quality workflow
- full canonical CI, exact-wheel smoke installs, security, first-proof, premium gate, and advanced Linux/macOS matrix at exact head

## Safety
- `target_code_execution=false`
- `scope=unknown`
- `safe_fix_candidate=false`
- `safe_fix_allowed=false`
- unknown signals remain low-confidence and review-first
- no automatic patch, merge, security dismissal, or semantic-equivalence claim

## Risk
- Medium: new diagnostic behavior and a production module
- no CLI registration or target-repository command execution
- existing Python extraction remains in place
- rollback: remove the adapter module, fixtures, focused tests, and quality-baseline entries

## Rebase status
Rebuilt on merged operator-surface `main` commit `48a57c839fbf6df9434fba0bca00a0407c9f6e62`. The previous stale mypy group change was replaced with a dedicated adapter ratchet so existing exact-group contracts remain intact.
