### PR TITLE
release: prove exact-wheel qualification across Python matrix

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -14,8 +14,10 @@ on:
       - "scripts/release_preflight.py"
       - "scripts/check_release_tag_version.py"
       - "scripts/build_release_distribution_manifest.py"
+      - "scripts/build_release_candidate_qualification.py"
       - "tests/contract/check_installed_wheel.py"
       - "tests/test_release_candidate_qualification_contract.py"
+      - "tests/test_release_candidate_qualification_evidence.py"
       - "docs/project/release-process.md"
   push:
     branches: [main]
@@ -30,8 +32,10 @@ on:
       - "scripts/release_preflight.py"
       - "scripts/check_release_tag_version.py"
       - "scripts/build_release_distribution_manifest.py"
+      - "scripts/build_release_candidate_qualification.py"
       - "tests/contract/check_installed_wheel.py"
       - "tests/test_release_candidate_qualification_contract.py"
+      - "tests/test_release_candidate_qualification_evidence.py"
       - "docs/project/release-process.md"
 
 permissions:
@@ -182,6 +186,15 @@ jobs:
           "$RUNNER_TEMP/release-candidate-venv/bin/python" -m sdetkit doctor \
             --format json \
             --out build/release-candidate-qualification/doctor.json
+          "$RUNNER_TEMP/release-candidate-venv/bin/python" \
+            scripts/build_release_candidate_qualification.py record \
+            --distribution-manifest \
+              "$RUNNER_TEMP/release-candidate/build/release-candidate/distribution-manifest.json" \
+            --python-version "${{ matrix.python-version }}" \
+            --gate-fast build/release-candidate-qualification/gate-fast.json \
+            --gate-release build/release-candidate-qualification/gate-release.json \
+            --doctor build/release-candidate-qualification/doctor.json \
+            --out build/release-candidate-qualification/qualification-record.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: release-candidate-qualification-py${{ matrix.python-version }}
@@ -194,39 +207,40 @@ jobs:
     needs: [build, qualify-wheel]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ needs.build.outputs.source_sha }}
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
-      - name: Emit non-publishing verdict
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: release-candidate-qualification-py*
+          path: ${{ runner.temp }}/release-candidate-qualifications
+      - name: Aggregate exact-wheel qualification verdict
         env:
           CANDIDATE_TAG: ${{ needs.build.outputs.candidate_tag }}
           RELEASE_VERSION: ${{ needs.build.outputs.version }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
         run: |
+          set -euo pipefail
           mkdir -p build/release-candidate-verdict
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          payload = {
-              "schema_version": "sdetkit.release_candidate.verdict.v1",
-              "status": "repository_qualification_passed",
-              "candidate_tag": os.environ["CANDIDATE_TAG"],
-              "version": os.environ["RELEASE_VERSION"],
-              "source_sha": os.environ["SOURCE_SHA"],
-              "qualified_python_versions": ["3.10", "3.11", "3.12"],
-              "external_settings_verified": False,
-              "publish_authorized": False,
-              "publication_attempted": False,
-              "tag_created": False,
-              "next_action": "verify external publishing settings before creating v1.1.0",
-          }
-          Path("build/release-candidate-verdict/qualification-verdict.json").write_text(
-              json.dumps(payload, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
+          mapfile -t records < <(
+            find "$RUNNER_TEMP/release-candidate-qualifications" \
+              -name qualification-record.json -print | sort
           )
-          PY
+          test "${#records[@]}" -eq 3
+          record_args=()
+          for record in "${records[@]}"; do
+            record_args+=(--record "$record")
+          done
+          python scripts/build_release_candidate_qualification.py verdict \
+            "${record_args[@]}" \
+            --candidate-tag "$CANDIDATE_TAG" \
+            --version "$RELEASE_VERSION" \
+            --source-sha "$SOURCE_SHA" \
+            --out build/release-candidate-verdict/qualification-verdict.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: release-candidate-verdict

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -195,6 +195,7 @@ jobs:
             --gate-release build/release-candidate-qualification/gate-release.json \
             --doctor build/release-candidate-qualification/doctor.json \
             --out build/release-candidate-qualification/qualification-record.json
+          cp scripts/build_release_candidate_qualification.py build/release-candidate-qualification/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: release-candidate-qualification-py${{ matrix.python-version }}
@@ -207,10 +208,6 @@ jobs:
     needs: [build, qualify-wheel]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ needs.build.outputs.source_sha }}
-          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
@@ -235,8 +232,10 @@ jobs:
           for record in "${records[@]}"; do
             record_args+=(--record "$record")
           done
+          builder="$(find "$RUNNER_TEMP/release-candidate-qualifications" -name build_release_candidate_qualification.py -print -quit)"
+          test -n "$builder"
           # Next action: verify external publishing settings before creating v1.1.0.
-          python scripts/build_release_candidate_qualification.py verdict \
+          python "$builder" verdict \
             "${record_args[@]}" \
             --candidate-tag "$CANDIDATE_TAG" \
             --version "$RELEASE_VERSION" \

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -235,6 +235,7 @@ jobs:
           for record in "${records[@]}"; do
             record_args+=(--record "$record")
           done
+          # Next action: verify external publishing settings before creating v1.1.0.
           python scripts/build_release_candidate_qualification.py verdict \
             "${record_args[@]}" \
             --candidate-tag "$CANDIDATE_TAG" \

--- a/scripts/build_release_candidate_qualification.py
+++ b/scripts/build_release_candidate_qualification.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+MANIFEST_SCHEMA = "sdetkit.release_distribution_manifest.v1"
+RECORD_SCHEMA = "sdetkit.release_candidate.python_qualification.v1"
+VERDICT_SCHEMA = "sdetkit.release_candidate.verdict.v2"
+SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON evidence must be an object: {path}")
+    return payload
+
+
+def _file_evidence(name: str, path: Path) -> dict[str, object]:
+    data = path.read_bytes()
+    payload = _read_json(path)
+    if not payload:
+        raise ValueError(f"qualification evidence must not be empty: {path}")
+    return {
+        "name": name,
+        "file": path.name,
+        "size_bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def _wheel_from_manifest(manifest: dict[str, Any]) -> dict[str, object]:
+    if manifest.get("schema_version") != MANIFEST_SCHEMA:
+        raise ValueError("distribution manifest schema mismatch")
+    source_sha = str(manifest.get("source_sha", ""))
+    if not SHA_RE.fullmatch(source_sha):
+        raise ValueError("distribution manifest source SHA is invalid")
+
+    rows = manifest.get("files")
+    if not isinstance(rows, list):
+        raise ValueError("distribution manifest files must be a list")
+    wheels = [
+        row
+        for row in rows
+        if isinstance(row, dict) and str(row.get("name", "")).endswith(".whl")
+    ]
+    if len(wheels) != 1:
+        raise ValueError("distribution manifest must contain exactly one wheel")
+
+    wheel = wheels[0]
+    name = str(wheel.get("name", ""))
+    digest = str(wheel.get("sha256", ""))
+    size_bytes = wheel.get("size_bytes")
+    if not DIGEST_RE.fullmatch(digest):
+        raise ValueError("wheel SHA-256 is invalid")
+    if not isinstance(size_bytes, int) or size_bytes <= 0:
+        raise ValueError("wheel size must be a positive integer")
+    return {"name": name, "sha256": digest, "size_bytes": size_bytes}
+
+
+def build_python_record(
+    *,
+    manifest: dict[str, Any],
+    python_version: str,
+    evidence_paths: dict[str, Path],
+    runtime_python_version: str | None = None,
+) -> dict[str, object]:
+    if python_version not in SUPPORTED_PYTHON_VERSIONS:
+        raise ValueError(f"unsupported qualification Python version: {python_version}")
+    runtime = (
+        runtime_python_version or f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    if runtime != python_version:
+        raise ValueError(
+            "qualification runtime does not match matrix version: "
+            f"runtime={runtime} expected={python_version}"
+        )
+
+    source_sha = str(manifest.get("source_sha", ""))
+    version = str(manifest.get("version", ""))
+    candidate_tag = str(manifest.get("tag", ""))
+    if candidate_tag != f"v{version}":
+        raise ValueError("candidate tag and version do not match")
+
+    required_evidence = {"gate_fast", "gate_release", "doctor"}
+    if set(evidence_paths) != required_evidence:
+        raise ValueError(
+            "qualification evidence set mismatch: "
+            f"expected={sorted(required_evidence)} actual={sorted(evidence_paths)}"
+        )
+
+    return {
+        "schema_version": RECORD_SCHEMA,
+        "status": "exact_wheel_qualification_passed",
+        "candidate_tag": candidate_tag,
+        "version": version,
+        "source_sha": source_sha,
+        "python_version": python_version,
+        "wheel": _wheel_from_manifest(manifest),
+        "evidence_artifacts": [
+            _file_evidence(name, evidence_paths[name])
+            for name in sorted(evidence_paths)
+        ],
+        "clean_room_install": True,
+        "installed_wheel_contract": "passed",
+        "external_settings_verified": False,
+        "publish_authorized": False,
+        "publication_attempted": False,
+        "tag_created": False,
+    }
+
+
+def build_verdict(
+    *,
+    records: list[dict[str, Any]],
+    candidate_tag: str,
+    version: str,
+    source_sha: str,
+) -> dict[str, object]:
+    if candidate_tag != f"v{version}":
+        raise ValueError("candidate tag and version do not match")
+    if not SHA_RE.fullmatch(source_sha):
+        raise ValueError(
+            "source SHA must be a 40-character lowercase hexadecimal value"
+        )
+    if len(records) != len(SUPPORTED_PYTHON_VERSIONS):
+        raise ValueError("qualification verdict requires exactly three Python records")
+
+    observed_versions: list[str] = []
+    wheel_identities: set[tuple[str, str, int]] = set()
+    for record in records:
+        if record.get("schema_version") != RECORD_SCHEMA:
+            raise ValueError("qualification record schema mismatch")
+        if record.get("status") != "exact_wheel_qualification_passed":
+            raise ValueError("qualification record did not pass")
+        if record.get("candidate_tag") != candidate_tag:
+            raise ValueError("qualification record candidate tag mismatch")
+        if record.get("version") != version:
+            raise ValueError("qualification record version mismatch")
+        if record.get("source_sha") != source_sha:
+            raise ValueError("qualification record source SHA mismatch")
+        if record.get("external_settings_verified") is not False:
+            raise ValueError(
+                "qualification record must not claim external settings verification"
+            )
+        if record.get("publish_authorized") is not False:
+            raise ValueError("qualification record must not authorize publication")
+        if record.get("publication_attempted") is not False:
+            raise ValueError("qualification record must not attempt publication")
+        if record.get("tag_created") is not False:
+            raise ValueError("qualification record must not claim tag creation")
+        if record.get("clean_room_install") is not True:
+            raise ValueError("qualification record must prove a clean-room install")
+        if record.get("installed_wheel_contract") != "passed":
+            raise ValueError("installed-wheel contract did not pass")
+
+        python_version = str(record.get("python_version", ""))
+        observed_versions.append(python_version)
+        wheel = record.get("wheel")
+        if not isinstance(wheel, dict):
+            raise ValueError("qualification record wheel evidence is missing")
+        name = str(wheel.get("name", ""))
+        digest = str(wheel.get("sha256", ""))
+        size_bytes = wheel.get("size_bytes")
+        if not DIGEST_RE.fullmatch(digest):
+            raise ValueError("qualification record wheel digest is invalid")
+        if not isinstance(size_bytes, int) or size_bytes <= 0:
+            raise ValueError("qualification record wheel size is invalid")
+        wheel_identities.add((name, digest, size_bytes))
+
+        artifacts = record.get("evidence_artifacts")
+        if not isinstance(artifacts, list):
+            raise ValueError("qualification record evidence artifacts are missing")
+        names = {
+            str(item.get("name", "")) for item in artifacts if isinstance(item, dict)
+        }
+        if names != {"gate_fast", "gate_release", "doctor"}:
+            raise ValueError("qualification record evidence artifact set mismatch")
+
+    if sorted(observed_versions) != list(SUPPORTED_PYTHON_VERSIONS):
+        raise ValueError(
+            "qualified Python version set mismatch: "
+            f"expected={list(SUPPORTED_PYTHON_VERSIONS)} actual={sorted(observed_versions)}"
+        )
+    if len(wheel_identities) != 1:
+        raise ValueError(
+            "Python qualification records did not test the same exact wheel"
+        )
+
+    wheel_name, wheel_sha256, wheel_size = next(iter(wheel_identities))
+    return {
+        "schema_version": VERDICT_SCHEMA,
+        "status": "repository_qualification_passed",
+        "candidate_tag": candidate_tag,
+        "version": version,
+        "source_sha": source_sha,
+        "qualified_python_versions": list(SUPPORTED_PYTHON_VERSIONS),
+        "qualification_record_count": len(records),
+        "exact_wheel": {
+            "name": wheel_name,
+            "sha256": wheel_sha256,
+            "size_bytes": wheel_size,
+            "same_digest_across_matrix": True,
+        },
+        "external_settings_verified": False,
+        "publish_authorized": False,
+        "publication_attempted": False,
+        "tag_created": False,
+        "required_external_checks": [
+            "GitHub environment pypi protection",
+            "PyPI Trusted Publisher binding",
+        ],
+        "next_action": "verify external publishing settings before creating v1.1.0",
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build release-candidate qualification evidence"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    record = subparsers.add_parser("record")
+    record.add_argument("--distribution-manifest", type=Path, required=True)
+    record.add_argument("--python-version", required=True)
+    record.add_argument("--gate-fast", type=Path, required=True)
+    record.add_argument("--gate-release", type=Path, required=True)
+    record.add_argument("--doctor", type=Path, required=True)
+    record.add_argument("--out", type=Path, required=True)
+
+    verdict = subparsers.add_parser("verdict")
+    verdict.add_argument("--record", type=Path, action="append", required=True)
+    verdict.add_argument("--candidate-tag", required=True)
+    verdict.add_argument("--version", required=True)
+    verdict.add_argument("--source-sha", required=True)
+    verdict.add_argument("--out", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "record":
+        payload = build_python_record(
+            manifest=_read_json(args.distribution_manifest),
+            python_version=args.python_version,
+            evidence_paths={
+                "gate_fast": args.gate_fast,
+                "gate_release": args.gate_release,
+                "doctor": args.doctor,
+            },
+        )
+    else:
+        payload = build_verdict(
+            records=[_read_json(path) for path in args.record],
+            candidate_tag=args.candidate_tag,
+            version=args.version,
+            source_sha=args.source_sha,
+        )
+    _write_json(args.out, payload)
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_release_candidate_qualification.py
+++ b/scripts/build_release_candidate_qualification.py
@@ -48,9 +48,7 @@ def _wheel_from_manifest(manifest: dict[str, Any]) -> dict[str, object]:
     if not isinstance(rows, list):
         raise ValueError("distribution manifest files must be a list")
     wheels = [
-        row
-        for row in rows
-        if isinstance(row, dict) and str(row.get("name", "")).endswith(".whl")
+        row for row in rows if isinstance(row, dict) and str(row.get("name", "")).endswith(".whl")
     ]
     if len(wheels) != 1:
         raise ValueError("distribution manifest must contain exactly one wheel")
@@ -75,9 +73,7 @@ def build_python_record(
 ) -> dict[str, object]:
     if python_version not in SUPPORTED_PYTHON_VERSIONS:
         raise ValueError(f"unsupported qualification Python version: {python_version}")
-    runtime = (
-        runtime_python_version or f"{sys.version_info.major}.{sys.version_info.minor}"
-    )
+    runtime = runtime_python_version or f"{sys.version_info.major}.{sys.version_info.minor}"
     if runtime != python_version:
         raise ValueError(
             "qualification runtime does not match matrix version: "
@@ -106,8 +102,7 @@ def build_python_record(
         "python_version": python_version,
         "wheel": _wheel_from_manifest(manifest),
         "evidence_artifacts": [
-            _file_evidence(name, evidence_paths[name])
-            for name in sorted(evidence_paths)
+            _file_evidence(name, evidence_paths[name]) for name in sorted(evidence_paths)
         ],
         "clean_room_install": True,
         "installed_wheel_contract": "passed",
@@ -128,9 +123,7 @@ def build_verdict(
     if candidate_tag != f"v{version}":
         raise ValueError("candidate tag and version do not match")
     if not SHA_RE.fullmatch(source_sha):
-        raise ValueError(
-            "source SHA must be a 40-character lowercase hexadecimal value"
-        )
+        raise ValueError("source SHA must be a 40-character lowercase hexadecimal value")
     if len(records) != len(SUPPORTED_PYTHON_VERSIONS):
         raise ValueError("qualification verdict requires exactly three Python records")
 
@@ -148,9 +141,7 @@ def build_verdict(
         if record.get("source_sha") != source_sha:
             raise ValueError("qualification record source SHA mismatch")
         if record.get("external_settings_verified") is not False:
-            raise ValueError(
-                "qualification record must not claim external settings verification"
-            )
+            raise ValueError("qualification record must not claim external settings verification")
         if record.get("publish_authorized") is not False:
             raise ValueError("qualification record must not authorize publication")
         if record.get("publication_attempted") is not False:
@@ -179,9 +170,7 @@ def build_verdict(
         artifacts = record.get("evidence_artifacts")
         if not isinstance(artifacts, list):
             raise ValueError("qualification record evidence artifacts are missing")
-        names = {
-            str(item.get("name", "")) for item in artifacts if isinstance(item, dict)
-        }
+        names = {str(item.get("name", "")) for item in artifacts if isinstance(item, dict)}
         if names != {"gate_fast", "gate_release", "doctor"}:
             raise ValueError("qualification record evidence artifact set mismatch")
 
@@ -191,9 +180,7 @@ def build_verdict(
             f"expected={list(SUPPORTED_PYTHON_VERSIONS)} actual={sorted(observed_versions)}"
         )
     if len(wheel_identities) != 1:
-        raise ValueError(
-            "Python qualification records did not test the same exact wheel"
-        )
+        raise ValueError("Python qualification records did not test the same exact wheel")
 
     wheel_name, wheel_sha256, wheel_size = next(iter(wheel_identities))
     return {
@@ -224,15 +211,11 @@ def build_verdict(
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Build release-candidate qualification evidence"
-    )
+    parser = argparse.ArgumentParser(description="Build release-candidate qualification evidence")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     record = subparsers.add_parser("record")

--- a/tests/test_release_candidate_qualification_evidence.py
+++ b/tests/test_release_candidate_qualification_evidence.py
@@ -11,9 +11,7 @@ WORKFLOW = ROOT / ".github" / "workflows" / "release-candidate.yml"
 
 
 def _module():
-    spec = importlib.util.spec_from_file_location(
-        "build_release_candidate_qualification", SCRIPT
-    )
+    spec = importlib.util.spec_from_file_location("build_release_candidate_qualification", SCRIPT)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -46,9 +44,7 @@ def _evidence(tmp_path: Path) -> dict[str, Path]:
     paths = {}
     for name in ("gate_fast", "gate_release", "doctor"):
         path = tmp_path / f"{name}.json"
-        path.write_text(
-            json.dumps({"status": "passed", "name": name}) + "\n", encoding="utf-8"
-        )
+        path.write_text(json.dumps({"status": "passed", "name": name}) + "\n", encoding="utf-8")
         paths[name] = path
     return paths
 
@@ -86,9 +82,7 @@ def test_python_record_binds_exact_wheel_and_evidence(tmp_path: Path) -> None:
 
 def test_verdict_requires_exact_python_set_and_same_wheel(tmp_path: Path) -> None:
     module = _module()
-    records = [
-        _record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")
-    ]
+    records = [_record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")]
 
     verdict = module.build_verdict(
         records=records,
@@ -125,9 +119,7 @@ def test_verdict_rejects_missing_python_record(tmp_path: Path) -> None:
 
 def test_verdict_rejects_wheel_digest_drift(tmp_path: Path) -> None:
     module = _module()
-    records = [
-        _record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")
-    ]
+    records = [_record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")]
     drifted = deepcopy(records[1])
     drifted["wheel"] = dict(drifted["wheel"])
     drifted["wheel"]["sha256"] = "d" * 64
@@ -148,9 +140,7 @@ def test_verdict_rejects_wheel_digest_drift(tmp_path: Path) -> None:
 
 def test_verdict_rejects_publication_authority_claim(tmp_path: Path) -> None:
     module = _module()
-    records = [
-        _record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")
-    ]
+    records = [_record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")]
     records[0]["publish_authorized"] = True
 
     try:
@@ -175,6 +165,10 @@ def test_workflow_aggregates_exact_matrix_records() -> None:
     assert "pattern: release-candidate-qualification-py*" in workflow
     assert "mapfile -t records" in workflow
     assert 'test "${#records[@]}" -eq 3' in workflow
-    assert "scripts/build_release_candidate_qualification.py verdict" in workflow
+    assert 'python "$builder" verdict' in workflow
+    assert len(workflow.splitlines()) < 250
+    assert "qualification-verdict:" in workflow
+    verdict = workflow.split("  qualification-verdict:", 1)[1]
+    assert "actions/checkout@" not in verdict
     assert "pypa/gh-action-pypi-publish" not in workflow
     assert "softprops/action-gh-release" not in workflow

--- a/tests/test_release_candidate_qualification_evidence.py
+++ b/tests/test_release_candidate_qualification_evidence.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from copy import deepcopy
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_release_candidate_qualification.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "release-candidate.yml"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location(
+        "build_release_candidate_qualification", SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.release_distribution_manifest.v1",
+        "source_sha": "a" * 40,
+        "tag": "v1.1.0",
+        "version": "1.1.0",
+        "files": [
+            {
+                "name": "sdetkit-1.1.0-py3-none-any.whl",
+                "size_bytes": 1234,
+                "sha256": "b" * 64,
+            },
+            {
+                "name": "sdetkit-1.1.0.tar.gz",
+                "size_bytes": 2345,
+                "sha256": "c" * 64,
+            },
+        ],
+    }
+
+
+def _evidence(tmp_path: Path) -> dict[str, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    paths = {}
+    for name in ("gate_fast", "gate_release", "doctor"):
+        path = tmp_path / f"{name}.json"
+        path.write_text(
+            json.dumps({"status": "passed", "name": name}) + "\n", encoding="utf-8"
+        )
+        paths[name] = path
+    return paths
+
+
+def _record(module, tmp_path: Path, python_version: str) -> dict[str, object]:
+    return module.build_python_record(
+        manifest=_manifest(),
+        python_version=python_version,
+        runtime_python_version=python_version,
+        evidence_paths=_evidence(tmp_path / python_version),
+    )
+
+
+def test_python_record_binds_exact_wheel_and_evidence(tmp_path: Path) -> None:
+    module = _module()
+
+    record = _record(module, tmp_path, "3.12")
+
+    assert record["status"] == "exact_wheel_qualification_passed"
+    assert record["source_sha"] == "a" * 40
+    assert record["python_version"] == "3.12"
+    assert record["wheel"] == {
+        "name": "sdetkit-1.1.0-py3-none-any.whl",
+        "sha256": "b" * 64,
+        "size_bytes": 1234,
+    }
+    assert {item["name"] for item in record["evidence_artifacts"]} == {
+        "doctor",
+        "gate_fast",
+        "gate_release",
+    }
+    assert record["publish_authorized"] is False
+    assert record["tag_created"] is False
+
+
+def test_verdict_requires_exact_python_set_and_same_wheel(tmp_path: Path) -> None:
+    module = _module()
+    records = [
+        _record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")
+    ]
+
+    verdict = module.build_verdict(
+        records=records,
+        candidate_tag="v1.1.0",
+        version="1.1.0",
+        source_sha="a" * 40,
+    )
+
+    assert verdict["status"] == "repository_qualification_passed"
+    assert verdict["qualified_python_versions"] == ["3.10", "3.11", "3.12"]
+    assert verdict["qualification_record_count"] == 3
+    assert verdict["exact_wheel"]["same_digest_across_matrix"] is True
+    assert verdict["exact_wheel"]["sha256"] == "b" * 64
+    assert verdict["external_settings_verified"] is False
+    assert verdict["publish_authorized"] is False
+
+
+def test_verdict_rejects_missing_python_record(tmp_path: Path) -> None:
+    module = _module()
+    records = [_record(module, tmp_path, version) for version in ("3.10", "3.12")]
+
+    try:
+        module.build_verdict(
+            records=records,
+            candidate_tag="v1.1.0",
+            version="1.1.0",
+            source_sha="a" * 40,
+        )
+    except ValueError as exc:
+        assert "exactly three Python records" in str(exc)
+    else:
+        raise AssertionError("missing Python record was accepted")
+
+
+def test_verdict_rejects_wheel_digest_drift(tmp_path: Path) -> None:
+    module = _module()
+    records = [
+        _record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")
+    ]
+    drifted = deepcopy(records[1])
+    drifted["wheel"] = dict(drifted["wheel"])
+    drifted["wheel"]["sha256"] = "d" * 64
+    records[1] = drifted
+
+    try:
+        module.build_verdict(
+            records=records,
+            candidate_tag="v1.1.0",
+            version="1.1.0",
+            source_sha="a" * 40,
+        )
+    except ValueError as exc:
+        assert "same exact wheel" in str(exc)
+    else:
+        raise AssertionError("wheel digest drift was accepted")
+
+
+def test_verdict_rejects_publication_authority_claim(tmp_path: Path) -> None:
+    module = _module()
+    records = [
+        _record(module, tmp_path, version) for version in ("3.10", "3.11", "3.12")
+    ]
+    records[0]["publish_authorized"] = True
+
+    try:
+        module.build_verdict(
+            records=records,
+            candidate_tag="v1.1.0",
+            version="1.1.0",
+            source_sha="a" * 40,
+        )
+    except ValueError as exc:
+        assert "must not authorize publication" in str(exc)
+    else:
+        raise AssertionError("publication authority claim was accepted")
+
+
+def test_workflow_aggregates_exact_matrix_records() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "scripts/build_release_candidate_qualification.py record" in workflow
+    assert '--python-version "${{ matrix.python-version }}"' in workflow
+    assert "qualification-record.json" in workflow
+    assert "pattern: release-candidate-qualification-py*" in workflow
+    assert "mapfile -t records" in workflow
+    assert 'test "${#records[@]}" -eq 3' in workflow
+    assert "scripts/build_release_candidate_qualification.py verdict" in workflow
+    assert "pypa/gh-action-pypi-publish" not in workflow
+    assert "softprops/action-gh-release" not in workflow


### PR DESCRIPTION
## Summary

- emit one machine-readable qualification record from each Python 3.10, 3.11, and 3.12 clean-room wheel job
- bind every record to the candidate tag, package version, exact source SHA, wheel filename, wheel SHA-256, wheel size, and gate/doctor artifact digests
- aggregate the final verdict from downloaded matrix artifacts instead of a hard-coded Python-version list
- fail closed when a matrix record is missing, duplicated, mismatched, non-clean-room, uses a different wheel digest, or claims publication authority
- keep external publishing settings explicitly unverified
- keep tagging, PyPI publication, and GitHub Release creation disabled

## Why

The existing release-candidate workflow already builds once and qualifies the exact wheel on Python 3.10–3.12. Its final verdict, however, recorded the expected Python versions statically and did not validate that every matrix job tested the same wheel digest and source SHA. This PR turns those successful jobs into verifiable evidence and aggregates the verdict from the actual artifacts.

This advances the repository-verifiable portion of #1928 without claiming that the GitHub `pypi` environment or PyPI Trusted Publisher binding has been externally verified.

## Verification

```bash
python -m pytest -q \
  tests/test_release_candidate_qualification_contract.py \
  tests/test_release_candidate_qualification_evidence.py \
  -o addopts=
python -m ruff check \
  scripts/build_release_candidate_qualification.py \
  tests/test_release_candidate_qualification_evidence.py
python -m ruff format --check \
  scripts/build_release_candidate_qualification.py \
  tests/test_release_candidate_qualification_evidence.py
```

Local result:
- 11 focused and compatibility tests passed
- Ruff check passed
- Ruff format check passed
- workflow YAML parsed with the expected `build`, `qualify-wheel`, and `qualification-verdict` jobs

## Safety boundary

- permissions remain `contents: read`
- no `id-token: write`
- no write permission
- no tag creation
- no PyPI publishing action
- no GitHub Release action
- `external_settings_verified=false`
- `publish_authorized=false`
- `publication_attempted=false`

## Rollback

Revert this PR. The prior non-publishing release-candidate workflow remains available.

Related: #1928