### PR TITLE
ci: make dependency radar evidence-first

### DIFF
--- a/.github/workflows/dependency-radar-bot.yml
+++ b/.github/workflows/dependency-radar-bot.yml
@@ -33,124 +33,19 @@ jobs:
 
       - name: Generate dependency radar artifacts
         id: radar
+        env:
+          GITHUB_OUTPUT_FILE: ${{ github.output }}
         run: |
           set -euo pipefail
           mkdir -p build
           python -m sdetkit intelligence upgrade-audit --format json --used-in-repo-only --top 10 > build/dependency-radar.json
           python -m sdetkit intelligence upgrade-audit --impact-area runtime-core --repo-usage-tier hot-path --format md > build/runtime-fast-follow.md
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          repo_root = str(Path.cwd())
-
-          def relativize_repo_paths(text: str) -> str:
-              if not text:
-                  return text
-              normalized = text.replace(f"{repo_root}/", "")
-              return normalized.replace(repo_root, ".")
-
-          data = json.loads(Path("build/dependency-radar.json").read_text(encoding="utf-8"))
-          if not isinstance(data, dict):
-              raise SystemExit("dependency radar JSON must be an object")
-          packages_raw = data.get("packages")
-          summary_raw = data.get("summary")
-          evidence_available = isinstance(packages_raw, list) and isinstance(summary_raw, dict)
-          packages = packages_raw[:5] if isinstance(packages_raw, list) else []
-          route_map = packages_raw[:3] if isinstance(packages_raw, list) else []
-          summary = summary_raw if isinstance(summary_raw, dict) else {}
-          actionable_value = summary.get("actionable_packages")
-          actionable_count_valid = isinstance(actionable_value, int) and actionable_value >= 0
-          actionable_count = actionable_value if actionable_count_valid else 0
-          actionable_reasons = []
-          if not evidence_available:
-              actionable_reasons.append("dependency audit evidence unavailable or malformed")
-          if not actionable_count_valid:
-              actionable_reasons.append("actionable package count unavailable or malformed")
-          if actionable_count > 0:
-              actionable_reasons.append(f"actionable dependency packages: {actionable_count}")
-          actionable = bool(actionable_reasons)
-
-          policy = {
-              "schema_version": "sdetkit.dependency_radar.issue_policy.v1",
-              "actionable": actionable,
-              "actionable_package_count": actionable_count,
-              "actionable_finding_count": len(actionable_reasons),
-              "actionable_reasons": actionable_reasons,
-              "evidence_available": evidence_available,
-              "actionable_count_valid": actionable_count_valid,
-              "issue_policy": "rolling_tracker_when_actionable",
-              "zero_finding_issue_creation": False,
-          }
-          Path("build/dependency-radar-policy.json").write_text(
-              json.dumps(policy, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-
-          lines = [
-              "# Dependency radar",
-              "",
-              f"- Packages audited: **{summary.get('packages_audited', len(packages_raw or []))}**",
-              f"- Actionable packages: **{actionable_count}**",
-              f"- Highest observed risk score: **{summary.get('max_risk_score', 0)}**",
-              f"- Audit evidence available: **{evidence_available}**",
-              "",
-              "## Priority packages",
-          ]
-          if packages:
-              for pkg in packages:
-                  lines.append(
-                      f"- **{pkg['name']}** · impact `{pkg.get('impact_area', 'unknown')}` · usage `{pkg.get('repo_usage_tier', 'unknown')}` · next `{pkg.get('manifest_action', 'watch')}`"
-                  )
-          else:
-              lines.append("- No packages returned by the audit for this scope.")
-          lines.extend(["", "## Validation route map"])
-          if route_map:
-              for pkg in route_map:
-                  validations = ", ".join(pkg.get("validation_commands", [])[:2]) or "n/a"
-                  lines.append(
-                      f"- **{pkg['name']}** → primary `{(pkg.get('validation_commands') or ['n/a'])[0]}`; backups `{validations}`"
-                  )
-          else:
-              lines.append("- No validation routes were emitted for this run.")
-          lines.extend([
-              "",
-              "## Runtime fast-follow watchlist",
-              relativize_repo_paths(
-                  Path("build/runtime-fast-follow.md").read_text(encoding="utf-8").strip()
-              ),
-          ])
-          if actionable:
-              lines.extend([
-                  "",
-                  "## Required follow-up",
-                  *[f"- {reason}" for reason in actionable_reasons],
-                  "",
-                  "A single rolling tracker is created or refreshed for these findings.",
-              ])
-          else:
-              lines.extend([
-                  "",
-                  "## Result",
-                  "- Healthy dependency evidence is retained as workflow artifacts.",
-                  "- No issue is created when the audit reports zero actionable packages.",
-              ])
-          lines.extend([
-              "",
-              "## Recommended follow-up",
-              "- Validate the hottest package lane before merging broad dependency refreshes.",
-              "- Turn recurring runtime-core drift into a scoped enhancement or maintenance PR.",
-              "",
-              "## Artifacts",
-              "- `build/dependency-radar.json`",
-              "- `build/dependency-radar-policy.json`",
-              "- `build/runtime-fast-follow.md`",
-          ])
-          Path("build/dependency-radar.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"actionable={'true' if actionable else 'false'}\n")
-          PY
+          python scripts/build_dependency_radar_policy.py \
+            --radar-json build/dependency-radar.json \
+            --runtime-markdown build/runtime-fast-follow.md \
+            --policy-json build/dependency-radar-policy.json \
+            --report-markdown build/dependency-radar.md \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Upload dependency radar artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/dependency-radar-bot.yml
+++ b/.github/workflows/dependency-radar-bot.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Generate dependency radar artifacts
         id: radar
-        env:
-          GITHUB_OUTPUT_FILE: ${{ github.output }}
         run: |
           set -euo pipefail
           mkdir -p build

--- a/.github/workflows/dependency-radar-bot.yml
+++ b/.github/workflows/dependency-radar-bot.yml
@@ -32,6 +32,7 @@ jobs:
         run: python -m pip install -c constraints-ci.txt -e .
 
       - name: Generate dependency radar artifacts
+        id: radar
         run: |
           set -euo pipefail
           mkdir -p build
@@ -39,6 +40,7 @@ jobs:
           python -m sdetkit intelligence upgrade-audit --impact-area runtime-core --repo-usage-tier hot-path --format md > build/runtime-fast-follow.md
           python - <<'PY'
           import json
+          import os
           from pathlib import Path
 
           repo_root = str(Path.cwd())
@@ -49,18 +51,52 @@ jobs:
               normalized = text.replace(f"{repo_root}/", "")
               return normalized.replace(repo_root, ".")
 
-          data = json.loads(Path('build/dependency-radar.json').read_text(encoding='utf-8'))
-          packages = data.get('packages', [])[:5]
-          route_map = data.get('packages', [])[:3]
-          summary = data.get('summary', {})
+          data = json.loads(Path("build/dependency-radar.json").read_text(encoding="utf-8"))
+          if not isinstance(data, dict):
+              raise SystemExit("dependency radar JSON must be an object")
+          packages_raw = data.get("packages")
+          summary_raw = data.get("summary")
+          evidence_available = isinstance(packages_raw, list) and isinstance(summary_raw, dict)
+          packages = packages_raw[:5] if isinstance(packages_raw, list) else []
+          route_map = packages_raw[:3] if isinstance(packages_raw, list) else []
+          summary = summary_raw if isinstance(summary_raw, dict) else {}
+          actionable_value = summary.get("actionable_packages")
+          actionable_count_valid = isinstance(actionable_value, int) and actionable_value >= 0
+          actionable_count = actionable_value if actionable_count_valid else 0
+          actionable_reasons = []
+          if not evidence_available:
+              actionable_reasons.append("dependency audit evidence unavailable or malformed")
+          if not actionable_count_valid:
+              actionable_reasons.append("actionable package count unavailable or malformed")
+          if actionable_count > 0:
+              actionable_reasons.append(f"actionable dependency packages: {actionable_count}")
+          actionable = bool(actionable_reasons)
+
+          policy = {
+              "schema_version": "sdetkit.dependency_radar.issue_policy.v1",
+              "actionable": actionable,
+              "actionable_package_count": actionable_count,
+              "actionable_finding_count": len(actionable_reasons),
+              "actionable_reasons": actionable_reasons,
+              "evidence_available": evidence_available,
+              "actionable_count_valid": actionable_count_valid,
+              "issue_policy": "rolling_tracker_when_actionable",
+              "zero_finding_issue_creation": False,
+          }
+          Path("build/dependency-radar-policy.json").write_text(
+              json.dumps(policy, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+
           lines = [
-              '# Dependency radar',
-              '',
-              f"- Packages audited: **{summary.get('packages_audited', len(data.get('packages', [])))}**",
-              f"- Actionable packages: **{summary.get('actionable_packages', 0)}**",
+              "# Dependency radar",
+              "",
+              f"- Packages audited: **{summary.get('packages_audited', len(packages_raw or []))}**",
+              f"- Actionable packages: **{actionable_count}**",
               f"- Highest observed risk score: **{summary.get('max_risk_score', 0)}**",
-              '',
-              '## Priority packages',
+              f"- Audit evidence available: **{evidence_available}**",
+              "",
+              "## Priority packages",
           ]
           if packages:
               for pkg in packages:
@@ -68,27 +104,52 @@ jobs:
                       f"- **{pkg['name']}** · impact `{pkg.get('impact_area', 'unknown')}` · usage `{pkg.get('repo_usage_tier', 'unknown')}` · next `{pkg.get('manifest_action', 'watch')}`"
                   )
           else:
-              lines.append('- No packages returned by the audit for this scope.')
-          lines.extend(['', '## Validation route map'])
+              lines.append("- No packages returned by the audit for this scope.")
+          lines.extend(["", "## Validation route map"])
           if route_map:
               for pkg in route_map:
-                  validations = ', '.join(pkg.get('validation_commands', [])[:2]) or 'n/a'
+                  validations = ", ".join(pkg.get("validation_commands", [])[:2]) or "n/a"
                   lines.append(
                       f"- **{pkg['name']}** → primary `{(pkg.get('validation_commands') or ['n/a'])[0]}`; backups `{validations}`"
                   )
           else:
-              lines.append('- No validation routes were emitted for this run.')
+              lines.append("- No validation routes were emitted for this run.")
           lines.extend([
-              '',
-              '## Runtime fast-follow watchlist',
-              relativize_repo_paths(Path('build/runtime-fast-follow.md').read_text(encoding='utf-8').strip()),
-              '',
-              '## Recommended follow-up',
-              '- [ ] Validate the hottest package lane before merging broad dependency refreshes.',
-              '- [ ] Turn any recurring runtime-core drift into a tracked enhancement or maintenance issue.',
-              '- [ ] Link completed upgrade PRs back to this radar issue for traceability.',
+              "",
+              "## Runtime fast-follow watchlist",
+              relativize_repo_paths(
+                  Path("build/runtime-fast-follow.md").read_text(encoding="utf-8").strip()
+              ),
           ])
-          Path('build/dependency-radar.md').write_text('\n'.join(lines) + '\n', encoding='utf-8')
+          if actionable:
+              lines.extend([
+                  "",
+                  "## Required follow-up",
+                  *[f"- {reason}" for reason in actionable_reasons],
+                  "",
+                  "A single rolling tracker is created or refreshed for these findings.",
+              ])
+          else:
+              lines.extend([
+                  "",
+                  "## Result",
+                  "- Healthy dependency evidence is retained as workflow artifacts.",
+                  "- No issue is created when the audit reports zero actionable packages.",
+              ])
+          lines.extend([
+              "",
+              "## Recommended follow-up",
+              "- Validate the hottest package lane before merging broad dependency refreshes.",
+              "- Turn recurring runtime-core drift into a scoped enhancement or maintenance PR.",
+              "",
+              "## Artifacts",
+              "- `build/dependency-radar.json`",
+              "- `build/dependency-radar-policy.json`",
+              "- `build/runtime-fast-follow.md`",
+          ])
+          Path("build/dependency-radar.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"actionable={'true' if actionable else 'false'}\n")
           PY
 
       - name: Upload dependency radar artifacts
@@ -98,25 +159,71 @@ jobs:
           retention-days: 7
           path: |
             build/dependency-radar.json
+            build/dependency-radar-policy.json
             build/dependency-radar.md
             build/runtime-fast-follow.md
 
-      - name: Create or update dependency radar issue
+      - name: Reconcile dependency radar tracker
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          ACTIONABLE: ${{ steps.radar.outputs.actionable }}
         with:
           script: |
             const fs = require('fs');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const weekOf = new Date().toISOString().slice(0, 10);
-            const title = `📡 Dependency radar + runtime watchlist (${weekOf})`;
-            const body = fs.readFileSync('build/dependency-radar.md', 'utf8');
+            const actionable = process.env.ACTIONABLE === 'true';
+            const rollingTitle = '📡 Dependency radar follow-up';
+            const generatedBodyMarker = '<!-- sdetkit:dependency-radar-tracker:v1 -->';
+            const body = `${generatedBodyMarker}\n${fs.readFileSync('build/dependency-radar.md', 'utf8')}`;
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const managedIssues = openIssues
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issue.user?.login === 'github-actions[bot]')
+              .filter((issue) =>
+                issue.title === rollingTitle
+                || issue.title.startsWith('📡 Dependency radar + runtime watchlist')
+                || issue.body?.startsWith(generatedBodyMarker)
+              );
+            const existing = managedIssues.find((issue) => issue.title === rollingTitle);
+
+            for (const issue of managedIssues) {
+              if (!existing || issue.number !== existing.number) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            }
+
+            if (!actionable) {
+              if (existing) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+              core.notice('dependency radar has zero actionable packages; artifacts uploaded');
+              return;
+            }
+
             const labels = [
               { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
               { name: 'dependencies', color: '1d76db', description: 'Dependency maintenance and upgrades' },
               { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
             ];
-
             for (const label of labels) {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name: label.name });
@@ -125,31 +232,19 @@ jobs:
               }
             }
 
-            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
-              owner,
-              repo,
-              state: 'open',
-              labels: 'dependencies',
-              per_page: 100,
-            });
-            const priorIssues = openIssues
-              .filter((issue) => !issue.pull_request)
-              .filter((issue) => issue.title.startsWith('📡 Dependency radar + runtime watchlist'));
-
-            for (const oldIssue of priorIssues) {
-              if (oldIssue.title !== title) {
-                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
-              }
-            }
-
-            const existing = priorIssues.find((issue) => issue.title === title);
             if (existing) {
-              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+                labels: ['maintenance', 'dependencies', 'priority:medium'],
+              });
             } else {
               await github.rest.issues.create({
                 owner,
                 repo,
-                title,
+                title: rollingTitle,
                 body,
                 labels: ['maintenance', 'dependencies', 'priority:medium'],
               });

--- a/scripts/build_dependency_radar_policy.py
+++ b/scripts/build_dependency_radar_policy.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "sdetkit.dependency_radar.issue_policy.v1"
+
+
+def _relativize_repo_paths(text: str, repo_root: Path) -> str:
+    if not text:
+        return text
+    root = str(repo_root)
+    normalized = text.replace(f"{root}/", "")
+    return normalized.replace(root, ".")
+
+
+def build_policy_and_markdown(
+    data: Any,
+    *,
+    runtime_fast_follow: str,
+    repo_root: Path,
+) -> tuple[dict[str, Any], str]:
+    if not isinstance(data, dict):
+        data = {}
+    packages_raw = data.get("packages")
+    summary_raw = data.get("summary")
+    evidence_available = isinstance(packages_raw, list) and isinstance(summary_raw, dict)
+    packages = packages_raw[:5] if isinstance(packages_raw, list) else []
+    route_map = packages_raw[:3] if isinstance(packages_raw, list) else []
+    summary = summary_raw if isinstance(summary_raw, dict) else {}
+    actionable_value = summary.get("actionable_packages")
+    actionable_count_valid = isinstance(actionable_value, int) and actionable_value >= 0
+    actionable_count = actionable_value if actionable_count_valid else 0
+
+    actionable_reasons: list[str] = []
+    if not evidence_available:
+        actionable_reasons.append("dependency audit evidence unavailable or malformed")
+    if not actionable_count_valid:
+        actionable_reasons.append("actionable package count unavailable or malformed")
+    if actionable_count > 0:
+        actionable_reasons.append(f"actionable dependency packages: {actionable_count}")
+    actionable = bool(actionable_reasons)
+
+    policy = {
+        "schema_version": SCHEMA,
+        "actionable": actionable,
+        "actionable_package_count": actionable_count,
+        "actionable_finding_count": len(actionable_reasons),
+        "actionable_reasons": actionable_reasons,
+        "evidence_available": evidence_available,
+        "actionable_count_valid": actionable_count_valid,
+        "issue_policy": "rolling_tracker_when_actionable",
+        "zero_finding_issue_creation": False,
+    }
+
+    audited = summary.get("packages_audited", len(packages_raw or []))
+    lines = [
+        "# Dependency radar",
+        "",
+        f"- Packages audited: **{audited}**",
+        f"- Actionable packages: **{actionable_count}**",
+        f"- Highest observed risk score: **{summary.get('max_risk_score', 0)}**",
+        f"- Audit evidence available: **{evidence_available}**",
+        "",
+        "## Priority packages",
+    ]
+    if packages:
+        for package in packages:
+            lines.append(
+                f"- **{package['name']}** · impact `{package.get('impact_area', 'unknown')}` "
+                f"· usage `{package.get('repo_usage_tier', 'unknown')}` "
+                f"· next `{package.get('manifest_action', 'watch')}`"
+            )
+    else:
+        lines.append("- No packages returned by the audit for this scope.")
+
+    lines.extend(["", "## Validation route map"])
+    if route_map:
+        for package in route_map:
+            commands = package.get("validation_commands") or ["n/a"]
+            backups = ", ".join(commands[:2]) or "n/a"
+            lines.append(
+                f"- **{package['name']}** → primary `{commands[0]}`; backups `{backups}`"
+            )
+    else:
+        lines.append("- No validation routes were emitted for this run.")
+
+    lines.extend(
+        [
+            "",
+            "## Runtime fast-follow watchlist",
+            _relativize_repo_paths(runtime_fast_follow.strip(), repo_root),
+        ]
+    )
+    if actionable:
+        lines.extend(
+            [
+                "",
+                "## Required follow-up",
+                *[f"- {reason}" for reason in actionable_reasons],
+                "",
+                "A single rolling tracker is created or refreshed for these findings.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "## Result",
+                "- Healthy dependency evidence is retained as workflow artifacts.",
+                "- No issue is created when the audit reports zero actionable packages.",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "## Recommended follow-up",
+            "- Validate the hottest package lane before merging broad dependency refreshes.",
+            "- Turn recurring runtime-core drift into a scoped enhancement or maintenance PR.",
+            "",
+            "## Artifacts",
+            "- `build/dependency-radar.json`",
+            "- `build/dependency-radar-policy.json`",
+            "- `build/runtime-fast-follow.md`",
+        ]
+    )
+    return policy, "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--radar-json", type=Path, required=True)
+    parser.add_argument("--runtime-markdown", type=Path, required=True)
+    parser.add_argument("--policy-json", type=Path, required=True)
+    parser.add_argument("--report-markdown", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    data = json.loads(args.radar_json.read_text(encoding="utf-8"))
+    runtime_text = args.runtime_markdown.read_text(encoding="utf-8")
+    policy, markdown = build_policy_and_markdown(
+        data,
+        runtime_fast_follow=runtime_text,
+        repo_root=Path.cwd(),
+    )
+    args.policy_json.write_text(
+        json.dumps(policy, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.report_markdown.write_text(markdown, encoding="utf-8")
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            output.write(f"actionable={'true' if policy['actionable'] else 'false'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_dependency_radar_policy.py
+++ b/scripts/build_dependency_radar_policy.py
@@ -81,9 +81,7 @@ def build_policy_and_markdown(
         for package in route_map:
             commands = package.get("validation_commands") or ["n/a"]
             backups = ", ".join(commands[:2]) or "n/a"
-            lines.append(
-                f"- **{package['name']}** → primary `{commands[0]}`; backups `{backups}`"
-            )
+            lines.append(f"- **{package['name']}** → primary `{commands[0]}`; backups `{backups}`")
     else:
         lines.append("- No validation routes were emitted for this run.")
 

--- a/tests/test_dependency_radar_artifact_policy.py
+++ b/tests/test_dependency_radar_artifact_policy.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "dependency-radar-bot.yml"
+
+
+def test_zero_actionable_dependency_run_is_artifact_only() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    healthy_guard = "if (!actionable) {"
+    create_call = "await github.rest.issues.create({"
+
+    assert "id: radar" in workflow
+    assert "build/dependency-radar-policy.json" in workflow
+    assert "ACTIONABLE: ${{ steps.radar.outputs.actionable }}" in workflow
+    assert '"zero_finding_issue_creation": False' in workflow
+    assert healthy_guard in workflow
+    assert "dependency radar has zero actionable packages; artifacts uploaded" in workflow
+    assert "return;" in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
+    assert workflow.index(healthy_guard) < workflow.rindex(create_call)
+
+
+def test_dependency_radar_uses_one_bot_managed_rolling_tracker() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const rollingTitle = '📡 Dependency radar follow-up';" in workflow
+    assert (
+        "const generatedBodyMarker = '<!-- sdetkit:dependency-radar-tracker:v1 -->';"
+        in workflow
+    )
+    assert "issue.user?.login === 'github-actions[bot]'" in workflow
+    assert "issue.title.startsWith('📡 Dependency radar + runtime watchlist')" in workflow
+    assert "state_reason: 'completed'" in workflow
+    assert "const weekOf" not in workflow
+
+
+def test_dependency_radar_fails_closed_on_malformed_audit_evidence() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "evidence_available = isinstance(packages_raw, list)" in workflow
+    assert "actionable_count_valid = isinstance(actionable_value, int)" in workflow
+    assert "dependency audit evidence unavailable or malformed" in workflow
+    assert "actionable package count unavailable or malformed" in workflow
+    assert "actionable = bool(actionable_reasons)" in workflow
+    assert '"issue_policy": "rolling_tracker_when_actionable"' in workflow
+
+
+def test_only_positive_actionable_count_creates_dependency_follow_up() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "if actionable_count > 0:" in workflow
+    assert 'actionable_reasons.append(f"actionable dependency packages: {actionable_count}")' in workflow
+    assert "No issue is created when the audit reports zero actionable packages." in workflow

--- a/tests/test_dependency_radar_artifact_policy.py
+++ b/tests/test_dependency_radar_artifact_policy.py
@@ -1,30 +1,85 @@
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "dependency-radar-bot.yml"
+SCRIPT = ROOT / "scripts" / "build_dependency_radar_policy.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("build_dependency_radar_policy", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_zero_actionable_dependency_run_is_artifact_only() -> None:
-    workflow = WORKFLOW.read_text(encoding="utf-8")
+    module = _load_script()
+    policy, markdown = module.build_policy_and_markdown(
+        {
+            "packages": [],
+            "summary": {
+                "packages_audited": 0,
+                "actionable_packages": 0,
+                "max_risk_score": 0,
+            },
+        },
+        runtime_fast_follow="# Runtime watchlist\n",
+        repo_root=ROOT,
+    )
 
+    assert policy["actionable"] is False
+    assert policy["actionable_package_count"] == 0
+    assert policy["zero_finding_issue_creation"] is False
+    assert policy["actionable_reasons"] == []
+    assert "No issue is created when the audit reports zero actionable packages." in markdown
+
+
+def test_dependency_radar_fails_closed_on_malformed_audit_evidence() -> None:
+    module = _load_script()
+    policy, _markdown = module.build_policy_and_markdown(
+        {},
+        runtime_fast_follow="",
+        repo_root=ROOT,
+    )
+
+    assert policy["actionable"] is True
+    assert policy["evidence_available"] is False
+    assert policy["actionable_count_valid"] is False
+    assert policy["actionable_reasons"] == [
+        "dependency audit evidence unavailable or malformed",
+        "actionable package count unavailable or malformed",
+    ]
+
+
+def test_positive_actionable_count_requires_dependency_follow_up() -> None:
+    module = _load_script()
+    policy, markdown = module.build_policy_and_markdown(
+        {
+            "packages": [{"name": "example", "validation_commands": ["pytest -q"]}],
+            "summary": {"packages_audited": 1, "actionable_packages": 1},
+        },
+        runtime_fast_follow="",
+        repo_root=ROOT,
+    )
+
+    assert policy["actionable"] is True
+    assert policy["actionable_package_count"] == 1
+    assert policy["actionable_reasons"] == ["actionable dependency packages: 1"]
+    assert "A single rolling tracker is created or refreshed" in markdown
+
+
+def test_workflow_uses_one_bot_managed_tracker_and_stays_below_heavy_budget() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
     healthy_guard = "if (!actionable) {"
     create_call = "await github.rest.issues.create({"
 
-    assert "id: radar" in workflow
-    assert "build/dependency-radar-policy.json" in workflow
+    assert len(workflow.splitlines()) < 250
+    assert "python scripts/build_dependency_radar_policy.py" in workflow
     assert "ACTIONABLE: ${{ steps.radar.outputs.actionable }}" in workflow
-    assert '"zero_finding_issue_creation": False' in workflow
-    assert healthy_guard in workflow
-    assert "dependency radar has zero actionable packages; artifacts uploaded" in workflow
-    assert "return;" in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
-    assert workflow.index(healthy_guard) < workflow.rindex(create_call)
-
-
-def test_dependency_radar_uses_one_bot_managed_rolling_tracker() -> None:
-    workflow = WORKFLOW.read_text(encoding="utf-8")
-
     assert "const rollingTitle = '📡 Dependency radar follow-up';" in workflow
     assert (
         "const generatedBodyMarker = '<!-- sdetkit:dependency-radar-tracker:v1 -->';"
@@ -34,22 +89,6 @@ def test_dependency_radar_uses_one_bot_managed_rolling_tracker() -> None:
     assert "issue.title.startsWith('📡 Dependency radar + runtime watchlist')" in workflow
     assert "state_reason: 'completed'" in workflow
     assert "const weekOf" not in workflow
-
-
-def test_dependency_radar_fails_closed_on_malformed_audit_evidence() -> None:
-    workflow = WORKFLOW.read_text(encoding="utf-8")
-
-    assert "evidence_available = isinstance(packages_raw, list)" in workflow
-    assert "actionable_count_valid = isinstance(actionable_value, int)" in workflow
-    assert "dependency audit evidence unavailable or malformed" in workflow
-    assert "actionable package count unavailable or malformed" in workflow
-    assert "actionable = bool(actionable_reasons)" in workflow
-    assert '"issue_policy": "rolling_tracker_when_actionable"' in workflow
-
-
-def test_only_positive_actionable_count_creates_dependency_follow_up() -> None:
-    workflow = WORKFLOW.read_text(encoding="utf-8")
-
-    assert "if actionable_count > 0:" in workflow
-    assert 'actionable_reasons.append(f"actionable dependency packages: {actionable_count}")' in workflow
-    assert "No issue is created when the audit reports zero actionable packages." in workflow
+    assert healthy_guard in workflow
+    assert "return;" in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
+    assert workflow.index(healthy_guard) < workflow.rindex(create_call)

--- a/tests/test_dependency_radar_artifact_policy.py
+++ b/tests/test_dependency_radar_artifact_policy.py
@@ -81,10 +81,7 @@ def test_workflow_uses_one_bot_managed_tracker_and_stays_below_heavy_budget() ->
     assert "python scripts/build_dependency_radar_policy.py" in workflow
     assert "ACTIONABLE: ${{ steps.radar.outputs.actionable }}" in workflow
     assert "const rollingTitle = '📡 Dependency radar follow-up';" in workflow
-    assert (
-        "const generatedBodyMarker = '<!-- sdetkit:dependency-radar-tracker:v1 -->';"
-        in workflow
-    )
+    assert "const generatedBodyMarker = '<!-- sdetkit:dependency-radar-tracker:v1 -->';" in workflow
     assert "issue.user?.login === 'github-actions[bot]'" in workflow
     assert "issue.title.startsWith('📡 Dependency radar + runtime watchlist')" in workflow
     assert "state_reason: 'completed'" in workflow


### PR DESCRIPTION
## Summary

- retain every dependency audit as JSON, Markdown, and policy artifacts
- create no issue when the audit reports zero actionable packages
- treat malformed or unavailable audit evidence as actionable
- use one rolling bot-managed dependency tracker instead of dated weekly issues
- close stale bot-created dated dependency-radar trackers without touching manual issues
- add a repository contract test for issue eligibility and tracker ownership

## Safety

- no workflow retirement
- no permission change
- no required-check rename
- no dependency or release mutation
- `issues: write` remains because actionable findings still use one rolling tracker

## Verification

```bash
python -m pytest -q tests/test_dependency_radar_artifact_policy.py tests/test_workflow_alias_regression_guards.py -o addopts=
python scripts/check_workflow_contracts.py \
  --root . \
  --topology-contract docs/contracts/workflow-topology.v1.json \
  --required-checks-contract docs/contracts/required-checks.v1.json
python -m pre_commit run -a
```

Related: #1924
