### PR TITLE
feat: add Adaptive Diagnosis Markdown handoff

### DIFF
--- a/tests/test_pr_quality_adaptive_diagnosis_markdown.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_markdown.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "render_pr_quality_adaptive_diagnosis_markdown.py"
+)
+SPEC = importlib.util.spec_from_file_location("adaptive_diagnosis_markdown", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+renderer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(renderer)
+
+
+def _card() -> dict[str, object]:
+    return {
+        "failure_class": "test",
+        "diagnostic_completeness": "complete",
+        "confidence": "high",
+        "checks": {
+            "exact_failure_detail_present": True,
+            "authority_boundary_preserved": True,
+        },
+        "owner_files": ["docs/contracts/quality-truth-baseline.v1.json"],
+        "proof_commands": ["python -m pytest -q tests/test_quality_truth_baseline.py -o addopts="],
+        "evidence_gaps": [],
+        "next_human_action": "Run the focused proof and inspect the owner file.",
+        "review_first": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_markdown_exposes_operator_handoff() -> None:
+    text = renderer.render_from_model({"adaptive_diagnosis": _card()})
+
+    assert text.startswith("# Adaptive Diagnosis")
+    assert "- Completeness: `complete`" in text
+    assert "- Confidence: `high`" in text
+    assert "- Failure class: `test`" in text
+    assert "`docs/contracts/quality-truth-baseline.v1.json`" in text
+    assert "python -m pytest -q" in text
+    assert "`authority_boundary_preserved`: `pass`" in text
+    assert "`automation_allowed=false`" in text
+    assert "`merge_authorized=false`" in text
+
+
+def test_markdown_reads_nested_card() -> None:
+    text = renderer.render_from_model({"primary_failure": {"adaptive_diagnosis": _card()}})
+    assert "- Status: `review_first`" in text
+
+
+def test_markdown_exposes_missing_safeguards_and_gaps() -> None:
+    card = _card()
+    card["checks"] = {"step_provenance_confirmed": False}
+    card["evidence_gaps"] = ["step_provenance_confirmed"]
+
+    text = renderer.render_adaptive_diagnosis_markdown(card)
+
+    assert "`step_provenance_confirmed`: `missing`" in text
+    assert "- `step_provenance_confirmed`" in text
+
+
+def test_markdown_rejects_missing_card() -> None:
+    with pytest.raises(ValueError, match="no adaptive diagnosis card"):
+        renderer.render_from_model({})
+
+
+def test_markdown_cli_writes_handoff(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    model = tmp_path / "model.json"
+    out = tmp_path / "adaptive-diagnosis.md"
+    model.write_text(json.dumps({"adaptive_diagnosis": _card()}), encoding="utf-8")
+
+    assert renderer.main(["--review-model", str(model), "--out", str(out)]) == 0
+
+    assert out.read_text(encoding="utf-8").startswith("# Adaptive Diagnosis")
+    stdout = capsys.readouterr().out
+    assert "adaptive_diagnosis_markdown_render=passed" in stdout
+    assert "reporting_only=true" in stdout
+    assert "automation_allowed=false" in stdout

--- a/tools/render_pr_quality_adaptive_diagnosis_markdown.py
+++ b/tools/render_pr_quality_adaptive_diagnosis_markdown.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: object) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    rendered = str(value).strip()
+    return rendered or default
+
+
+def adaptive_diagnosis_card(model: JsonObject) -> JsonObject:
+    card = _as_dict(model.get("adaptive_diagnosis"))
+    if card:
+        return card
+    return _as_dict(_as_dict(model.get("primary_failure")).get("adaptive_diagnosis"))
+
+
+def _bullet_lines(values: object, *, empty: str) -> list[str]:
+    items = [_text(item) for item in _as_list(values) if _text(item)]
+    return [f"- `{item}`" for item in items] if items else [f"- {empty}"]
+
+
+def render_adaptive_diagnosis_markdown(card: JsonObject) -> str:
+    checks = _as_dict(card.get("checks"))
+    check_lines = [
+        f"- `{name}`: `{'pass' if bool(passed) else 'missing'}`" for name, passed in checks.items()
+    ] or ["- No adaptive checks were emitted."]
+
+    authority_fields = (
+        "reporting_only",
+        "automation_allowed",
+        "patch_application_allowed",
+        "security_dismissal_allowed",
+        "merge_authorized",
+        "semantic_equivalence_proven",
+    )
+    authority_lines = [
+        f"- `{field}={str(bool(card.get(field, False))).lower()}`" for field in authority_fields
+    ]
+    decision = "review_first" if bool(card.get("review_first", True)) else "actionable"
+
+    lines = [
+        "# Adaptive Diagnosis",
+        "",
+        "## Decision",
+        "",
+        f"- Completeness: `{_text(card.get('diagnostic_completeness'), 'insufficient')}`",
+        f"- Confidence: `{_text(card.get('confidence'), 'low')}`",
+        f"- Failure class: `{_text(card.get('failure_class'), 'unknown')}`",
+        f"- Status: `{decision}`",
+        "",
+        "## Safeguards",
+        "",
+        *check_lines,
+        "",
+        "## Owner files",
+        "",
+        *_bullet_lines(card.get("owner_files"), empty="No owner file was resolved."),
+        "",
+        "## Focused proof",
+        "",
+        *_bullet_lines(
+            card.get("proof_commands"),
+            empty="No focused reproduction command was resolved.",
+        ),
+        "",
+        "## Evidence gaps",
+        "",
+        *_bullet_lines(card.get("evidence_gaps"), empty="No evidence gaps were reported."),
+        "",
+        "## Next human action",
+        "",
+        _text(
+            card.get("next_human_action"),
+            "Collect exact failure evidence before changing code.",
+        ),
+        "",
+        "## Authority boundary",
+        "",
+        *authority_lines,
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_from_model(model: JsonObject) -> str:
+    card = adaptive_diagnosis_card(model)
+    if not card:
+        raise ValueError("review model has no adaptive diagnosis card")
+    return render_adaptive_diagnosis_markdown(card)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render a contributor-facing Adaptive Diagnosis Markdown handoff."
+    )
+    parser.add_argument("--review-model", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = json.loads(args.review_model.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("review model must be a JSON object")
+    rendered = render_from_model(payload)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(rendered, encoding="utf-8", newline="\n")
+    print("adaptive_diagnosis_markdown_render=passed")
+    print(f"out={args.out.as_posix()}")
+    print("reporting_only=true")
+    print("automation_allowed=false")
+    print("merge_authorized=false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- render the existing Adaptive Diagnosis evidence as a portable Markdown handoff
- expose decision, completeness, confidence, failure class, safeguards, owner files, focused proof, evidence gaps, next human action, and authority state
- keep the output reporting-only and non-authorizing

## Verification
- `python -m pytest -q tests/test_pr_quality_adaptive_diagnosis_markdown.py -o addopts=` — 5 passed locally
- `python -m ruff format --check --line-length 100 tools/render_pr_quality_adaptive_diagnosis_markdown.py tests/test_pr_quality_adaptive_diagnosis_markdown.py`
- `python -m ruff check --line-length 100 tools/render_pr_quality_adaptive_diagnosis_markdown.py tests/test_pr_quality_adaptive_diagnosis_markdown.py`

## Risk
Low. Additive tool and tests only. No workflow, package, security, or public import changes. Rollback is a revert.

## Authority
- `reporting_only=true`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `security_dismissal_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`