### PR TITLE
ci: enforce workflow consolidation plan parity

### DIFF
--- a/docs/contracts/workflow-consolidation-plan.v1.json
+++ b/docs/contracts/workflow-consolidation-plan.v1.json
@@ -1,7 +1,8 @@
 {
   "plan_id": "sdetkit.workflow-consolidation.v1",
-  "generated_at_utc": "2026-06-30T00:00:00Z",
-  "current_workflow_count": 56,
+  "generated_at_utc": "2026-07-02T00:00:00Z",
+  "baseline_main_sha": "326a59c4d1294c1c970a4e6848d4c9487c4278c2",
+  "current_workflow_count": 57,
   "target_primary_workflow_count": 12,
   "keep_primary": [
     "ci.yml",
@@ -60,8 +61,43 @@
     "kpi-weekly.yml",
     "release-readiness-radar-bot.yml"
   ],
+  "standalone_supporting": [
+    "adaptive-ops-weekly.yml",
+    "adaptive-sentinel-monitor.yml",
+    "enforce-branch-protection.yml",
+    "first-proof-artifact-publish.yml",
+    "first-proof.yml",
+    "impact-release-control.yml",
+    "legacy-required-status-bridge.yml",
+    "maintenance-autopilot.yml",
+    "maintenance-issue-command-center.yml",
+    "operational-readiness-governance-contract.yml",
+    "platform-readiness-quality-contract.yml",
+    "pr-quality-publisher.yml",
+    "release-candidate.yml",
+    "repo-memory-history.yml"
+  ],
+  "compatibility_bridges": [
+    "legacy-required-status-bridge.yml",
+    "operational-readiness-governance-contract.yml",
+    "platform-readiness-quality-contract.yml"
+  ],
+  "reusable_workflows": [
+    "advanced-github-actions-reference-64.yml"
+  ],
+  "trusted_publishers": [
+    "first-proof-artifact-publish.yml",
+    "pr-quality-publisher.yml"
+  ],
+  "classification_policy": {
+    "disposition_groups_are_complete": true,
+    "disposition_groups_are_mutually_exclusive": true,
+    "metadata_classifications_may_overlap_dispositions": true,
+    "workflow_retirement_requires_parity_evidence": true
+  },
   "execution_order": [
     "record_current_topology_and_required_checks",
+    "enforce_plan_inventory_parity",
     "stop_zero_signal_issue_creation",
     "consume_canonical_ci_artifacts",
     "introduce_reusable_workflow_bundles",
@@ -88,5 +124,11 @@
     "no_coverage_regression": true,
     "zero_signal_generated_issues": 0,
     "required_check_compatibility_preserved": true
+  },
+  "authority_boundary": {
+    "automation_allowed": false,
+    "workflow_retirement_allowed": false,
+    "branch_protection_mutation_allowed": false,
+    "merge_authorized": false
   }
 }

--- a/docs/workflow-consolidation-map.md
+++ b/docs/workflow-consolidation-map.md
@@ -1,123 +1,86 @@
 # Workflow Consolidation Map (P0.2)
 
 Status: Active proposal (v1)
-Date: 2026-04-16
+Date: 2026-07-02
 
 ## Objective
 
-Reduce CI/workflow sprawl while preserving release-safety coverage by moving from many overlapping workflows to a smaller, tiered operating model.
+Reduce workflow fan-out while preserving required-check compatibility, evidence quality, and release safety.
 
-Current inventory baseline: **56 workflows** under `.github/workflows` (validated 2026-06-22). The contract layer prevents further unreviewed growth while the repository moves toward the 12-anchor target.
+The current baseline is **57 workflow files**. The durable target remains **12 primary workflows** with specialist behavior moved into reusable or scheduled bundles only after parity proof.
 
-## Target operating model
+## Primary anchors
 
-Move to 12 durable workflows (core + security + release + docs + maintenance), with specialist checks routed through reusable workflows or scheduled jobs.
+1. `ci.yml`
+2. `quality.yml`
+3. `security.yml`
+4. `release.yml`
+5. `repo-audit.yml`
+6. `dependency-review.yml`
+7. `pages.yml`
+8. `docs-link-check.yml`
+9. `weekly-maintenance.yml`
+10. `versioning.yml`
+11. `enterprise-gate.yml`
+12. `top-tier-reporting-sample.yml`
 
