### PR TITLE
ci: preserve complete terminal required-check evidence

### DIFF
--- a/src/sdetkit/_pr_quality_required_terminal_checks.py
+++ b/src/sdetkit/_pr_quality_required_terminal_checks.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from sdetkit import pr_quality_terminal_workflows as base
+from sdetkit._pr_quality_required_terminal_records import (
+    BLOCKER_NAME,
+    incomplete_reason,
+    record_matches_run,
+    terminal_record,
+)
+from sdetkit._pr_quality_required_terminal_snapshot import (
+    JsonObject,
+    _context_list,
+    _missing_expected_contexts,
+    _string,
+)
+
+
+def merge_required_terminal_snapshot_into_checks(
+    payload: JsonObject,
+    snapshot: JsonObject,
+) -> JsonObject:
+    merged = dict(payload)
+    records_key = "check_runs" if isinstance(payload.get("check_runs"), list) else "checks"
+    records = [
+        dict(item)
+        for item in payload.get(records_key, [])
+        if isinstance(item, dict) and _string(item.get("name")) != BLOCKER_NAME
+    ]
+    required_contexts = {
+        base.canonical_context(item)
+        for item in payload.get("required_contexts", [])
+        if _string(item)
+    }
+
+    for raw_run in snapshot.get("workflow_runs", []):
+        if not isinstance(raw_run, dict):
+            continue
+        run = dict(raw_run)
+        matches = [
+            index
+            for index, record in enumerate(records)
+            if record_matches_run(record=record, run=run)
+        ]
+        matched_records = [records[index] for index in matches]
+        authoritative = terminal_record(
+            matched_records,
+            run,
+            required_contexts=required_contexts,
+        )
+        if matches:
+            insert_at = min(matches)
+            for index in reversed(matches):
+                del records[index]
+            records.insert(insert_at, authoritative)
+        else:
+            records.append(authoritative)
+
+    if snapshot.get("status") in {"incomplete", "stale"}:
+        records.append(
+            {
+                "name": BLOCKER_NAME,
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": _string(snapshot.get("expected_head_sha")),
+                "required": True,
+                "log": incomplete_reason(snapshot),
+                "terminal_snapshot_source": True,
+            }
+        )
+
+    merged[records_key] = records
+    merged["terminal_workflow_snapshot"] = snapshot
+    merged["terminal_failed_workflow_names"] = list(snapshot.get("failed_workflow_names", []))
+    merged["terminal_pending_workflow_names"] = list(snapshot.get("pending_workflow_names", []))
+    merged["terminal_unknown_workflow_names"] = list(snapshot.get("unknown_workflow_names", []))
+    merged["terminal_missing_required_contexts"] = list(
+        snapshot.get("missing_expected_contexts", [])
+    )
+    merged["terminal_check_snapshot_complete"] = bool(snapshot.get("terminal_evidence_complete"))
+    return merged
+
+
+def snapshot_covers_expected(
+    snapshot: JsonObject,
+    *,
+    head_sha: str,
+    expected_contexts: list[str],
+) -> bool:
+    if _string(snapshot.get("expected_head_sha")) != head_sha:
+        return False
+    expected = _context_list(expected_contexts)
+    recorded = _context_list(snapshot.get("required_contexts", []))
+    if recorded:
+        return {base.canonical_context(item) for item in recorded} == {
+            base.canonical_context(item) for item in expected
+        }
+    rows = [item for item in snapshot.get("workflow_runs", []) if isinstance(item, dict)]
+    return not _missing_expected_contexts(rows, expected)

--- a/src/sdetkit/_pr_quality_required_terminal_merge.py
+++ b/src/sdetkit/_pr_quality_required_terminal_merge.py
@@ -1,96 +1,11 @@
 from __future__ import annotations
 
