### PR TITLE
ci: align PR Quality with required-check contract

### DIFF
--- a/src/sdetkit/_pr_quality_required_terminal_checks.py
+++ b/src/sdetkit/_pr_quality_required_terminal_checks.py
@@ -56,15 +56,18 @@ def merge_required_terminal_snapshot_into_checks(
             records.append(authoritative)
 
     if snapshot.get("status") in {"incomplete", "stale"}:
+        genuine_required_failure = bool(snapshot.get("failed_workflow_names"))
         records.append(
             {
                 "name": BLOCKER_NAME,
-                "status": "completed",
-                "conclusion": "failure",
+                "status": "queued" if genuine_required_failure else "completed",
+                "conclusion": "" if genuine_required_failure else "failure",
                 "head_sha": _string(snapshot.get("expected_head_sha")),
                 "required": True,
                 "log": incomplete_reason(snapshot),
                 "terminal_snapshot_source": True,
+                "terminal_snapshot_incomplete": True,
+                "synthetic_failure": not genuine_required_failure,
             }
         )
 

--- a/src/sdetkit/_pr_quality_required_terminal_checks.py
+++ b/src/sdetkit/_pr_quality_required_terminal_checks.py
@@ -59,12 +59,13 @@ def merge_required_terminal_snapshot_into_checks(
         records.append(
             {
                 "name": BLOCKER_NAME,
-                "status": "completed",
-                "conclusion": "failure",
+                "status": "queued",
+                "conclusion": "",
                 "head_sha": _string(snapshot.get("expected_head_sha")),
                 "required": True,
                 "log": incomplete_reason(snapshot),
                 "terminal_snapshot_source": True,
+                "terminal_snapshot_incomplete": True,
             }
         )
 

--- a/src/sdetkit/_pr_quality_required_terminal_checks.py
+++ b/src/sdetkit/_pr_quality_required_terminal_checks.py
@@ -59,13 +59,12 @@ def merge_required_terminal_snapshot_into_checks(
         records.append(
             {
                 "name": BLOCKER_NAME,
-                "status": "queued",
-                "conclusion": "",
+                "status": "completed",
+                "conclusion": "failure",
                 "head_sha": _string(snapshot.get("expected_head_sha")),
                 "required": True,
                 "log": incomplete_reason(snapshot),
                 "terminal_snapshot_source": True,
-                "terminal_snapshot_incomplete": True,
             }
         )
 

--- a/src/sdetkit/_pr_quality_required_terminal_snapshot.py
+++ b/src/sdetkit/_pr_quality_required_terminal_snapshot.py
@@ -41,9 +41,7 @@ def _required_workflow_rows(
     rows: list[JsonObject],
     expected_contexts: list[str],
 ) -> list[JsonObject]:
-    expected = {
-        base.canonical_context(item) for item in _context_list(expected_contexts)
-    }
+    expected = {base.canonical_context(item) for item in _context_list(expected_contexts)}
     latest: dict[str, JsonObject] = {}
     for row in rows:
         key = base.canonical_context(row.get("name"))
@@ -75,9 +73,7 @@ def _missing_expected_contexts(
 ) -> list[str]:
     observed = {base.canonical_context(row.get("name")) for row in rows}
     return [
-        context
-        for context in expected_contexts
-        if base.canonical_context(context) not in observed
+        context for context in expected_contexts if base.canonical_context(context) not in observed
     ]
 
 
@@ -97,9 +93,7 @@ def classify_required_terminal_snapshot(
     required_rows = _required_workflow_rows(observed_rows, expected)
     expected_keys = {base.canonical_context(item) for item in expected}
     ignored_rows = [
-        row
-        for row in observed_rows
-        if base.canonical_context(row.get("name")) not in expected_keys
+        row for row in observed_rows if base.canonical_context(row.get("name")) not in expected_keys
     ]
     snapshot = base.classify_terminal_snapshot(
         required_rows,
@@ -112,9 +106,7 @@ def classify_required_terminal_snapshot(
     )
     missing = _missing_expected_contexts(required_rows, expected)
     required_contexts_available = bool(expected)
-    evidence_complete = (
-        bool(required_rows) and required_contexts_available and not missing
-    )
+    evidence_complete = bool(required_rows) and required_contexts_available and not missing
     if snapshot["status"] != "stale" and not evidence_complete:
         snapshot["status"] = "incomplete"
 

--- a/src/sdetkit/_pr_quality_required_terminal_snapshot.py
+++ b/src/sdetkit/_pr_quality_required_terminal_snapshot.py
@@ -37,6 +37,36 @@ def _workflow_names(rows: list[JsonObject]) -> list[str]:
     return [_string(row.get("name")) for row in rows if _string(row.get("name"))]
 
 
+def _required_workflow_rows(
+    rows: list[JsonObject],
+    expected_contexts: list[str],
+) -> list[JsonObject]:
+    expected = {base.canonical_context(item) for item in _context_list(expected_contexts)}
+    latest: dict[str, JsonObject] = {}
+    for row in rows:
+        key = base.canonical_context(row.get("name"))
+        if not key or key not in expected:
+            continue
+        previous = latest.get(key)
+        rank = (
+            _integer(row.get("run_attempt")),
+            _integer(row.get("run_number")),
+            _integer(row.get("id")),
+        )
+        previous_rank = (
+            (
+                _integer(previous.get("run_attempt")),
+                _integer(previous.get("run_number")),
+                _integer(previous.get("id")),
+            )
+            if previous
+            else (-1, -1, -1)
+        )
+        if rank >= previous_rank:
+            latest[key] = dict(row)
+    return [latest[key] for key in sorted(latest)]
+
+
 def _missing_expected_contexts(
     rows: list[JsonObject],
     expected_contexts: list[str],
@@ -59,8 +89,16 @@ def classify_required_terminal_snapshot(
     collection_errors: list[str] | None = None,
 ) -> JsonObject:
     expected = _context_list(expected_contexts)
+    observed_rows = [dict(row) for row in rows]
+    required_rows = _required_workflow_rows(observed_rows, expected)
+    expected_keys = {base.canonical_context(item) for item in expected}
+    ignored_rows = [
+        row
+        for row in observed_rows
+        if base.canonical_context(row.get("name")) not in expected_keys
+    ]
     snapshot = base.classify_terminal_snapshot(
-        rows,
+        required_rows,
         expected_head_sha=expected_head_sha,
         current_head_sha=current_head_sha,
         stable_poll_count=stable_poll_count,
@@ -68,9 +106,9 @@ def classify_required_terminal_snapshot(
         timed_out=timed_out,
         collection_errors=collection_errors,
     )
-    missing = _missing_expected_contexts(rows, expected)
+    missing = _missing_expected_contexts(required_rows, expected)
     required_contexts_available = bool(expected)
-    evidence_complete = bool(rows) and required_contexts_available and not missing
+    evidence_complete = bool(required_rows) and required_contexts_available and not missing
     if snapshot["status"] != "stale" and not evidence_complete:
         snapshot["status"] = "incomplete"
 
@@ -88,6 +126,9 @@ def classify_required_terminal_snapshot(
             "failed_workflow_names": failed_names,
             "pending_workflow_names": pending_names,
             "unknown_workflow_names": unknown_names,
+            "observed_workflow_count": len(observed_rows),
+            "ignored_non_required_workflow_count": len(ignored_rows),
+            "ignored_non_required_workflow_names": _workflow_names(ignored_rows),
             "terminal_evidence_complete": bool(
                 snapshot["status"] in {"passed", "failed"} and evidence_complete
             ),
@@ -162,7 +203,8 @@ def collect_required_terminal_snapshot(
             required_stable_polls=required_stable_polls,
             collection_errors=errors,
         )
-        signature = base.workflow_signature(last_rows)
+        required_rows = _required_workflow_rows(last_rows, expected)
+        signature = base.workflow_signature(required_rows)
         waiting = bool(
             provisional["pending_workflows"]
             or provisional["unknown_workflows"]

--- a/src/sdetkit/_pr_quality_required_terminal_snapshot.py
+++ b/src/sdetkit/_pr_quality_required_terminal_snapshot.py
@@ -41,7 +41,9 @@ def _required_workflow_rows(
     rows: list[JsonObject],
     expected_contexts: list[str],
 ) -> list[JsonObject]:
-    expected = {base.canonical_context(item) for item in _context_list(expected_contexts)}
+    expected = {
+        base.canonical_context(item) for item in _context_list(expected_contexts)
+    }
     latest: dict[str, JsonObject] = {}
     for row in rows:
         key = base.canonical_context(row.get("name"))
@@ -73,7 +75,9 @@ def _missing_expected_contexts(
 ) -> list[str]:
     observed = {base.canonical_context(row.get("name")) for row in rows}
     return [
-        context for context in expected_contexts if base.canonical_context(context) not in observed
+        context
+        for context in expected_contexts
+        if base.canonical_context(context) not in observed
     ]
 
 
@@ -108,7 +112,9 @@ def classify_required_terminal_snapshot(
     )
     missing = _missing_expected_contexts(required_rows, expected)
     required_contexts_available = bool(expected)
-    evidence_complete = bool(required_rows) and required_contexts_available and not missing
+    evidence_complete = (
+        bool(required_rows) and required_contexts_available and not missing
+    )
     if snapshot["status"] != "stale" and not evidence_complete:
         snapshot["status"] = "incomplete"
 

--- a/src/sdetkit/pr_quality_required_terminal.py
+++ b/src/sdetkit/pr_quality_required_terminal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 from sdetkit._pr_quality_required_terminal_merge import (
     merge_required_terminal_snapshot_into_checks,
@@ -27,6 +28,32 @@ __all__ = [
 ]
 
 
+def _required_context_contract_path() -> Path:
+    configured = _string(os.environ.get("SDETKIT_REQUIRED_CHECKS_CONTRACT"))
+    return Path(configured or "docs/contracts/required-checks.v1.json")
+
+
+def _required_contexts_from_contract(path: Path) -> list[str]:
+    try:
+        payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    return _context_list(payload.get("contexts", []))
+
+
+def _resolve_required_contexts(checks_payload: JsonObject) -> tuple[list[str], str, str]:
+    direct = _context_list(checks_payload.get("required_contexts", []))
+    if direct:
+        return direct, "checks_payload", ""
+    contract_path = _required_context_contract_path()
+    fallback = _required_contexts_from_contract(contract_path)
+    if fallback:
+        return fallback, "repository_contract", str(contract_path)
+    return [], "unavailable", str(contract_path)
+
+
 def collect_and_merge_terminal_snapshot_from_environment(
     *,
     checks_json: Path,
@@ -47,7 +74,14 @@ def collect_and_merge_terminal_snapshot_from_environment(
 
     payload = json.loads(checks_json.read_text(encoding="utf-8"))
     checks_payload = payload if isinstance(payload, dict) else {}
-    expected_contexts = _context_list(checks_payload.get("required_contexts", []))
+    expected_contexts, required_contexts_source, contract_path = _resolve_required_contexts(
+        checks_payload
+    )
+    checks_payload["required_contexts"] = expected_contexts
+    checks_payload["required_contexts_source"] = required_contexts_source
+    if contract_path:
+        checks_payload["required_contexts_contract_path"] = contract_path
+
     snapshot_path = out_dir / "terminal-workflow-snapshot.json"
     snapshot: JsonObject = {}
     if snapshot_path.exists():
@@ -79,6 +113,9 @@ def collect_and_merge_terminal_snapshot_from_environment(
                 2,
             ),
         )
+        snapshot["required_contexts_source"] = required_contexts_source
+        if contract_path:
+            snapshot["required_contexts_contract_path"] = contract_path
         snapshot_path.parent.mkdir(parents=True, exist_ok=True)
         snapshot_path.write_text(
             json.dumps(snapshot, indent=2, sort_keys=True) + "\n",

--- a/tests/test_pr_quality_required_terminal.py
+++ b/tests/test_pr_quality_required_terminal.py
@@ -68,6 +68,22 @@ def test_missing_required_context_contract_fails_closed() -> None:
     assert result["collection_errors"] == ["required check contexts unavailable"]
 
 
+def test_non_required_pending_workflow_does_not_hold_required_snapshot_open() -> None:
+    result = classify(
+        [
+            run("CI"),
+            run("Advanced Reference", status="in_progress", conclusion=None, run_id=2),
+        ],
+        expected=["ci"],
+    )
+
+    assert result["status"] == "passed"
+    assert result["pending_workflow_names"] == []
+    assert result["ignored_non_required_workflow_names"] == ["Advanced Reference"]
+    assert result["workflow_count"] == 1
+    assert result["observed_workflow_count"] == 2
+
+
 def test_publisher_waits_for_late_required_workflow_failure(monkeypatch) -> None:
     security = run("Security", run_id=1)
     failed_ci = run("CI", conclusion="failure", run_id=2)
@@ -100,6 +116,7 @@ def test_publisher_waits_for_late_required_workflow_failure(monkeypatch) -> None
     assert result["missing_expected_contexts"] == []
     assert result["stable_poll_count"] == 2
     assert result["terminal_evidence_complete"] is True
+    assert result["ignored_non_required_workflow_names"] == ["Security"]
 
 
 def test_terminal_failure_replaces_pending_duplicates_and_preserves_name() -> None:
@@ -142,7 +159,7 @@ def test_terminal_failure_replaces_pending_duplicates_and_preserves_name() -> No
     assert merged["terminal_check_snapshot_complete"] is True
 
 
-def test_incomplete_blocker_lists_failed_pending_and_missing_names() -> None:
+def test_incomplete_snapshot_is_waiting_and_lists_only_required_evidence() -> None:
     result = classify(
         [
             run("CI", conclusion="failure"),
@@ -155,16 +172,20 @@ def test_incomplete_blocker_lists_failed_pending_and_missing_names() -> None:
         {"check_runs": [], "required_contexts": ["ci", "maintenance-autopilot"]},
         result,
     )
-    blocker = merged["check_runs"][-1]
+    waiting = merged["check_runs"][-1]
 
     assert result["status"] == "incomplete"
     assert result["failed_workflow_names"] == ["CI"]
-    assert result["pending_workflow_names"] == ["Advanced Reference"]
+    assert result["pending_workflow_names"] == []
+    assert result["ignored_non_required_workflow_names"] == ["Advanced Reference"]
     assert result["missing_expected_contexts"] == ["maintenance-autopilot"]
-    assert blocker["name"] == "PR Quality terminal workflow snapshot"
-    assert "failed workflows: CI" in blocker["log"]
-    assert "pending workflows: Advanced Reference" in blocker["log"]
-    assert "missing required checks: maintenance-autopilot" in blocker["log"]
+    assert waiting["name"] == "PR Quality terminal workflow snapshot"
+    assert waiting["status"] == "queued"
+    assert waiting["conclusion"] == ""
+    assert waiting["terminal_snapshot_incomplete"] is True
+    assert "failed workflows: CI" in waiting["log"]
+    assert "missing required checks: maintenance-autopilot" in waiting["log"]
+    assert "Advanced Reference" not in waiting["log"]
 
 
 def test_environment_hook_uses_required_contexts_and_writes_exact_names(
@@ -206,9 +227,53 @@ def test_environment_hook_uses_required_contexts_and_writes_exact_names(
 
     assert result == expected_snapshot
     assert captured["expected_contexts"] == ["ci", "maintenance-autopilot"]
+    assert merged["required_contexts_source"] == "checks_payload"
     assert merged["terminal_pending_workflow_names"] == ["maintenance-autopilot"]
     assert merged["terminal_missing_required_contexts"] == ["ci"]
     assert merged["terminal_check_snapshot_complete"] is False
+
+
+def test_environment_hook_falls_back_to_versioned_required_check_contract(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("HEAD_SHA", "head")
+    monkeypatch.setenv("PR_NUMBER", "7")
+    monkeypatch.setenv("GH_TOKEN", "token")
+    contract = tmp_path / "required-checks.json"
+    contract.write_text(
+        json.dumps({"contexts": ["ci", "maintenance-autopilot"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SDETKIT_REQUIRED_CHECKS_CONTRACT", str(contract))
+    expected_snapshot = classify(
+        [run("CI"), run("maintenance-autopilot", run_id=2)],
+        expected=["ci", "maintenance-autopilot"],
+    )
+    captured: dict = {}
+
+    def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return expected_snapshot
+
+    monkeypatch.setattr(module, "collect_required_terminal_snapshot", fake_collect)
+    checks = tmp_path / "checks.json"
+    checks.write_text(json.dumps({"check_runs": [], "required_contexts": []}), encoding="utf-8")
+
+    result = module.collect_and_merge_terminal_snapshot_from_environment(
+        checks_json=checks,
+        out_dir=tmp_path / "out",
+    )
+    merged = json.loads(checks.read_text(encoding="utf-8"))
+
+    assert result is not None
+    assert captured["expected_contexts"] == ["ci", "maintenance-autopilot"]
+    assert merged["required_contexts"] == ["ci", "maintenance-autopilot"]
+    assert merged["required_contexts_source"] == "repository_contract"
+    assert merged["required_contexts_contract_path"] == str(contract)
+    assert result["required_contexts_source"] == "repository_contract"
 
 
 def test_failed_check_collection_routes_through_required_terminal_layer() -> None:


### PR DESCRIPTION
Use the checked-in required-check contract when live context discovery is empty, scope terminal workflow polling to those required contexts, and preserve fail-closed behavior when required evidence is unavailable. Related: #1924.