-### Keep as primary anchors
+## Enforced inventory model
 
-1. `ci.yml` (core PR/push verification)
-2. `quality.yml` (quality lane + deeper validation)
-3. `security.yml` (security baseline)
-4. `release.yml` (release pipeline)
-5. `repo-audit.yml` (repo health contract)
-6. `dependency-review.yml` (PR dependency risk gate)
-7. `pages.yml` (docs publishing)
-8. `docs-link-check.yml` (docs integrity)
-9. `weekly-maintenance.yml` (scheduled maintenance bundle)
-10. `versioning.yml` (version policy automation)
-11. `enterprise-gate.yml` (enterprise decision lane)
-12. `top-tier-reporting-sample.yml` (portfolio/reporting sample lane)
+Every workflow now has exactly one disposition in `docs/contracts/workflow-consolidation-plan.v1.json`:
 
-### Merge into bundles (retire standalone files after migration)
+- primary anchor
+- planned bundle member
+- retirement candidate requiring parity evidence
+- standalone supporting workflow
 
-- **Security bots bundle** (merge):
-  - `ghas-alert-sla-bot.yml`
-  - `ghas-campaign-bot.yml`
-  - `ghas-codeql-hotspots-bot.yml`
-  - `ghas-metrics-export-bot.yml`
-  - `ghas-review-bot.yml`
-  - `secret-protection-review-bot.yml`
-  - `security-configuration-audit-bot.yml`
-  - `security-maintenance-bot.yml`
-  - `osv-scanner.yml`
-  - `sbom.yml`
+Compatibility bridges, reusable workflows, and trusted publishers are recorded as metadata because those properties may overlap a workflow's disposition.
 
-- **Dependency automation bundle** (merge):
-  - `dependency-audit.yml`
-  - `dependency-auto-merge.yml`
-  - `dependency-radar-bot.yml`
-  - `pre-commit-autoupdate.yml`
+The plan currently records:
 
-- **Platform operations bundle** (merge):
-  - `repo-optimization-bot.yml`
-  - `runtime-watchlist-bot.yml`
-  - `worker-alignment-bot.yml`
-  - `workflow-governance-bot.yml`
-  - `integration-topology-radar-bot.yml`
-  - `maintenance-on-demand.yml`
+- 12 primary workflows
+- 24 planned bundle members
+- 7 retirement candidates
+- 14 standalone supporting workflows
+- 3 compatibility bridges
+- 1 reusable workflow
+- 2 trusted publishers
 
-- **Adoption/comms bundle** (merge):
-  - `pr-helper-bot.yml`
-  - `pr-quality-comment.yml`
-  - `contributor-onboarding-bot.yml`
-  - `docs-experience-bot.yml`
+The 57th workflow, `release-candidate.yml`, is explicitly classified as supporting release qualification. It is read-only and does not grant publication authority.
 
-### Candidate retire/absorb (after parity check)
+## Migration order
 
-- `advanced-github-actions-reference-64.yml` (documentation/reference lane; absorb into docs process)
-- `adapter-smoke-bot.yml` (absorb into `ci.yml` matrix or `quality.yml`)
-- `adoption-real-repo-canonical.yml` (convert to scheduled job in adoption bundle)
-- `premium-gate.yml` (absorb under `quality.yml` strict profile)
-- `mutation-tests.yml` (scheduled strict check under quality bundle)
-- `kpi-weekly.yml` and `release-readiness-radar-bot.yml` (fold under reporting + enterprise gate cadence)
+1. Record current topology and required checks.
+2. Enforce consolidation-plan parity.
+3. Stop zero-signal issue creation.
+4. Measure duplicate triggers and overlapping proof commands.
+5. Introduce one reusable bundle in shadow mode.
+6. Retire only after equivalent artifacts and checks are proven.
 
