### PR TITLE
feat: guide contributors through SDET Quality Gate failures

### DIFF
--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -582,11 +582,115 @@ def _green_proof_commands(
     return _dedupe(commands)[:5]
 
 
+_PROOF_EXECUTABLES = {
+    "bash",
+    "gh",
+    "make",
+    "mkdocs",
+    "mypy",
+    "nox",
+    "npm",
+    "pnpm",
+    "poetry",
+    "pre-commit",
+    "pytest",
+    "python",
+    "python3",
+    "ruff",
+    "sh",
+    "tox",
+    "uv",
+    "yarn",
+}
+_CLEANUP_ONLY_EXECUTABLES = {
+    "cat",
+    "cp",
+    "echo",
+    "find",
+    "mkdir",
+    "mv",
+    "printf",
+    "rm",
+    "sed",
+    "touch",
+}
+
+
+def _proof_command_executable(command: str) -> str:
+    parts = command.strip().split()
+    while parts and "=" in parts[0]:
+        name, separator, _value = parts[0].partition("=")
+        if not separator or not name or not name.replace("_", "").isalnum():
+            break
+        parts = parts[1:]
+    return parts[0] if parts else ""
+
+
+def _actionable_proof_command(command: str) -> bool:
+    stripped = command.strip()
+    if not stripped or "\n" in stripped:
+        return False
+    executable = _proof_command_executable(stripped)
+    if executable in _CLEANUP_ONLY_EXECUTABLES:
+        return False
+    if executable == "git" and any(
+        token in stripped for token in (" clean ", " reset --hard", " checkout -- ")
+    ):
+        return False
+    return executable in _PROOF_EXECUTABLES or executable.startswith("./")
+
+
+def _failure_path(failure: JsonObject) -> str:
+    for key in ("path", "failing_file", "owner_hint"):
+        value = str(failure.get(key) or "").strip()
+        if value:
+            return value
+    for key in ("affected_files", "owner_files", "likely_owner_files"):
+        for item in _string_list(failure.get(key)):
+            if item:
+                return item
+
+    match = re.search(
+        r"(?P<path>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.(?:py|pyi|js|jsx|ts|tsx|go|rs|java))",
+        _failure_text(failure),
+    )
+    return match.group("path") if match is not None else ""
+
+
+def _focused_failure_proof(failure: JsonObject) -> str:
+    text = _failure_text(failure)
+    path = _failure_path(failure)
+    test_node_match = re.search(
+        r"(?P<node>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.py::[A-Za-z0-9_\[\].:-]+)",
+        text,
+    )
+    if test_node_match is not None:
+        return f"python -m pytest -q {test_node_match.group('node')} -o addopts="
+    if (
+        path
+        and "ruff" in text
+        and any(token in text for token in ("format", "reformat", "would reformat"))
+    ):
+        return f"python -m ruff format --check {path}"
+
+    candidates = [
+        *_string_list(failure.get("proof_commands")),
+        *_string_list(failure.get("recommended_fix")),
+    ]
+    return next(
+        (command.strip() for command in candidates if _actionable_proof_command(command)),
+        "",
+    )
+
+
 def _commands_from_failure(failure: JsonObject) -> list[str]:
-    commands = _string_list(failure.get("proof_commands"))
-    if commands:
-        return commands
-    return _string_list(failure.get("recommended_fix"))[:3]
+    focused = _focused_failure_proof(failure)
+    pre_commit = "python -m pre_commit run -a"
+    if not focused:
+        return [pre_commit]
+    if "pre_commit run -a" in focused or "pre-commit run -a" in focused:
+        return [focused]
+    return [f"{focused} && {pre_commit}"]
 
 
 def _commands_from_nodes(nodes: list[JsonObject]) -> list[str]:
@@ -995,8 +1099,9 @@ def _operator_action(
 ) -> list[str]:
     if failure:
         return [
-            "Fix the primary failed command or contract before treating advisory findings as blockers.",
-            "Use the proof commands below to verify the smallest safe fix.",
+            "Fix the first actionable failure shown above.",
+            "Run the exact proof command below, then push the commit.",
+            "The SDET Quality Gate refreshes automatically on the new PR head.",
         ]
     if quality_ok and nodes:
         return [

--- a/tests/test_pr_quality_gate_contributor_guidance.py
+++ b/tests/test_pr_quality_gate_contributor_guidance.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import pr_quality_evidence_narrative as narrative
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_failure_guidance_rejects_cleanup_and_selects_exact_formatter_proof(
+    tmp_path: Path,
+) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "Would reformat: tests/test_probe.py\nProcess completed with exit code 1\n",
+    )
+    bundle = _write_json(
+        tmp_path / "failure-bundle.json",
+        {
+            "primary_diagnosis_code": "RUFF_FORMAT_FAILURE",
+            "diagnoses": [
+                {
+                    "code": "RUFF_FORMAT_FAILURE",
+                    "title": "Ruff format check failed",
+                    "diagnosis": "Would reformat: tests/test_probe.py",
+                    "evidence": ["Would reformat: tests/test_probe.py"],
+                    "proof_commands": [
+                        "rm -rf dist build/lib build/bdist.*",
+                        "python -m ruff format --check .",
+                    ],
+                }
+            ],
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="failure",
+        sentinel_control_room=None,
+        evidence_graph=None,
+        failure_bundle=bundle,
+        changed_files=None,
+    )
+
+    assert payload["next_proof"] == [
+        "python -m ruff format --check tests/test_probe.py && python -m pre_commit run -a"
+    ]
+    assert "rm -rf" not in " ".join(payload["next_proof"])
+    assert payload["operator_action"] == [
+        "Fix the first actionable failure shown above.",
+        "Run the exact proof command below, then push the commit.",
+        "The SDET Quality Gate refreshes automatically on the new PR head.",
+    ]
+
+
+def test_failure_guidance_preserves_review_first_authority() -> None:
+    commands = narrative._commands_from_failure(
+        {
+            "code": "PYTEST_ASSERTION_FAILURE",
+            "diagnosis": "FAILED tests/test_probe.py::test_probe - AssertionError",
+            "proof_commands": ["rm -rf build"],
+        }
+    )
+
+    assert commands == [
+        "python -m pytest -q tests/test_probe.py::test_probe -o addopts= "
+        "&& python -m pre_commit run -a"
+    ]


### PR DESCRIPTION
## Summary

- reject cleanup-only commands such as `rm -rf` from contributor-facing proof guidance
- derive the smallest actionable proof from the actual failure, including exact pytest nodes and Ruff-formatted files
- append the full `pre_commit` proof so contributors know when the fix is complete
- tell contributors to push the verified commit and explain that the SDET Quality Gate refreshes automatically on the new PR head
- preserve the reporting-only, review-first authority boundary
- add focused regression coverage for formatter drift and pytest failures

## Why

The canonical SDET Quality Gate was highlighted correctly, but a real blocked run exposed an unhelpful reproduction command: a cleanup command was surfaced before the command that actually proved the failure. Contributors also lacked a direct runbook explaining the focused proof, the final repository proof, and how the gate refreshes after a push.

This PR makes the existing canonical gate materially more useful without adding another workflow or another bot comment.

## Verification

```bash
python -m pytest -q \
  tests/test_pr_quality_gate_contributor_guidance.py \
  tests/test_pr_quality_evidence_narrative.py \
  -o addopts=
python -m ruff check \
  src/sdetkit/pr_quality_evidence_narrative.py \
  tests/test_pr_quality_gate_contributor_guidance.py
python -m ruff format --check \
  src/sdetkit/pr_quality_evidence_narrative.py \
  tests/test_pr_quality_gate_contributor_guidance.py
```

Local result: 25 tests passed; Ruff check and format passed.

## Safety

- no permission change
- no required-check rename
- no workflow addition
- no automated patch application
- no automated merge authorization
- no security dismissal
- no comments posted by this work

## Rollback

Revert this PR. Existing PR Quality publishing and lifecycle reconciliation remain intact.

Related: #1924