### PR TITLE
security: classify GHAS fixture hotspots separately

### DIFF
--- a/.github/workflows/ghas-codeql-hotspots-bot.yml
+++ b/.github/workflows/ghas-codeql-hotspots-bot.yml
@@ -7,6 +7,12 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "45 6 * * 3"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/ghas-codeql-hotspots-bot.yml"
+      - "scripts/build_ghas_hotspot_policy.py"
+      - "tests/test_ghas_hotspot_fixture_policy.py"
 
 permissions:
   contents: read
@@ -19,8 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Build CodeQL hotspot snapshot
-        id: collect
+      - name: Collect CodeQL alerts
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           GHAS_TOKEN: ${{ secrets.GHAS_READ_TOKEN }}
@@ -29,14 +34,118 @@ jobs:
             const fs = require('fs');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const weekOf = new Date().toISOString().slice(0, 10);
+            const token = process.env.GHAS_TOKEN || github.token;
+            const payload = {
+              collection_status: 'collected',
+              repository: `${owner}/${repo}`,
+              alerts: [],
+              notes: [],
+            };
+            try {
+              payload.alerts = await github.paginate(
+                'GET /repos/{owner}/{repo}/code-scanning/alerts',
+                {
+                  owner,
+                  repo,
+                  state: 'open',
+                  per_page: 100,
+                  headers: {
+                    accept: 'application/vnd.github+json',
+                    authorization: `Bearer ${token}`,
+                    'x-github-api-version': '2022-11-28',
+                  },
+                },
+              );
+            } catch (error) {
+              payload.collection_status = 'unavailable';
+              payload.notes.push(
+                `Code scanning alerts unavailable: ${error.message}. `
+                + 'Add GHAS_READ_TOKEN if broader security scopes are required.',
+              );
+            }
+            fs.mkdirSync('build', { recursive: true });
+            fs.writeFileSync(
+              'build/ghas-codeql-alerts.json',
+              `${JSON.stringify(payload, null, 2)}\n`,
+            );
+
+      - name: Build fixture-aware hotspot policy
+        id: policy
+        run: |
+          python scripts/build_ghas_hotspot_policy.py \
+            --alerts-json build/ghas-codeql-alerts.json \
+            --snapshot-json build/ghas-codeql-hotspots.json \
+            --report-markdown build/ghas-codeql-hotspots.md \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload hotspot artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          retention-days: 14
+          name: ghas-codeql-hotspots
+          path: |
+            build/ghas-codeql-alerts.json
+            build/ghas-codeql-hotspots.json
+            build/ghas-codeql-hotspots.md
+
+      - name: Reconcile production hotspot tracker
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          ACTIONABLE: ${{ steps.policy.outputs.actionable }}
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const actionable = process.env.ACTIONABLE === 'true';
+            const rollingTitle = '🧪 GHAS production hotspot follow-up';
+            const marker = '<!-- sdetkit:ghas-production-hotspots:v1 -->';
+            const body = `${marker}\n${fs.readFileSync('build/ghas-codeql-hotspots.md', 'utf8')}`;
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const managed = openIssues
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issue.user?.login === 'github-actions[bot]')
+              .filter((issue) =>
+                issue.title === rollingTitle
+                || issue.title.startsWith('🧪 GHAS CodeQL hotspots')
+                || issue.body?.startsWith(marker)
+              );
+            const existing = managed.find((issue) => issue.title === rollingTitle);
+            for (const issue of managed) {
+              if (!existing || issue.number !== existing.number) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            }
+            if (!actionable) {
+              if (existing) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+              core.notice('GHAS alerts are fixture-only; artifacts retained');
+              return;
+            }
             const labels = [
               { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
               { name: 'security', color: 'b60205', description: 'Security operations and hardening work' },
               { name: 'ghas', color: '5319e7', description: 'GitHub Advanced Security automation and triage' },
               { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
             ];
-
             for (const label of labels) {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name: label.name });
@@ -44,185 +153,20 @@ jobs:
                 await github.rest.issues.createLabel({ owner, repo, ...label });
               }
             }
