### PR TITLE
docs: sharpen public product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="docs/assets/logo-mark.svg" alt="DevS69 mark" width="68" />
   <h1>DevS69 SDETKit</h1>
-  <p><strong>Deterministic release confidence for ship / no-ship decisions.</strong></p>
+  <p><strong>From noisy CI evidence to deterministic ship / no-ship decisions.</strong></p>
 </div>
 
 DevS69 SDETKit is a release-confidence CLI for deterministic ship/no-ship decisions with machine-readable evidence.
@@ -24,10 +24,6 @@ python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor --format json --out build/doctor.json
 ```
 
-## Release channel
-
-The command above installs the latest published package, `sdetkit==1.0.3`. The repository `main` branch contains additional diagnostic, verification, benchmark, trajectory, and adoption capabilities that remain **main-only** until the next qualified release. See the [current product delta](docs/current-product-delta.md) before using repository documentation as installed-wheel proof.
-
 Generated first-run artifacts:
 
 ```text
@@ -37,6 +33,27 @@ build/
 └── doctor.json
 ```
 
+## Why SDETKit?
+
+Most quality tools stop at a failed check. SDETKit connects the evidence into an operator decision:
+
+- **Decide:** produce deterministic `SHIP` / `NO-SHIP` evidence.
+- **Diagnose:** extract the first meaningful failure instead of repeating the loudest wrapper error.
+- **Prove:** recommend exact verification commands and preserve machine-readable artifacts.
+- **Protect:** keep investigation and remediation review-first unless an explicit guarded policy allows more.
+
+## From failure to next action
+
+```text
+input: FAILED tests/test_release_contract.py::test_wheel_smoke
+classification: test
+affected_file: tests/test_release_contract.py
+next_command: python -m pytest -q tests/test_release_contract.py -o addopts=
+authority: review-first; no repository mutation or merge authorization
+```
+
+Start with [`docs/first-failure-triage.md`](docs/first-failure-triage.md) and [`docs/investigation-operator-guide.md`](docs/investigation-operator-guide.md).
+
 ## Decision contract
 
 | Signal | Decision |
@@ -44,8 +61,6 @@ build/
 | `gate-fast.json.ok == true` and `release-preflight.json.ok == true` | ✅ SHIP |
 | Any `ok: false` | ❌ NO-SHIP |
 | `failed_steps` present in either artifact | ❌ NO-SHIP |
-
-Canonical gate commands: `python -m sdetkit gate fast`, `python -m sdetkit gate release`, and `python -m sdetkit doctor`.
 
 Secondary lanes cover review, investigation, quality, maintenance, and CI automation once the primary gate decision is stable. Investigation/reporting/planning lanes are diagnostic-only by default; repository mutation requires explicit guarded policy and PR-only remediation controls.
 
@@ -57,21 +72,6 @@ Secondary lanes cover review, investigation, quality, maintenance, and CI automa
 - **Guarded automation path:** remediation and PR automation are explicit opt-in lanes, not the default behavior.
 - **One workflow everywhere:** use the same core commands locally, in CI, and during operator handoff.
 
-## Real-world learning and governance lanes
-
-The `main` branch includes read-only adoption and learning lanes for understanding real repositories before recommending proof or remediation. These main-only lanes are advisory by default: they collect evidence, classify repo shape, surface review-first unknowns, and produce upgrade candidates for SDETKit itself without installing target dependencies, running target tests, mutating target repositories, or opening target PRs/issues.
-
-Use these lanes when you need to evaluate repository readiness beyond the local release gate:
-
-| Lane | Start here | What it proves |
-| --- | --- | --- |
-| External repo adoption | [`docs/adoption.md`](docs/adoption.md) | Detects language, package, CI, docs, release, security, artifact, and proof-command surfaces. |
-| Evidence bundles | [`docs/artifact-reference.md`](docs/artifact-reference.md) | Keeps operator evidence reviewable and machine-readable. |
-| Learning loop | [`docs/investigation-operator-guide.md`](docs/investigation-operator-guide.md) | Turns repeated gaps into detector, report, memory, or roadmap upgrades. |
-| Product maturity radar | [`docs/docs-map.md`](docs/docs-map.md) | Treats radar/report tools as control panels, not replacements for the roadmap. |
-
-Authority boundary remains unchanged: `automation_allowed=false`, `patch_application_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false`.
-
 | Lane | Command | Start here when... |
 | --- | --- | --- |
 | Release gate | `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor` | You need a ship/no-ship decision. |
@@ -79,9 +79,6 @@ Authority boundary remains unchanged: `automation_allowed=false`, `patch_applica
 | Review | `python -m sdetkit review . --no-workspace --format operator-json` | You need operator-facing findings. |
 | Investigation | `python -m sdetkit investigate failure --log build/quality.log --format markdown` | A CI log or PR check needs triage before remediation. |
 | CI-ready | `./ci.sh quick --artifact-dir .sdetkit/out` and `make merge-ready` | You want a local CI-equivalent smoke path. |
