### PR TITLE
ci: make workflow governance evidence-first

### DIFF
--- a/.github/workflows/workflow-governance-bot.yml
+++ b/.github/workflows/workflow-governance-bot.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Audit workflow governance posture
+        id: governance
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -92,64 +93,88 @@ jobs:
           }
 
           Path('build').mkdir(exist_ok=True)
-          Path('build/workflow-governance-audit.json').write_text(json.dumps(report, indent=2) + '\n', encoding='utf-8')
-
-          lines = [
-              '# Workflow governance audit',
-              '',
-              'This issue is auto-generated to keep GitHub Actions permissions, pinning, and recovery posture in a reviewable state.',
-              '',
-              '## Snapshot',
-              f"- Workflows scanned: **{summary['workflow_count']}**",
-              f"- Findings: **{len(findings)}**",
-              '',
-              '## Missing top-level permissions',
-          ]
-          lines.extend([f'- ⚠️ {name}' for name in summary['missing_permissions']] or ['- None'])
-          lines.extend(['', '## Unpinned reusable actions'])
-          lines.extend([f"- ⚠️ {item['workflow']} → `{item['target']}`" for item in summary['unpinned_uses']] or ['- None'])
-          lines.extend(['', '## Scheduled workflows missing manual recovery'])
-          lines.extend([f'- ⚠️ {name}' for name in summary['missing_dispatch']] or ['- None'])
-          lines.extend(['', '## pull_request_target usage'])
-          lines.extend([f'- ⚠️ {name}' for name in summary['pr_target']] or ['- None'])
-          lines.extend([
-              '',
-              '## Suggested follow-up',
-              '- [ ] Add least-privilege top-level permissions where missing.',
-              '- [ ] Pin reusable actions to full SHAs for deterministic supply-chain posture.',
-              '- [ ] Ensure scheduled workflows can be re-run manually with `workflow_dispatch`.',
-              '',
-              '## Artifact',
-              '- `build/workflow-governance-audit.json`',
-          ])
-          Path('build/workflow-governance-audit.md').write_text('\n'.join(lines) + '\n', encoding='utf-8')
+          Path('build/workflow-governance-audit.json').write_text(
+              json.dumps(report, indent=2) + '\n',
+              encoding='utf-8',
+          )
           PY
+          python scripts/build_workflow_governance_policy.py \
+            --audit-json build/workflow-governance-audit.json \
+            --policy-json build/workflow-governance-policy.json \
+            --report-markdown build/workflow-governance-audit.md \
+            --github-output "$GITHUB_OUTPUT"
 
-      - name: Upload governance artifact
+      - name: Upload governance artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           retention-days: 14
           name: workflow-governance-audit
           path: |
             build/workflow-governance-audit.json
+            build/workflow-governance-policy.json
             build/workflow-governance-audit.md
 
-      - name: Publish workflow governance issue
+      - name: Reconcile workflow governance tracker
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          ACTIONABLE: ${{ steps.governance.outputs.actionable }}
         with:
           script: |
             const fs = require('fs');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const monthOf = new Date().toISOString().slice(0, 7);
-            const title = `🧾 Workflow governance audit (${monthOf})`;
-            const body = fs.readFileSync('build/workflow-governance-audit.md', 'utf8');
+            const actionable = process.env.ACTIONABLE === 'true';
+            const rollingTitle = '🧾 Workflow governance follow-up';
+            const generatedBodyMarker = '<!-- sdetkit:workflow-governance-tracker:v1 -->';
+            const body = `${generatedBodyMarker}\n${fs.readFileSync('build/workflow-governance-audit.md', 'utf8')}`;
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const managedIssues = openIssues
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issue.user?.login === 'github-actions[bot]')
+              .filter((issue) =>
+                issue.title === rollingTitle
+                || issue.title.startsWith('🧾 Workflow governance audit')
+                || issue.body?.startsWith(generatedBodyMarker)
+              );
+            const existing = managedIssues.find((issue) => issue.title === rollingTitle);
+
+            for (const issue of managedIssues) {
+              if (!existing || issue.number !== existing.number) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            }
+
+            if (!actionable) {
+              if (existing) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+              core.notice('workflow governance has zero actionable findings; artifacts uploaded');
+              return;
+            }
+
             const labels = [
               { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
               { name: 'automation', color: '1d76db', description: 'GitHub Actions and automation work' },
               { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
             ];
-
             for (const label of labels) {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name: label.name });
@@ -158,31 +183,19 @@ jobs:
               }
             }
 
