### PR TITLE
verification: bind and verify protected proof artifacts

### DIFF
--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -35,7 +35,7 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 487,
+    "source_module_count": 488,
     "typing_debt_module_count": 474,
     "typing_debt_inventory_sha256": "38e949d397eadffa94385375663b6ff2e9fc6ffe3cbdbac91ea5143565c01ad6",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
@@ -51,6 +51,7 @@
       "sdetkit.diagnostic_worker_trajectory",
       "sdetkit.failure_vector",
       "sdetkit.failure_vector_adapters",
+      "sdetkit.protected_proof_chain",
       "sdetkit.safety_gate",
       "sdetkit.trajectory_store"
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,10 @@ module = "sdetkit.failure_vector_adapters"
 ignore_errors = false
 
 [[tool.mypy.overrides]]
+module = "sdetkit.protected_proof_chain"
+ignore_errors = false
+
+[[tool.mypy.overrides]]
 module = [
   "sdetkit.diagnostic_execution_plan",
   "sdetkit.trajectory_store",

--- a/src/sdetkit/protected_proof_chain.py
+++ b/src/sdetkit/protected_proof_chain.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+
+SCHEMA_VERSION = "sdetkit.protected_proof_chain.v1"
+VERIFICATION_SCHEMA_VERSION = "sdetkit.protected_proof_chain_verification.v1"
+STATUS = "bound_review_first"
+
+STAGE_ORDER = (
+    "diagnostic_job",
+    "failure_vector",
+    "safety_gate",
+    "proof_result",
+    "verifier_result",
+    "patch_score",
+    "pr_report",
+    "trajectory",
+)
+JSON_STAGES = frozenset(stage for stage in STAGE_ORDER if stage != "pr_report")
+AUTHORITY_KEYS = frozenset(
+    {
+        "automation_allowed",
+        "patch_application_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+        "semantic_equivalence_claim",
+        "security_dismissal_allowed",
+        "automatic_security_fix_allowed",
+        "automatic_dismissal_allowed",
+        "security_dismissal",
+    }
+)
+ENABLED_TEXT = frozenset(
+    {
+        "1",
+        "allow",
+        "allowed",
+        "authorize",
+        "authorized",
+        "enable",
+        "enabled",
+        "proven",
+        "true",
+        "yes",
+    }
+)
+REPOSITORY_RE = re.compile(r"^[^\s/]+/[^\s/]+$")
+COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+MARKDOWN_AUTHORITY_RE = re.compile(
+    rf"(?im)^\s*(?:[-*]\s*)?(?P<key>{'|'.join(sorted(AUTHORITY_KEYS))})"
+    r"\s*[:=]\s*(?P<value>[^\n]+)$"
+)
+
+DECISION_BOUNDARY: dict[str, bool] = {
+    "automation_allowed": False,
+    "patch_application_allowed": False,
+    "merge_authorized": False,
+    "semantic_equivalence_proven": False,
+    "security_dismissal_allowed": False,
+}
+SEPARATION_OF_DUTIES: dict[str, object] = {
+    "worker_result_stage": "proof_result",
+    "independent_verifier_stage": "verifier_result",
+    "worker_may_self_certify": False,
+    "verifier_result_required": True,
+}
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _authority_enabled(value: object) -> bool:
+    if value is True:
+        return True
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().strip("`'\"").lower() in ENABLED_TEXT
+    return False
+
+
+def _json_violations(value: object, location: str = "$") -> list[str]:
+    violations: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_location = f"{location}.{key}"
+            if key in AUTHORITY_KEYS and _authority_enabled(child):
+                violations.append(child_location)
+            violations.extend(_json_violations(child, child_location))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            violations.extend(_json_violations(child, f"{location}[{index}]"))
+    return violations
+
+
+def _markdown_violations(text: str) -> list[str]:
+    return [
+        f"markdown:{match.group('key')}"
+        for match in MARKDOWN_AUTHORITY_RE.finditer(text)
+        if _authority_enabled(match.group("value"))
+    ]
+
+
+def _normalize_artifacts(artifacts: Mapping[str, str | Path]) -> dict[str, Path]:
+    provided = set(artifacts)
+    required = set(STAGE_ORDER)
+    missing = sorted(required - provided)
+    unexpected = sorted(provided - required)
+    if missing or unexpected:
+        details: list[str] = []
+        if missing:
+            details.append("missing=" + ",".join(missing))
+        if unexpected:
+            details.append("unexpected=" + ",".join(unexpected))
+        raise ValueError("invalid protected proof stages: " + "; ".join(details))
+
+    normalized = {stage: Path(artifacts[stage]) for stage in STAGE_ORDER}
+    absent = [stage for stage, path in normalized.items() if not path.is_file()]
+    if absent:
+        raise ValueError("missing protected proof artifact files: " + ", ".join(absent))
+    return normalized
+
+
+def _identity(repository: str, commit_sha: str) -> tuple[str, str]:
+    repository_text = repository.strip()
+    commit_text = commit_sha.strip()
+    if not REPOSITORY_RE.fullmatch(repository_text):
+        raise ValueError("repository identity must use owner/name form")
+    if not COMMIT_RE.fullmatch(commit_text):
+        raise ValueError("commit SHA must contain 7 to 64 hexadecimal characters")
+    return repository_text, commit_text.lower()
+
+
+def _entry(stage: str, path: Path) -> tuple[dict[str, object], list[str]]:
+    data = path.read_bytes()
+    entry: dict[str, object] = {
+        "stage": stage,
+        "artifact_name": path.name,
+        "sha256": _sha256(data),
+        "size_bytes": len(data),
+        "media_type": "application/json" if stage in JSON_STAGES else "text/markdown",
+    }
+    if stage in JSON_STAGES:
+        payload = json.loads(data)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object for protected proof artifact: {path}")
+        entry["artifact_schema_version"] = str(payload.get("schema_version") or "unknown")
+        violations = _json_violations(payload)
+    else:
+        entry["artifact_schema_version"] = "markdown"
+        violations = _markdown_violations(data.decode("utf-8", errors="replace"))
+    entry["authority_violation_count"] = len(violations)
+    return entry, violations
+
+
+def _material(
+    repository: str,
+    commit_sha: str,
+    entries: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": STATUS,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "stage_order": list(STAGE_ORDER),
+        "entries": entries,
+        "separation_of_duties": dict(SEPARATION_OF_DUTIES),
+        "decision_boundary": dict(DECISION_BOUNDARY),
+    }
+
+
+def build_protected_proof_chain(
+    *,
+    repository: str,
+    commit_sha: str,
+    artifacts: Mapping[str, str | Path],
+) -> dict[str, object]:
+    repository_text, commit_text = _identity(repository, commit_sha)
+    normalized = _normalize_artifacts(artifacts)
+    entries: list[dict[str, object]] = []
+    violations: list[str] = []
+    for stage in STAGE_ORDER:
+        entry, stage_violations = _entry(stage, normalized[stage])
+        entries.append(entry)
+        violations.extend(f"{stage}:{item}" for item in stage_violations)
+    if violations:
+        raise ValueError(
+            "protected proof artifacts attempted to expand authority: "
+            + ", ".join(violations)
+        )
+    material = _material(repository_text, commit_text, entries)
+    return {**material, "chain_id": _sha256(_canonical_json(material))}
+
+
+def verify_protected_proof_chain(
+    manifest: Mapping[str, object],
+    *,
+    artifacts: Mapping[str, str | Path],
+    expected_repository: str,
+    expected_commit_sha: str,
+) -> dict[str, object]:
+    repository_text, commit_text = _identity(expected_repository, expected_commit_sha)
+    rebuilt = build_protected_proof_chain(
+        repository=repository_text,
+        commit_sha=commit_text,
+        artifacts=artifacts,
+    )
+    fields = (
+        "schema_version",
+        "status",
+        "repository",
+        "commit_sha",
+        "stage_order",
+        "entries",
+        "separation_of_duties",
+        "decision_boundary",
+        "chain_id",
+    )
+    mismatches = [
+        {
+            "stage": f"manifest.{field}",
+            "expected": rebuilt[field],
+            "actual": manifest.get(field),
+        }
+        for field in fields
+        if manifest.get(field) != rebuilt[field]
+    ]
+    return {
+        "schema_version": VERIFICATION_SCHEMA_VERSION,
+        "ok": not mismatches,
+        "chain_id": str(manifest.get("chain_id") or ""),
+        "mismatches": mismatches,
+        "decision_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+    }
+
+
+def write_protected_proof_chain(
+    payload: Mapping[str, object],
+    *,
+    json_path: Path,
+    markdown_path: Path,
+) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_protected_proof_chain(payload), encoding="utf-8")
+
+
+def render_protected_proof_chain(payload: Mapping[str, object]) -> str:
+    entries = payload.get("entries")
+    safe_entries = entries if isinstance(entries, list) else []
+    lines = [
+        "# Protected proof chain",
+        "",
+        f"- status: `{payload.get('status', 'unknown')}`",
+        f"- repository: `{payload.get('repository', 'unknown')}`",
+        f"- commit_sha: `{payload.get('commit_sha', 'unknown')}`",
+        f"- chain_id: `{payload.get('chain_id', 'unknown')}`",
+        "- automation_allowed: `false`",
+        "- patch_application_allowed: `false`",
+        "- merge_authorized: `false`",
+        "- semantic_equivalence_proven: `false`",
+        "",
+        "## Bound stages",
+        "",
+    ]
+    for entry in safe_entries:
+        if isinstance(entry, dict):
+            lines.append(
+                f"- `{entry.get('stage', 'unknown')}`: `{entry.get('sha256', 'unknown')}` "
+                f"({entry.get('size_bytes', 0)} bytes)"
+            )
+    lines.extend(
+        [
+            "",
+            "The worker proof result and protected verifier result are separate bound stages.",
+            "This manifest records evidence identity only; it does not authorize a patch or merge.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/sdetkit/protected_proof_chain.py
+++ b/src/sdetkit/protected_proof_chain.py
@@ -200,8 +200,7 @@ def build_protected_proof_chain(
         violations.extend(f"{stage}:{item}" for item in stage_violations)
     if violations:
         raise ValueError(
-            "protected proof artifacts attempted to expand authority: "
-            + ", ".join(violations)
+            "protected proof artifacts attempted to expand authority: " + ", ".join(violations)
         )
     material = _material(repository_text, commit_text, entries)
     return {**material, "chain_id": _sha256(_canonical_json(material))}

--- a/tests/test_protected_proof_chain.py
+++ b/tests/test_protected_proof_chain.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.protected_proof_chain import (
+    STAGE_ORDER,
+    build_protected_proof_chain,
+    verify_protected_proof_chain,
+    write_protected_proof_chain,
+)
+
+REPOSITORY = "owner/repo"
+COMMIT_SHA = "a" * 40
+
+
+def _artifacts(root: Path) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for stage in STAGE_ORDER:
+        path = root / (f"{stage}.md" if stage == "pr_report" else f"{stage}.json")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if stage == "pr_report":
+            path.write_text("# PR report\n\nReview required.\n", encoding="utf-8")
+        else:
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": f"test.{stage}.v1",
+                        "automation_allowed": False,
+                        "patch_application_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_proven": False,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        result[stage] = path
+    return result
+
+
+def _build(artifacts: dict[str, Path]) -> dict[str, object]:
+    return build_protected_proof_chain(
+        repository=REPOSITORY,
+        commit_sha=COMMIT_SHA,
+        artifacts=artifacts,
+    )
+
+
+def _verify(
+    manifest: dict[str, object],
+    artifacts: dict[str, Path],
+    repository: str = REPOSITORY,
+    commit_sha: str = COMMIT_SHA,
+) -> dict[str, object]:
+    return verify_protected_proof_chain(
+        manifest,
+        artifacts=artifacts,
+        expected_repository=repository,
+        expected_commit_sha=commit_sha,
+    )
+
+
+def test_proof_chain_is_deterministic_and_review_first(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    first = _build(artifacts)
+    second = _build(artifacts)
+
+    assert first == second
+    assert first["stage_order"] == list(STAGE_ORDER)
+    assert first["separation_of_duties"]["worker_may_self_certify"] is False
+    assert first["separation_of_duties"]["verifier_result_required"] is True
+    assert all(value is False for value in first["decision_boundary"].values())
+    assert _verify(first, artifacts)["ok"] is True
+
+
+def test_proof_chain_detects_artifact_tampering(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    manifest = _build(artifacts)
+    artifacts["proof_result"].write_text(
+        '{"schema_version":"tampered","automation_allowed":false}\n',
+        encoding="utf-8",
+    )
+
+    result = _verify(manifest, artifacts)
+
+    assert result["ok"] is False
+    assert {item["stage"] for item in result["mismatches"]} == {
+        "manifest.entries",
+        "manifest.chain_id",
+    }
+
+
+@pytest.mark.parametrize("enabled", [True, 1, "true", "yes", "authorized"])
+def test_proof_chain_rejects_json_authority_expansion(
+    tmp_path: Path,
+    enabled: object,
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    artifacts["verifier_result"].write_text(
+        json.dumps(
+            {
+                "schema_version": "test.verifier.v1",
+                "nested": {"merge_authorized": enabled},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="attempted to expand authority"):
+        _build(artifacts)
+
+
+def test_proof_chain_rejects_markdown_authority_expansion(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    artifacts["pr_report"].write_text(
+        "# PR report\n\nmerge_authorized: `true`\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="pr_report:markdown:merge_authorized"):
+        _build(artifacts)
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("status", "verified"),
+        ("stage_order", ["verifier_result"]),
+        ("decision_boundary", {"merge_authorized": True}),
+    ],
+)
+def test_proof_chain_detects_manifest_tampering(
+    tmp_path: Path,
+    field: str,
+    replacement: object,
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    manifest = _build(artifacts)
+    tampered = copy.deepcopy(manifest)
+    tampered[field] = replacement
+
+    result = _verify(tampered, artifacts)
+
+    assert result["ok"] is False
+    assert f"manifest.{field}" in {item["stage"] for item in result["mismatches"]}
+
+
+def test_proof_chain_binds_external_identity_and_required_stages(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    manifest = _build(artifacts)
+    mismatch = _verify(manifest, artifacts, "other/repo", "b" * 40)
+    assert mismatch["ok"] is False
+    assert {item["stage"] for item in mismatch["mismatches"]} >= {
+        "manifest.repository",
+        "manifest.commit_sha",
+        "manifest.chain_id",
+    }
+
+    artifacts.pop("trajectory")
+    with pytest.raises(ValueError, match="missing=trajectory"):
+        _build(artifacts)
+
+
+def test_proof_chain_writes_reviewable_outputs(tmp_path: Path) -> None:
+    payload = _build(_artifacts(tmp_path))
+    json_path = tmp_path / "out" / "chain.json"
+    markdown_path = tmp_path / "out" / "chain.md"
+    write_protected_proof_chain(payload, json_path=json_path, markdown_path=markdown_path)
+
+    assert json.loads(json_path.read_text(encoding="utf-8"))["chain_id"] == payload["chain_id"]
+    markdown = markdown_path.read_text(encoding="utf-8")
+    assert "worker proof result and protected verifier result are separate" in markdown
+    assert "merge_authorized: `false`" in markdown

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,11 +24,11 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 487
+    assert payload["observed"]["source_module_count"] == 488
     assert payload["observed"]["typing_debt_module_count"] == 474
-    assert (
-        "sdetkit.failure_vector_adapters" in payload["observed"]["explicitly_type_checked_modules"]
-    )
+    checked = payload["observed"]["explicitly_type_checked_modules"]
+    assert "sdetkit.failure_vector_adapters" in checked
+    assert "sdetkit.protected_proof_chain" in checked
     assert payload["typing_debt_inventory"]["module_count"] == 474
     assert len(payload["typing_debt_inventory"]["modules"]) == 474
 


### PR DESCRIPTION
## Summary
- add a deterministic protected proof-chain contract covering diagnostic job, failure vector, safety gate, worker proof, protected verifier result, patch score, PR report, and trajectory
- bind every stage to repository identity, commit SHA, artifact name, schema, size, and SHA-256 digest
- require an externally supplied expected repository and commit SHA during verification
- compare the complete canonical manifest, not only artifact hashes
- reject authority escalation expressed as JSON booleans, numbers, strings, or Markdown fields
- require worker proof and verifier result as separate stages
- keep all automation, patch, merge, security-dismissal, and semantic-equivalence authority false
- opt the new module into a dedicated mypy ratchet while keeping typing debt flat at 474 modules

## Why
Individual diagnostic and verifier artifacts are not enough unless operators can prove they belong to the same repository state and have not been modified or used to expand authority. This PR creates a local, file-backed integrity boundary without executing commands or authorizing remediation.

## Verification
- `python -m pytest -q tests/test_protected_proof_chain.py tests/test_quality_truth_baseline.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- full Quality, CI, package, security, first-proof, premium, and advanced-platform proof

## Safety
- evidence binding only
- no target command execution
- no patch application
- `worker_may_self_certify=false`
- `verifier_result_required=true`
- external expected repository/SHA required for verification
- authority escalation is rejected in both JSON and Markdown inputs

## Risk
- Medium: new verifier-adjacent artifact contract
- no CLI registration or workflow authority change
- no external service or queue dependency
- rollback: remove the module, tests, and quality-baseline ratchet

## Supersedes
This replaces #1933 and the intermediate corrupted draft branch. It is rebuilt directly on merged main commit `25cdb812716d0ed09c2bd3c9038519730a8e6c41`.