-| First proof | `make first-proof` | You are validating this repository's full first-proof bundle. |
-
-Guided router: `make upgrade-next`.
 
 ## Product proof
 
@@ -95,7 +92,44 @@ SDETKit is backed by committed live-adoption proof.
 - **Proof page:** [`docs/live-adoption-product-proof.md`](docs/live-adoption-product-proof.md)
 <!-- product-proof-end -->
 
-For this repository, `make first-proof` emits `FIRST_PROOF_DECISION=SHIP|NO-SHIP` and writes the consolidated bundle under `build/first-proof/`. Use [`docs/upgrade-next-commands.md`](docs/upgrade-next-commands.md), [`docs/first-proof-troubleshooting.md`](docs/first-proof-troubleshooting.md), and [`docs/first-proof-learning-db.md`](docs/first-proof-learning-db.md) for the full first-proof/ops command set.
+For this repository, `make first-proof` emits `FIRST_PROOF_DECISION=SHIP|NO-SHIP` and writes the consolidated bundle under `build/first-proof/`.
+
+## Release channel
+
+The install command above uses the latest published package, `sdetkit==1.0.3`. The repository `main` branch contains additional diagnostic, verification, benchmark, trajectory, and adoption capabilities that remain **main-only** until the next qualified release. See the [current product delta](docs/current-product-delta.md) before treating repository documentation as installed-wheel proof.
+
+## Documentation map
+
+- Start in 5 minutes: [docs/start-here-5-minutes.md](docs/start-here-5-minutes.md)
+- Operator essentials: [docs/operator-essentials.md](docs/operator-essentials.md)
+- Investigation operator guide: [docs/investigation-operator-guide.md](docs/investigation-operator-guide.md)
+- Adaptive diagnosis: [docs/adaptive-diagnosis.md](docs/adaptive-diagnosis.md)
+- Artifact reference: [docs/artifact-reference.md](docs/artifact-reference.md)
+- Recommended CI flow: [docs/recommended-ci-flow.md](docs/recommended-ci-flow.md)
+- CLI reference: [docs/cli.md](docs/cli.md)
+- Contributor guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Advanced lanes live in docs
+
+Historical and transition-era references (secondary) remain outside the first-time path.
+
+- External repository adoption: [docs/adoption.md](docs/adoption.md)
+- Portfolio readiness and reporting: [docs/portfolio-readiness.md](docs/portfolio-readiness.md)
+- Operations handbook: [docs/operations-handbook.md](docs/operations-handbook.md)
+- Remediation cookbook: [docs/remediation-cookbook.md](docs/remediation-cookbook.md)
+- Release process: [docs/project/release-process.md](docs/project/release-process.md)
+
+## Top-tier reporting sample pipeline
+
+Run `make top-tier-reporting`; see [docs/portfolio-reporting-recipe.md](docs/portfolio-reporting-recipe.md) and [docs/kpi-schema.md](docs/kpi-schema.md).
+
+## Upgrade next (intent router)
+
+Run `make upgrade-next`; see [docs/upgrade-next-commands.md](docs/upgrade-next-commands.md).
+
+## Real workflow operations
+
+See [docs/real-workflow-operations.md](docs/real-workflow-operations.md). Common aliases: `make ops-daily`, `make ops-daily-fast`, `make ops-weekly`, `make ops-premerge`, `make ops-premerge-fast`, `make ops-premerge-next`, `make ops-premerge-next-fast`, `make ops-followup`, `make ops-now`, `make ops-now-lite`, `make ops-next`.
 
 ## Repository layout
 