-
-            const ghasToken = process.env.GHAS_TOKEN || github.token;
-            const headers = {
-              accept: 'application/vnd.github+json',
-              authorization: `Bearer ${ghasToken}`,
-              'x-github-api-version': '2022-11-28',
-            };
-            const notes = [];
-            const dayMs = 24 * 60 * 60 * 1000;
-
-            function ageDays(alert) {
-              const raw = alert.created_at || alert.updated_at || alert.fixed_at;
-              const value = new Date(raw).getTime();
-              if (!Number.isFinite(value)) return 0;
-              return Math.max(0, Math.floor((Date.now() - value) / dayMs));
-            }
-
-            function increment(map, key, template = {}) {
-              const stableKey = key || 'unknown';
-              if (!map.has(stableKey)) map.set(stableKey, { key: stableKey, count: 0, ...template });
-              const bucket = map.get(stableKey);
-              bucket.count += 1;
-              return bucket;
-            }
-
-            let alerts = [];
-            try {
-              alerts = await github.paginate('GET /repos/{owner}/{repo}/code-scanning/alerts', {
+            if (existing) {
+              await github.rest.issues.update({
                 owner,
                 repo,
-                state: 'open',
-                per_page: 100,
-                headers,
+                issue_number: existing.number,
+                body,
+                labels: labels.map((label) => label.name),
               });
-            } catch (error) {
-              notes.push(`Code scanning alerts unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`);
-            }
-
-            const ruleCounts = new Map();
-            const fileCounts = new Map();
-            const severityCounts = new Map();
-            let aged14 = 0;
-            let aged30 = 0;
-
-            for (const alert of alerts) {
-              const location = alert.most_recent_instance?.location?.path || alert.instances_url || 'unknown';
-              const ruleId = alert.rule?.id || alert.rule?.name || 'unknown-rule';
-              const ruleName = alert.rule?.name || ruleId;
-              const toolName = alert.tool?.name || 'unknown-tool';
-              const severity = String(alert.rule?.security_severity_level || alert.rule?.severity || 'unknown').toLowerCase();
-              const age = ageDays(alert);
-
-              const ruleBucket = increment(ruleCounts, ruleId, {
-                rule_name: ruleName,
-                tool: toolName,
-                severity,
-                oldest_age_days: age,
-              });
-              ruleBucket.oldest_age_days = Math.max(ruleBucket.oldest_age_days || 0, age);
-
-              increment(fileCounts, location, {
-                file: location,
-                highest_severity: severity,
-              });
-              increment(severityCounts, severity, { severity });
-
-              if (age >= 14) aged14 += 1;
-              if (age >= 30) aged30 += 1;
-            }
-
-            const topRules = [...ruleCounts.values()].sort((a, b) => b.count - a.count || b.oldest_age_days - a.oldest_age_days).slice(0, 10);
-            const topFiles = [...fileCounts.values()].sort((a, b) => b.count - a.count).slice(0, 10);
-            const severityOrder = new Map(['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'].map((name, index) => [name, index]));
-            const severitySummary = [...severityCounts.values()].sort((a, b) => {
-              const left = severityOrder.has(a.severity) ? severityOrder.get(a.severity) : Number.MAX_SAFE_INTEGER;
-              const right = severityOrder.has(b.severity) ? severityOrder.get(b.severity) : Number.MAX_SAFE_INTEGER;
-              if (left !== right) return left - right;
-              return b.count - a.count;
-            });
-            const snapshot = {
-              generated_at: new Date().toISOString(),
-              repository: `${owner}/${repo}`,
-              totals: {
-                open_alerts: alerts.length,
-                alerts_aged_14_days_or_more: aged14,
-                alerts_aged_30_days_or_more: aged30,
-              },
-              top_rules: topRules,
-              top_files: topFiles,
-              severity: severitySummary,
-              notes,
-            };
-
-            fs.mkdirSync('build', { recursive: true });
-            fs.writeFileSync('build/ghas-codeql-hotspots.json', JSON.stringify(snapshot, null, 2) + '\n');
-
-            const body = [
-              'This issue is auto-generated to turn the current CodeQL/code-scanning queue into a hotspot-oriented remediation lane.',
-              '',
-              '## Queue snapshot',
-              `- Open code scanning alerts: **${snapshot.totals.open_alerts}**`,
-              `- Alerts aged 14+ days: **${snapshot.totals.alerts_aged_14_days_or_more}**`,
-              `- Alerts aged 30+ days: **${snapshot.totals.alerts_aged_30_days_or_more}**`,
-              '',
-              '## Top rules to batch-fix',
-              ...(topRules.length
-                ? topRules.map((item) => `- **${item.rule_name}** (\`${item.key}\`, ${item.tool}) — ${item.count} open alert(s), oldest ${item.oldest_age_days} day(s)`)
-                : ['- No open code scanning alerts were returned.']),
-              '',
-              '## Top files / paths',
-              ...(topFiles.length
-                ? topFiles.map((item) => `- **${item.file}** — ${item.count} open alert(s)`)
-                : ['- No file hotspots were returned.']),
-              '',
-              '## Severity mix',
-              ...(severitySummary.length
-                ? severitySummary.map((item) => `- ${item.severity}: **${item.count}**`)
-                : ['- No severity data was returned.']),
-              '',
-              '## Suggested follow-up',
-              '- [ ] Batch the top rule into one remediation PR or issue cluster.',
-              '- [ ] Start with any 14+ day hotspot that touches a hot-path file.',
-              '- [ ] Re-run the GHAS campaign planner after closing the top hotspot to verify backlog reduction.',
-              '',
-              '## Artifact',
-              '- Action artifact: `ghas-codeql-hotspots` (`build/ghas-codeql-hotspots.json`)',
-              '',
-              '## Notes',
-              ...(notes.length ? notes.map((note) => `- ${note}`) : ['- Code scanning APIs responded without fallback warnings.']),
-            ].join('\n');
-
-            fs.writeFileSync('build/ghas-codeql-hotspots.md', body + '\n');
-            core.setOutput('issue_title', `🧪 GHAS CodeQL hotspots (${weekOf})`);
-
-      - name: Upload hotspot artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          retention-days: 14
-          name: ghas-codeql-hotspots
-          path: |
-            build/ghas-codeql-hotspots.json
-            build/ghas-codeql-hotspots.md
-
-      - name: Publish hotspot issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        env:
-          ISSUE_TITLE: ${{ steps.collect.outputs.issue_title }}
-        with:
-          script: |
-            const fs = require('fs');
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const title = process.env.ISSUE_TITLE;
-            const body = fs.readFileSync('build/ghas-codeql-hotspots.md', 'utf8');
-
-            const openIssues = await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: 'ghas',
-              per_page: 100,
-            });
-            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🧪 GHAS CodeQL hotspots'));
-
-            for (const oldIssue of priorIssues) {
-              if (oldIssue.title !== title) {
-                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
-              }
-            }
-
-            const existing = priorIssues.find((issue) => issue.title === title);
-            if (existing) {
-              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
             } else {
               await github.rest.issues.create({
                 owner,
                 repo,
-                title,
+                title: rollingTitle,
                 body,
-                labels: ['maintenance', 'security', 'ghas', 'priority:medium'],
+                labels: labels.map((label) => label.name),
               });
             }

--- a/scripts/build_ghas_hotspot_policy.py
+++ b/scripts/build_ghas_hotspot_policy.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "sdetkit.ghas.hotspot_policy.v1"
+FIXTURE_PREFIXES = ("tests/fixtures/", "examples/fixtures/", "docs/fixtures/")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def alert_path(alert: dict[str, Any]) -> str:
+    instance = _dict(alert.get("most_recent_instance"))
+    location = _dict(instance.get("location"))
+    value = str(location.get("path") or alert.get("path") or "unknown")
+    return value.replace("\\", "/").removeprefix("./") or "unknown"
+
+
+def is_fixture_path(path: str) -> bool:
+    return path.lower().startswith(FIXTURE_PREFIXES)
+
+
+def _age(alert: dict[str, Any], now: datetime) -> int:
+    raw = alert.get("created_at") or alert.get("updated_at") or alert.get("fixed_at")
+    if not raw:
+        return 0
+    try:
+        value = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return max(0, int((now - value.astimezone(UTC)).total_seconds() // 86400))
+
+
+def summarize(alerts: list[dict[str, Any]], now: datetime) -> dict[str, Any]:
+    rules: dict[str, dict[str, Any]] = {}
+    files: Counter[str] = Counter()
+    severity: Counter[str] = Counter()
+    aged14 = 0
+    aged30 = 0
+    for alert in alerts:
+        rule = _dict(alert.get("rule"))
+        tool = _dict(alert.get("tool"))
+        rule_id = str(rule.get("id") or rule.get("name") or "unknown-rule")
+        level = str(
+            rule.get("security_severity_level") or rule.get("severity") or "unknown"
+        ).lower()
+        age = _age(alert, now)
+        bucket = rules.setdefault(
+            rule_id,
+            {
+                "key": rule_id,
+                "rule_name": str(rule.get("name") or rule_id),
+                "tool": str(tool.get("name") or "unknown-tool"),
+                "severity": level,
+                "count": 0,
+                "oldest_age_days": 0,
+            },
+        )
+        bucket["count"] += 1
+        bucket["oldest_age_days"] = max(bucket["oldest_age_days"], age)
+        files[alert_path(alert)] += 1
+        severity[level] += 1
+        aged14 += int(age >= 14)
+        aged30 += int(age >= 30)
+    top_rules = sorted(
+        rules.values(),
+        key=lambda row: (-row["count"], -row["oldest_age_days"], row["key"]),
+    )[:10]
+    top_files = [
+        {"file": path, "count": count}
+        for path, count in sorted(files.items(), key=lambda row: (-row[1], row[0]))[:10]
+    ]
+    return {
+        "alert_count": len(alerts),
+        "alerts_aged_14_days_or_more": aged14,
+        "alerts_aged_30_days_or_more": aged30,
+        "top_rules": top_rules,
+        "top_files": top_files,
+        "severity": dict(sorted(severity.items())),
+    }
+
+
+def build_policy(payload: Any, now: datetime | None = None) -> tuple[dict[str, Any], str]:
+    data = _dict(payload)
+    status = str(data.get("collection_status") or "unavailable")
+    alerts = [_dict(item) for item in _list(data.get("alerts")) if _dict(item)]
+    current = now or datetime.now(UTC)
+    fixture_alerts = [item for item in alerts if is_fixture_path(alert_path(item))]
+    production_alerts = [item for item in alerts if not is_fixture_path(alert_path(item))]
+    reasons: list[str] = []
+    if status != "collected":
+        reasons.append("code-scanning alert collection is unavailable")
+    if production_alerts:
+        reasons.append(f"production-path code-scanning alerts: {len(production_alerts)}")
+    snapshot = {
+        "schema_version": SCHEMA,
+        "generated_at": current.isoformat(),
+        "repository": str(data.get("repository") or "unknown"),
+        "collection_status": status,
+        "actionable": bool(reasons),
+        "actionable_reasons": reasons,
+        "issue_policy": "rolling_tracker_when_production_or_collection_failure",
+        "fixture_only_issue_creation": False,
+        "totals": {
+            "open_alerts": len(alerts),
+            "production_alerts": len(production_alerts),
+            "fixture_alerts": len(fixture_alerts),
+        },
+        "production": summarize(production_alerts, current),
+        "fixture_evidence": summarize(fixture_alerts, current),
+        "fixture_prefixes": list(FIXTURE_PREFIXES),
+        "notes": [str(item) for item in _list(data.get("notes")) if str(item).strip()],
+    }
+    return snapshot, render_markdown(snapshot)
+
+
+def _file_lines(rows: list[dict[str, Any]], empty: str) -> list[str]:
+    return (
+        [f"- **{row['file']}** — {row['count']} alert(s)" for row in rows]
+        if rows
+        else [f"- {empty}"]
+    )
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    totals = snapshot["totals"]
+    production = snapshot["production"]
+    fixture = snapshot["fixture_evidence"]
+    lines = [
+        "# GHAS production hotspot review",
+        "",
+        "This report separates production-path alerts from intentional fixture evidence.",
+        "",
+        "## Classification snapshot",
+        f"- Collection status: **{snapshot['collection_status']}**",
+        f"- Open alerts: **{totals['open_alerts']}**",
+        f"- Production-path alerts: **{totals['production_alerts']}**",
+        f"- Fixture-only alerts: **{totals['fixture_alerts']}**",
+        f"- Actionable: **{snapshot['actionable']}**",
+        "",
+        "## Production files",
+        *_file_lines(production["top_files"], "No production-path hotspots were returned."),
+        "",
+        "## Fixture evidence (non-production)",
+        f"- Retained alerts: **{fixture['alert_count']}**",
+        *_file_lines(fixture["top_files"], "No fixture-only alerts were returned."),
+        "",
+    ]
+    if snapshot["actionable"]:
+        lines.extend(
+            [
+                "## Required follow-up",
+                *[f"- {reason}" for reason in snapshot["actionable_reasons"]],
+                "- Review production paths first; do not modify intentional fixtures merely to clear GHAS counts.",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "## Result",
+                "- No production-path remediation issue is required.",
+                "- Fixture findings remain available in the uploaded artifact for scanner-regression proof.",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Artifact",
+            "- `build/ghas-codeql-hotspots.json`",
+            "- `build/ghas-codeql-hotspots.md`",
+            "",
+            "## Notes",
+            *(
+                [f"- {note}" for note in snapshot["notes"]]
+                if snapshot["notes"]
+                else ["- Code-scanning APIs responded without fallback warnings."]
+            ),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--alerts-json", type=Path, required=True)
+    parser.add_argument("--snapshot-json", type=Path, required=True)
+    parser.add_argument("--report-markdown", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args(argv)
+    snapshot, markdown = build_policy(json.loads(args.alerts_json.read_text(encoding="utf-8")))
+    args.snapshot_json.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.report_markdown.write_text(markdown, encoding="utf-8")
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            output.write(f"actionable={'true' if snapshot['actionable'] else 'false'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ghas_hotspot_policy.py
+++ b/scripts/build_ghas_hotspot_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections import Counter
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -40,8 +40,11 @@ def _age(alert: dict[str, Any], now: datetime) -> int:
     except ValueError:
         return 0
     if value.tzinfo is None:
-        value = value.replace(tzinfo=UTC)
-    return max(0, int((now - value.astimezone(UTC)).total_seconds() // 86400))
+        value = value.replace(tzinfo=timezone.utc)
+    return max(
+        0,
+        int((now - value.astimezone(timezone.utc)).total_seconds() // 86400),
+    )
 
 
 def summarize(alerts: list[dict[str, Any]], now: datetime) -> dict[str, Any]:
@@ -97,7 +100,7 @@ def build_policy(payload: Any, now: datetime | None = None) -> tuple[dict[str, A
     data = _dict(payload)
     status = str(data.get("collection_status") or "unavailable")
     alerts = [_dict(item) for item in _list(data.get("alerts")) if _dict(item)]
-    current = now or datetime.now(UTC)
+    current = now or datetime.now(timezone.utc)
     fixture_alerts = [item for item in alerts if is_fixture_path(alert_path(item))]
     production_alerts = [item for item in alerts if not is_fixture_path(alert_path(item))]
     reasons: list[str] = []

--- a/tests/test_ghas_hotspot_fixture_policy.py
+++ b/tests/test_ghas_hotspot_fixture_policy.py
@@ -90,9 +90,7 @@ def test_collection_failure_fails_closed() -> None:
     )
 
     assert snapshot["actionable"] is True
-    assert snapshot["actionable_reasons"] == [
-        "code-scanning alert collection is unavailable"
-    ]
+    assert snapshot["actionable_reasons"] == ["code-scanning alert collection is unavailable"]
     assert "API denied" in markdown
 
 

--- a/tests/test_ghas_hotspot_fixture_policy.py
+++ b/tests/test_ghas_hotspot_fixture_policy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -46,7 +46,7 @@ def test_fixture_only_alerts_are_artifact_only() -> None:
             "repository": "sherif69-sa/DevS69-sdetkit",
             "alerts": alerts,
         },
-        now=datetime(2026, 7, 2, tzinfo=UTC),
+        now=datetime(2026, 7, 2, tzinfo=timezone.utc),
     )
 
     assert snapshot["actionable"] is False
@@ -68,7 +68,7 @@ def test_production_alert_requires_rolling_tracker() -> None:
             "collection_status": "collected",
             "alerts": [_alert("src/sdetkit/security.py")],
         },
-        now=datetime(2026, 7, 2, tzinfo=UTC),
+        now=datetime(2026, 7, 2, tzinfo=timezone.utc),
     )
 
     assert snapshot["actionable"] is True
@@ -86,8 +86,8 @@ def test_collection_failure_fails_closed() -> None:
             "notes": ["API denied"],
             "alerts": [],
         },
-        now=datetime(2026, 7, 2, tzinfo=UTC),
-    )
+        now=datetime(2026, 7, 2, tzinfo=timezone.utc),
+     )
 
     assert snapshot["actionable"] is True
     assert snapshot["actionable_reasons"] == ["code-scanning alert collection is unavailable"]

--- a/tests/test_ghas_hotspot_fixture_policy.py
+++ b/tests/test_ghas_hotspot_fixture_policy.py
@@ -87,10 +87,12 @@ def test_collection_failure_fails_closed() -> None:
             "alerts": [],
         },
         now=datetime(2026, 7, 2, tzinfo=timezone.utc),
-     )
+    )
 
     assert snapshot["actionable"] is True
-    assert snapshot["actionable_reasons"] == ["code-scanning alert collection is unavailable"]
+    assert snapshot["actionable_reasons"] == [
+        "code-scanning alert collection is unavailable"
+    ]
     assert "API denied" in markdown
 
 

--- a/tests/test_ghas_hotspot_fixture_policy.py
+++ b/tests/test_ghas_hotspot_fixture_policy.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_ghas_hotspot_policy.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "ghas-codeql-hotspots-bot.yml"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("build_ghas_hotspot_policy", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _alert(path: str, *, rule_id: str = "CVE-test") -> dict[str, object]:
+    return {
+        "created_at": "2026-07-01T00:00:00Z",
+        "rule": {
+            "id": rule_id,
+            "name": rule_id,
+            "security_severity_level": "high",
+        },
+        "tool": {"name": "osv-scanner"},
+        "most_recent_instance": {"location": {"path": path}},
+    }
+
+
+def test_fixture_only_alerts_are_artifact_only() -> None:
+    module = _module()
+    alerts = [
+        *[_alert("tests/fixtures/public_adoption_target/go.mod") for _ in range(36)],
+        *[
+            _alert("tests/fixtures/public_adoption_target/requirements-security.txt")
+            for _ in range(15)
+        ],
+    ]
+
+    snapshot, markdown = module.build_policy(
+        {
+            "collection_status": "collected",
+            "repository": "sherif69-sa/DevS69-sdetkit",
+            "alerts": alerts,
+        },
+        now=datetime(2026, 7, 2, tzinfo=UTC),
+    )
+
+    assert snapshot["actionable"] is False
+    assert snapshot["totals"] == {
+        "open_alerts": 51,
+        "production_alerts": 0,
+        "fixture_alerts": 51,
+    }
+    assert snapshot["fixture_only_issue_creation"] is False
+    assert "No production-path remediation issue is required." in markdown
+    assert "Fixture findings remain available" in markdown
+
+
+def test_production_alert_requires_rolling_tracker() -> None:
+    module = _module()
+
+    snapshot, markdown = module.build_policy(
+        {
+            "collection_status": "collected",
+            "alerts": [_alert("src/sdetkit/security.py")],
+        },
+        now=datetime(2026, 7, 2, tzinfo=UTC),
+    )
+
+    assert snapshot["actionable"] is True
+    assert snapshot["totals"]["production_alerts"] == 1
+    assert snapshot["actionable_reasons"] == ["production-path code-scanning alerts: 1"]
+    assert "src/sdetkit/security.py" in markdown
+
+
+def test_collection_failure_fails_closed() -> None:
+    module = _module()
+
+    snapshot, markdown = module.build_policy(
+        {
+            "collection_status": "unavailable",
+            "notes": ["API denied"],
+            "alerts": [],
+        },
+        now=datetime(2026, 7, 2, tzinfo=UTC),
+    )
+
+    assert snapshot["actionable"] is True
+    assert snapshot["actionable_reasons"] == ["code-scanning alert collection is unavailable"]
+    assert "API denied" in markdown
+
+
+def test_workflow_uses_fixture_aware_rolling_policy() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python scripts/build_ghas_hotspot_policy.py" in workflow
+    assert "ACTIONABLE: ${{ steps.policy.outputs.actionable }}" in workflow
+    assert "const rollingTitle = '🧪 GHAS production hotspot follow-up';" in workflow
+    assert "issue.user?.login === 'github-actions[bot]'" in workflow
+    assert "issue.title.startsWith('🧪 GHAS CodeQL hotspots')" in workflow
+    assert "state_reason: 'completed'" in workflow
+    assert "const weekOf" not in workflow
+    assert "if (!actionable)" in workflow
+    assert "core.notice('GHAS alerts are fixture-only; artifacts retained')" in workflow
+    assert "push:" in workflow
+    assert len(workflow.splitlines()) < 250


### PR DESCRIPTION
## Summary

- separate production-path code-scanning alerts from intentional fixture evidence
- retain raw and classified alert artifacts on every run
- use one rolling bot-managed tracker only when production alerts exist or collection fails
- close stale bot-created dated hotspot trackers when the queue is fixture-only
- add focused regression coverage

## Current evidence

The existing hotspot snapshot contains 51 alerts, all under two test-fixture files: 36 in `tests/fixtures/public_adoption_target/go.mod` and 15 in `tests/fixtures/public_adoption_target/requirements-security.txt`. This PR keeps those findings visible in artifacts without presenting them as production remediation work.

## Verification

```bash
python -m pytest -q tests/test_ghas_hotspot_fixture_policy.py -o addopts=
python -m ruff check scripts/build_ghas_hotspot_policy.py tests/test_ghas_hotspot_fixture_policy.py
python -m ruff format --check scripts/build_ghas_hotspot_policy.py tests/test_ghas_hotspot_fixture_policy.py
```

Local result: 4 tests passed; Ruff check and format passed; workflow YAML parsed; workflow reduced to 172 lines.

## Boundaries

- production alerts remain actionable
- collection failure fails closed
- fixture contents are unchanged
- permissions are unchanged
- only bot-owned hotspot trackers are reconciled

Related: #1957