### PR TITLE
feat: add contributor-facing Adaptive Diagnosis artifact

### DIFF
--- a/tests/test_pr_quality_adaptive_diagnosis_rendering.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_rendering.py
@@ -68,9 +68,7 @@ def test_render_exposes_adaptive_diagnosis_for_contributors() -> None:
 
 
 def test_render_reads_card_from_primary_failure() -> None:
-    html = renderer.render_from_model(
-        {"primary_failure": {"adaptive_diagnosis": _card()}}
-    )
+    html = renderer.render_from_model({"primary_failure": {"adaptive_diagnosis": _card()}})
     assert "Review first" in html
 
 
@@ -97,9 +95,7 @@ def test_cli_writes_standalone_html(tmp_path: Path, capsys: pytest.CaptureFixtur
         encoding="utf-8",
     )
 
-    assert renderer.main(
-        ["--review-model", str(model_path), "--out", str(out)]
-    ) == 0
+    assert renderer.main(["--review-model", str(model_path), "--out", str(out)]) == 0
 
     rendered = out.read_text(encoding="utf-8")
     captured = capsys.readouterr().out

--- a/tests/test_pr_quality_adaptive_diagnosis_rendering.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_rendering.py
@@ -7,13 +7,9 @@ from pathlib import Path
 import pytest
 
 MODULE_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "tools"
-    / "render_pr_quality_adaptive_diagnosis.py"
+    Path(__file__).resolve().parents[1] / "tools" / "render_pr_quality_adaptive_diagnosis.py"
 )