@@ -103,58 +137,12 @@ For this repository, `make first-proof` emits `FIRST_PROOF_DECISION=SHIP|NO-SHIP
 | --- | --- |
 | `src/` | SDETKit Python package and CLI implementation. |
 | `tests/` | Unit, workflow, docs, and contract tests. |
-| `docs/` | Operator guides, artifact references, quality gates, and developer docs. |
-| `docs/artifacts/` | Committed generated/sample artifacts and historical proof packs. |
-| `docs/project/` | Project-level architecture, workflow, release, quality, and enterprise docs moved out of the root. |
+| `docs/` | Operator guides, artifact references, quality gates, and developer docs, including `docs/artifacts/`. |
 | `.github/workflows/` | CI, quality, maintenance, and artifact upload automation. |
-
-## Documentation map
-
-- Current released versus main product delta: [docs/current-product-delta.md](docs/current-product-delta.md)
-- Start in 5 minutes: [docs/start-here-5-minutes.md](docs/start-here-5-minutes.md)
-- Docs index: [docs/index.md](docs/index.md)
-- Operator essentials: [docs/operator-essentials.md](docs/operator-essentials.md)
-- Investigation operator guide: [docs/investigation-operator-guide.md](docs/investigation-operator-guide.md)
-- Adaptive diagnosis: [docs/adaptive-diagnosis.md](docs/adaptive-diagnosis.md)
-- Artifact reference and generated sample map: [docs/artifact-reference.md](docs/artifact-reference.md)
-- CI artifact walkthrough: [docs/ci-artifact-walkthrough.md](docs/ci-artifact-walkthrough.md)
-- Recommended CI flow: [docs/recommended-ci-flow.md](docs/recommended-ci-flow.md)
-- CLI reference: [docs/cli.md](docs/cli.md)
-- Portfolio reporting recipe: [docs/portfolio-reporting-recipe.md](docs/portfolio-reporting-recipe.md)
-- Portfolio readiness: [docs/portfolio-readiness.md](docs/portfolio-readiness.md)
-- Operations handbook: [docs/operations-handbook.md](docs/operations-handbook.md)
-- Remediation cookbook: [docs/remediation-cookbook.md](docs/remediation-cookbook.md)
-
-Historical and transition-era references (secondary) are intentionally secondary. Open the docs index after the canonical first path is working.
-
-## Advanced lanes live in docs
-
-To keep this README readable, advanced command matrices live in focused guides:
-
-- First-proof and operator command router: [docs/upgrade-next-commands.md](docs/upgrade-next-commands.md)
-- Multi-repo and portfolio posture: [docs/portfolio-readiness.md](docs/portfolio-readiness.md) and [docs/portfolio-reporting-recipe.md](docs/portfolio-reporting-recipe.md)
-- Maintenance and recurring operations: [docs/operations-handbook.md](docs/operations-handbook.md)
-- Rollback/remediation examples: [docs/integrations/rollback-remediation-examples.md](docs/integrations/rollback-remediation-examples.md)
-- Failure remediation workflow example: [examples/kits/intelligence/failure-fix-playbook.md](examples/kits/intelligence/failure-fix-playbook.md)
-
-## Top-tier reporting sample pipeline
-
-Run `make top-tier-reporting` for the sample reporting lane. See [docs/portfolio-reporting-recipe.md](docs/portfolio-reporting-recipe.md) and [docs/kpi-schema.md](docs/kpi-schema.md).
-
-## Upgrade next (intent router)
-
-Run `make upgrade-next` for the guided next-command router. Full details live in [docs/upgrade-next-commands.md](docs/upgrade-next-commands.md).
-
-## Real workflow operations
-
-Real workflow operations live in [docs/real-workflow-operations.md](docs/real-workflow-operations.md). Common aliases: `make ops-daily`, `make ops-daily-fast`, `make ops-weekly`, `make ops-premerge`, `make ops-premerge-fast`, `make ops-premerge-next`, `make ops-premerge-next-fast`, `make ops-followup`, `make ops-now`, `make ops-now-lite`, `make ops-next`.
 
 ## Project policies
 
-- Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Docs map: [docs/docs-map.md](docs/docs-map.md)
 - Security: [SECURITY.md](SECURITY.md)
-- Security docs: [docs/security.md](docs/security.md)
-- Policy baselines: [docs/policy-and-baselines.md](docs/policy-and-baselines.md)
 - Quality playbook: [docs/project/quality-playbook.md](docs/project/quality-playbook.md)
-- Release process: [docs/project/release-process.md](docs/project/release-process.md)
 - Release notes: [CHANGELOG.md](CHANGELOG.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,29 +15,44 @@ The current package is backed by a committed live-adoption proof pack:
 
 DevS69 SDETKit is a release-confidence CLI for deterministic ship/no-ship decisions with machine-readable evidence.
 
+**From noisy CI evidence to a reviewable decision, diagnosis, and exact next command.**
+
 **Primary outcome:** know if a change is ready to ship.
 
 Canonical first path: `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor`.
-
-Guided alias for first-time users: `python -m sdetkit start --journey fast-start --format markdown`.
 
 This page is the product homepage/router for first-time adoption.
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🧭 Choose your path](choose-your-path.md) · [🧭 Repo tour](repo-tour.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [📦 Artifact reference](artifact-reference.md) · [Operator guide](operator-essentials.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
+[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
 
 </div>
 
 ### Top journeys
 
-
-- Run a read-only external-repo adoption check and inspect evidence before prescribing work
-- Convert repeated real-world repo gaps into detector, report, memory, or roadmap upgrades
-- Use the product maturity radar as a roadmap control panel without replacing review-first governance
 - Run first command in under 60 seconds
 - Validate docs links and anchors before publishing
 - Ship a first contribution with deterministic quality gates
+
+## Why teams use SDETKit
+
+- **Release owners:** deterministic `SHIP` / `NO-SHIP` evidence.
+- **SDET and QA engineers:** the first meaningful failure rather than a wrapper verdict.
+- **Platform teams:** machine-readable evidence and exact proof commands.
+- **Reviewers:** explicit review-first authority boundaries.
+
+## Failure to next action
+
+```text
+classification: test
+first_failure: FAILED tests/test_release_contract.py::test_wheel_smoke
+affected_file: tests/test_release_contract.py
+verification: python -m pytest -q tests/test_release_contract.py -o addopts=
+decision: review-first
+```
+
+Use [First failure triage](first-failure-triage.md) for the shortest operator path and [Investigation operator guide](investigation-operator-guide.md) for the full safety contract.
 
 ## Fast start
 
@@ -47,134 +62,82 @@ python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 
-New teams should stop here first, then inspect artifacts before exploring advanced commands.
-
-Compatibility aliases still supported: `python -m sdetkit gate fast`, `python -m sdetkit gate release`, and `python -m sdetkit doctor`.
-
-## What you get
+Generated artifacts:
 
 ```text
 build/gate-fast.json
 build/release-preflight.json
 ```
 
-## Pick your path first
+New teams should stop here first, inspect the evidence, and only then expand into advanced lanes.
 
-- [Choose your path (30-second router)](choose-your-path.md)
-- Equivalent namespace form: `python -m sdetkit release gate fast --format json --stable-json --out build/gate-fast.json`
-- Full release path: `python -m sdetkit release gate fast` -> `python -m sdetkit release gate release` -> `python -m sdetkit release doctor`
+## Choose your path
 
-## Try it quickly
-
+- [Choose your path](choose-your-path.md)
 - [Start Here in 5 Minutes](start-here-5-minutes.md)
-- [Upgrade next commands (intent router)](upgrade-next-commands.md)
 - [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
 - [First run quickstart](ready-to-use.md)
-- [Quickstart (copy-paste)](quickstart-copy-paste.md)
 - [Fit decision guide](decision-guide.md)
 
-## Keep first adoption simple
+## Operator path
 
-1. Start with the canonical path (`gate fast` -> `gate release` -> `doctor`).
-2. Optional guided onboarding prompt: `python -m sdetkit start --journey fast-start --format markdown`.
-3. For reviewer handoff + adoption planning, prefer the one-command bundle:
-   - `make adoption-control-loop-full`
-4. Expand to individual sub-steps only when debugging or customizing:
-   - `make gate-decision-summary`
-   - `make adoption-followup`
-   - `make adoption-followup-contract`
-   - `make adoption-posture`
-   - `make adoption-validate`
-
-## Docs information architecture
-
-Use this index as the primary human navigation map. The docs are organized around common operator jobs rather than historical delivery waves:
-
-- **Getting started:** first commands, first artifacts, and adoption quickstarts.
-- **Operator guide:** daily release-confidence commands and diagnostic-only investigation.
-- **Investigation / diagnosis:** failure triage, adaptive diagnosis, and proof selection.
-- **Maintenance / autopilot:** guarded workflow evidence, safe-fix audit trails, and PR-only remediation boundaries.
-- **Quality gates:** release, security, premium, and determinism gates.
-- **Artifact reference:** runtime artifact paths plus committed generated/sample artifact labels.
-- **Contributor / developer docs:** repo tour, contribution flow, tests, and release maintenance.
-
-For a compact tree-level map, use [Docs map and organization](docs-map.md).
-
-## Team rollout / CI
-
-## Real-world learning and governance
-
-SDETKit can now run read-only adoption and learning lanes against cloned external repositories while keeping artifacts outside the target repo. These lanes are designed for product learning and operator evidence, not automatic target patching.
-
-- Start with [Adopt in your repository](adoption.md) for external-repo readiness and adoption-surface evidence.
-- Use [Artifact reference and generated sample map](artifact-reference.md) to understand machine-readable outputs and evidence bundles.
-- Use [Artifact reference and generated sample map](artifact-reference.md#evidence-circuit-artifact-source-map) to map evidence-circuit docs to PR Quality, Runtime Proof, and ProtectedVerifier artifacts.
-- Use [Investigation operator guide](investigation-operator-guide.md) when a CI log, repo shape, or proof command needs review-first diagnosis.
-- Use this docs homepage and [Docs map and organization](docs-map.md) to keep radar, report, and governance tools connected to the broader roadmap.
+- [Operator essentials](operator-essentials.md)
+- [Investigation operator guide](investigation-operator-guide.md)
+- [First failure triage](first-failure-triage.md)
+- [Adaptive Diagnosis Intelligence](adaptive-diagnosis.md)
+- [Artifact reference and generated sample map](artifact-reference.md)
+- [CI artifact walkthrough](ci-artifact-walkthrough.md)
+- [Recommended CI flow](recommended-ci-flow.md)
+- [Release confidence flow](release-confidence-flow.md)
 
 Safety boundary: adoption and learning outputs are advisory unless an explicit guarded policy says otherwise.
 
+## Adoption and team rollout
 
 - [Adopt in your repository](adoption.md)
 - [Team adoption checklist](team-adoption-checklist.md)
-- [Operator essentials](operator-essentials.md)
-- [Investigation operator guide](investigation-operator-guide.md)
-- [Artifact reference and generated sample map](artifact-reference.md)
-- [Docs map and organization](docs-map.md)
 - [Operator onboarding (7-day)](operator-onboarding-7-day.md)
-- [Baseline readiness execution checklist](operations-execution-checklist.md)
-- [Next 10 follow-ups](next-10-followups.md)
-- [Recommended CI flow](recommended-ci-flow.md)
-- [CI artifact walkthrough](ci-artifact-walkthrough.md)
-- [Release confidence flow](release-confidence-flow.md)
-- [First failure triage](first-failure-triage.md)
-- [Phase-by-phase execution plan](operations-execution-plan.md)
-- [One-by-one phase execution](operations-execution-guide.md)
+- [Real repository adoption](real-repo-adoption.md)
+- [Portfolio readiness](portfolio-readiness.md)
+- [Portfolio reporting recipe](portfolio-reporting-recipe.md)
 
-## Investigation, maintenance, and quality gates
+SDETKit can inspect cloned external repositories in read-only mode, keep artifacts outside the target repository, and report unknown surfaces as review-first.
 
-- [Adaptive Diagnosis Intelligence](adaptive-diagnosis.md)
-- [Investigation operator guide](investigation-operator-guide.md)
-- [Maintenance/autopilot artifact map](artifact-reference.md#maintenance-autopilot-upload-set)
-- [Remediation cookbook](remediation-cookbook.md)
+## Quality, security, and remediation
+
 - [Premium quality gate](premium-quality-gate.md)
 - [Security gate](security-gate.md)
-- [PR automation for audit auto-fixes](pr-automation.md)
-
-## Reference / advanced
-
-- [CLI reference](cli.md)
-- [Artifact reference and generated sample map](artifact-reference.md)
-- [Doctor checks](doctor.md)
-- [Stability levels](stability-levels.md)
+- [Remediation cookbook](remediation-cookbook.md)
+- [PR automation boundary](pr-automation.md)
 - [Versioning and support posture](versioning-and-support.md)
-- [Integrations and extension boundary](integrations-and-extension-boundary.md)
-- [Why SDETKit for teams](why-sdetkit-for-teams.md)
-- [Use cases](use-cases.md)
-- [Release confidence ROI](release-confidence-roi.md)
-- [Repo health dashboard](repo-health-dashboard.md)
-- [Deep Repo Index Engine (Wave 1)](repo-index-engine.md)
-- [Business execution hub](business_execution/index.md)
-- [Merge readiness and execution checklist](business_execution/08-merge-readiness-checklist.md)
+- [Stability levels](stability-levels.md)
+
+## Contributor and developer path
+
+- [Contributing](contributing.md)
+- [Repository tour](repo-tour.md)
+- [CLI reference](cli.md)
+- [Docs map and organization](docs-map.md)
+- [Project structure](project-structure.md)
+- [Operations handbook](operations-handbook.md)
+- [Release process](project/release-process.md)
+
+## Architecture and evidence
+
+- [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md)
+- [Operator evidence review guide](operator-evidence-review-guide.md)
+- [Evidence graph summary](evidence-graph-summary.md)
+- [Evidence circuit review pack](evidence-circuit-review-pack.md)
+- [Release-readiness evidence handoff](release-readiness-evidence-handoff.md)
 
 ## Legacy reports
 
-Historical and transition-era references remain intentionally secondary to first-time adoption; use archive index material only after the canonical first proof path is operating.
+Historical and transition-era references remain intentionally secondary to first-time adoption. Use the [archive index](archive/index.md) only after the canonical first proof path is operating.
 
-- Archive index: [docs/archive/index.md](archive/index.md)
-- Top-tier reporting troubleshooting: [top-tier-reporting-troubleshooting.md](top-tier-reporting-troubleshooting.md)
+- [Top-tier reporting troubleshooting](top-tier-reporting-troubleshooting.md)
 
 ## Install and runtime notes
 
 - Python 3.10+
-- Prefer isolated environments
-- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q`
-
-## Architecture checkpoints
-
-- [Evidence circuit architecture checkpoint](evidence-circuit-architecture-checkpoint.md): documents the completed FailureVectorEngine → SafetyGate → TrajectoryStore → RepoMemory → ProtectedVerifier → PR Quality → Runtime Proof → benchmark replay circuit and the reporting-only stop condition.
-- [Operator evidence review guide](operator-evidence-review-guide.md): explains how reviewers should inspect the completed evidence circuit without granting patch, dismissal, merge, or semantic authority.
-- [Evidence graph summary](evidence-graph-summary.md): maps the completed evidence circuit into reviewer-facing source, authority, and artifact inspection steps.
-- [Dashboard and reporting polish](dashboard-reporting-polish.md): explains how to read PR Quality dashboards, artifact centers, Runtime Proof summaries, and ProtectedVerifier output without expanding authority.
-- [Evidence circuit review pack](evidence-circuit-review-pack.md): bundles the dashboard, artifact, graph, operator, and release-readiness docs into one reviewer path.
-- [Release-readiness evidence handoff](release-readiness-evidence-handoff.md): gives release reviewers a reporting-only template for PR Quality, Runtime Proof, and ProtectedVerifier evidence.
+- Prefer isolated environments.
+- Validate docs with `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q`.


