### PR TITLE
ci: add deterministic workflow overlap inventory

### DIFF
--- a/docs/workflow-consolidation-map.md
+++ b/docs/workflow-consolidation-map.md
@@ -47,6 +47,31 @@ The plan currently records:
 
 The 57th workflow, `release-candidate.yml`, is explicitly classified as supporting release qualification. It is read-only and does not grant publication authority.
 
+## Overlap evidence
+
+Generate deterministic JSON and Markdown inventories with:
+
+```bash
+python scripts/build_workflow_overlap_report.py \
+  --out-json build/workflow-overlap/report.json \
+  --out-md build/workflow-overlap/report.md
+```
+
+The report records, for every workflow:
+
+- triggers
+- top-level and job-level permissions
+- effective write scopes
+- job status names
+- uploaded and downloaded artifacts
+- pinned actions
+- normalized proof commands
+- consolidation disposition
+
+It also groups repeated trigger sets, proof commands, actions, and artifact names. Required contexts from `docs/contracts/required-checks.v1.json` are mapped back to their workflow or job evidence.
+
+The report is evidence only. Duplicate commands are candidates for later shadow-mode consolidation, not automatic retirement authority.
+
 ## Migration order
 
 1. Record current topology and required checks.
@@ -62,7 +87,7 @@ The 57th workflow, `release-candidate.yml`, is explicitly classified as supporti
 - [x] Complete and mutually exclusive disposition coverage for all 57 workflows.
 - [x] Zero-finding issue creation prohibited by contract.
 - [ ] Run-frequency and failure-rate telemetry.
-- [ ] Duplicate trigger and proof-command report.
+- [x] Duplicate trigger and proof-command report.
 - [ ] First reusable bundle with shadow parity.
 
 ## Safety boundary

