### PR TITLE
release: qualify artifacts and require Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
           printf 'version=%s\nsource_sha=%s\n' "$version" "$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Install release validation dependencies
         run: |
-          python -m pip install -c constraints-ci.txt \
-            -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
+          python -m pip install -c constraints-ci.txt -e .[packaging] \
+            -r requirements-test.txt -r requirements-docs.txt
       - name: Release metadata preflight
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.value }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,134 +1,236 @@
-# Local equivalent command:
-#   python -m sdetkit workflow-governance-report --root . --format text
-#   See docs/ci/workflow-local-equivalents.md#release for workflow-specific operator notes.
+# Local equivalent: make release-preflight && python -m build
+# External requirement: protected GitHub environment `pypi`
+# External requirement: PyPI Trusted Publisher bound to release.yml and `pypi`
 name: Release
 
 on:
   push:
-    tags:
-      - "v*.*.*"
+    tags: ["v*.*.*"]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to release (example: v1.0.2)"
+        description: "Existing tag to release (example: v1.1.0)"
         required: true
         type: string
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  release:
+  build:
+    name: Build release distributions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.tag.outputs.value }}
+      version: ${{ steps.meta.outputs.version }}
+      source-sha: ${{ steps.meta.outputs.source_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
-
-      - name: Resolve tag
-        id: resolved
+          persist-credentials: false
+      - name: Resolve and validate tag
+        id: tag
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
           if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            candidate="$GITHUB_REF_NAME"
           else
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            candidate="${REQUESTED_TAG:-}"
           fi
-
-      - name: Checkout tag (workflow_dispatch)
+          [[ "$candidate" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "Release tag must match vX.Y.Z" >&2
+            exit 1
+          }
+          printf 'value=%s\n' "$candidate" >> "$GITHUB_OUTPUT"
+      - name: Checkout requested tag
         if: ${{ github.ref_type != 'tag' }}
-        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
         run: |
-          set -euo pipefail
           git fetch --tags --force origin
-          git checkout "refs/tags/${{ steps.resolved.outputs.tag }}"
-
+          git checkout --detach "refs/tags/${RELEASE_TAG}"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
-          cache: "pip"
+          cache: pip
           cache-dependency-path: |
             pyproject.toml
             requirements-test.txt
             requirements-docs.txt
-
-
+            constraints-ci.txt
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          printf 'version=%s\nsource_sha=%s\n' "$version" "$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Install release validation dependencies
+        run: |
+          python -m pip install -c constraints-ci.txt \
+            -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
       - name: Release metadata preflight
-        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
         run: |
-          set -euo pipefail
-          mkdir -p build
-          python scripts/release_preflight.py --tag "${{ steps.resolved.outputs.tag }}" --format json --out build/release-preflight.json
-
-      - name: Verify tag matches package version
-        shell: bash
-        run: |
-          set -euo pipefail
-          python scripts/check_release_tag_version.py "${{ steps.resolved.outputs.tag }}"
-      - name: Install + quality gates
-        shell: bash
+          mkdir -p build/release
+          python scripts/release_preflight.py --tag "$RELEASE_TAG" --format json \
+            --out build/release/release-preflight.json
+          python scripts/check_release_tag_version.py "$RELEASE_TAG"
+      - name: Run release quality gates
         env:
           COV_FAIL_UNDER: "95"
         run: |
-          set -euo pipefail
-          python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
           bash quality.sh cov
-
-      - name: Build dist
-        shell: bash
+          NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
+      - name: Build and validate distributions
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+          SOURCE_SHA: ${{ steps.meta.outputs.source_sha }}
         run: |
-          set -euo pipefail
+          rm -rf dist build/lib build/bdist.*
           python -m build
           python -m twine check dist/*
           python -m check_wheel_contents --ignore W009 dist/*.whl
-
-      - name: Wheel smoke test
-        shell: bash
-        run: |
-          set -euo pipefail
-          python -m pip install -c constraints-ci.txt --force-reinstall dist/*.whl
-          sdetkit --help
-
-      - name: Publish to PyPI when token is configured
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${TWINE_PASSWORD:-}" ]; then
-            echo "PyPI publish skipped: configure repository secret PYPI_API_TOKEN to enable upload."
-            exit 0
-          fi
-          python -m twine upload dist/*
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+          python scripts/build_release_distribution_manifest.py \
+            --tag "$RELEASE_TAG" --version "$RELEASE_VERSION" --source-sha "$SOURCE_SHA" \
+            --out build/release/distribution-manifest.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          subject-path: 'dist/*'
+          name: release-distributions
+          path: |
+            dist/*
+            build/release/*.json
+          retention-days: 30
+          if-no-files-found: error
 
-      - name: Create GitHub Release
+  qualify-wheel:
+    name: Qualify exact wheel (py${{ matrix.python-version }})
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ needs.build.outputs.tag }}
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: release-distributions
+          path: release-candidate
+      - name: Install and exercise exact wheel
+        run: |
+          python -m venv .venv-release
+          . .venv-release/bin/activate
+          wheel="$(find release-candidate/dist -name '*.whl' -print -quit)"
+          test -n "$wheel"
+          python -m pip install -c constraints-ci.txt --force-reinstall "$wheel"
+          python tests/contract/check_installed_wheel.py --python .venv-release/bin/python --repo-root .
+          mkdir -p build/release-qualification
+          python -m sdetkit gate fast --format json --stable-json --out build/release-qualification/gate-fast.json
+          python -m sdetkit gate release --format json --out build/release-qualification/gate-release.json
+          python -m sdetkit doctor --format json --out build/release-qualification/doctor.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: release-qualification-py${{ matrix.python-version }}
+          path: build/release-qualification/
+          retention-days: 30
+          if-no-files-found: error
+
+  attest-github:
+    needs: [build, qualify-wheel]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: release-distributions
+          path: release-candidate
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+        with:
+          subject-path: release-candidate/dist/*
+
+  publish-pypi:
+    needs: [build, qualify-wheel, attest-github]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sdetkit
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: release-distributions
+          path: release-candidate
+      - name: Publish with PyPI Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          packages-dir: release-candidate/dist/
+          attestations: true
+          print-hash: true
+
+  verify-pypi:
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: release-distributions
+          path: release-candidate
+      - name: Verify public package
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          mkdir -p build/release-verification
+          python scripts/verify_pypi_release.py --version "$RELEASE_VERSION" \
+            --manifest release-candidate/build/release/distribution-manifest.json \
+            --out build/release-verification/pypi-release.json
+          python -m pip install --no-cache-dir --index-url https://pypi.org/simple/ "sdetkit==$RELEASE_VERSION"
+          python -m sdetkit --help
+          python -m pip show sdetkit
+
+  github-release:
+    needs: [build, verify-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: release-distributions
+          path: release-candidate
+      - name: Create GitHub Release after PyPI verification
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
-          tag_name: ${{ steps.resolved.outputs.tag }}
-          name: ${{ steps.resolved.outputs.tag }}
+          tag_name: ${{ needs.build.outputs.tag }}
+          name: ${{ needs.build.outputs.tag }}
           generate_release_notes: true
           fail_on_unmatched_files: true
-          files: |
-            dist/*
-
-      - name: Upload release diagnostics
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: release-diagnostics
-          path: build/release-preflight.json
-          retention-days: 30
-          if-no-files-found: warn
+          files: release-candidate/dist/*

--- a/build/sdetkit/workflow-permission-release-provenance-evidence.json
+++ b/build/sdetkit/workflow-permission-release-provenance-evidence.json
@@ -18,7 +18,7 @@
   "patch_application_allowed": false,
   "permission_group": "release_or_provenance",
   "release_threat_model": {
-    "finding_count": 3,
+    "finding_count": 2,
     "review_first": true,
     "status": "review_required",
     "workflow_mutation": false,

--- a/docs/project/release-process.md
+++ b/docs/project/release-process.md
@@ -1,133 +1,178 @@
 # Release Process
 
-This project follows semantic versioning and a reproducible release flow.
+This project follows semantic versioning and a reproducible, fail-closed release flow.
 
 Current version is taken from `[project].version` in `pyproject.toml`.
 
-Release tags must be `vX.Y.Z` and must match the package version. `CHANGELOG.md` must include a matching heading (for example: `## [X.Y.Z]` or `## vX.Y.Z`).
+Release tags must be `vX.Y.Z` and must match the package version. `CHANGELOG.md` must include a matching heading, for example `## [X.Y.Z]` or `## vX.Y.Z`.
 
-## Versioning Policy
+## Versioning policy
 
-- `0.x`: fast iteration is allowed, but the patch-spec schema stays versioned (`spec_version`).
-- `1.0+`: patch spec is stable; incompatible changes require a new schema version and deprecation window.
+- `0.x`: fast iteration is allowed, but public schemas remain versioned.
+- `1.0+`: incompatible public API, CLI, or artifact-contract changes require a new version and an explicit compatibility plan.
 
-## Release preconditions (before any tag push)
+## Release preconditions
 
-- Repository secret `PYPI_API_TOKEN` must be configured to enable PyPI upload.
-- If `PYPI_API_TOKEN` is not configured, the release workflow still builds artifacts and creates a GitHub Release, but PyPI upload is skipped.
-- The release workflow requires:
-  - `pyproject.toml` `[project].version`
-  - matching heading in `CHANGELOG.md`
-  - tag in the form `vX.Y.Z` that matches version
+Before any release tag is pushed:
 
-## Maintainer path (first public release)
+1. Configure a protected GitHub environment named `pypi`.
+2. Configure the PyPI project `sdetkit` with a GitHub Actions Trusted Publisher for:
+   - owner: `sherif69-sa`
+   - repository: `DevS69-sdetkit`
+   - workflow: `release.yml`
+   - environment: `pypi`
+3. Add required reviewers and deployment protection to the GitHub `pypi` environment.
+4. Do not configure or rely on a long-lived `PYPI_API_TOKEN` for this workflow.
+5. Confirm:
+   - `[project].version` is final;
+   - `CHANGELOG.md` has a matching release heading;
+   - the release tag is `vX.Y.Z` and matches the package version;
+   - current main and all required release-readiness PRs are green.
 
-1. Finalize release metadata for the target version:
-   - update `[project].version` in `pyproject.toml`
-   - add matching heading in `CHANGELOG.md`
-2. Run local preflight (single command):
+Missing or incorrect Trusted Publisher configuration is a release blocker. The workflow does not silently skip PyPI publication and continue to GitHub Release creation.
+
+Manual dispatch accepts only an existing tag matching `vX.Y.Z`. The input is passed through the environment, validated before shell use, and never interpolated directly into a shell script.
+
+## Maintainer path
+
+1. Finalize release metadata:
+   - update `[project].version` in `pyproject.toml`;
+   - add a matching section in `CHANGELOG.md`;
+   - refresh release-candidate adoption and quality evidence.
+2. Run local preflight:
 
    ```bash
    make release-preflight
    ```
 
-   This runs release metadata validation, `doctor --release --skip clean_tree`, artifact build validation, and wheel smoke install.
-3. Generate post-release verification plan and confirm package install string before tagging:
+3. Generate the post-release verification plan and validate the install string:
 
    ```bash
    make release-verify-plan
    python scripts/release_verify_post_publish.py --assert-install-string
    ```
 
-   This validates the canonical external install target (`pip install sdetkit==<version>`) and prints a deterministic verification plan maintainers can execute after publish.
-4. Create and push the tag:
+4. Run focused repository proof:
 
    ```bash
-   git tag vX.Y.Z
+   python -m pre_commit run -a
+   COV_FAIL_UNDER=95 bash quality.sh cov
+   NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
+   python -m build
+   python -m twine check dist/*
+   python -m check_wheel_contents --ignore W009 dist/*.whl
+   ```
+
+5. Merge the release metadata PR only after required checks are green.
+6. Create and push the signed tag:
+
+   ```bash
+   git tag -s vX.Y.Z -m "Release vX.Y.Z"
    git push origin vX.Y.Z
    ```
-5. Watch `.github/workflows/release.yml` complete.
-6. Verify outcomes:
-   - GitHub Release exists and includes `dist/*` artifacts.
-   - PyPI upload occurred only if `PYPI_API_TOKEN` secret is configured.
-   - Dependency/security workflows are green for the same commit/tag.
 
-## Workflow triggers
+7. Approve the protected `pypi` environment deployment only after reviewing the exact tag, source SHA, distribution manifest, and Python-version qualification jobs.
+8. Watch `.github/workflows/release.yml` complete.
+9. Confirm the public PyPI metadata and distribution digests match the build manifest.
+10. Confirm the public PyPI install verification succeeded.
+11. Confirm the GitHub Release was created only after PyPI verification.
 
-- **Tag push**: automatic for tags matching `v*.*.*`.
-- **Manual dispatch**: `workflow_dispatch` with an existing `tag` input.
+## Workflow contract
 
-The workflow performs:
-1. release metadata preflight (`scripts/release_preflight.py`)
-2. tag/version consistency check (`scripts/check_release_tag_version.py`)
-3. quality gates + coverage
-4. artifact build + metadata checks + wheel smoke test
-5. conditional PyPI upload
-6. provenance attestation + GitHub Release creation
+The release workflow performs these ordered jobs:
 
-## What not to claim before publish is real
+1. **Build**
+   - validate the requested tag before shell use;
+   - check out the existing tag;
+   - validate tag, package version, and changelog metadata;
+   - run coverage and strict docs proof;
+   - build the wheel and sdist exactly once;
+   - record SHA-256 digests in a distribution manifest.
+2. **Qualify exact wheel**
+   - download the immutable build artifact;
+   - install and exercise the exact wheel on Python 3.10, 3.11, and 3.12;
+   - run installed-wheel and canonical command contracts.
+3. **Attest**
+   - attach GitHub build provenance to the qualified distributions.
+4. **Publish to PyPI**
+   - enter the protected `pypi` environment;
+   - request a short-lived OIDC credential through Trusted Publishing;
+   - publish the same qualified files;
+   - generate PyPI publish attestations.
+5. **Verify public publication**
+   - wait for the exact version to appear on PyPI with bounded retries;
+   - compare every published filename and SHA-256 digest with the build manifest;
+   - install the exact version from the public PyPI index and verify metadata and CLI availability.
+6. **Create GitHub Release**
+   - create the GitHub Release only after successful PyPI verification;
+   - attach the exact published distributions and release diagnostics.
 
-Do not claim public PyPI availability until:
-- the release workflow succeeded,
-- the PyPI upload step ran (not skipped), and
-- install from PyPI is verified externally.
+No job rebuilds the distributions after the build job.
 
-## Post-release verification (external-user perspective)
+## What not to claim
 
-Run these in a clean shell after the release workflow shows a successful PyPI upload:
+Do not claim public availability, successful publication, attestation, or release completion until:
+
+- the exact-wheel qualification matrix is green;
+- Trusted Publishing completed successfully;
+- the public PyPI digest and install verification is green;
+- the GitHub Release exists and contains the same distribution files;
+- the tag, source SHA, and distribution manifest agree.
+
+A prediction, workflow configuration, pending environment approval, or successful local build is not publication proof.
+
+## Post-release verification
+
+The workflow performs automated public-index verification. A maintainer should also verify from a separate clean environment:
 
 ```bash
 python -m venv .venv-release-verify
 . .venv-release-verify/bin/activate
 python -m pip install -U pip
-python -m pip install sdetkit==X.Y.Z
+python -m pip install --index-url https://pypi.org/simple/ sdetkit==X.Y.Z
 python -m sdetkit --help
 python -m pip show sdetkit
 ```
 
 Success means:
-- `pip install` resolves from default PyPI index without private index overrides.
-- `python -m sdetkit --help` exits 0 and prints CLI usage.
-- `pip show sdetkit` reports the expected version (`X.Y.Z`).
 
-Also confirm:
-- GitHub Release page for `vX.Y.Z` is present with generated notes and `dist/*` artifacts.
-- PyPI project/version page exists and files include wheel + source tarball.
-- The release workflow job includes a successful **Publish to PyPI** step (not skipped).
-
-Only after all checks pass is it safe to claim public availability.
+- the package resolves from public PyPI without a private index override;
+- the installed version equals `X.Y.Z`;
+- the CLI starts successfully;
+- PyPI contains the wheel and sdist with the expected hashes;
+- PyPI publish attestations are present;
+- the GitHub Release contains the exact qualified artifacts.
 
 ## Record public verification evidence
 
-After completing external-user verification for a real release, add a short record to `docs/release-verification.md` using the page template.
+After a real release is published and externally validated, add a factual record to `docs/release-verification.md` containing:
 
-Keep entries factual and minimal:
-- exact released version
-- exact install and validation commands run
-- verifier environment (OS, Python, pip)
-- success signals + links (PyPI version page and GitHub Release)
-- support path if users cannot install
+- exact version, tag, and source SHA;
+- exact install and validation commands;
+- verifier OS, Python, and pip versions;
+- distribution hashes;
+- PyPI and GitHub Release references;
+- attestation verification result;
+- support path for failed installation.
 
-Do not add a verification entry unless the release was actually published and validated externally.
+Do not add a release-verification entry before publication and clean-room validation actually complete.
 
-## Optional risk-reduction rehearsal (TestPyPI)
+## Optional TestPyPI rehearsal
 
-If maintainers want a dry run before the first real publish, run from local `dist/*` against TestPyPI manually with a separate token:
+A TestPyPI rehearsal must use a separate, explicitly configured Trusted Publisher and protected environment. It is not part of the default production release workflow and must not reuse production release authority.
 
-```bash
-python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple sdetkit==X.Y.Z
-```
-
-This repository does not auto-publish to TestPyPI in CI; this path is an optional rehearsal only.
-
-## Release checklist (required)
-
-Before pushing a release tag, maintainers must complete this checklist:
+## Required release checklist
 
 - [ ] Version updated in `pyproject.toml`.
 - [ ] Matching version heading added in `CHANGELOG.md`.
+- [ ] Current product-delta and release-candidate evidence reviewed.
 - [ ] `make release-preflight` completed successfully.
-- [ ] Post-release verify plan generated and install string validated.
-- [ ] Release tag `vX.Y.Z` pushed and workflow monitored to completion.
-- [ ] External install verification completed before public availability claims.
+- [ ] Full quality, package, and docs proof completed.
+- [ ] GitHub `pypi` environment protection verified.
+- [ ] PyPI Trusted Publisher configuration verified.
+- [ ] Signed tag `vX.Y.Z` pushed.
+- [ ] Exact wheel qualified on Python 3.10, 3.11, and 3.12.
+- [ ] Trusted Publishing and attestations succeeded.
+- [ ] Public PyPI digest and installation verification succeeded.
+- [ ] GitHub Release created after PyPI verification.
+- [ ] External verification record added only after proof.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,7 +2,7 @@
 
 This project uses semantic versioning and a tag-driven, fail-closed release workflow.
 
-Current published baseline: **v1.0.3**.
+Current baseline release: **v1.0.3**.
 
 ## Version bump rules
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,88 +1,113 @@
 # Releasing sdetkit
 
-This project uses semantic versioning (`MAJOR.MINOR.PATCH`) and a tag-driven release workflow.
+This project uses semantic versioning and a tag-driven, fail-closed release workflow.
 
-Current baseline release: **v1.0.3**.
+Current published baseline: **v1.0.3**.
 
 ## Version bump rules
 
-- **PATCH** (`x.y.Z`): bug fixes, docs-only operational improvements, non-breaking internal changes.
+- **PATCH** (`x.y.Z`): bug fixes, documentation-only operational improvements, and non-breaking internal changes.
 - **MINOR** (`x.Y.z`): backward-compatible features.
-- **MAJOR** (`X.y.z`): breaking public API or CLI behavior changes.
+- **MAJOR** (`X.y.z`): breaking public API, CLI, or artifact-contract changes.
+
+## One-time publisher configuration
+
+Production publishing requires:
+
+- a protected GitHub environment named `pypi`;
+- a PyPI Trusted Publisher bound to `sherif69-sa/DevS69-sdetkit`;
+- workflow filename `.github/workflows/release.yml`;
+- GitHub environment `pypi`.
+
+The workflow uses OIDC and does not consume a long-lived PyPI API token. Missing publisher configuration causes publication to fail; it cannot produce a successful GitHub Release without a verified PyPI publication.
 
 ## Release checklist
 
 1. Update `version` in `pyproject.toml`.
 2. Add a matching version section to `CHANGELOG.md`.
-3. Run local quality and packaging checks:
+3. Refresh current product-delta and release-candidate evidence.
+4. Run local quality and packaging checks:
 
    ```bash
-   pre-commit run -a
-   bash quality.sh cov
+   python -m pre_commit run -a
+   COV_FAIL_UNDER=95 bash quality.sh cov
+   NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
    python -m build
    python -m twine check dist/*
-   NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
+   python -m check_wheel_contents --ignore W009 dist/*.whl
    ```
 
-4. Commit changes and open/merge a PR.
-5. Create and push a signed tag: `vX.Y.Z`.
-6. Confirm GitHub Actions release workflow succeeded.
-7. Confirm artifacts were published to PyPI (workflow step must be successful, not skipped).
-8. Run external-user verification in a clean virtual environment:
+5. Run release metadata preflight:
 
    ```bash
-   python -m venv .venv-release-verify
-   . .venv-release-verify/bin/activate
-   python -m pip install -U pip
-   python -m pip install sdetkit==X.Y.Z
-   python -m sdetkit --help
-   python -m pip show sdetkit
+   make release-preflight
+   make release-verify-plan
+   python scripts/release_verify_post_publish.py --assert-install-string
    ```
 
-9. Confirm index/release pages:
-   - `https://pypi.org/project/sdetkit/X.Y.Z/` is reachable.
-   - GitHub Release for `vX.Y.Z` includes dist artifacts.
+6. Commit release metadata and merge only after required checks are green.
+7. Create and push a signed tag: `vX.Y.Z`.
+8. Review the exact source SHA and distribution manifest, then approve the protected `pypi` environment deployment.
+9. Confirm the release workflow completed in order:
+   - build once;
+   - exact-wheel qualification on Python 3.10, 3.11, and 3.12;
+   - GitHub provenance attestation;
+   - PyPI Trusted Publishing and publish attestations;
+   - public PyPI filename, digest, and installation verification;
+   - GitHub Release creation.
+10. Run an independent clean-environment verification:
+
+    ```bash
+    python -m venv .venv-release-verify
+    . .venv-release-verify/bin/activate
+    python -m pip install -U pip
+    python -m pip install --index-url https://pypi.org/simple/ sdetkit==X.Y.Z
+    python -m sdetkit --help
+    python -m pip show sdetkit
+    ```
 
 ## CI release safeguards
 
-Every PR validates packaging integrity with:
+Every pull request validates packaging integrity with build, Twine, wheel-content, and isolated installed-wheel contracts.
 
-- `python -m build`
-- `python -m twine check dist/*`
-- wheel smoke install and CLI check (`sdetkit --help`)
+The tag-only release workflow adds stronger controls:
 
-The release workflow also verifies the tag matches `pyproject.toml` version.
+- manual inputs are environment-bound and validated as `vX.Y.Z` before shell use;
+- wheel and sdist are built once and recorded in a SHA-256 manifest;
+- the exact wheel is qualified on every supported Python version;
+- publish authority is protected behind the `pypi` environment;
+- job-level `id-token: write` is limited to attestation and publication;
+- PyPI filenames and SHA-256 digests must match the build manifest;
+- public installation must pass before the GitHub Release is created;
+- missing publication proof fails closed.
 
-## Publishing to PyPI
+## Publishing boundary
 
-Publishing is handled by GitHub Actions in `.github/workflows/release.yml`.
+Publishing is handled only by `.github/workflows/release.yml` using PyPI Trusted Publishing. The official PyPA action receives a short-lived OIDC credential and uploads attestations for the exact distributions.
 
-- On tag push `v*.*.*`, artifacts are built and uploaded.
-- Upload uses the configured `PYPI_API_TOKEN` secret.
-- If no token is configured, packaging checks still run and release artifacts are generated.
+The following are not publication proof:
 
+- a successful build;
+- a successful TestPyPI rehearsal;
+- a pending `pypi` environment approval;
+- a skipped or failed publish job;
+- a GitHub artifact containing distributions;
+- a local install from `dist/`.
 
 ## Record public verification evidence
 
-After completing external-user verification for a real release, add a short record to `docs/release-verification.md` using the page template.
+After publication and independent verification, add a factual record to `docs/release-verification.md` with:
 
-Keep entries factual and minimal:
-- exact released version
-- exact install and validation commands run
-- verifier environment (OS, Python, pip)
-- success signals + links (PyPI version page and GitHub Release)
-- support path if users cannot install
+- exact version, tag, and source SHA;
+- distribution hashes;
+- exact validation commands;
+- verifier OS, Python, and pip versions;
+- PyPI and GitHub Release references;
+- attestation status;
+- support path if installation fails.
 
-Do not add a verification entry unless the release was actually published and validated externally.
+Do not add a public verification record until the release exists and clean-room verification has completed.
 
 ## Optional TestPyPI rehearsal
 
-Before first real publish, maintainers can rehearse upload/install manually:
-
-```bash
-python -m build
-python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple sdetkit==X.Y.Z
-```
-
-This is optional and not wired to the default release workflow.
+A TestPyPI rehearsal may use a separate Trusted Publisher and protected environment. It is intentionally separate from the production workflow and does not authorize a production release.

--- a/scripts/build_release_distribution_manifest.py
+++ b/scripts/build_release_distribution_manifest.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SCHEMA_VERSION = "sdetkit.release_distribution_manifest.v1"
+
+
+def build_manifest(
+    *,
+    dist_dir: Path,
+    tag: str,
+    version: str,
+    source_sha: str,
+) -> dict[str, object]:
+    if not TAG_RE.fullmatch(tag):
+        raise ValueError("release tag must match vX.Y.Z")
+    if tag.removeprefix("v") != version:
+        raise ValueError("release tag and package version do not match")
+    if not SHA_RE.fullmatch(source_sha):
+        raise ValueError("source SHA must be a 40-character lowercase hexadecimal value")
+
+    files = [
+        {
+            "name": path.name,
+            "size_bytes": path.stat().st_size,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+        for path in sorted(dist_dir.iterdir())
+        if path.is_file()
+    ]
+    if not any(str(item["name"]).endswith(".whl") for item in files):
+        raise ValueError("release build did not produce a wheel")
+    if not any(str(item["name"]).endswith(".tar.gz") for item in files):
+        raise ValueError("release build did not produce an sdist")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_sha": source_sha,
+        "tag": tag,
+        "version": version,
+        "files": files,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the release distribution manifest")
+    parser.add_argument("--dist-dir", type=Path, default=Path("dist"))
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_manifest(
+        dist_dir=args.dist_dir,
+        tag=args.tag,
+        version=args.version,
+        source_sha=args.source_sha,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.pypi_release_verification.v1"
+
+
+def compare_distribution_hashes(
+    manifest: dict[str, Any],
+    pypi_payload: dict[str, Any],
+) -> dict[str, object]:
+    expected = {
+        str(item["name"]): str(item["sha256"])
+        for item in manifest.get("files", [])
+        if isinstance(item, dict)
+    }
+    actual = {
+        str(item["filename"]): str(item["digests"]["sha256"])
+        for item in pypi_payload.get("urls", [])
+        if isinstance(item, dict) and isinstance(item.get("digests"), dict)
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": bool(expected) and actual == expected,
+        "expected": expected,
+        "actual": actual,
+        "missing": sorted(set(expected) - set(actual)),
+        "unexpected": sorted(set(actual) - set(expected)),
+        "digest_mismatches": sorted(
+            name for name in set(expected) & set(actual) if expected[name] != actual[name]
+        ),
+    }
+
+
+def fetch_sdetkit_release(
+    version: str,
+    *,
+    attempts: int = 12,
+    delay_seconds: float = 10.0,
+) -> dict[str, Any]:
+    url = f"https://pypi.org/pypi/sdetkit/{version}/json"
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=15) as response:
+                payload = json.load(response)
+            if not isinstance(payload, dict):
+                raise ValueError("PyPI response must be a JSON object")
+            return payload
+        except urllib.error.HTTPError as error:
+            if error.code != 404 or attempt == attempts:
+                raise
+            print(f"PyPI propagation attempt {attempt}/{attempts} did not resolve the release yet")
+            time.sleep(delay_seconds)
+    raise RuntimeError("PyPI release lookup exhausted without a response")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify PyPI files against a release manifest")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    result = compare_distribution_hashes(manifest, fetch_sdetkit_release(args.version))
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_distribution_scripts.py
+++ b/tests/test_release_distribution_scripts.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_distribution_manifest_records_exact_wheel_and_sdist(tmp_path: Path) -> None:
+    module = _module(
+        "build_release_distribution_manifest",
+        ROOT / "scripts/build_release_distribution_manifest.py",
+    )
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "sdetkit-1.1.0-py3-none-any.whl").write_bytes(b"wheel")
+    (dist / "sdetkit-1.1.0.tar.gz").write_bytes(b"sdist")
+
+    payload = module.build_manifest(
+        dist_dir=dist,
+        tag="v1.1.0",
+        version="1.1.0",
+        source_sha="a" * 40,
+    )
+
+    assert payload["schema_version"] == "sdetkit.release_distribution_manifest.v1"
+    assert payload["tag"] == "v1.1.0"
+    assert payload["source_sha"] == "a" * 40
+    assert {item["name"] for item in payload["files"]} == {
+        "sdetkit-1.1.0-py3-none-any.whl",
+        "sdetkit-1.1.0.tar.gz",
+    }
+    assert all(len(item["sha256"]) == 64 for item in payload["files"])
+
+
+@pytest.mark.parametrize(
+    ("tag", "version", "source_sha", "message"),
+    [
+        ("1.1.0", "1.1.0", "a" * 40, "vX.Y.Z"),
+        ("v1.1.0", "1.1.1", "a" * 40, "do not match"),
+        ("v1.1.0", "1.1.0", "not-a-sha", "40-character"),
+    ],
+)
+def test_distribution_manifest_rejects_invalid_identity(
+    tmp_path: Path,
+    tag: str,
+    version: str,
+    source_sha: str,
+    message: str,
+) -> None:
+    module = _module(
+        "build_release_distribution_manifest",
+        ROOT / "scripts/build_release_distribution_manifest.py",
+    )
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "sdetkit.whl").write_bytes(b"wheel")
+    (dist / "sdetkit.tar.gz").write_bytes(b"sdist")
+
+    with pytest.raises(ValueError, match=message):
+        module.build_manifest(
+            dist_dir=dist,
+            tag=tag,
+            version=version,
+            source_sha=source_sha,
+        )
+
+
+def test_distribution_manifest_requires_both_distribution_types(tmp_path: Path) -> None:
+    module = _module(
+        "build_release_distribution_manifest",
+        ROOT / "scripts/build_release_distribution_manifest.py",
+    )
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "sdetkit-1.1.0-py3-none-any.whl").write_bytes(b"wheel")
+
+    with pytest.raises(ValueError, match="sdist"):
+        module.build_manifest(
+            dist_dir=dist,
+            tag="v1.1.0",
+            version="1.1.0",
+            source_sha="a" * 40,
+        )
+
+
+def test_pypi_verifier_accepts_exact_distribution_hashes() -> None:
+    module = _module("verify_pypi_release", ROOT / "scripts/verify_pypi_release.py")
+    manifest = {
+        "files": [
+            {"name": "sdetkit.whl", "sha256": "a" * 64},
+            {"name": "sdetkit.tar.gz", "sha256": "b" * 64},
+        ]
+    }
+    payload = {
+        "urls": [
+            {"filename": "sdetkit.whl", "digests": {"sha256": "a" * 64}},
+            {"filename": "sdetkit.tar.gz", "digests": {"sha256": "b" * 64}},
+        ]
+    }
+
+    result = module.compare_distribution_hashes(manifest, payload)
+
+    assert result["ok"] is True
+    assert result["missing"] == []
+    assert result["unexpected"] == []
+    assert result["digest_mismatches"] == []
+
+
+def test_pypi_verifier_rejects_missing_unexpected_and_mismatched_files() -> None:
+    module = _module("verify_pypi_release", ROOT / "scripts/verify_pypi_release.py")
+    manifest = {
+        "files": [
+            {"name": "sdetkit.whl", "sha256": "a" * 64},
+            {"name": "sdetkit.tar.gz", "sha256": "b" * 64},
+        ]
+    }
+    payload = {
+        "urls": [
+            {"filename": "sdetkit.whl", "digests": {"sha256": "c" * 64}},
+            {"filename": "unexpected.zip", "digests": {"sha256": "d" * 64}},
+        ]
+    }
+
+    result = module.compare_distribution_hashes(manifest, payload)
+
+    assert result["ok"] is False
+    assert result["missing"] == ["sdetkit.tar.gz"]
+    assert result["unexpected"] == ["unexpected.zip"]
+    assert result["digest_mismatches"] == ["sdetkit.whl"]

--- a/tests/test_release_trusted_publishing_contract.py
+++ b/tests/test_release_trusted_publishing_contract.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _workflow() -> str:
+    return RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+
+def _section(text: str, start: str, end: str) -> str:
+    return text[text.index(start) : text.index(end)]
+
+
+def test_release_workflow_uses_trusted_publishing_without_long_lived_token() -> None:
+    text = _workflow()
+
+    assert "PYPI_API_TOKEN" not in text
+    assert "TWINE_PASSWORD" not in text
+    assert "Publish with PyPI Trusted Publishing" in text
+    assert "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" in text
+    assert "# v1.14.0" in text
+    assert "environment:\n      name: pypi" in text
+    assert "permissions:\n      id-token: write" in text
+
+
+def test_release_dispatch_input_is_validated_before_shell_use() -> None:
+    text = _workflow()
+    resolve_step = _section(
+        text,
+        "      - name: Resolve and validate tag",
+        "      - name: Checkout requested tag",
+    )
+
+    assert "REQUESTED_TAG: ${{ inputs.tag }}" in resolve_step
+    assert 'candidate="${REQUESTED_TAG:-}"' in resolve_step
+    assert '[[ "$candidate" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]' in resolve_step
+    assert "${{ inputs.tag }}" not in resolve_step.split("run: |", 1)[1]
+    assert "Release tag must match vX.Y.Z" in resolve_step
+
+
+def test_release_manifest_uses_validated_environment_values() -> None:
+    text = _workflow()
+    build_step = _section(
+        text,
+        "      - name: Build and validate distributions",
+        "      - uses: actions/upload-artifact@",
+    )
+
+    assert "RELEASE_TAG: ${{ steps.tag.outputs.value }}" in build_step
+    assert "RELEASE_VERSION: ${{ steps.meta.outputs.version }}" in build_step
+    assert "SOURCE_SHA: ${{ steps.meta.outputs.source_sha }}" in build_step
+    assert "scripts/build_release_distribution_manifest.py" in build_step
+    assert '--tag "$RELEASE_TAG"' in build_step
+    assert '--version "$RELEASE_VERSION"' in build_step
+    assert '--source-sha "$SOURCE_SHA"' in build_step
+    assert "${{ inputs.tag }}" not in build_step
+
+
+def test_release_workflow_builds_once_and_qualifies_exact_wheel() -> None:
+    text = _workflow()
+
+    assert text.count("python -m build") == 2  # local-equivalent comment plus one build step
+    assert 'python-version: ["3.10", "3.11", "3.12"]' in text
+    assert "name: release-distributions" in text
+    assert "Install and exercise exact wheel" in text
+    assert "tests/contract/check_installed_wheel.py" in text
+    assert "python -m sdetkit gate fast" in text
+    assert "python -m sdetkit gate release" in text
+    assert "python -m sdetkit doctor" in text
+
+
+def test_release_workflow_attests_publishes_and_verifies_in_order() -> None:
+    text = _workflow()
+
+    attest_index = text.index("  attest-github:")
+    publish_index = text.index("  publish-pypi:")
+    verify_index = text.index("  verify-pypi:")
+    release_index = text.index("  github-release:")
+
+    assert attest_index < publish_index < verify_index < release_index
+    assert "needs: [build, qualify-wheel, attest-github]" in text
+    assert "needs: [build, publish-pypi]" in text
+    assert "needs: [build, verify-pypi]" in text
+    assert "actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373" in text
+    assert "scripts/verify_pypi_release.py" in text
+    assert "Create GitHub Release after PyPI verification" in text
+
+
+def test_release_workflow_fails_closed_with_narrow_permissions_and_budget() -> None:
+    text = _workflow()
+
+    assert "PyPI publish skipped" not in text
+    assert "exit 0" not in _section(text, "  publish-pypi:", "  verify-pypi:")
+    assert "if-no-files-found: error" in text
+    assert "permissions:\n  contents: read\n" in text
+    assert text.count("      contents: write") == 1
+    assert "      attestations: write" in text
+    assert len(text.splitlines()) < 250

--- a/tests/test_workflow_release_guardrails.py
+++ b/tests/test_workflow_release_guardrails.py
@@ -9,14 +9,17 @@ def _workflow(name: str) -> str:
 
 def test_release_workflow_installs_release_dependencies_with_constraints() -> None:
     text = _workflow("release.yml")
+    install_step = text[
+        text.index("      - name: Install release validation dependencies") : text.index(
+            "      - name: Run release quality gates"
+        )
+    ]
 
-    assert (
-        "python -m pip install -c constraints-ci.txt -r requirements-test.txt "
-        "-r requirements-docs.txt -e .[packaging]"
-    ) in text
-    assert (
-        "python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging]"
-    ) not in text
+    assert "python -m pip install -c constraints-ci.txt" in install_step
+    assert "-r requirements-test.txt" in install_step
+    assert "-r requirements-docs.txt" in install_step
+    assert "-e .[packaging]" in install_step
+    assert "python -m pip install -r requirements-test.txt" not in install_step
 
 
 def test_impact_release_control_uses_least_privilege_permissions_and_constraints() -> None:


### PR DESCRIPTION
## Summary
- split release execution into build, exact-wheel qualification, provenance, PyPI publication, public-index verification, and GitHub Release jobs
- validate manual `tag` input as `vX.Y.Z` before shell use and avoid direct expression interpolation inside shell/Python bodies
- build wheel and sdist once and retain a SHA-256 distribution manifest
- qualify the exact wheel on Python 3.10, 3.11, and 3.12
- require a protected `pypi` GitHub environment and job-scoped OIDC permission
- replace long-lived PyPI tokens with the SHA-pinned official PyPA publisher action
- verify PyPI filenames and SHA-256 digests against the build manifest
- verify public installation before creating the GitHub Release
- keep the six trust-boundary jobs below the existing heavy-workflow budget by extracting deterministic release scripts
- add executable tests for manifest construction, tag/version/SHA validation, and PyPI digest comparison

## Why
The previous workflow could skip PyPI upload when a token was absent and still continue toward a GitHub Release. It also interpolated manual workflow input directly inside shell commands. Release completion must instead mean that a validated tag produced qualified, attested artifacts that were published through short-lived OIDC, matched the build manifest on PyPI, and installed successfully from the public index.

## Exact-head diagnosis and correction
The earlier CI headline identified the coverage job, but coverage itself passed at 96.69% against the retained 95% critical-spine threshold. The actual blockers were three repository contracts:
- release-baseline wording in `docs/releasing.md`
- constrained dependency-install command shape in `.github/workflows/release.yml`
- stale release-threat-model finding count in the generated provenance evidence

All three were corrected narrowly. No coverage threshold, test, verifier, workflow budget, or release safeguard was weakened.

## Verification
Exact head: `422111aeb6d77c22c2fdb7aee0486e5fe79ab6ca`

Completed successfully:
- canonical CI, including full coverage and strict docs
- workflow and required-check contracts
- build, Twine check, wheel-content validation, and isolated wheel smoke installs
- advanced Linux/macOS matrix on Python 3.11, 3.12, and 3.13
- first-proof matrix on Python 3.10, 3.11, 3.12, and 3.13
- Security, OSV, dependency review/audit, Premium, Enterprise, maintenance, repo audit, and release-control gates
- PR Quality reporting

Focused commands:
- `python -m pytest -q tests/test_release_distribution_scripts.py tests/test_release_trusted_publishing_contract.py tests/test_workflow_release_guardrails.py tests/test_workflow_release_provenance_evidence_contract.py -o addopts=`
- `python scripts/check_workflow_contracts.py --root . --topology-contract docs/contracts/workflow-topology.v1.json --required-checks-contract docs/contracts/required-checks.v1.json`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`

## External configuration required before tagging
- create and protect GitHub environment `pypi`
- configure the PyPI Trusted Publisher for owner `sherif69-sa`, repository `DevS69-sdetkit`, workflow `release.yml`, environment `pypi`
- record human verification of both settings

## Risk
- High release and supply-chain surface; review-first
- no version bump or tag in this PR
- the Release workflow has no `pull_request` trigger
- no publish action occurs while reviewing this PR
- no credentials are added to the repository
- GitHub Release creation is downstream of successful PyPI digest and install verification
- rollback: revert the release workflow, two docs pages, two scripts, generated release-governance evidence, and focused tests

## Rebase status
Rebuilt directly on merged protected-verifier `main` commit `8a256600cc875e7003233e98c89b91728af0e55d`; stale pre-verifier proof was discarded.

## Merge boundary
Repository proof is green at the exact head, but this PR remains draft because the protected GitHub environment and PyPI Trusted Publisher configuration are external settings that cannot be proven from repository files. It is not a tag, release, or publication request.