### PR DESCRIPTION
## Summary
- lead the README with the core value: noisy CI evidence to deterministic ship/no-ship decisions
- add a compact failure-to-next-action example for first-time visitors
- simplify the documentation homepage around operator journeys, proof, adoption, and contribution
- preserve the canonical command path, product-proof markers, artifact paths, review-first safety boundary, and guarded operator-navigation contracts

## Why
The repository already has substantial engineering depth, but first-time visitors need to understand the product value within seconds. This PR makes the public front doors clearer without changing runtime behavior or expanding automation authority.

## Verification

### Initial CI diagnosis
The first run exposed six documentation contract failures after the rewrite removed guarded navigation anchors and operator links. The loud wrapper described a coverage failure, but actual coverage was **96.69%**, above the required 95%. The real failures were:

- docs navigation quick-jump and top-journey baseline
- explicit demotion wording for transition-era material
- real-workflow operations link and aliases
- top-tier reporting references
- upgrade-next intent-router reference

The follow-up commits restored those contracts while retaining the clearer product story. The corrected head is now running through CI.

### Focused proof contract

```bash
python -m pytest -q \
  tests/test_docs_navigation.py::test_docs_navigation_json_and_strict_success \
  tests/test_public_front_door_alignment.py::test_secondary_material_is_explicitly_demoted_from_front_door \
  tests/test_real_workflow_ops_contract.py::test_readme_links_real_workflow_and_ops_aliases \
  tests/test_top_tier_reporting_docs_index.py::test_docs_index_mentions_top_tier_troubleshooting \
  tests/test_top_tier_reporting_readme.py::test_readme_mentions_top_tier_reporting_pipeline \
  tests/test_upgrade_next_onramp.py::test_readme_links_upgrade_next_intent_router \
  -o addopts=
NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
python -m pre_commit run -a
```

## Risk
- Low: documentation-only public positioning change
- Runtime behavior: unchanged
- Automation authority: unchanged
- Rollback: easy; revert the documentation commits

## Notes
- The README remains within the existing concise-front-door limit at 150 lines.
- PyPI/package metadata already uses compatible release-confidence positioning, so this PR intentionally avoids version or release-workflow changes.
- Qualified 1.1.0 publication remains tracked separately in #1928.