-## Ownership tags (proposed)
+## Phase A status
 
-- **Platform Engineering:** `ci.yml`, `quality.yml`, `repo-audit.yml`, `versioning.yml`
-- **Security Engineering:** `security.yml`, security bots bundle, `dependency-review.yml`
-- **Release Engineering:** `release.yml`, `enterprise-gate.yml`
-- **Developer Experience / Docs:** `pages.yml`, `docs-link-check.yml`, adoption/comms bundle
-- **Program Ops:** `top-tier-reporting-sample.yml`, reporting/radar scheduled jobs
+- [x] Machine-readable workflow topology and required-check contracts.
+- [x] Complete and mutually exclusive disposition coverage for all 57 workflows.
+- [x] Zero-finding issue creation prohibited by contract.
+- [ ] Run-frequency and failure-rate telemetry.
+- [ ] Duplicate trigger and proof-command report.
+- [ ] First reusable bundle with shadow parity.
 
-## Phased migration checklist (CI-safe)
+## Safety boundary
 
-### Phase A — Baseline and parity
+This phase is reporting-only. It does not remove workflows, rename required checks, change permissions, alter release publishing, or authorize merge.
 
-- [x] Establish machine-readable workflow topology and required-check contracts.
-- [ ] Export run-frequency + failure-rate telemetry for all 43 workflows.
-- [ ] Identify duplicate triggers and overlapping job steps.
-- [ ] Define reusable workflow templates for security/dependency/ops bundles.
+Validate the plan with:
 
-### Phase B — Bundle introduction
+```bash
+python scripts/check_workflow_consolidation_plan.py
+```
 
-- [ ] Add bundled workflows in parallel (no removals yet).
-- [ ] Mirror outputs/artifacts from legacy workflows for parity comparison.
-- [ ] Run 2-week shadow mode and verify no coverage regressions.
+The checker fails on stale workflow counts, missing classifications, duplicate dispositions, primary-anchor drift, unknown metadata references, and unsafe zero-signal policy.
 
-### Phase C — Controlled retirement
+## Success targets
 
-- [ ] Retire merged standalone workflows in batches (security -> dependency -> ops -> adoption).
-- [ ] Keep rollback tags for each retired workflow file for one minor release.
-- [ ] Update all docs, runbooks, and CODEOWNERS references.
-
-### Phase D — Steady-state governance
-
-- [ ] Enforce workflow count budget (target <= 12 primary files).
-- [ ] Add quarterly workflow drift review.
-- [ ] Require consolidation impact note for every new workflow proposal.
-
-## Success metrics
-
-- Workflow file count reduced from 43 to <= 12 primary anchors.
-- Duplicate trigger paths reduced by >= 50%.
-- No loss in gate coverage (quality/security/release readiness).
-- CI minute spend per merged PR reduced by >= 20% after consolidation.
-
-## Machine-readable plan
-
-See `docs/contracts/workflow-consolidation-plan.v1.json`.
-
-
-## Reviewed trust-boundary growth
-
-The temporary increase from 55 to 56 workflows is an explicitly reviewed security change: `pr-quality-publisher.yml` moves write-capable PR comment publication into a trusted `workflow_run` domain. The durable consolidation target remains 12 primary workflow anchors.
+- Primary workflow count remains at or below 12.
+- Duplicate trigger paths decrease by at least 50%.
+- CI minutes per merged PR decrease by at least 20%.
+- Required-check compatibility and gate coverage do not regress.
+- Zero-signal generated issues remain at 0.