--- a/scripts/build_workflow_overlap_report.py
+++ b/scripts/build_workflow_overlap_report.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPORT_SCHEMA = "sdetkit.workflow-overlap-report.v1"
+
+_PROOF_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("python -m pre_commit", re.compile(r"(?:python\s+-m\s+)?pre[_-]commit\b")),
+    ("pytest", re.compile(r"(?:python\s+-m\s+)?pytest\b")),
+    ("bash quality.sh", re.compile(r"(?:bash\s+)?\.?/?quality\.sh\b")),
+    ("python -m sdetkit gate fast", re.compile(r"python\s+-m\s+sdetkit\s+gate\s+fast\b")),
+    (
+        "python -m sdetkit gate release",
+        re.compile(r"python\s+-m\s+sdetkit\s+gate\s+release\b"),
+    ),
+    ("python -m sdetkit doctor", re.compile(r"python\s+-m\s+sdetkit\s+doctor\b")),
+    ("ruff check", re.compile(r"(?:python\s+-m\s+)?ruff\s+check\b")),
+    ("ruff format", re.compile(r"(?:python\s+-m\s+)?ruff\s+format\b")),
+    ("mypy", re.compile(r"(?:python\s+-m\s+)?mypy\b")),
+    ("mkdocs build", re.compile(r"(?:python\s+-m\s+)?mkdocs\s+build\b")),
+    ("python -m build", re.compile(r"python\s+-m\s+build\b")),
+    ("twine check", re.compile(r"(?:python\s+-m\s+)?twine\s+check\b")),
+    (
+        "check-wheel-contents",
+        re.compile(r"(?:python\s+-m\s+)?check[_-]wheel[_-]contents\b"),
+    ),
+    ("pip-audit", re.compile(r"(?:python\s+-m\s+)?pip[_-]audit\b")),
+    ("osv-scanner", re.compile(r"\bosv-scanner\b")),
+    ("trivy", re.compile(r"\btrivy\b")),
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in value.items()}
+
+
+def _list(value: object) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _strings(value: object) -> list[str]:
+    return [str(item).strip() for item in _list(value) if str(item).strip()]
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    payload = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"expected YAML mapping in {path}")
+    return {str(key): value for key, value in payload.items()}
+
+
+def _triggers(workflow: Mapping[str, Any]) -> list[str]:
+    raw = workflow.get("on", {})
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return sorted({str(item) for item in raw})
+    if isinstance(raw, Mapping):
+        return sorted(str(key) for key in raw)
+    return []
+
+
+def _permission_map(value: object) -> dict[str, str]:
+    if isinstance(value, str):
+        return {"*": value}
+    return {str(key): str(item) for key, item in _mapping(value).items()}
+
+
+def _permission_summary(workflow: Mapping[str, Any]) -> dict[str, Any]:
+    top_level = _permission_map(workflow.get("permissions"))
+    jobs: dict[str, dict[str, str]] = {}
+    effective_write_scopes: set[str] = {
+        key for key, value in top_level.items() if str(value).casefold() == "write"
+    }
+    for job_id, raw_job in sorted(_mapping(workflow.get("jobs")).items()):
+        job_permissions = _permission_map(_mapping(raw_job).get("permissions"))
+        if job_permissions:
+            jobs[job_id] = job_permissions
+            effective_write_scopes.update(
+                key for key, value in job_permissions.items() if str(value).casefold() == "write"
+            )
+    return {
+        "top_level": dict(sorted(top_level.items())),
+        "jobs": jobs,
+        "effective_write_scopes": sorted(effective_write_scopes),
+    }
+
+
+def _joined_shell_lines(run: str) -> list[str]:
+    joined: list[str] = []
+    buffer = ""
+    for raw_line in run.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        buffer = f"{buffer} {line}".strip() if buffer else line
+        if buffer.endswith("\\"):
+            buffer = buffer[:-1].rstrip()
+            continue
+        joined.append(buffer)
+        buffer = ""
+    if buffer:
+        joined.append(buffer)
+    return joined
+
+
+def _proof_signatures(run: str) -> list[str]:
+    found: set[str] = set()
+    for line in _joined_shell_lines(run):
+        compact = re.sub(r"\s+", " ", line).strip()
+        for name, pattern in _PROOF_PATTERNS:
+            if pattern.search(compact):
+                found.add(name)
+    return sorted(found)
+
+
+def _artifact_step(step: Mapping[str, Any]) -> dict[str, Any] | None:
+    uses = str(step.get("uses") or "")
+    if "actions/upload-artifact@" in uses:
+        direction = "produces"
+    elif "actions/download-artifact@" in uses:
+        direction = "consumes"
+    else:
+        return None
+    with_block = _mapping(step.get("with"))
+    return {
+        "direction": direction,
+        "name": str(with_block.get("name") or "<dynamic-or-default>"),
+        "path": str(with_block.get("path") or ""),
+        "action": uses,
+    }
+
+
+def _job_records(
+    workflow: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], list[str], list[dict[str, Any]]]:
+    records: list[dict[str, Any]] = []
+    proofs: set[str] = set()
+    artifacts: list[dict[str, Any]] = []
+    for job_id, raw_job in sorted(_mapping(workflow.get("jobs")).items()):
+        job = _mapping(raw_job)
+        status_name = str(job.get("name") or job_id)
+        job_proofs: set[str] = set()
+        job_artifacts: list[dict[str, Any]] = []
+        actions: set[str] = set()
+        for raw_step in _list(job.get("steps")):
+            step = _mapping(raw_step)
+            uses = str(step.get("uses") or "")
+            if uses:
+                actions.add(uses)
+            run = str(step.get("run") or "")
+            job_proofs.update(_proof_signatures(run))
+            artifact = _artifact_step(step)
+            if artifact is not None:
+                artifact["job"] = job_id
+                job_artifacts.append(artifact)
+        proofs.update(job_proofs)
+        artifacts.extend(job_artifacts)
+        records.append(
+            {
+                "id": job_id,
+                "status_name": status_name,
+                "runs_on": job.get("runs-on", ""),
+                "proof_commands": sorted(job_proofs),
+                "actions": sorted(actions),
+                "artifacts": job_artifacts,
+            }
+        )
+    return records, sorted(proofs), artifacts
+
+
+def _classification_map(plan: Mapping[str, Any]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for workflow in _strings(plan.get("keep_primary")):
+        out[workflow] = "primary"
+    for values in _mapping(plan.get("merge_bundles")).values():
+        for workflow in _strings(values):
+            out[workflow] = "merge_bundle"
+    for workflow in _strings(plan.get("candidate_retire_or_absorb")):
+        out[workflow] = "retirement_candidate"
+    for workflow in _strings(plan.get("standalone_supporting")):
+        out[workflow] = "standalone_supporting"
+    return out
+
+
+def _overlap_groups(
+    index: Mapping[object, Iterable[str]], *, key_name: str
+) -> list[dict[str, Any]]:
+    groups: list[dict[str, Any]] = []
+    for key, values in index.items():
+        workflows = sorted(set(values))
+        if len(workflows) < 2:
+            continue
+        groups.append({key_name: key, "workflow_count": len(workflows), "workflows": workflows})
+    return sorted(groups, key=lambda item: (-int(item["workflow_count"]), str(item[key_name])))
+
+
+def build_report(
+    root: Path,
+    *,
+    topology_contract: Path,
+    required_checks_contract: Path,
+    consolidation_plan: Path,
+) -> dict[str, Any]:
+    topology = _read_json(topology_contract)
+    required = _read_json(required_checks_contract)
+    plan = _read_json(consolidation_plan)
+    classifications = _classification_map(plan)
+    violations: list[dict[str, Any]] = []
+    workflows: list[dict[str, Any]] = []
+    trigger_index: defaultdict[tuple[str, ...], list[str]] = defaultdict(list)
+    proof_index: defaultdict[str, list[str]] = defaultdict(list)
+    action_index: defaultdict[str, list[str]] = defaultdict(list)
+    artifact_index: defaultdict[str, list[str]] = defaultdict(list)
+    display_name_index: defaultdict[str, list[str]] = defaultdict(list)
+
+    inventory = _strings(topology.get("inventory"))
+    for relative in inventory:
+        path = root / relative
+        name = Path(relative).name
+        if not path.is_file():
+            violations.append({"code": "workflow_missing", "path": relative})
+            continue
+        try:
+            workflow = _load_workflow(path)
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            violations.append(
+                {"code": "workflow_parse_failed", "path": relative, "error": str(exc)}
+            )
+            continue
+        display_name = str(workflow.get("name") or Path(relative).stem)
+        triggers = _triggers(workflow)
+        jobs, proofs, artifacts = _job_records(workflow)
+        permissions = _permission_summary(workflow)
+        if name not in classifications:
+            violations.append({"code": "workflow_unclassified", "workflow": name})
+        record = {
+            "path": relative,
+            "workflow": name,
+            "display_name": display_name,
+            "disposition": classifications.get(name, "unknown"),
+            "triggers": triggers,
+            "permissions": permissions,
+            "job_status_names": [job["status_name"] for job in jobs],
+            "jobs": jobs,
+            "proof_commands": proofs,
+            "artifacts": artifacts,
+        }
+        workflows.append(record)
+        trigger_index[tuple(triggers)].append(name)
+        display_name_index[display_name.casefold()].append(name)
+        for proof in proofs:
+            proof_index[proof].append(name)
+        for job in jobs:
+            for action in job["actions"]:
+                action_index[action.split("@", 1)[0]].append(name)
+        for artifact in artifacts:
+            artifact_index[str(artifact["name"])].append(name)
+
+    required_contexts = _strings(required.get("contexts"))
+    required_context_mapping: dict[str, list[str]] = {}
+    for context in required_contexts:
+        matches = sorted(display_name_index.get(context.casefold(), []))
+        if not matches:
+            matches = sorted(
+                record["workflow"]
+                for record in workflows
+                if context.casefold()
+                in {str(item).casefold() for item in record["job_status_names"]}
+            )
+        required_context_mapping[context] = matches
+        if not matches:
+            violations.append({"code": "required_context_unmapped", "context": context})
+
+    proof_groups = _overlap_groups(proof_index, key_name="proof_command")
+    trigger_groups = _overlap_groups(trigger_index, key_name="triggers")
+    action_groups = _overlap_groups(action_index, key_name="action")
+    artifact_groups = _overlap_groups(artifact_index, key_name="artifact_name")
+    duplicate_workflow_memberships = sorted(
+        {workflow for group in proof_groups for workflow in group["workflows"]}
+    )
+    proof_occurrences = Counter(proof for record in workflows for proof in record["proof_commands"])
+
+    workflows.sort(key=lambda item: item["workflow"])
+    return {
+        "schema_version": REPORT_SCHEMA,
+        "status": "passed" if not violations else "failed",
+        "reporting_only": True,
+        "source": {
+            "topology_contract": topology_contract.relative_to(root).as_posix(),
+            "required_checks_contract": required_checks_contract.relative_to(root).as_posix(),
+            "consolidation_plan": consolidation_plan.relative_to(root).as_posix(),
+        },
+        "metrics": {
+            "workflow_count": len(workflows),
+            "required_context_count": len(required_contexts),
+            "duplicate_trigger_group_count": len(trigger_groups),
+            "duplicate_proof_command_group_count": len(proof_groups),
+            "workflows_with_duplicate_proof_membership": len(duplicate_workflow_memberships),
+            "duplicate_action_group_count": len(action_groups),
+            "duplicate_artifact_name_group_count": len(artifact_groups),
+            "workflow_with_write_permissions_count": sum(
+                bool(record["permissions"]["effective_write_scopes"]) for record in workflows
+            ),
+        },
+        "required_status_contexts": required_contexts,
+        "required_context_mapping": required_context_mapping,
+        "proof_command_occurrences": dict(sorted(proof_occurrences.items())),
+        "overlaps": {
+            "triggers": trigger_groups,
+            "proof_commands": proof_groups,
+            "actions": action_groups,
+            "artifact_names": artifact_groups,
+        },
+        "workflows": workflows,
+        "violations": violations,
+        "authority_boundary": {
+            "automation_allowed": False,
+            "workflow_retirement_allowed": False,
+            "required_check_rename_allowed": False,
+            "permission_change_allowed": False,
+            "merge_authorized": False,
+        },
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    metrics = _mapping(report.get("metrics"))
+    lines = [
+        "# Workflow overlap inventory",
+        "",
+        f"- status: `{report.get('status')}`",
+        f"- workflow_count: {metrics.get('workflow_count', 0)}",
+        f"- duplicate_trigger_group_count: {metrics.get('duplicate_trigger_group_count', 0)}",
+        (
+            "- duplicate_proof_command_group_count: "
+            f"{metrics.get('duplicate_proof_command_group_count', 0)}"
+        ),
+        (
+            "- workflows_with_duplicate_proof_membership: "
+            f"{metrics.get('workflows_with_duplicate_proof_membership', 0)}"
+        ),
+        f"- reporting_only: {str(report.get('reporting_only', False)).lower()}",
+        "",
+        "## Required status contexts",
+        "",
+    ]
+    mapping = _mapping(report.get("required_context_mapping"))
+    for context in _strings(report.get("required_status_contexts")):
+        matches = ", ".join(_strings(mapping.get(context))) or "UNMAPPED"
+        lines.append(f"- `{context}` -> {matches}")
+    lines.extend(["", "## Repeated proof commands", ""])
+    proof_groups = _mapping(report.get("overlaps")).get("proof_commands", [])
+    if isinstance(proof_groups, list) and proof_groups:
+        for group in proof_groups:
+            item = _mapping(group)
+            workflows = ", ".join(_strings(item.get("workflows")))
+            lines.append(
+                f"- `{item.get('proof_command')}` ({item.get('workflow_count')}): {workflows}"
+            )
+    else:
+        lines.append("- none")
+    lines.extend(
+        ["", "## Safety boundary", "", "No workflow retirement is authorized by this report."]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="build_workflow_overlap_report.py")
+    parser.add_argument("--root", default=".")
+    parser.add_argument(
+        "--topology-contract",
+        default="docs/contracts/workflow-topology.v1.json",
+    )
+    parser.add_argument(
+        "--required-checks-contract",
+        default="docs/contracts/required-checks.v1.json",
+    )
+    parser.add_argument(
+        "--consolidation-plan",
+        default="docs/contracts/workflow-consolidation-plan.v1.json",
+    )
+    parser.add_argument("--out-json", default="")
+    parser.add_argument("--out-md", default="")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = Path(args.root).resolve()
+    report = build_report(
+        root,
+        topology_contract=root / args.topology_contract,
+        required_checks_contract=root / args.required_checks_contract,
+        consolidation_plan=root / args.consolidation_plan,
+    )
+    if args.out_json:
+        target = Path(args.out_json)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.out_md:
+        target = Path(args.out_md)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(render_markdown(report), encoding="utf-8")
+    print(f"status={report['status']}")
+    for key, value in sorted(_mapping(report["metrics"]).items()):
+        print(f"{key}={value}")
+    print(f"violation_count={len(_list(report['violations']))}")
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_workflow_overlap_report.py
+++ b/scripts/build_workflow_overlap_report.py
@@ -61,10 +61,13 @@ def _strings(value: object) -> list[str]:
 
 
 def _load_workflow(path: Path) -> dict[str, Any]:
-    payload = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
         raise ValueError(f"expected YAML mapping in {path}")
-    return {str(key): value for key, value in payload.items()}
+    normalized = dict(payload)
+    if True in normalized and "on" not in normalized:
+        normalized["on"] = normalized.pop(True)
+    return {str(key): value for key, value in normalized.items()}
 
 
 def _triggers(workflow: Mapping[str, Any]) -> list[str]:

--- a/tests/test_workflow_overlap_report.py
+++ b/tests/test_workflow_overlap_report.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_workflow_overlap_report.py"
+
+
+def _module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("build_workflow_overlap_report", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _fixture_repo(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text(
+        """name: CI
+on:
+  pull_request:
+  push:
+permissions:
+  contents: read
+jobs:
+  tests:
+    name: ci
+    runs-on: ubuntu-latest
+    steps:
+      - run: python -m pytest -q
+      - uses: actions/upload-artifact@1111111111111111111111111111111111111111
+        with:
+          name: proof
+          path: build/proof.json
+""",
+        encoding="utf-8",
+    )
+    (workflows / "maintenance-autopilot.yml").write_text(
+        """name: maintenance-autopilot
+on:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * *'
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: python -m pytest tests/test_contract.py
+      - uses: actions/download-artifact@2222222222222222222222222222222222222222
+        with:
+          name: proof
+""",
+        encoding="utf-8",
+    )
+    topology = tmp_path / "docs" / "contracts" / "workflow-topology.v1.json"
+    required = tmp_path / "docs" / "contracts" / "required-checks.v1.json"
+    plan = tmp_path / "docs" / "contracts" / "workflow-consolidation-plan.v1.json"
+    _write_json(
+        topology,
+        {
+            "inventory": [
+                ".github/workflows/ci.yml",
+                ".github/workflows/maintenance-autopilot.yml",
+            ]
+        },
+    )
+    _write_json(required, {"contexts": ["ci", "maintenance-autopilot"]})
+    _write_json(
+        plan,
+        {
+            "keep_primary": ["ci.yml"],
+            "merge_bundles": {},
+            "candidate_retire_or_absorb": [],
+            "standalone_supporting": ["maintenance-autopilot.yml"],
+        },
+    )
+    return tmp_path, topology, required, plan
+
+
+def test_fixture_report_records_triggers_permissions_artifacts_and_proof_overlap(
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    root, topology, required, plan = _fixture_repo(tmp_path)
+
+    report = module.build_report(
+        root,
+        topology_contract=topology,
+        required_checks_contract=required,
+        consolidation_plan=plan,
+    )
+
+    assert report["status"] == "passed", report["violations"]
+    assert report["metrics"]["workflow_count"] == 2
+    assert report["required_context_mapping"] == {
+        "ci": ["ci.yml"],
+        "maintenance-autopilot": ["maintenance-autopilot.yml"],
+    }
+    assert report["proof_command_occurrences"]["pytest"] == 2
+    pytest_group = next(
+        group
+        for group in report["overlaps"]["proof_commands"]
+        if group["proof_command"] == "pytest"
+    )
+    assert pytest_group["workflows"] == ["ci.yml", "maintenance-autopilot.yml"]
+    maintenance = next(
+        item for item in report["workflows"] if item["workflow"] == "maintenance-autopilot.yml"
+    )
+    assert maintenance["permissions"]["effective_write_scopes"] == ["issues"]
+    assert maintenance["artifacts"][0]["direction"] == "consumes"
+    assert report["overlaps"]["artifact_names"][0]["artifact_name"] == "proof"
+
+
+def test_report_is_deterministic(tmp_path: Path) -> None:
+    module = _module()
+    root, topology, required, plan = _fixture_repo(tmp_path)
+
+    first = module.build_report(
+        root,
+        topology_contract=topology,
+        required_checks_contract=required,
+        consolidation_plan=plan,
+    )
+    second = module.build_report(
+        root,
+        topology_contract=topology,
+        required_checks_contract=required,
+        consolidation_plan=plan,
+    )
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_missing_workflow_fails_closed(tmp_path: Path) -> None:
+    module = _module()
+    root, topology, required, plan = _fixture_repo(tmp_path)
+    payload = json.loads(topology.read_text(encoding="utf-8"))
+    payload["inventory"].append(".github/workflows/missing.yml")
+    _write_json(topology, payload)
+
+    report = module.build_report(
+        root,
+        topology_contract=topology,
+        required_checks_contract=required,
+        consolidation_plan=plan,
+    )
+
+    assert report["status"] == "failed"
+    assert {item["code"] for item in report["violations"]} >= {"workflow_missing"}
+
+
+def test_repository_overlap_inventory_covers_current_contracts() -> None:
+    module = _module()
+
+    report = module.build_report(
+        ROOT,
+        topology_contract=ROOT / "docs" / "contracts" / "workflow-topology.v1.json",
+        required_checks_contract=ROOT / "docs" / "contracts" / "required-checks.v1.json",
+        consolidation_plan=ROOT / "docs" / "contracts" / "workflow-consolidation-plan.v1.json",
+    )
+
+    assert report["status"] == "passed", report["violations"]
+    assert report["metrics"]["workflow_count"] == 57
+    assert report["required_status_contexts"] == ["ci", "maintenance-autopilot"]
+    assert set(report["required_context_mapping"]) == {"ci", "maintenance-autopilot"}
+    assert all(report["required_context_mapping"].values())
+    assert len(report["workflows"]) == 57
+    assert all(item["disposition"] != "unknown" for item in report["workflows"])
+    assert report["metrics"]["duplicate_proof_command_group_count"] > 0
+    assert report["authority_boundary"]["workflow_retirement_allowed"] is False
+    assert report["authority_boundary"]["required_check_rename_allowed"] is False

--- a/tests/test_workflow_overlap_yaml_contract.py
+++ b/tests/test_workflow_overlap_yaml_contract.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_workflow_overlap_report.py"
+
+
+def test_workflow_event_key_is_preserved(tmp_path: Path) -> None:
+    spec = importlib.util.spec_from_file_location("workflow_overlap", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "name: Example\non:\n  pull_request:\n  push:\njobs: {}\n",
+        encoding="utf-8",
+    )
+
+    loaded = module._load_workflow(workflow)
+
+    assert module._triggers(loaded) == ["pull_request", "push"]


### PR DESCRIPTION
## Summary

- inventory triggers, permissions, job names, actions, artifacts, and proof commands across all workflows
- map required status contexts to their workflow evidence
- group repeated triggers, commands, actions, and artifact names
- add fixture and full-repository regression tests
- document JSON and Markdown report generation

## Scope

This is a reporting-only change. It does not remove workflows or change workflow configuration.

## Verification

```bash
python -m pytest -q tests/test_workflow_overlap_report.py -o addopts=
python scripts/build_workflow_overlap_report.py
python -m pre_commit run -a
```

Related: #1924