-            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
-              owner,
-              repo,
-              state: 'open',
-              labels: 'maintenance',
-              per_page: 100,
-            });
-            const priorIssues = openIssues
-              .filter((issue) => !issue.pull_request)
-              .filter((issue) => issue.title.startsWith('🧾 Workflow governance audit'));
-
-            for (const oldIssue of priorIssues) {
-              if (oldIssue.title !== title) {
-                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
-              }
-            }
-
-            const existing = priorIssues.find((issue) => issue.title === title);
             if (existing) {
-              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+                labels: ['maintenance', 'automation', 'priority:medium'],
+              });
             } else {
               await github.rest.issues.create({
                 owner,
                 repo,
-                title,
+                title: rollingTitle,
                 body,
                 labels: ['maintenance', 'automation', 'priority:medium'],
               });

--- a/scripts/build_workflow_governance_policy.py
+++ b/scripts/build_workflow_governance_policy.py
@@ -71,7 +71,11 @@ def build_policy_and_markdown(data: Any) -> tuple[dict[str, Any], str]:
     )
     lines.extend(["", "## Unpinned reusable actions"])
     lines.extend(
-        [f"- ⚠️ {item.get('workflow', 'unknown')} → `{item.get('target', 'unknown')}`" for item in unpinned_uses]
+        [
+            f"- ⚠️ {item.get('workflow', 'unknown')} → "
+            f"`{item.get('target', 'unknown')}`"
+            for item in unpinned_uses
+        ]
         if isinstance(unpinned_uses, list) and unpinned_uses
         else ["- None"]
     )