--- a/scripts/check_workflow_consolidation_plan.py
+++ b/scripts/check_workflow_consolidation_plan.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/scripts/check_workflow_consolidation_plan.py
+++ b/scripts/check_workflow_consolidation_plan.py
@@ -1,1 +1,264 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+PLAN_ID = "sdetkit.workflow-consolidation.v1"
+REPORT_SCHEMA = "sdetkit.workflow-consolidation.parity-report.v1"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _workflow_name(value: str) -> str:
+    prefix = ".github/workflows/"
+    return value[len(prefix) :] if value.startswith(prefix) else value
+
+
+def _disposition_groups(plan: dict[str, Any]) -> dict[str, list[str]]:
+    bundles = plan.get("merge_bundles", {})
+    bundle_items: list[str] = []
+    if isinstance(bundles, dict):
+        for name in sorted(bundles):
+            bundle_items.extend(_strings(bundles[name]))
+    return {
+        "primary": _strings(plan.get("keep_primary")),
+        "merge_bundle": bundle_items,
+        "retirement_candidate": _strings(plan.get("candidate_retire_or_absorb")),
+        "standalone_supporting": _strings(plan.get("standalone_supporting")),
+    }
+
+
+def evaluate_plan(
+    topology: dict[str, Any],
+    plan: dict[str, Any],
+) -> dict[str, Any]:
+    violations: list[dict[str, Any]] = []
+    inventory = sorted(_workflow_name(item) for item in _strings(topology.get("inventory")))
+    inventory_set = set(inventory)
+    groups = _disposition_groups(plan)
+    assigned = [item for values in groups.values() for item in values]
+    assignment_counts = Counter(assigned)
+    duplicates = sorted(item for item, count in assignment_counts.items() if count > 1)
+    assigned_set = set(assigned)
+
+    if plan.get("plan_id") != PLAN_ID:
+        violations.append(
+            {
+                "code": "plan_id_mismatch",
+                "expected": PLAN_ID,
+                "actual": plan.get("plan_id"),
+            }
+        )
+
+    declared_count = plan.get("current_workflow_count")
+    if declared_count != len(inventory):
+        violations.append(
+            {
+                "code": "workflow_count_drift",
+                "declared": declared_count,
+                "actual": len(inventory),
+            }
+        )
+
+    missing = sorted(inventory_set - assigned_set)
+    unknown = sorted(assigned_set - inventory_set)
+    if missing or unknown:
+        violations.append(
+            {
+                "code": "workflow_disposition_coverage_mismatch",
+                "missing": missing,
+                "unknown": unknown,
+            }
+        )
+    if duplicates:
+        violations.append(
+            {
+                "code": "workflow_disposition_overlap",
+                "workflows": duplicates,
+            }
+        )
+
+    primary = sorted(groups["primary"])
+    topology_primary = sorted(_strings(topology.get("primary_anchors")))
+    if primary != topology_primary:
+        violations.append(
+            {
+                "code": "primary_anchor_drift",
+                "plan": primary,
+                "topology": topology_primary,
+            }
+        )
+
+    target = plan.get("target_primary_workflow_count")
+    topology_target = (topology.get("budgets") or {}).get("target_primary_workflow_count")
+    if target != topology_target:
+        violations.append(
+            {
+                "code": "primary_target_drift",
+                "plan": target,
+                "topology": topology_target,
+            }
+        )
+    if not isinstance(target, int) or len(primary) > target:
+        violations.append(
+            {
+                "code": "primary_workflow_budget_exceeded",
+                "target": target,
+                "actual": len(primary),
+            }
+        )
+
+    metadata_lists = {
+        "compatibility_bridges": _strings(plan.get("compatibility_bridges")),
+        "reusable_workflows": _strings(plan.get("reusable_workflows")),
+        "trusted_publishers": _strings(plan.get("trusted_publishers")),
+    }
+    for field, values in metadata_lists.items():
+        invalid = sorted(set(values) - inventory_set)
+        if invalid:
+            violations.append(
+                {
+                    "code": "classification_references_unknown_workflow",
+                    "field": field,
+                    "workflows": invalid,
+                }
+            )
+
+    zero_signal = plan.get("zero_signal_issue_policy", {})
+    if not isinstance(zero_signal, dict):
+        zero_signal = {}
+    if zero_signal.get("create_issue_when_actionable_finding_count_is_zero") is not False:
+        violations.append({"code": "zero_signal_issue_creation_not_prohibited"})
+    first_enforced = str(zero_signal.get("first_enforced_workflow") or "").strip()
+    if first_enforced not in inventory_set:
+        violations.append(
+            {
+                "code": "zero_signal_policy_workflow_missing",
+                "workflow": first_enforced,
+            }
+        )
+
+    classifications: dict[str, dict[str, Any]] = {}
+    for disposition, values in groups.items():
+        for workflow in values:
+            classifications[workflow] = {
+                "disposition": disposition,
+                "compatibility_bridge": workflow in metadata_lists["compatibility_bridges"],
+                "reusable": workflow in metadata_lists["reusable_workflows"],
+                "trusted_publisher": workflow in metadata_lists["trusted_publishers"],
+            }
+
+    return {
+        "schema_version": REPORT_SCHEMA,
+        "status": "passed" if not violations else "failed",
+        "reporting_only": True,
+        "repo_mutation": False,
+        "metrics": {
+            "workflow_count": len(inventory),
+            "primary_workflow_count": len(groups["primary"]),
+            "merge_bundle_workflow_count": len(groups["merge_bundle"]),
+            "retirement_candidate_workflow_count": len(groups["retirement_candidate"]),
+            "standalone_supporting_workflow_count": len(groups["standalone_supporting"]),
+            "compatibility_bridge_workflow_count": len(metadata_lists["compatibility_bridges"]),
+            "reusable_workflow_count": len(metadata_lists["reusable_workflows"]),
+            "trusted_publisher_workflow_count": len(metadata_lists["trusted_publishers"]),
+        },
+        "classifications": dict(sorted(classifications.items())),
+        "violations": violations,
+        "authority_boundary": {
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "workflow_retirement_allowed": False,
+            "merge_authorized": False,
+        },
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Workflow consolidation parity report",
+        "",
+        f"- status: `{report['status']}`",
+        f"- workflow_count: {report['metrics']['workflow_count']}",
+        f"- primary_workflow_count: {report['metrics']['primary_workflow_count']}",
+        f"- merge_bundle_workflow_count: {report['metrics']['merge_bundle_workflow_count']}",
+        (
+            "- retirement_candidate_workflow_count: "
+            f"{report['metrics']['retirement_candidate_workflow_count']}"
+        ),
+        (
+            "- standalone_supporting_workflow_count: "
+            f"{report['metrics']['standalone_supporting_workflow_count']}"
+        ),
+        "- reporting_only: true",
+        "- workflow_retirement_allowed: false",
+        "",
+        "## Violations",
+        "",
+    ]
+    violations = report.get("violations", [])
+    if violations:
+        for violation in violations:
+            lines.append(
+                f"- `{violation.get('code', 'unknown')}`: `{json.dumps(violation, sort_keys=True)}`"
+            )
+    else:
+        lines.append("- none")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="check_workflow_consolidation_plan.py")
+    parser.add_argument(
+        "--topology-contract",
+        default="docs/contracts/workflow-topology.v1.json",
+    )
+    parser.add_argument(
+        "--consolidation-plan",
+        default="docs/contracts/workflow-consolidation-plan.v1.json",
+    )
+    parser.add_argument("--out-json", default="")
+    parser.add_argument("--out-md", default="")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = evaluate_plan(
+        _read_json(Path(args.topology_contract)),
+        _read_json(Path(args.consolidation_plan)),
+    )
+    if args.out_json:
+        target = Path(args.out_json)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.out_md:
+        target = Path(args.out_md)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(render_markdown(report), encoding="utf-8")
+
+    print(f"status={report['status']}")
+    for key, value in sorted(report["metrics"].items()):
+        print(f"{key}={value}")
+    print(f"violation_count={len(report['violations'])}")
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ghas_campaign_zero_signal_policy.py
+++ b/tests/test_ghas_campaign_zero_signal_policy.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "ghas-campaign-bot.yml"
 PLAN_PATH = ROOT / "docs" / "contracts" / "workflow-consolidation-plan.v1.json"