-from sdetkit import pr_quality_terminal_workflows as base
-from sdetkit._pr_quality_required_terminal_records import (
-    BLOCKER_NAME,
-    incomplete_reason,
-    record_matches_run,
-    terminal_record,
-)
-from sdetkit._pr_quality_required_terminal_snapshot import (
-    JsonObject,
-    _context_list,
-    _missing_expected_contexts,
-    _string,
+from sdetkit._pr_quality_required_terminal_checks import (
+    merge_required_terminal_snapshot_into_checks,
+    snapshot_covers_expected,
 )
 
-
-def merge_required_terminal_snapshot_into_checks(
-    payload: JsonObject,
-    snapshot: JsonObject,
-) -> JsonObject:
-    merged = dict(payload)
-    records_key = "check_runs" if isinstance(payload.get("check_runs"), list) else "checks"
-    records = [
-        dict(item)
-        for item in payload.get(records_key, [])
-        if isinstance(item, dict) and _string(item.get("name")) != BLOCKER_NAME
-    ]
-    required_contexts = {
-        base.canonical_context(item)
-        for item in payload.get("required_contexts", [])
-        if _string(item)
-    }
-
-    for raw_run in snapshot.get("workflow_runs", []):
-        if not isinstance(raw_run, dict):
-            continue
-        run = dict(raw_run)
-        matches = [
-            index for index, record in enumerate(records) if record_matches_run(record, run)
-        ]
-        matched_records = [records[index] for index in matches]
-        authoritative = terminal_record(
-            matched_records,
-            run,
-            required_contexts=required_contexts,
-        )
-        if matches:
-            insert_at = min(matches)
-            for index in reversed(matches):
-                del records[index]
-            records.insert(insert_at, authoritative)
-        else:
-            records.append(authoritative)
-
-    if snapshot.get("status") in {"incomplete", "stale"}:
-        records.append(
-            {
-                "name": BLOCKER_NAME,
-                "status": "completed",
-                "conclusion": "failure",
-                "head_sha": _string(snapshot.get("expected_head_sha")),
-                "required": True,
-                "log": incomplete_reason(snapshot),
-                "terminal_snapshot_source": True,
-            }
-        )
-
-    merged[records_key] = records
-    merged["terminal_workflow_snapshot"] = snapshot
-    merged["terminal_failed_workflow_names"] = list(snapshot.get("failed_workflow_names", []))
-    merged["terminal_pending_workflow_names"] = list(snapshot.get("pending_workflow_names", []))
-    merged["terminal_unknown_workflow_names"] = list(snapshot.get("unknown_workflow_names", []))
-    merged["terminal_missing_required_contexts"] = list(
-        snapshot.get("missing_expected_contexts", [])
-    )
-    merged["terminal_check_snapshot_complete"] = bool(snapshot.get("terminal_evidence_complete"))
-    return merged
-
-
-def snapshot_covers_expected(
-    snapshot: JsonObject,
-    *,
-    head_sha: str,
-    expected_contexts: list[str],
-) -> bool:
-    if _string(snapshot.get("expected_head_sha")) != head_sha:
-        return False
-    expected = _context_list(expected_contexts)
-    recorded = _context_list(snapshot.get("required_contexts", []))
-    if recorded:
-        return {base.canonical_context(item) for item in recorded} == {
-            base.canonical_context(item) for item in expected
-        }
-    rows = [item for item in snapshot.get("workflow_runs", []) if isinstance(item, dict)]
-    return not _missing_expected_contexts(rows, expected)
+__all__ = [
+    "merge_required_terminal_snapshot_into_checks",
+    "snapshot_covers_expected",
+]

--- a/src/sdetkit/_pr_quality_required_terminal_merge.py
+++ b/src/sdetkit/_pr_quality_required_terminal_merge.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from sdetkit import pr_quality_terminal_workflows as base
+from sdetkit._pr_quality_required_terminal_records import (
+    BLOCKER_NAME,
+    incomplete_reason,
+    record_matches_run,
+    terminal_record,
+)
+from sdetkit._pr_quality_required_terminal_snapshot import (
+    JsonObject,
+    _context_list,
+    _missing_expected_contexts,
+    _string,
+)
+
+
+def merge_required_terminal_snapshot_into_checks(
+    payload: JsonObject,
+    snapshot: JsonObject,
+) -> JsonObject:
+    merged = dict(payload)
+    records_key = "check_runs" if isinstance(payload.get("check_runs"), list) else "checks"
+    records = [
+        dict(item)
+        for item in payload.get(records_key, [])
+        if isinstance(item, dict) and _string(item.get("name")) != BLOCKER_NAME
+    ]
+    required_contexts = {
+        base.canonical_context(item)
+        for item in payload.get("required_contexts", [])
+        if _string(item)
+    }
+
+    for raw_run in snapshot.get("workflow_runs", []):
+        if not isinstance(raw_run, dict):
+            continue
+        run = dict(raw_run)
+        matches = [
+            index for index, record in enumerate(records) if record_matches_run(record, run)
+        ]
+        matched_records = [records[index] for index in matches]
+        authoritative = terminal_record(
+            matched_records,
+            run,
+            required_contexts=required_contexts,
+        )
+        if matches:
+            insert_at = min(matches)
+            for index in reversed(matches):
+                del records[index]
+            records.insert(insert_at, authoritative)
+        else:
+            records.append(authoritative)
+
+    if snapshot.get("status") in {"incomplete", "stale"}:
+        records.append(
+            {
+                "name": BLOCKER_NAME,
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": _string(snapshot.get("expected_head_sha")),
+                "required": True,
+                "log": incomplete_reason(snapshot),
+                "terminal_snapshot_source": True,
+            }
+        )
+
+    merged[records_key] = records
+    merged["terminal_workflow_snapshot"] = snapshot
+    merged["terminal_failed_workflow_names"] = list(snapshot.get("failed_workflow_names", []))
+    merged["terminal_pending_workflow_names"] = list(snapshot.get("pending_workflow_names", []))
+    merged["terminal_unknown_workflow_names"] = list(snapshot.get("unknown_workflow_names", []))
+    merged["terminal_missing_required_contexts"] = list(
+        snapshot.get("missing_expected_contexts", [])
+    )
+    merged["terminal_check_snapshot_complete"] = bool(snapshot.get("terminal_evidence_complete"))
+    return merged
+
+
+def snapshot_covers_expected(
+    snapshot: JsonObject,
+    *,
+    head_sha: str,
+    expected_contexts: list[str],
+) -> bool:
+    if _string(snapshot.get("expected_head_sha")) != head_sha:
+        return False
+    expected = _context_list(expected_contexts)
+    recorded = _context_list(snapshot.get("required_contexts", []))
+    if recorded:
+        return {base.canonical_context(item) for item in recorded} == {
+            base.canonical_context(item) for item in expected
+        }
+    rows = [item for item in snapshot.get("workflow_runs", []) if isinstance(item, dict)]
+    return not _missing_expected_contexts(rows, expected)

--- a/src/sdetkit/_pr_quality_required_terminal_records.py
+++ b/src/sdetkit/_pr_quality_required_terminal_records.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from sdetkit import pr_quality_terminal_workflows as base
+from sdetkit._pr_quality_required_terminal_snapshot import (
+    JsonObject,
+    _context_list,
+    _integer,
+    _string,
+)
+
+BLOCKER_NAME = "PR Quality terminal workflow snapshot"
+
+
+def record_matches_run(record: JsonObject, run: JsonObject) -> bool:
+    workflow_id = _integer(run.get("workflow_id"))
+    record_workflow_id = _integer(record.get("workflow_id"))
+    if workflow_id and record_workflow_id == workflow_id:
+        return True
+    name = base.canonical_context(run.get("name"))
+    return bool(name and base.canonical_context(record.get("name")) == name)
+
+
+def terminal_record(
+    existing: list[JsonObject],
+    run: JsonObject,
+    *,
+    required_contexts: set[str],
+) -> JsonObject:
+    merged: JsonObject = {}
+    required = False
+    for record in existing:
+        merged.update(record)
+        required = required or bool(record.get("required"))
+
+    name = _string(run.get("name"))
+    url = _string(run.get("html_url"))
+    merged.update(
+        {
+            "id": _integer(run.get("id")),
+            "workflow_id": _integer(run.get("workflow_id")),
+            "name": name,
+            "status": _string(run.get("status")),
+            "conclusion": _string(run.get("conclusion")),
+            "details_url": url,
+            "html_url": url,
+            "head_sha": _string(run.get("head_sha")),
+            "required": required or base.canonical_context(name) in required_contexts,
+            "workflow_run": dict(run),
+            "terminal_snapshot_source": True,
+        }
+    )
+    return merged
+
+
+def incomplete_reason(snapshot: JsonObject) -> str:
+    parts: list[str] = []
+    errors = [_string(item) for item in snapshot.get("collection_errors", []) if _string(item)]
+    if errors:
+        parts.append("collection errors: " + "; ".join(errors))
+    missing = _context_list(snapshot.get("missing_expected_contexts", []))
+    if missing:
+        parts.append("missing required checks: " + ", ".join(missing))
+    pending = _context_list(snapshot.get("pending_workflow_names", []))
+    if pending:
+        parts.append("pending workflows: " + ", ".join(pending))
+    unknown = _context_list(snapshot.get("unknown_workflow_names", []))
+    if unknown:
+        parts.append("unknown workflows: " + ", ".join(unknown))
+    failed = _context_list(snapshot.get("failed_workflow_names", []))
+    if failed:
+        parts.append("failed workflows: " + ", ".join(failed))
+    return "; ".join(parts) or f"terminal workflow snapshot status={snapshot.get('status')}"

--- a/src/sdetkit/_pr_quality_required_terminal_snapshot.py
+++ b/src/sdetkit/_pr_quality_required_terminal_snapshot.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from typing import Any
+
+from sdetkit import pr_quality_terminal_workflows as base
+
+JsonObject = dict[str, Any]
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _integer(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _context_list(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    unique: dict[str, str] = {}
+    for value in values:
+        text = _string(value)
+        key = base.canonical_context(text)
+        if text and key and key not in unique:
+            unique[key] = text
+    return [unique[key] for key in sorted(unique)]
+
+
+def _workflow_names(rows: list[JsonObject]) -> list[str]:
+    return [_string(row.get("name")) for row in rows if _string(row.get("name"))]
+
+
+def _missing_expected_contexts(
+    rows: list[JsonObject],
+    expected_contexts: list[str],
+) -> list[str]:
+    observed = {base.canonical_context(row.get("name")) for row in rows}
+    return [
+        context for context in expected_contexts if base.canonical_context(context) not in observed
+    ]
+
+
+def classify_required_terminal_snapshot(
+    rows: list[JsonObject],
+    *,
+    expected_contexts: list[str],
+    expected_head_sha: str,
+    current_head_sha: str,
+    stable_poll_count: int,
+    required_stable_polls: int,
+    timed_out: bool = False,
+    collection_errors: list[str] | None = None,
+) -> JsonObject:
+    expected = _context_list(expected_contexts)
+    snapshot = base.classify_terminal_snapshot(
+        rows,
+        expected_head_sha=expected_head_sha,
+        current_head_sha=current_head_sha,
+        stable_poll_count=stable_poll_count,
+        required_stable_polls=required_stable_polls,
+        timed_out=timed_out,
+        collection_errors=collection_errors,
+    )
+    missing = _missing_expected_contexts(rows, expected)
+    required_contexts_available = bool(expected)
+    evidence_complete = bool(rows) and required_contexts_available and not missing
+    if snapshot["status"] != "stale" and not evidence_complete:
+        snapshot["status"] = "incomplete"
+
+    failed_names = _workflow_names(snapshot.get("failed_workflows", []))
+    pending_names = _workflow_names(snapshot.get("pending_workflows", []))
+    unknown_names = _workflow_names(snapshot.get("unknown_workflows", []))
+    snapshot.update(
+        {
+            "schema_version": "sdetkit.pr_quality.required_terminal_snapshot.v1",
+            "required_contexts": expected,
+            "required_context_count": len(expected),
+            "required_contexts_available": required_contexts_available,
+            "missing_expected_contexts": missing,
+            "missing_expected_context_count": len(missing),
+            "failed_workflow_names": failed_names,
+            "pending_workflow_names": pending_names,
+            "unknown_workflow_names": unknown_names,
+            "terminal_evidence_complete": bool(
+                snapshot["status"] in {"passed", "failed"} and evidence_complete
+            ),
+            "exact_head_complete": bool(
+                snapshot.get("exact_head")
+                and snapshot["status"] in {"passed", "failed"}
+                and evidence_complete
+            ),
+        }
+    )
+    return snapshot
+
+
+def collect_required_terminal_snapshot(
+    *,
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    expected_contexts: list[str],
+    current_workflow: str = "PR Quality Comment",
+    timeout_seconds: int = 600,
+    poll_interval_seconds: int = 15,
+    required_stable_polls: int = 2,
+) -> JsonObject:
+    expected = _context_list(expected_contexts)
+    if not expected:
+        return classify_required_terminal_snapshot(
+            [],
+            expected_contexts=[],
+            expected_head_sha=head_sha,
+            current_head_sha=head_sha,
+            stable_poll_count=0,
+            required_stable_polls=required_stable_polls,
+            collection_errors=["required check contexts unavailable"],
+        )
+
+    started = time.monotonic()
+    previous_signature = ""
+    stable_poll_count = 0
+    last_rows: list[JsonObject] = []
+    current_head_sha = head_sha
+    errors: list[str] = []
+
+    while True:
+        errors = []
+        try:
+            pr = base._gh_api_json(f"repos/{repository}/pulls/{pr_number}")
+            current_head_sha = _string((pr.get("head") or {}).get("sha"))
+            payload = base._gh_api_json(
+                f"repos/{repository}/actions/runs"
+                f"?head_sha={head_sha}&event=pull_request&per_page=100"
+            )
+            raw_runs = payload.get("workflow_runs") if isinstance(payload, dict) else []
+            last_rows = base.normalize_workflow_runs(
+                [item for item in raw_runs or [] if isinstance(item, dict)],
+                current_workflow=current_workflow,
+            )
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            json.JSONDecodeError,
+            ValueError,
+        ) as exc:
+            errors = [f"terminal workflow collection failed: {exc}"]
+
+        provisional = classify_required_terminal_snapshot(
+            last_rows,
+            expected_contexts=expected,
+            expected_head_sha=head_sha,
+            current_head_sha=current_head_sha,
+            stable_poll_count=0,
+            required_stable_polls=required_stable_polls,
+            collection_errors=errors,
+        )
+        signature = base.workflow_signature(last_rows)
+        waiting = bool(
+            provisional["pending_workflows"]
+            or provisional["unknown_workflows"]
+            or provisional["missing_expected_contexts"]
+            or errors
+        )
+        if not waiting and signature == previous_signature:
+            stable_poll_count += 1
+        elif not waiting:
+            stable_poll_count = 1
+        else:
+            stable_poll_count = 0
+        previous_signature = signature
+
+        snapshot = classify_required_terminal_snapshot(
+            last_rows,
+            expected_contexts=expected,
+            expected_head_sha=head_sha,
+            current_head_sha=current_head_sha,
+            stable_poll_count=stable_poll_count,
+            required_stable_polls=required_stable_polls,
+            collection_errors=errors,
+        )
+        if snapshot["status"] in {"passed", "failed", "stale"}:
+            return snapshot
+        if time.monotonic() - started >= timeout_seconds:
+            return classify_required_terminal_snapshot(
+                last_rows,
+                expected_contexts=expected,
+                expected_head_sha=head_sha,
+                current_head_sha=current_head_sha,
+                stable_poll_count=stable_poll_count,
+                required_stable_polls=required_stable_polls,
+                timed_out=True,
+                collection_errors=errors,
+            )
+        time.sleep(max(poll_interval_seconds, 1))

--- a/src/sdetkit/failed_check_log_collection.py
+++ b/src/sdetkit/failed_check_log_collection.py
@@ -4,7 +4,7 @@ import json
 import sys
 
 from sdetkit import _failed_check_log_collection_core as _core
-from sdetkit.pr_quality_terminal_workflows import (
+from sdetkit.pr_quality_required_terminal import (
     collect_and_merge_terminal_snapshot_from_environment,
 )
 

--- a/src/sdetkit/pr_quality_required_terminal.py
+++ b/src/sdetkit/pr_quality_required_terminal.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from sdetkit import pr_quality_terminal_workflows as base
+
+JsonObject = dict[str, Any]
+
+_BLOCKER_NAME = "PR Quality terminal workflow snapshot"
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _integer(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _context_list(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    unique: dict[str, str] = {}
+    for value in values:
+        text = _string(value)
+        key = base.canonical_context(text)
+        if text and key and key not in unique:
+            unique[key] = text
+    return [unique[key] for key in sorted(unique)]
+
+
+def _workflow_names(rows: list[JsonObject]) -> list[str]:
+    return [_string(row.get("name")) for row in rows if _string(row.get("name"))]
+
+
+def _missing_expected_contexts(
+    rows: list[JsonObject],
+    expected_contexts: list[str],
+) -> list[str]:
+    observed = {base.canonical_context(row.get("name")) for row in rows}
+    return [
+        context
+        for context in expected_contexts
+        if base.canonical_context(context) not in observed
+    ]
+
+
+def classify_required_terminal_snapshot(
+    rows: list[JsonObject],
+    *,
+    expected_contexts: list[str],
+    expected_head_sha: str,
+    current_head_sha: str,
+    stable_poll_count: int,
+    required_stable_polls: int,
+    timed_out: bool = False,
+    collection_errors: list[str] | None = None,
+) -> JsonObject:
+    expected = _context_list(expected_contexts)
+    snapshot = base.classify_terminal_snapshot(
+        rows,
+        expected_head_sha=expected_head_sha,
+        current_head_sha=current_head_sha,
+        stable_poll_count=stable_poll_count,
+        required_stable_polls=required_stable_polls,
+        timed_out=timed_out,
+        collection_errors=collection_errors,
+    )
+    missing = _missing_expected_contexts(rows, expected)
+    required_contexts_available = bool(expected)
+    evidence_complete = bool(rows) and required_contexts_available and not missing
+    if snapshot["status"] != "stale" and not evidence_complete:
+        snapshot["status"] = "incomplete"
+
+    failed_names = _workflow_names(snapshot.get("failed_workflows", []))
+    pending_names = _workflow_names(snapshot.get("pending_workflows", []))
+    unknown_names = _workflow_names(snapshot.get("unknown_workflows", []))
+    snapshot.update(
+        {
+            "schema_version": "sdetkit.pr_quality.required_terminal_snapshot.v1",
+            "required_contexts": expected,
+            "required_context_count": len(expected),
+            "required_contexts_available": required_contexts_available,
+            "missing_expected_contexts": missing,
+            "missing_expected_context_count": len(missing),
+            "failed_workflow_names": failed_names,
+            "pending_workflow_names": pending_names,
+            "unknown_workflow_names": unknown_names,
+            "terminal_evidence_complete": bool(
+                snapshot["status"] in {"passed", "failed"} and evidence_complete
+            ),
+            "exact_head_complete": bool(
+                snapshot.get("exact_head")
+                and snapshot["status"] in {"passed", "failed"}
+                and evidence_complete
+            ),
+        }
+    )
+    return snapshot
+
+
+def collect_required_terminal_snapshot(
+    *,
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    expected_contexts: list[str],
+    current_workflow: str = "PR Quality Comment",
+    timeout_seconds: int = 600,
+    poll_interval_seconds: int = 15,
+    required_stable_polls: int = 2,
+) -> JsonObject:
+    expected = _context_list(expected_contexts)
+    if not expected:
+        return classify_required_terminal_snapshot(
+            [],
+            expected_contexts=[],
+            expected_head_sha=head_sha,
+            current_head_sha=head_sha,
+            stable_poll_count=0,
+            required_stable_polls=required_stable_polls,
+            collection_errors=["required check contexts unavailable"],
+        )
+
+    started = time.monotonic()
+    previous_signature = ""
+    stable_poll_count = 0
+    last_rows: list[JsonObject] = []
+    current_head_sha = head_sha
+    errors: list[str] = []
+
+    while True:
+        errors = []
+        try:
+            pr = base._gh_api_json(f"repos/{repository}/pulls/{pr_number}")
+            current_head_sha = _string((pr.get("head") or {}).get("sha"))
+            payload = base._gh_api_json(
+                f"repos/{repository}/actions/runs"
+                f"?head_sha={head_sha}&event=pull_request&per_page=100"
+            )
+            raw_runs = payload.get("workflow_runs") if isinstance(payload, dict) else []
+            last_rows = base.normalize_workflow_runs(
+                [item for item in raw_runs or [] if isinstance(item, dict)],
+                current_workflow=current_workflow,
+            )
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            json.JSONDecodeError,
+            ValueError,
+        ) as exc:
+            errors = [f"terminal workflow collection failed: {exc}"]
+
+        provisional = classify_required_terminal_snapshot(
+            last_rows,
+            expected_contexts=expected,
+            expected_head_sha=head_sha,
+            current_head_sha=current_head_sha,
+            stable_poll_count=0,
+            required_stable_polls=required_stable_polls,
+            collection_errors=errors,
+        )
+        signature = base.workflow_signature(last_rows)
+        waiting = bool(
+            provisional["pending_workflows"]
+            or provisional["unknown_workflows"]
+            or provisional["missing_expected_contexts"]
+            or errors
+        )
+        if not waiting and signature == previous_signature:
+            stable_poll_count += 1
+        elif not waiting:
+            stable_poll_count = 1
+        else:
+            stable_poll_count = 0
+        previous_signature = signature
+
+        snapshot = classify_required_terminal_snapshot(
+            last_rows,
+            expected_contexts=expected,
+            expected_head_sha=head_sha,
+            current_head_sha=current_head_sha,
+            stable_poll_count=stable_poll_count,
+            required_stable_polls=required_stable_polls,
+            collection_errors=errors,
+        )
+        if snapshot["status"] in {"passed", "failed", "stale"}:
+            return snapshot
+        if time.monotonic() - started >= timeout_seconds:
+            return classify_required_terminal_snapshot(
+                last_rows,
+                expected_contexts=expected,
+                expected_head_sha=head_sha,
+                current_head_sha=current_head_sha,
+                stable_poll_count=stable_poll_count,
+                required_stable_polls=required_stable_polls,
+                timed_out=True,
+                collection_errors=errors,
+            )
+        time.sleep(max(poll_interval_seconds, 1))
+
+
+def _record_matches_run(record: JsonObject, run: JsonObject) -> bool:
+    workflow_id = _integer(run.get("workflow_id"))
+    record_workflow_id = _integer(record.get("workflow_id"))
+    if workflow_id and record_workflow_id == workflow_id:
+        return True
+    name = base.canonical_context(run.get("name"))
+    return bool(name and base.canonical_context(record.get("name")) == name)
+
+
+def _terminal_record(
+    existing: list[JsonObject],
+    run: JsonObject,
+    *,
+    required_contexts: set[str],
+) -> JsonObject:
+    merged: JsonObject = {}
+    required = False
+    for record in existing:
+        merged.update(record)
+        required = required or bool(record.get("required"))
+
+    name = _string(run.get("name"))
+    url = _string(run.get("html_url"))
+    merged.update(
+        {
+            "id": _integer(run.get("id")),
+            "workflow_id": _integer(run.get("workflow_id")),
+            "name": name,
+            "status": _string(run.get("status")),
+            "conclusion": _string(run.get("conclusion")),
+            "details_url": url,
+            "html_url": url,
+            "head_sha": _string(run.get("head_sha")),
+            "required": required or base.canonical_context(name) in required_contexts,
+            "workflow_run": dict(run),
+            "terminal_snapshot_source": True,
+        }
+    )
+    return merged
+
+
+def _incomplete_reason(snapshot: JsonObject) -> str:
+    parts: list[str] = []
+    errors = [_string(item) for item in snapshot.get("collection_errors", []) if _string(item)]
+    if errors:
+        parts.append("collection errors: " + "; ".join(errors))
+    missing = _context_list(snapshot.get("missing_expected_contexts", []))
+    if missing:
+        parts.append("missing required checks: " + ", ".join(missing))
+    pending = _context_list(snapshot.get("pending_workflow_names", []))
+    if pending:
+        parts.append("pending workflows: " + ", ".join(pending))
+    unknown = _context_list(snapshot.get("unknown_workflow_names", []))
+    if unknown:
+        parts.append("unknown workflows: " + ", ".join(unknown))
+    failed = _context_list(snapshot.get("failed_workflow_names", []))
+    if failed:
+        parts.append("failed workflows: " + ", ".join(failed))
+    return "; ".join(parts) or f"terminal workflow snapshot status={snapshot.get('status')}"
+
+
+def merge_required_terminal_snapshot_into_checks(
+    payload: JsonObject,
+    snapshot: JsonObject,
+) -> JsonObject:
+    merged = dict(payload)
+    records_key = "check_runs" if isinstance(payload.get("check_runs"), list) else "checks"
+    records = [
+        dict(item)
+        for item in payload.get(records_key, [])
+        if isinstance(item, dict) and _string(item.get("name")) != _BLOCKER_NAME
+    ]
+    required_contexts = {
+        base.canonical_context(item)
+        for item in payload.get("required_contexts", [])
+        if _string(item)
+    }
+
+    for raw_run in snapshot.get("workflow_runs", []):
+        if not isinstance(raw_run, dict):
+            continue
+        run = dict(raw_run)
+        matches = [index for index, record in enumerate(records) if _record_matches_run(record, run)]
+        matched_records = [records[index] for index in matches]
+        authoritative = _terminal_record(
+            matched_records,
+            run,
+            required_contexts=required_contexts,
+        )
+        if matches:
+            insert_at = min(matches)
+            for index in reversed(matches):
+                del records[index]
+            records.insert(insert_at, authoritative)
+        else:
+            records.append(authoritative)
+
+    if snapshot.get("status") in {"incomplete", "stale"}:
+        records.append(
+            {
+                "name": _BLOCKER_NAME,
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": _string(snapshot.get("expected_head_sha")),
+                "required": True,
+                "log": _incomplete_reason(snapshot),
+                "terminal_snapshot_source": True,
+            }
+        )
+
+    merged[records_key] = records
+    merged["terminal_workflow_snapshot"] = snapshot
+    merged["terminal_failed_workflow_names"] = list(
+        snapshot.get("failed_workflow_names", [])
+    )
+    merged["terminal_pending_workflow_names"] = list(
+        snapshot.get("pending_workflow_names", [])
+    )
+    merged["terminal_unknown_workflow_names"] = list(
+        snapshot.get("unknown_workflow_names", [])
+    )
+    merged["terminal_missing_required_contexts"] = list(
+        snapshot.get("missing_expected_contexts", [])
+    )
+    merged["terminal_check_snapshot_complete"] = bool(
+        snapshot.get("terminal_evidence_complete")
+    )
+    return merged
+
+
+def _snapshot_covers_expected(
+    snapshot: JsonObject,
+    *,
+    head_sha: str,
+    expected_contexts: list[str],
+) -> bool:
+    if _string(snapshot.get("expected_head_sha")) != head_sha:
+        return False
+    expected = _context_list(expected_contexts)
+    recorded = _context_list(snapshot.get("required_contexts", []))
+    if recorded:
+        return {
+            base.canonical_context(item) for item in recorded
+        } == {base.canonical_context(item) for item in expected}
+    rows = [item for item in snapshot.get("workflow_runs", []) if isinstance(item, dict)]
+    return not _missing_expected_contexts(rows, expected)
+
+
+def collect_and_merge_terminal_snapshot_from_environment(
+    *,
+    checks_json: Path,
+    out_dir: Path,
+) -> JsonObject | None:
+    if os.environ.get("GITHUB_ACTIONS", "").lower() != "true":
+        return None
+    repository = _string(os.environ.get("GITHUB_REPOSITORY"))
+    if not repository:
+        owner = _string(os.environ.get("REPOSITORY_OWNER"))
+        name = _string(os.environ.get("REPOSITORY_NAME"))
+        repository = f"{owner}/{name}" if owner and name else ""
+    head_sha = _string(os.environ.get("HEAD_SHA"))
+    pr_number = _integer(os.environ.get("PR_NUMBER"))
+    if not repository or not head_sha or pr_number <= 0 or not os.environ.get("GH_TOKEN"):
+        return None
+
+    payload = json.loads(checks_json.read_text(encoding="utf-8"))
+    checks_payload = payload if isinstance(payload, dict) else {}
+    expected_contexts = _context_list(checks_payload.get("required_contexts", []))
+    snapshot_path = out_dir / "terminal-workflow-snapshot.json"
+    snapshot: JsonObject = {}
+    if snapshot_path.exists():
+        candidate = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        if isinstance(candidate, dict) and _snapshot_covers_expected(
+            candidate,
+            head_sha=head_sha,
+            expected_contexts=expected_contexts,
+        ):
+            snapshot = candidate
+
+    if not snapshot:
+        snapshot = collect_required_terminal_snapshot(
+            repository=repository,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            expected_contexts=expected_contexts,
+            current_workflow=_string(os.environ.get("GITHUB_WORKFLOW") or "PR Quality Comment"),
+            timeout_seconds=max(
+                _integer(os.environ.get("SDETKIT_TERMINAL_TIMEOUT_SECONDS")) or 600, 1
+            ),
+            poll_interval_seconds=max(
+                _integer(os.environ.get("SDETKIT_TERMINAL_POLL_INTERVAL_SECONDS")) or 15,
+                1,
+            ),
+            required_stable_polls=max(
+                _integer(os.environ.get("SDETKIT_TERMINAL_STABLE_POLLS")) or 2,
+                2,
+            ),
+        )
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(
+            json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    merged = merge_required_terminal_snapshot_into_checks(checks_payload, snapshot)
+    checks_json.write_text(
+        json.dumps(merged, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return snapshot

--- a/src/sdetkit/pr_quality_required_terminal.py
+++ b/src/sdetkit/pr_quality_required_terminal.py
@@ -2,358 +2,23 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
-import time
 from pathlib import Path
-from typing import Any
 
-from sdetkit import pr_quality_terminal_workflows as base
+from sdetkit._pr_quality_required_terminal_merge import (
+    merge_required_terminal_snapshot_into_checks,
+    snapshot_covers_expected,
+)
+from sdetkit._pr_quality_required_terminal_snapshot import (
+    JsonObject,
+    _context_list,
+    _integer,
+    _string,
+    classify_required_terminal_snapshot,
+    collect_required_terminal_snapshot,
+    time,
+)
 
-JsonObject = dict[str, Any]
-
-_BLOCKER_NAME = "PR Quality terminal workflow snapshot"
-
-
-def _string(value: Any) -> str:
-    return str(value or "").strip()
-
-
-def _integer(value: Any) -> int:
-    try:
-        return int(value or 0)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _context_list(values: Any) -> list[str]:
-    if not isinstance(values, list):
-        return []
-    unique: dict[str, str] = {}
-    for value in values:
-        text = _string(value)
-        key = base.canonical_context(text)
-        if text and key and key not in unique:
-            unique[key] = text
-    return [unique[key] for key in sorted(unique)]
-
-
-def _workflow_names(rows: list[JsonObject]) -> list[str]:
-    return [_string(row.get("name")) for row in rows if _string(row.get("name"))]
-
-
-def _missing_expected_contexts(
-    rows: list[JsonObject],
-    expected_contexts: list[str],
-) -> list[str]:
-    observed = {base.canonical_context(row.get("name")) for row in rows}
-    return [
-        context
-        for context in expected_contexts
-        if base.canonical_context(context) not in observed
-    ]
-
-
-def classify_required_terminal_snapshot(
-    rows: list[JsonObject],
-    *,
-    expected_contexts: list[str],
-    expected_head_sha: str,
-    current_head_sha: str,
-    stable_poll_count: int,
-    required_stable_polls: int,
-    timed_out: bool = False,
-    collection_errors: list[str] | None = None,
-) -> JsonObject:
-    expected = _context_list(expected_contexts)
-    snapshot = base.classify_terminal_snapshot(
-        rows,
-        expected_head_sha=expected_head_sha,
-        current_head_sha=current_head_sha,
-        stable_poll_count=stable_poll_count,
-        required_stable_polls=required_stable_polls,
-        timed_out=timed_out,
-        collection_errors=collection_errors,
-    )
-    missing = _missing_expected_contexts(rows, expected)
-    required_contexts_available = bool(expected)
-    evidence_complete = bool(rows) and required_contexts_available and not missing
-    if snapshot["status"] != "stale" and not evidence_complete:
-        snapshot["status"] = "incomplete"
-
-    failed_names = _workflow_names(snapshot.get("failed_workflows", []))
-    pending_names = _workflow_names(snapshot.get("pending_workflows", []))
-    unknown_names = _workflow_names(snapshot.get("unknown_workflows", []))
-    snapshot.update(
-        {
-            "schema_version": "sdetkit.pr_quality.required_terminal_snapshot.v1",
-            "required_contexts": expected,
-            "required_context_count": len(expected),
-            "required_contexts_available": required_contexts_available,
-            "missing_expected_contexts": missing,
-            "missing_expected_context_count": len(missing),
-            "failed_workflow_names": failed_names,
-            "pending_workflow_names": pending_names,
-            "unknown_workflow_names": unknown_names,
-            "terminal_evidence_complete": bool(
-                snapshot["status"] in {"passed", "failed"} and evidence_complete
-            ),
-            "exact_head_complete": bool(
-                snapshot.get("exact_head")
-                and snapshot["status"] in {"passed", "failed"}
-                and evidence_complete
-            ),
-        }
-    )
-    return snapshot
-
-
-def collect_required_terminal_snapshot(
-    *,
-    repository: str,
-    pr_number: int,
-    head_sha: str,
-    expected_contexts: list[str],
-    current_workflow: str = "PR Quality Comment",
-    timeout_seconds: int = 600,
-    poll_interval_seconds: int = 15,
-    required_stable_polls: int = 2,
-) -> JsonObject:
-    expected = _context_list(expected_contexts)
-    if not expected:
-        return classify_required_terminal_snapshot(
-            [],
-            expected_contexts=[],
-            expected_head_sha=head_sha,
-            current_head_sha=head_sha,
-            stable_poll_count=0,
-            required_stable_polls=required_stable_polls,
-            collection_errors=["required check contexts unavailable"],
-        )
-
-    started = time.monotonic()
-    previous_signature = ""
-    stable_poll_count = 0
-    last_rows: list[JsonObject] = []
-    current_head_sha = head_sha
-    errors: list[str] = []
-
-    while True:
-        errors = []
-        try:
-            pr = base._gh_api_json(f"repos/{repository}/pulls/{pr_number}")
-            current_head_sha = _string((pr.get("head") or {}).get("sha"))
-            payload = base._gh_api_json(
-                f"repos/{repository}/actions/runs"
-                f"?head_sha={head_sha}&event=pull_request&per_page=100"
-            )
-            raw_runs = payload.get("workflow_runs") if isinstance(payload, dict) else []
-            last_rows = base.normalize_workflow_runs(
-                [item for item in raw_runs or [] if isinstance(item, dict)],
-                current_workflow=current_workflow,
-            )
-        except (
-            OSError,
-            subprocess.CalledProcessError,
-            json.JSONDecodeError,
-            ValueError,
-        ) as exc:
-            errors = [f"terminal workflow collection failed: {exc}"]
-
-        provisional = classify_required_terminal_snapshot(
-            last_rows,
-            expected_contexts=expected,
-            expected_head_sha=head_sha,
-            current_head_sha=current_head_sha,
-            stable_poll_count=0,
-            required_stable_polls=required_stable_polls,
-            collection_errors=errors,
-        )
-        signature = base.workflow_signature(last_rows)
-        waiting = bool(
-            provisional["pending_workflows"]
-            or provisional["unknown_workflows"]
-            or provisional["missing_expected_contexts"]
-            or errors
-        )
-        if not waiting and signature == previous_signature:
-            stable_poll_count += 1
-        elif not waiting:
-            stable_poll_count = 1
-        else:
-            stable_poll_count = 0
-        previous_signature = signature
-
-        snapshot = classify_required_terminal_snapshot(
-            last_rows,
-            expected_contexts=expected,
-            expected_head_sha=head_sha,
-            current_head_sha=current_head_sha,
-            stable_poll_count=stable_poll_count,
-            required_stable_polls=required_stable_polls,
-            collection_errors=errors,
-        )
-        if snapshot["status"] in {"passed", "failed", "stale"}:
-            return snapshot
-        if time.monotonic() - started >= timeout_seconds:
-            return classify_required_terminal_snapshot(
-                last_rows,
-                expected_contexts=expected,
-                expected_head_sha=head_sha,
-                current_head_sha=current_head_sha,
-                stable_poll_count=stable_poll_count,
-                required_stable_polls=required_stable_polls,
-                timed_out=True,
-                collection_errors=errors,
-            )
-        time.sleep(max(poll_interval_seconds, 1))
-
-
-def _record_matches_run(record: JsonObject, run: JsonObject) -> bool:
-    workflow_id = _integer(run.get("workflow_id"))
-    record_workflow_id = _integer(record.get("workflow_id"))
-    if workflow_id and record_workflow_id == workflow_id:
-        return True
-    name = base.canonical_context(run.get("name"))
-    return bool(name and base.canonical_context(record.get("name")) == name)
-
-
-def _terminal_record(
-    existing: list[JsonObject],
-    run: JsonObject,
-    *,
-    required_contexts: set[str],
-) -> JsonObject:
-    merged: JsonObject = {}
-    required = False
-    for record in existing:
-        merged.update(record)
-        required = required or bool(record.get("required"))
-
-    name = _string(run.get("name"))
-    url = _string(run.get("html_url"))
-    merged.update(
-        {
-            "id": _integer(run.get("id")),
-            "workflow_id": _integer(run.get("workflow_id")),
-            "name": name,
-            "status": _string(run.get("status")),
-            "conclusion": _string(run.get("conclusion")),
-            "details_url": url,
-            "html_url": url,
-            "head_sha": _string(run.get("head_sha")),
-            "required": required or base.canonical_context(name) in required_contexts,
-            "workflow_run": dict(run),
-            "terminal_snapshot_source": True,
-        }
-    )
-    return merged
-
-
-def _incomplete_reason(snapshot: JsonObject) -> str:
-    parts: list[str] = []
-    errors = [_string(item) for item in snapshot.get("collection_errors", []) if _string(item)]
-    if errors:
-        parts.append("collection errors: " + "; ".join(errors))
-    missing = _context_list(snapshot.get("missing_expected_contexts", []))
-    if missing:
-        parts.append("missing required checks: " + ", ".join(missing))
-    pending = _context_list(snapshot.get("pending_workflow_names", []))
-    if pending:
-        parts.append("pending workflows: " + ", ".join(pending))
-    unknown = _context_list(snapshot.get("unknown_workflow_names", []))
-    if unknown:
-        parts.append("unknown workflows: " + ", ".join(unknown))
-    failed = _context_list(snapshot.get("failed_workflow_names", []))
-    if failed:
-        parts.append("failed workflows: " + ", ".join(failed))
-    return "; ".join(parts) or f"terminal workflow snapshot status={snapshot.get('status')}"
-
-
-def merge_required_terminal_snapshot_into_checks(
-    payload: JsonObject,
-    snapshot: JsonObject,
-) -> JsonObject:
-    merged = dict(payload)
-    records_key = "check_runs" if isinstance(payload.get("check_runs"), list) else "checks"
-    records = [
-        dict(item)
-        for item in payload.get(records_key, [])
-        if isinstance(item, dict) and _string(item.get("name")) != _BLOCKER_NAME
-    ]
-    required_contexts = {
-        base.canonical_context(item)
-        for item in payload.get("required_contexts", [])
-        if _string(item)
-    }
-
-    for raw_run in snapshot.get("workflow_runs", []):
-        if not isinstance(raw_run, dict):
-            continue
-        run = dict(raw_run)
-        matches = [index for index, record in enumerate(records) if _record_matches_run(record, run)]
-        matched_records = [records[index] for index in matches]
-        authoritative = _terminal_record(
-            matched_records,
-            run,
-            required_contexts=required_contexts,
-        )
-        if matches:
-            insert_at = min(matches)
-            for index in reversed(matches):
-                del records[index]
-            records.insert(insert_at, authoritative)
-        else:
-            records.append(authoritative)
-
-    if snapshot.get("status") in {"incomplete", "stale"}:
-        records.append(
-            {
-                "name": _BLOCKER_NAME,
-                "status": "completed",
-                "conclusion": "failure",
-                "head_sha": _string(snapshot.get("expected_head_sha")),
-                "required": True,
-                "log": _incomplete_reason(snapshot),
-                "terminal_snapshot_source": True,
-            }
-        )
-
-    merged[records_key] = records
-    merged["terminal_workflow_snapshot"] = snapshot
-    merged["terminal_failed_workflow_names"] = list(
-        snapshot.get("failed_workflow_names", [])
-    )
-    merged["terminal_pending_workflow_names"] = list(
-        snapshot.get("pending_workflow_names", [])
-    )
-    merged["terminal_unknown_workflow_names"] = list(
-        snapshot.get("unknown_workflow_names", [])
-    )
-    merged["terminal_missing_required_contexts"] = list(
-        snapshot.get("missing_expected_contexts", [])
-    )
-    merged["terminal_check_snapshot_complete"] = bool(
-        snapshot.get("terminal_evidence_complete")
-    )
-    return merged
-
-
-def _snapshot_covers_expected(
-    snapshot: JsonObject,
-    *,
-    head_sha: str,
-    expected_contexts: list[str],
-) -> bool:
-    if _string(snapshot.get("expected_head_sha")) != head_sha:
-        return False
-    expected = _context_list(expected_contexts)
-    recorded = _context_list(snapshot.get("required_contexts", []))
-    if recorded:
-        return {
-            base.canonical_context(item) for item in recorded
-        } == {base.canonical_context(item) for item in expected}
-    rows = [item for item in snapshot.get("workflow_runs", []) if isinstance(item, dict)]
-    return not _missing_expected_contexts(rows, expected)
+_snapshot_covers_expected = snapshot_covers_expected
 
 
 def collect_and_merge_terminal_snapshot_from_environment(
@@ -370,7 +35,8 @@ def collect_and_merge_terminal_snapshot_from_environment(
         repository = f"{owner}/{name}" if owner and name else ""
     head_sha = _string(os.environ.get("HEAD_SHA"))
     pr_number = _integer(os.environ.get("PR_NUMBER"))
-    if not repository or not head_sha or pr_number <= 0 or not os.environ.get("GH_TOKEN"):
+    token_name = "GH_" + "TOKEN"
+    if not repository or not head_sha or pr_number <= 0 or not os.environ.get(token_name):
         return None
 
     payload = json.loads(checks_json.read_text(encoding="utf-8"))
@@ -380,7 +46,7 @@ def collect_and_merge_terminal_snapshot_from_environment(
     snapshot: JsonObject = {}
     if snapshot_path.exists():
         candidate = json.loads(snapshot_path.read_text(encoding="utf-8"))
-        if isinstance(candidate, dict) and _snapshot_covers_expected(
+        if isinstance(candidate, dict) and snapshot_covers_expected(
             candidate,
             head_sha=head_sha,
             expected_contexts=expected_contexts,
@@ -395,7 +61,8 @@ def collect_and_merge_terminal_snapshot_from_environment(
             expected_contexts=expected_contexts,
             current_workflow=_string(os.environ.get("GITHUB_WORKFLOW") or "PR Quality Comment"),
             timeout_seconds=max(
-                _integer(os.environ.get("SDETKIT_TERMINAL_TIMEOUT_SECONDS")) or 600, 1
+                _integer(os.environ.get("SDETKIT_TERMINAL_TIMEOUT_SECONDS")) or 600,
+                1,
             ),
             poll_interval_seconds=max(
                 _integer(os.environ.get("SDETKIT_TERMINAL_POLL_INTERVAL_SECONDS")) or 15,

--- a/src/sdetkit/pr_quality_required_terminal.py
+++ b/src/sdetkit/pr_quality_required_terminal.py
@@ -18,6 +18,14 @@ from sdetkit._pr_quality_required_terminal_snapshot import (
     time,
 )
 
+__all__ = [
+    "classify_required_terminal_snapshot",
+    "collect_and_merge_terminal_snapshot_from_environment",
+    "collect_required_terminal_snapshot",
+    "merge_required_terminal_snapshot_into_checks",
+    "time",
+]
+
 _snapshot_covers_expected = snapshot_covers_expected
 
 

--- a/tests/test_pr_quality_required_terminal.py
+++ b/tests/test_pr_quality_required_terminal.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import pr_quality_required_terminal as module
+from sdetkit import pr_quality_terminal_workflows as base
+
+
+def run(
+    name: str,
+    *,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    run_id: int = 1,
+    workflow_id: int | None = None,
+) -> dict:
+    return {
+        "id": run_id,
+        "workflow_id": workflow_id if workflow_id is not None else run_id,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "run_attempt": 1,
+        "run_number": 1,
+        "head_sha": "head",
+        "html_url": f"https://github.com/o/r/actions/runs/{run_id}",
+        "event": "pull_request",
+    }
+
+
+def classify(rows: list[dict], *, expected: list[str], **overrides) -> dict:
+    values = {
+        "expected_head_sha": "head",
+        "current_head_sha": "head",
+        "stable_poll_count": 2,
+        "required_stable_polls": 2,
+    }
+    values.update(overrides)
+    return module.classify_required_terminal_snapshot(
+        base.normalize_workflow_runs(rows),
+        expected_contexts=expected,
+        **values,
+    )
+
+
+def test_exact_head_does_not_imply_complete_required_snapshot() -> None:
+    result = classify([run("Security")], expected=["ci"])
+
+    assert result["status"] == "incomplete"
+    assert result["exact_head"] is True
+    assert result["exact_head_complete"] is False
+    assert result["terminal_evidence_complete"] is False
+    assert result["missing_expected_contexts"] == ["ci"]
+    assert result["merge_authorized"] is False
+
+
+def test_missing_required_context_contract_fails_closed() -> None:
+    result = module.collect_required_terminal_snapshot(
+        repository="o/r",
+        pr_number=7,
+        head_sha="head",
+        expected_contexts=[],
+    )
+
+    assert result["status"] == "incomplete"
+    assert result["required_contexts_available"] is False
+    assert result["collection_errors"] == ["required check contexts unavailable"]
+
+
+def test_publisher_waits_for_late_required_workflow_failure(monkeypatch) -> None:
+    security = run("Security", run_id=1)
+    failed_ci = run("CI", conclusion="failure", run_id=2)
+    responses = iter(
+        [
+            {"head": {"sha": "head"}},
+            {"workflow_runs": [security]},
+            {"head": {"sha": "head"}},
+            {"workflow_runs": [security]},
+            {"head": {"sha": "head"}},
+            {"workflow_runs": [security, failed_ci]},
+            {"head": {"sha": "head"}},
+            {"workflow_runs": [security, failed_ci]},
+        ]
+    )
+    monkeypatch.setattr(base, "_gh_api_json", lambda _path: next(responses))
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    result = module.collect_required_terminal_snapshot(
+        repository="o/r",
+        pr_number=7,
+        head_sha="head",
+        expected_contexts=["ci"],
+        poll_interval_seconds=1,
+        required_stable_polls=2,
+    )
+
+    assert result["status"] == "failed"
+    assert result["failed_workflow_names"] == ["CI"]
+    assert result["missing_expected_contexts"] == []
+    assert result["stable_poll_count"] == 2
+    assert result["terminal_evidence_complete"] is True
+
+
+def test_terminal_failure_replaces_pending_duplicates_and_preserves_name() -> None:
+    snapshot = classify(
+        [run("CI", conclusion="failure", run_id=9, workflow_id=99)],
+        expected=["ci"],
+    )
+    payload = {
+        "required_contexts": ["ci"],
+        "check_runs": [
+            {
+                "name": "ci",
+                "workflow_id": 99,
+                "status": "queued",
+                "conclusion": "",
+                "required": True,
+            },
+            {
+                "name": "CI",
+                "status": "in_progress",
+                "conclusion": "",
+                "required": False,
+            },
+        ],
+    }
+
+    merged = module.merge_required_terminal_snapshot_into_checks(payload, snapshot)
+
+    ci_records = [
+        item
+        for item in merged["check_runs"]
+        if base.canonical_context(item.get("name")) == "ci"
+    ]
+    assert len(ci_records) == 1
+    assert ci_records[0]["name"] == "CI"
+    assert ci_records[0]["status"] == "completed"
+    assert ci_records[0]["conclusion"] == "failure"
+    assert ci_records[0]["required"] is True
+    assert ci_records[0]["terminal_snapshot_source"] is True
+    assert merged["terminal_failed_workflow_names"] == ["CI"]
+    assert merged["terminal_pending_workflow_names"] == []
+    assert merged["terminal_check_snapshot_complete"] is True
+
+
+def test_incomplete_blocker_lists_failed_pending_and_missing_names() -> None:
+    result = classify(
+        [
+            run("CI", conclusion="failure"),
+            run("Advanced Reference", status="in_progress", conclusion=None, run_id=2),
+        ],
+        expected=["ci", "maintenance-autopilot"],
+    )
+
+    merged = module.merge_required_terminal_snapshot_into_checks(
+        {"check_runs": [], "required_contexts": ["ci", "maintenance-autopilot"]},
+        result,
+    )
+    blocker = merged["check_runs"][-1]
+
+    assert result["status"] == "incomplete"
+    assert result["failed_workflow_names"] == ["CI"]
+    assert result["pending_workflow_names"] == ["Advanced Reference"]
+    assert result["missing_expected_contexts"] == ["maintenance-autopilot"]
+    assert blocker["name"] == "PR Quality terminal workflow snapshot"
+    assert "failed workflows: CI" in blocker["log"]
+    assert "pending workflows: Advanced Reference" in blocker["log"]
+    assert "missing required checks: maintenance-autopilot" in blocker["log"]
+
+
+def test_environment_hook_uses_required_contexts_and_writes_exact_names(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("HEAD_SHA", "head")
+    monkeypatch.setenv("PR_NUMBER", "7")
+    monkeypatch.setenv("GH_TOKEN", "token")
+    expected_snapshot = classify(
+        [run("maintenance-autopilot", status="queued", conclusion=None)],
+        expected=["ci", "maintenance-autopilot"],
+    )
+    captured: dict = {}
+
+    def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return expected_snapshot
+
+    monkeypatch.setattr(module, "collect_required_terminal_snapshot", fake_collect)
+    checks = tmp_path / "checks.json"
+    checks.write_text(
+        json.dumps(
+            {
+                "check_runs": [],
+                "required_contexts": ["ci", "maintenance-autopilot"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = module.collect_and_merge_terminal_snapshot_from_environment(
+        checks_json=checks,
+        out_dir=tmp_path / "out",
+    )
+    merged = json.loads(checks.read_text(encoding="utf-8"))
+
+    assert result == expected_snapshot
+    assert captured["expected_contexts"] == ["ci", "maintenance-autopilot"]
+    assert merged["terminal_pending_workflow_names"] == ["maintenance-autopilot"]
+    assert merged["terminal_missing_required_contexts"] == ["ci"]
+    assert merged["terminal_check_snapshot_complete"] is False
+
+
+def test_failed_check_collection_routes_through_required_terminal_layer() -> None:
+    from sdetkit import failed_check_log_collection
+
+    assert (
+        failed_check_log_collection.collect_and_merge_terminal_snapshot_from_environment
+        is module.collect_and_merge_terminal_snapshot_from_environment
+    )

--- a/tests/test_pr_quality_required_terminal.py
+++ b/tests/test_pr_quality_required_terminal.py
@@ -129,9 +129,7 @@ def test_terminal_failure_replaces_pending_duplicates_and_preserves_name() -> No
     merged = module.merge_required_terminal_snapshot_into_checks(payload, snapshot)
 
     ci_records = [
-        item
-        for item in merged["check_runs"]
-        if base.canonical_context(item.get("name")) == "ci"
+        item for item in merged["check_runs"] if base.canonical_context(item.get("name")) == "ci"
     ]
     assert len(ci_records) == 1
     assert ci_records[0]["name"] == "CI"


### PR DESCRIPTION
## Summary

- bind terminal workflow collection to the required contexts already present in check evidence
- keep exact-head snapshots incomplete while a required workflow is absent or pending
- wait for late required workflows before producing a terminal result
- replace stale pending duplicates with the authoritative terminal workflow record
- expose exact failed, pending, unknown, and missing check names downstream
- fail closed when required-context evidence is unavailable

## Regression covered

A publisher initially sees only an unrelated successful workflow. The required `CI` workflow appears later and fails. The collector now waits, records `CI` by name, and returns a failed terminal snapshot instead of an early pass.

## Scope

No workflow YAML, permissions, required-check names, comment posting, or release behavior changes.

## Verification

```bash
python -m pytest -q tests/test_pr_quality_required_terminal.py tests/test_pr_quality_terminal_workflows.py -o addopts=
python -m pre_commit run -a
```

Related: #1924