--- a/scripts/build_workflow_governance_policy.py
+++ b/scripts/build_workflow_governance_policy.py
@@ -72,8 +72,7 @@ def build_policy_and_markdown(data: Any) -> tuple[dict[str, Any], str]:
     lines.extend(["", "## Unpinned reusable actions"])
     lines.extend(
         [
-            f"- ⚠️ {item.get('workflow', 'unknown')} → "
-            f"`{item.get('target', 'unknown')}`"
+            f"- ⚠️ {item.get('workflow', 'unknown')} → `{item.get('target', 'unknown')}`"
             for item in unpinned_uses
         ]
         if isinstance(unpinned_uses, list) and unpinned_uses

--- a/scripts/build_workflow_governance_policy.py
+++ b/scripts/build_workflow_governance_policy.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "sdetkit.workflow_governance.issue_policy.v1"
+
+
+def build_policy_and_markdown(data: Any) -> tuple[dict[str, Any], str]:
+    if not isinstance(data, dict):
+        data = {}
+
+    summary_raw = data.get("summary")
+    findings_raw = data.get("findings")
+    finding_count_raw = data.get("finding_count")
+
+    evidence_available = isinstance(summary_raw, dict) and isinstance(findings_raw, list)
+    finding_count_valid = isinstance(finding_count_raw, int) and finding_count_raw >= 0
+    findings = findings_raw if isinstance(findings_raw, list) else []
+    summary = summary_raw if isinstance(summary_raw, dict) else {}
+    finding_count = finding_count_raw if finding_count_valid else 0
+    finding_count_matches = finding_count_valid and finding_count == len(findings)
+
+    actionable_reasons: list[str] = []
+    if not evidence_available:
+        actionable_reasons.append("workflow governance audit evidence unavailable or malformed")
+    if not finding_count_valid:
+        actionable_reasons.append("workflow governance finding count unavailable or malformed")
+    elif not finding_count_matches:
+        actionable_reasons.append("workflow governance finding count does not match evidence")
+    if finding_count > 0:
+        actionable_reasons.append(f"workflow governance findings: {finding_count}")
+
+    actionable = bool(actionable_reasons)
+    policy = {
+        "schema_version": SCHEMA,
+        "actionable": actionable,
+        "workflow_finding_count": finding_count,
+        "actionable_finding_count": len(actionable_reasons),
+        "actionable_reasons": actionable_reasons,
+        "evidence_available": evidence_available,
+        "finding_count_valid": finding_count_valid,
+        "finding_count_matches": finding_count_matches,
+        "issue_policy": "rolling_tracker_when_actionable",
+        "zero_finding_issue_creation": False,
+    }
+
+    missing_permissions = summary.get("missing_permissions")
+    unpinned_uses = summary.get("unpinned_uses")
+    missing_dispatch = summary.get("missing_dispatch")
+    pr_target = summary.get("pr_target")
+
+    lines = [
+        "# Workflow governance audit",
+        "",
+        "This report keeps GitHub Actions permissions, pinning, and recovery posture reviewable.",
+        "",
+        "## Snapshot",
+        f"- Workflows scanned: **{summary.get('workflow_count', 0)}**",
+        f"- Findings: **{finding_count}**",
+        f"- Audit evidence available: **{evidence_available}**",
+        "",
+        "## Missing top-level permissions",
+    ]
+    lines.extend(
+        [f"- ⚠️ {name}" for name in missing_permissions]
+        if isinstance(missing_permissions, list) and missing_permissions
+        else ["- None"]
+    )
+    lines.extend(["", "## Unpinned reusable actions"])
+    lines.extend(
+        [f"- ⚠️ {item.get('workflow', 'unknown')} → `{item.get('target', 'unknown')}`" for item in unpinned_uses]
+        if isinstance(unpinned_uses, list) and unpinned_uses
+        else ["- None"]
+    )
+    lines.extend(["", "## Scheduled workflows missing manual recovery"])
+    lines.extend(
+        [f"- ⚠️ {name}" for name in missing_dispatch]
+        if isinstance(missing_dispatch, list) and missing_dispatch
+        else ["- None"]
+    )
+    lines.extend(["", "## pull_request_target usage"])
+    lines.extend(
+        [f"- ⚠️ {name}" for name in pr_target]
+        if isinstance(pr_target, list) and pr_target
+        else ["- None"]
+    )
+
+    if actionable:
+        lines.extend(
+            [
+                "",
+                "## Required follow-up",
+                *[f"- {reason}" for reason in actionable_reasons],
+                "",
+                "A single rolling tracker is created or refreshed for these findings.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "## Result",
+                "- Healthy workflow-governance evidence is retained as workflow artifacts.",
+                "- No issue is created when the audit reports zero actionable findings.",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Suggested follow-up",
+            "- Add least-privilege top-level permissions where missing.",
+            "- Pin reusable actions to full SHAs for deterministic supply-chain posture.",
+            "- Ensure scheduled workflows can be re-run manually with `workflow_dispatch`.",
+            "",
+            "## Artifacts",
+            "- `build/workflow-governance-audit.json`",
+            "- `build/workflow-governance-policy.json`",
+        ]
+    )
+    return policy, "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--audit-json", type=Path, required=True)
+    parser.add_argument("--policy-json", type=Path, required=True)
+    parser.add_argument("--report-markdown", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    data = json.loads(args.audit_json.read_text(encoding="utf-8"))
+    policy, markdown = build_policy_and_markdown(data)
+    args.policy_json.write_text(
+        json.dumps(policy, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.report_markdown.write_text(markdown, encoding="utf-8")
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            output.write(f"actionable={'true' if policy['actionable'] else 'false'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workflow_governance_artifact_policy.py
+++ b/tests/test_workflow_governance_artifact_policy.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "workflow-governance-bot.yml"
+SCRIPT = ROOT / "scripts" / "build_workflow_governance_policy.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("build_workflow_governance_policy", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _healthy_audit() -> dict[str, object]:
+    return {
+        "summary": {
+            "workflow_count": 57,
+            "missing_permissions": [],
+            "unpinned_uses": [],
+            "missing_dispatch": [],
+            "pr_target": [],
+        },
+        "finding_count": 0,
+        "findings": [],
+    }
+
+
+def test_zero_finding_workflow_governance_run_is_artifact_only() -> None:
+    module = _load_script()
+    policy, markdown = module.build_policy_and_markdown(_healthy_audit())
+
+    assert policy["actionable"] is False
+    assert policy["workflow_finding_count"] == 0
+    assert policy["zero_finding_issue_creation"] is False
+    assert policy["actionable_reasons"] == []
+    assert "No issue is created when the audit reports zero actionable findings." in markdown
+
+
+def test_workflow_governance_fails_closed_on_malformed_evidence() -> None:
+    module = _load_script()
+    policy, _markdown = module.build_policy_and_markdown({})
+
+    assert policy["actionable"] is True
+    assert policy["evidence_available"] is False
+    assert policy["finding_count_valid"] is False
+    assert policy["actionable_reasons"] == [
+        "workflow governance audit evidence unavailable or malformed",
+        "workflow governance finding count unavailable or malformed",
+    ]
+
+
+def test_positive_workflow_governance_findings_require_follow_up() -> None:
+    module = _load_script()
+    audit = _healthy_audit()
+    audit["finding_count"] = 1
+    audit["findings"] = [
+        {"type": "missing_permissions", "workflow": "example.yml"},
+    ]
+    summary = audit["summary"]
+    assert isinstance(summary, dict)
+    summary["missing_permissions"] = ["example.yml"]
+
+    policy, markdown = module.build_policy_and_markdown(audit)
+
+    assert policy["actionable"] is True
+    assert policy["workflow_finding_count"] == 1
+    assert policy["actionable_reasons"] == ["workflow governance findings: 1"]
+    assert "A single rolling tracker is created or refreshed" in markdown
+
+
+def test_workflow_uses_one_bot_managed_tracker_and_stays_below_heavy_budget() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    healthy_guard = "if (!actionable) {"
+    create_call = "await github.rest.issues.create({"
+
+    assert len(workflow.splitlines()) < 250
+    assert "python scripts/build_workflow_governance_policy.py" in workflow
+    assert "ACTIONABLE: ${{ steps.governance.outputs.actionable }}" in workflow
+    assert "const rollingTitle = '🧾 Workflow governance follow-up';" in workflow
+    assert "const generatedBodyMarker = '<!-- sdetkit:workflow-governance-tracker:v1 -->';" in workflow
+    assert "issue.user?.login === 'github-actions[bot]'" in workflow
+    assert "issue.title.startsWith('🧾 Workflow governance audit')" in workflow
+    assert "state_reason: 'completed'" in workflow
+    assert "const monthOf" not in workflow
+    assert healthy_guard in workflow
+    assert "return;" in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
+    assert workflow.index(healthy_guard) < workflow.rindex(create_call)

--- a/tests/test_workflow_governance_artifact_policy.py
+++ b/tests/test_workflow_governance_artifact_policy.py
@@ -82,7 +82,10 @@ def test_workflow_uses_one_bot_managed_tracker_and_stays_below_heavy_budget() ->
     assert "python scripts/build_workflow_governance_policy.py" in workflow
     assert "ACTIONABLE: ${{ steps.governance.outputs.actionable }}" in workflow
     assert "const rollingTitle = '🧾 Workflow governance follow-up';" in workflow
-    assert "const generatedBodyMarker = '<!-- sdetkit:workflow-governance-tracker:v1 -->';" in workflow
+    assert (
+        "const generatedBodyMarker = '<!-- sdetkit:workflow-governance-tracker:v1 -->';"
+        in workflow
+    )
     assert "issue.user?.login === 'github-actions[bot]'" in workflow
     assert "issue.title.startsWith('🧾 Workflow governance audit')" in workflow
     assert "state_reason: 'completed'" in workflow

--- a/tests/test_workflow_governance_artifact_policy.py
+++ b/tests/test_workflow_governance_artifact_policy.py
@@ -9,7 +9,9 @@ SCRIPT = ROOT / "scripts" / "build_workflow_governance_policy.py"
 
 
 def _load_script():
-    spec = importlib.util.spec_from_file_location("build_workflow_governance_policy", SCRIPT)
+    spec = importlib.util.spec_from_file_location(
+        "build_workflow_governance_policy", SCRIPT
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -38,7 +40,10 @@ def test_zero_finding_workflow_governance_run_is_artifact_only() -> None:
     assert policy["workflow_finding_count"] == 0
     assert policy["zero_finding_issue_creation"] is False
     assert policy["actionable_reasons"] == []
-    assert "No issue is created when the audit reports zero actionable findings." in markdown
+    assert (
+        "No issue is created when the audit reports zero actionable findings."
+        in markdown
+    )
 
 
 def test_workflow_governance_fails_closed_on_malformed_evidence() -> None:
@@ -91,5 +96,8 @@ def test_workflow_uses_one_bot_managed_tracker_and_stays_below_heavy_budget() ->
     assert "state_reason: 'completed'" in workflow
     assert "const monthOf" not in workflow
     assert healthy_guard in workflow
-    assert "return;" in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
+    assert (
+        "return;"
+        in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
+    )
     assert workflow.index(healthy_guard) < workflow.rindex(create_call)

--- a/tests/test_workflow_governance_artifact_policy.py
+++ b/tests/test_workflow_governance_artifact_policy.py
@@ -9,9 +9,7 @@ SCRIPT = ROOT / "scripts" / "build_workflow_governance_policy.py"
 
 
 def _load_script():
-    spec = importlib.util.spec_from_file_location(
-        "build_workflow_governance_policy", SCRIPT
-    )
+    spec = importlib.util.spec_from_file_location("build_workflow_governance_policy", SCRIPT)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -40,10 +38,7 @@ def test_zero_finding_workflow_governance_run_is_artifact_only() -> None:
     assert policy["workflow_finding_count"] == 0
     assert policy["zero_finding_issue_creation"] is False
     assert policy["actionable_reasons"] == []
-    assert (
-        "No issue is created when the audit reports zero actionable findings."
-        in markdown
-    )
+    assert "No issue is created when the audit reports zero actionable findings." in markdown
 
 
 def test_workflow_governance_fails_closed_on_malformed_evidence() -> None:
@@ -88,16 +83,12 @@ def test_workflow_uses_one_bot_managed_tracker_and_stays_below_heavy_budget() ->
     assert "ACTIONABLE: ${{ steps.governance.outputs.actionable }}" in workflow
     assert "const rollingTitle = '🧾 Workflow governance follow-up';" in workflow
     assert (
-        "const generatedBodyMarker = '<!-- sdetkit:workflow-governance-tracker:v1 -->';"
-        in workflow
+        "const generatedBodyMarker = '<!-- sdetkit:workflow-governance-tracker:v1 -->';" in workflow
     )
     assert "issue.user?.login === 'github-actions[bot]'" in workflow
     assert "issue.title.startsWith('🧾 Workflow governance audit')" in workflow
     assert "state_reason: 'completed'" in workflow
     assert "const monthOf" not in workflow
     assert healthy_guard in workflow
-    assert (
-        "return;"
-        in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
-    )
+    assert "return;" in workflow[workflow.index(healthy_guard) : workflow.rindex(create_call)]
     assert workflow.index(healthy_guard) < workflow.rindex(create_call)


### PR DESCRIPTION
## Summary
- retain workflow-governance JSON, Markdown, and policy artifacts for every run
- create no issue when the audit reports zero actionable findings
- fail closed when governance evidence or finding counts are malformed
- reconcile one bot-managed rolling tracker for actionable findings
- close stale bot-created dated governance trackers without touching human-created issues
- add focused contract coverage for healthy, malformed, and actionable evidence

## Why
The workflow-consolidation roadmap requires zero-signal scheduled runs to stay artifact-only. `workflow-governance-bot.yml` still created a dated monthly issue even when its audit found nothing actionable. This continues the evidence-first issue policy established in the recent adapter, release-readiness, and dependency-radar changes.

Advances #1924.

## Verification
Locally validated while constructing the patch:
- Python compilation of the new policy renderer and test module
- healthy/malformed/actionable policy smoke cases
- workflow line budget: 202 lines

Required repository proof:
```bash
python -m pytest -q tests/test_workflow_governance_artifact_policy.py tests/test_workflow_alias_regression_guards.py -o addopts=
python scripts/check_workflow_contracts.py \
  --root . \
  --topology-contract docs/contracts/workflow-topology.v1.json \
  --required-checks-contract docs/contracts/required-checks.v1.json
python -m pre_commit run -a
```

## Risk
- Medium: scheduled workflow behavior and issue reconciliation change
- No workflow retirement
- No required-check rename
- No permission expansion
- No runtime, dependency, release, or contributor-task change
- Rollback: revert this PR

## Notes
- Only issues owned by `github-actions[bot]` and matching the workflow-governance marker/title family are reconciled.
- Healthy evidence remains available in uploaded artifacts.
- This PR does not close #1924; workflow telemetry and the first reusable shadow-parity bundle remain separate follow-ups.