-SPEC = importlib.util.spec_from_file_location(
-    "adaptive_diagnosis_renderer", MODULE_PATH
-)
+SPEC = importlib.util.spec_from_file_location("adaptive_diagnosis_renderer", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 renderer = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(renderer)
@@ -70,9 +66,7 @@ def test_render_exposes_adaptive_diagnosis_for_contributors() -> None:
 
 
 def test_render_reads_card_from_primary_failure() -> None:
-    html = renderer.render_from_model(
-        {"primary_failure": {"adaptive_diagnosis": _card()}}
-    )
+    html = renderer.render_from_model({"primary_failure": {"adaptive_diagnosis": _card()}})
     assert "Review first" in html
 
 
@@ -91,9 +85,7 @@ def test_render_rejects_model_without_adaptive_card() -> None:
         renderer.render_from_model({})
 
 
-def test_cli_writes_standalone_html(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_cli_writes_standalone_html(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     model_path = tmp_path / "model.json"
     out = tmp_path / "adaptive-diagnosis.html"
     model_path.write_text(

--- a/tests/test_pr_quality_adaptive_diagnosis_rendering.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_rendering.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "render_pr_quality_adaptive_diagnosis.py"
+)
+SPEC = importlib.util.spec_from_file_location("adaptive_diagnosis_renderer", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+renderer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(renderer)
+
+
+def _card() -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive_diagnosis_card.v1",
+        "status": "review_first",
+        "failure_class": "test",
+        "diagnostic_completeness": "complete",
+        "confidence": "high",
+        "checks": {
+            "exact_failure_detail_present": True,
+            "expected_observed_specific": True,
+            "owner_file_resolved": True,
+            "reproduction_command_resolved": True,
+            "step_provenance_confirmed": True,
+            "authority_boundary_preserved": True,
+        },
+        "evidence_gaps": [],
+        "owner_files": ["docs/contracts/quality-truth-baseline.v1.json"],
+        "proof_commands": [
+            "python -m pytest -q "
+            "tests/test_quality_truth_baseline.py::"
+            "test_quality_truth_baseline_matches_current_repository_configuration "
+            "-o addopts="
+        ],
+        "next_human_action": (
+            "Run the focused proof, inspect the owner file, and review the first contract."
+        ),
+        "review_first": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_render_exposes_adaptive_diagnosis_for_contributors() -> None:
+    html = renderer.render_from_model({"adaptive_diagnosis": _card()})
+
+    assert "<h1>Adaptive Diagnosis</h1>" in html
+    assert "Complete" in html
+    assert "High" in html
+    assert "Test" in html
+    assert "docs/contracts/quality-truth-baseline.v1.json" in html
+    assert "python -m pytest -q" in html
+    assert "authority_boundary_preserved" in html
+    assert "automation_allowed" in html
+    assert ">false<" in html
+
+
+def test_render_reads_card_from_primary_failure() -> None:
+    html = renderer.render_from_model(
+        {"primary_failure": {"adaptive_diagnosis": _card()}}
+    )
+    assert "Review first" in html
+
+
+def test_render_escapes_untrusted_evidence() -> None:
+    card = _card()
+    card["next_human_action"] = "<script>alert('unsafe')</script>"
+
+    html = renderer.render_adaptive_diagnosis_html(card)
+
+    assert "<script>alert" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_rejects_model_without_adaptive_card() -> None:
+    with pytest.raises(ValueError, match="no adaptive diagnosis card"):
+        renderer.render_from_model({})
+
+
+def test_cli_writes_standalone_html(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    model_path = tmp_path / "model.json"
+    out = tmp_path / "adaptive-diagnosis.html"
+    model_path.write_text(
+        json.dumps({"adaptive_diagnosis": _card()}),
+        encoding="utf-8",
+    )
+
+    assert renderer.main(
+        ["--review-model", str(model_path), "--out", str(out)]
+    ) == 0
+
+    rendered = out.read_text(encoding="utf-8")
+    captured = capsys.readouterr().out
+    assert "<h1>Adaptive Diagnosis</h1>" in rendered
+    assert "adaptive_diagnosis_render=passed" in captured
+    assert "reporting_only=true" in captured
+    assert "automation_allowed=false" in captured
+    assert "merge_authorized=false" in captured

--- a/tests/test_pr_quality_adaptive_diagnosis_rendering.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_rendering.py
@@ -11,7 +11,9 @@ MODULE_PATH = (
     / "tools"
     / "render_pr_quality_adaptive_diagnosis.py"
 )
-SPEC = importlib.util.spec_from_file_location("adaptive_diagnosis_renderer", MODULE_PATH)
+SPEC = importlib.util.spec_from_file_location(
+    "adaptive_diagnosis_renderer", MODULE_PATH
+)
 assert SPEC is not None and SPEC.loader is not None
 renderer = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(renderer)
@@ -68,7 +70,9 @@ def test_render_exposes_adaptive_diagnosis_for_contributors() -> None:
 
 
 def test_render_reads_card_from_primary_failure() -> None:
-    html = renderer.render_from_model({"primary_failure": {"adaptive_diagnosis": _card()}})
+    html = renderer.render_from_model(
+        {"primary_failure": {"adaptive_diagnosis": _card()}}
+    )
     assert "Review first" in html
 
 
@@ -87,7 +91,9 @@ def test_render_rejects_model_without_adaptive_card() -> None:
         renderer.render_from_model({})
 
 
-def test_cli_writes_standalone_html(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_cli_writes_standalone_html(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     model_path = tmp_path / "model.json"
     out = tmp_path / "adaptive-diagnosis.html"
     model_path.write_text(

--- a/tools/render_pr_quality_adaptive_diagnosis.py
+++ b/tools/render_pr_quality_adaptive_diagnosis.py
@@ -73,9 +73,7 @@ def render_adaptive_diagnosis_html(card: JsonObject) -> str:
     )
     completeness = _text(card.get("diagnostic_completeness"), "insufficient").title()
     confidence = _text(card.get("confidence"), "low").title()
-    failure_class = (
-        _text(card.get("failure_class"), "unknown").replace("_", " ").title()
-    )
+    failure_class = _text(card.get("failure_class"), "unknown").replace("_", " ").title()
     decision = "Review first" if bool(card.get("review_first", True)) else "Actionable"
 
     return f"""<!doctype html>
@@ -127,7 +125,7 @@ code{{overflow-wrap:anywhere}}.action{{font-size:1.05rem;font-weight:700}}
 </section>
 <section>
 <h2>Authority boundary</h2>
-<table><thead><tr><th>Field</th><th>Value</th></tr></thead><tbody>{authority_rows}</tbody></table>
+<table><thead><tr><th>Field</th><th>Value</th></thead><tbody>{authority_rows}</tbody></table>
 </section>
 </body>
 </html>

--- a/tools/render_pr_quality_adaptive_diagnosis.py
+++ b/tools/render_pr_quality_adaptive_diagnosis.py
@@ -73,7 +73,9 @@ def render_adaptive_diagnosis_html(card: JsonObject) -> str:
     )
     completeness = _text(card.get("diagnostic_completeness"), "insufficient").title()
     confidence = _text(card.get("confidence"), "low").title()
-    failure_class = _text(card.get("failure_class"), "unknown").replace("_", " ").title()
+    failure_class = (
+        _text(card.get("failure_class"), "unknown").replace("_", " ").title()
+    )
     decision = "Review first" if bool(card.get("review_first", True)) else "Actionable"
 
     return f"""<!doctype html>

--- a/tools/render_pr_quality_adaptive_diagnosis.py
+++ b/tools/render_pr_quality_adaptive_diagnosis.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import argparse
+import json
+from html import escape
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+AUTHORITY_FIELDS = (
+    "reporting_only",
+    "automation_allowed",
+    "patch_application_allowed",
+    "security_dismissal_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _as_dict(value: object) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    rendered = str(value).strip()
+    return rendered or default
+
+
+def adaptive_diagnosis_card(model: JsonObject) -> JsonObject:
+    card = _as_dict(model.get("adaptive_diagnosis"))
+    if card:
+        return card
+    primary_failure = _as_dict(model.get("primary_failure"))
+    return _as_dict(primary_failure.get("adaptive_diagnosis"))
+
+
+def _html_list(values: object, *, empty: str) -> str:
+    items = [_text(item) for item in _as_list(values) if _text(item)]
+    if not items:
+        return f"<p>{escape(empty)}</p>"
+    rendered = "".join(f"<li><code>{escape(item)}</code></li>" for item in items)
+    return f"<ul>{rendered}</ul>"
+
+
+def render_adaptive_diagnosis_html(card: JsonObject) -> str:
+    checks = _as_dict(card.get("checks"))
+    check_rows = "".join(
+        "<tr>"
+        f"<td><code>{escape(_text(name))}</code></td>"
+        f"<td>{'Pass' if bool(passed) else 'Missing'}</td>"
+        "</tr>"
+        for name, passed in checks.items()
+    )
+    if not check_rows:
+        check_rows = '<tr><td colspan="2">No adaptive checks were emitted.</td></tr>'
+
+    authority_rows = "".join(
+        "<tr>"
+        f"<td><code>{field}</code></td>"
+        f"<td>{str(bool(card.get(field, False))).lower()}</td>"
+        "</tr>"
+        for field in AUTHORITY_FIELDS
+    )
+    next_action = _text(
+        card.get("next_human_action"),
+        "Collect exact failure evidence before changing code.",
+    )
+    completeness = _text(card.get("diagnostic_completeness"), "insufficient").title()
+    confidence = _text(card.get("confidence"), "low").title()
+    failure_class = _text(card.get("failure_class"), "unknown").replace("_", " ").title()
+    decision = "Review first" if bool(card.get("review_first", True)) else "Actionable"
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Adaptive Diagnosis</title>
+<style>
+:root{{color-scheme:light dark;font-family:Inter,ui-sans-serif,system-ui,sans-serif}}
+body{{max-width:1100px;margin:0 auto;padding:40px 24px;line-height:1.55}}
+header,section{{border:1px solid #7f8ea3;border-radius:18px;padding:24px;margin-bottom:20px}}
+.grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:14px}}
+.metric{{border:1px solid #7f8ea3;border-radius:14px;padding:16px}}
+.metric span{{display:block;font-size:.78rem;text-transform:uppercase;opacity:.72}}
+.metric strong{{display:block;margin-top:6px;font-size:1.15rem}}
+table{{width:100%;border-collapse:collapse}}
+th,td{{padding:10px;border-bottom:1px solid #7f8ea3;text-align:left}}
+code{{overflow-wrap:anywhere}}.action{{font-size:1.05rem;font-weight:700}}
+</style>
+</head>
+<body>
+<header>
+<p><strong>Contributor evidence</strong></p>
+<h1>Adaptive Diagnosis</h1>
+<p>The first violated contract, its evidence quality, and the exact review-first action.</p>
+</header>
+<section class="grid">
+<div class="metric"><span>Completeness</span><strong>{escape(completeness)}</strong></div>
+<div class="metric"><span>Confidence</span><strong>{escape(confidence)}</strong></div>
+<div class="metric"><span>Failure class</span><strong>{escape(failure_class)}</strong></div>
+<div class="metric"><span>Decision</span><strong>{decision}</strong></div>
+</section>
+<section>
+<h2>Safeguards</h2>
+<table><thead><tr><th>Check</th><th>Result</th></tr></thead><tbody>{check_rows}</tbody></table>
+</section>
+<section>
+<h2>Owner files</h2>
+{_html_list(card.get("owner_files"), empty="No owner file was resolved.")}
+<h2>Focused proof</h2>
+{_html_list(card.get("proof_commands"), empty="No focused reproduction command was resolved.")}
+<h2>Evidence gaps</h2>
+{_html_list(card.get("evidence_gaps"), empty="No evidence gaps were reported.")}
+</section>
+<section>
+<h2>Next human action</h2>
+<p class="action">{escape(next_action)}</p>
+</section>
+<section>
+<h2>Authority boundary</h2>
+<table><thead><tr><th>Field</th><th>Value</th></tr></thead><tbody>{authority_rows}</tbody></table>
+</section>
+</body>
+</html>
+"""
+
+
+def render_from_model(model: JsonObject) -> str:
+    card = adaptive_diagnosis_card(model)
+    if not card:
+        raise ValueError("review model has no adaptive diagnosis card")
+    return render_adaptive_diagnosis_html(card)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render a contributor-facing Adaptive Diagnosis artifact."
+    )
+    parser.add_argument("--review-model", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = json.loads(args.review_model.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("review model must be a JSON object")
+    rendered = render_from_model(payload)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(rendered, encoding="utf-8", newline="\n")
+    print("adaptive_diagnosis_render=passed")
+    print(f"out={args.out.as_posix()}")
+    print("reporting_only=true")
+    print("automation_allowed=false")
+    print("merge_authorized=false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standalone HTML view for the existing Adaptive Diagnosis evidence
- show completeness, confidence, failure class, safeguards, owner files, proof commands, evidence gaps, next action, and authority state
- escape untrusted evidence

## Verification
- `python -m pytest -q tests/test_pr_quality_adaptive_diagnosis_rendering.py -o addopts=` (5 passed locally)
- `python -m py_compile tools/render_pr_quality_adaptive_diagnosis.py`

## Risk
Low. Additive tool and tests only. No workflow or package changes. Rollback is a revert.