### PR TITLE
security: remove synthetic fixture alerts from OSV results

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -23,6 +23,9 @@ jobs:
     with:
       scan-args: |-
         -r
+        # This fixture models external-repository discovery only. It is not a
+        # shipped dependency surface and must not create repository security noise.
+        --exclude=tests/fixtures/public_adoption_target
         ./
       fail-on-vuln: false
       upload-sarif: true

--- a/tests/fixtures/public_adoption_target/go.mod
+++ b/tests/fixtures/public_adoption_target/go.mod
@@ -1,3 +1,3 @@
 module example.com/public-adoption-target
 
-go 1.23
+go 1.26

--- a/tests/fixtures/public_adoption_target/requirements-security.txt
+++ b/tests/fixtures/public_adoption_target/requirements-security.txt
@@ -1,1 +1,1 @@
-pip-audit==2.7.3
+pip-audit==2.10.1

--- a/tests/test_osv_scanner_fixture_scope.py
+++ b/tests/test_osv_scanner_fixture_scope.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "osv-scanner.yml"
+FIXTURE = ROOT / "tests" / "fixtures" / "public_adoption_target"
+
+
+def test_osv_repo_scan_preserves_root_coverage_and_excludes_non_runtime_fixture() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    normalized_lines = {line.strip() for line in workflow.splitlines()}
+
+    assert "-r" in normalized_lines
+    assert "./" in normalized_lines
+    assert "--exclude=tests/fixtures/public_adoption_target" in normalized_lines
+    assert "upload-sarif: true" in normalized_lines
+
+
+def test_public_adoption_fixture_uses_current_security_toolchain_markers() -> None:
+    requirement = (FIXTURE / "requirements-security.txt").read_text(encoding="utf-8").strip()
+    requirement_match = re.fullmatch(r"pip-audit==(\d+)\.(\d+)\.(\d+)", requirement)
+    assert requirement_match is not None
+    assert tuple(int(part) for part in requirement_match.groups()) >= (2, 10, 1)
+
+    go_mod = (FIXTURE / "go.mod").read_text(encoding="utf-8")
+    go_match = re.search(r"^go (\d+)\.(\d+)$", go_mod, flags=re.MULTILINE)
+    assert go_match is not None
+    assert tuple(int(part) for part in go_match.groups()) >= (1, 26)


### PR DESCRIPTION
## Summary

- keep the repository-wide recursive OSV scan active
- exclude the non-runtime `tests/fixtures/public_adoption_target` discovery fixture from repository security results
- refresh the fixture marker from `pip-audit==2.7.3` to `pip-audit==2.10.1`
- refresh the fixture Go language version from `1.23` to `1.26`
- add a regression contract that preserves root scan coverage, SARIF upload, and the narrow fixture exclusion

## Root cause

The current 51 open code-scanning findings are one noise class rather than 51 production vulnerabilities:

```text
tool=osv-scanner
state=open
classification=test
fixture=tests/fixtures/public_adoption_target
python_dependency_findings=15
go_stdlib_findings=36
production_runtime_findings=0
```

The Python findings come from the stale transitive dependency tree of `pip-audit==2.7.3`. The Go findings come from the synthetic fixture's `go 1.23` marker. This directory exists only to demonstrate read-only adoption-surface discovery and is not installed, executed, packaged, or shipped.

## Safety boundary

- recursive scan of `./` remains enabled
- SARIF upload remains enabled
- no vulnerability ID is ignored or dismissed
- no production manifest or runtime dependency is excluded
- exclusion is limited to one documented non-runtime fixture directory
- future fixture drift is guarded by a focused test

## Verification

CI must prove:

```bash
python -m pytest -q tests/test_osv_scanner_fixture_scope.py tests/test_public_launch_proof_contract.py -o addopts=
python -m pre_commit run -a
python -m sdetkit workflow-governance-report --root . --format text
```

The OSV pull-request scan must complete without recreating the 51 fixture findings. After merge, the main-branch scan must refresh Code Scanning so the existing alerts close as fixed/absent from the latest analysis.

## Risk

Low and bounded. The change narrows one synthetic fixture path while retaining the repository root scan and all production dependency surfaces.