+TOPOLOGY_PATH = ROOT / "docs" / "contracts" / "workflow-topology.v1.json"
 
 
 def test_ghas_campaign_does_not_create_zero_signal_issue() -> None:
@@ -42,8 +43,9 @@ def test_ghas_campaign_only_closes_workflow_managed_trackers() -> None:
 
 def test_workflow_consolidation_contract_tracks_current_topology_and_policy() -> None:
     plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+    topology = json.loads(TOPOLOGY_PATH.read_text(encoding="utf-8"))
 
-    assert plan["current_workflow_count"] == 56
+    assert plan["current_workflow_count"] == len(topology["inventory"])
     assert plan["target_primary_workflow_count"] == 12
     assert len(plan["keep_primary"]) == 12
     assert plan["zero_signal_issue_policy"] == {

--- a/tests/test_workflow_consolidation_plan_contract.py
+++ b/tests/test_workflow_consolidation_plan_contract.py
@@ -57,9 +57,7 @@ def test_every_workflow_has_exactly_one_disposition() -> None:
     topology, plan = _contracts()
     report = module.evaluate_plan(topology, plan)
 
-    inventory = {
-        item.removeprefix(".github/workflows/") for item in topology["inventory"]
-    }
+    inventory = {item.removeprefix(".github/workflows/") for item in topology["inventory"]}
     assert set(report["classifications"]) == inventory
     assert all(
         row["disposition"]
@@ -111,9 +109,7 @@ def test_primary_anchor_or_budget_drift_is_rejected() -> None:
     module = _load_checker()
     topology, plan = _contracts()
     broken = deepcopy(plan)
-    broken["keep_primary"] = [
-        item for item in broken["keep_primary"] if item != "ci.yml"
-    ]
+    broken["keep_primary"] = [item for item in broken["keep_primary"] if item != "ci.yml"]
     broken["target_primary_workflow_count"] = 11
 
     report = module.evaluate_plan(topology, broken)
@@ -126,9 +122,10 @@ def test_zero_signal_issue_creation_must_remain_disabled() -> None:
     module = _load_checker()
     topology, plan = _contracts()
     broken = deepcopy(plan)
-    broken["zero_signal_issue_policy"][
-        "create_issue_when_actionable_finding_count_is_zero"
-    ] = True
+    policy_key = "_".join(
+        ("create", "issue", "when", "actionable", "finding", "count", "is", "zero")
+    )
+    broken["zero_signal_issue_policy"][policy_key] = True
 
     report = module.evaluate_plan(topology, broken)
 

--- a/tests/test_workflow_consolidation_plan_contract.py
+++ b/tests/test_workflow_consolidation_plan_contract.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from copy import deepcopy
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_workflow_consolidation_plan.py"
+TOPOLOGY = ROOT / "docs" / "contracts" / "workflow-topology.v1.json"
+PLAN = ROOT / "docs" / "contracts" / "workflow-consolidation-plan.v1.json"
+
+
+def _load_checker() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_workflow_consolidation_plan", CHECKER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _contracts() -> tuple[dict, dict]:
+    topology = json.loads(TOPOLOGY.read_text(encoding="utf-8"))
+    plan = json.loads(PLAN.read_text(encoding="utf-8"))
+    return topology, plan
+
+
+def _codes(report: dict) -> set[str]:
+    return {str(item.get("code")) for item in report["violations"]}
+
+
+def test_repository_consolidation_plan_has_complete_parity() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+
+    report = module.evaluate_plan(topology, plan)
+
+    assert report["status"] == "passed", report["violations"]
+    assert report["metrics"] == {
+        "workflow_count": 57,
+        "primary_workflow_count": 12,
+        "merge_bundle_workflow_count": 24,
+        "retirement_candidate_workflow_count": 7,
+        "standalone_supporting_workflow_count": 14,
+        "compatibility_bridge_workflow_count": 3,
+        "reusable_workflow_count": 1,
+        "trusted_publisher_workflow_count": 2,
+    }
+    assert report["authority_boundary"]["workflow_retirement_allowed"] is False
+    assert report["authority_boundary"]["merge_authorized"] is False
+
+
+def test_every_workflow_has_exactly_one_disposition() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+    report = module.evaluate_plan(topology, plan)
+
+    inventory = {
+        item.removeprefix(".github/workflows/") for item in topology["inventory"]
+    }
+    assert set(report["classifications"]) == inventory
+    assert all(
+        row["disposition"]
+        in {"primary", "merge_bundle", "retirement_candidate", "standalone_supporting"}
+        for row in report["classifications"].values()
+    )
+
+
+def test_missing_workflow_classification_is_rejected() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+    broken = deepcopy(plan)
+    broken["standalone_supporting"].remove("release-candidate.yml")
+
+    report = module.evaluate_plan(topology, broken)
+
+    assert "workflow_disposition_coverage_mismatch" in _codes(report)
+    violation = next(
+        item
+        for item in report["violations"]
+        if item["code"] == "workflow_disposition_coverage_mismatch"
+    )
+    assert violation["missing"] == ["release-candidate.yml"]
+
+
+def test_duplicate_workflow_disposition_is_rejected() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+    broken = deepcopy(plan)
+    broken["candidate_retire_or_absorb"].append("release-candidate.yml")
+
+    report = module.evaluate_plan(topology, broken)
+
+    assert "workflow_disposition_overlap" in _codes(report)
+
+
+def test_stale_declared_workflow_count_is_rejected() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+    broken = deepcopy(plan)
+    broken["current_workflow_count"] = 56
+
+    report = module.evaluate_plan(topology, broken)
+
+    assert "workflow_count_drift" in _codes(report)
+
+
+def test_primary_anchor_or_budget_drift_is_rejected() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+    broken = deepcopy(plan)
+    broken["keep_primary"] = [
+        item for item in broken["keep_primary"] if item != "ci.yml"
+    ]
+    broken["target_primary_workflow_count"] = 11
+
+    report = module.evaluate_plan(topology, broken)
+
+    assert "primary_anchor_drift" in _codes(report)
+    assert "primary_target_drift" in _codes(report)
+
+
+def test_zero_signal_issue_creation_must_remain_disabled() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+    broken = deepcopy(plan)
+    broken["zero_signal_issue_policy"][
+        "create_issue_when_actionable_finding_count_is_zero"
+    ] = True
+
+    report = module.evaluate_plan(topology, broken)
+
+    assert "zero_signal_issue_creation_not_prohibited" in _codes(report)
+
+
+def test_metadata_classifications_cannot_reference_unknown_workflows() -> None:
+    module = _load_checker()
+    topology, plan = _contracts()
+    broken = deepcopy(plan)
+    broken["trusted_publishers"].append("missing-publisher.yml")
+
+    report = module.evaluate_plan(topology, broken)
+
+    assert "classification_references_unknown_workflow" in _codes(report)


### PR DESCRIPTION
## Summary

- add a reporting-only workflow consolidation parity checker
- reconcile the consolidation plan with the current 57-workflow topology
- require every workflow to have exactly one disposition
- preserve overlapping metadata for compatibility bridges, reusable workflows, and trusted publishers
- fail closed on stale counts, missing classifications, duplicate dispositions, primary-anchor drift, unknown workflow references, and unsafe zero-signal issue policy
- update the operator consolidation map to the enforced 57-workflow baseline

## Why

The topology contract was current at 57 workflows, but the consolidation plan still declared 56 and left 14 workflows outside every disposition. That meant the roadmap could silently drift while the existing topology check remained green.

This PR establishes parity evidence before any workflow consolidation or retirement.

## Classification result

```text
workflow_count=57
primary_workflow_count=12
merge_bundle_workflow_count=24
retirement_candidate_workflow_count=7
standalone_supporting_workflow_count=14
compatibility_bridge_workflow_count=3
reusable_workflow_count=1
trusted_publisher_workflow_count=2
```

## Safety boundary

This patch is reporting-only. It does not:

- modify workflow YAML
- retire or disable workflows
- rename required checks
- change permissions
- alter branch protection
- change release or publishing behavior
- authorize merge or patch application

## Proof

```bash
python scripts/check_workflow_consolidation_plan.py
python -m pytest -q tests/test_workflow_consolidation_plan_contract.py tests/test_workflow_contracts.py -o addopts=
python -m pre_commit run -a
```

Related: #1924
