### PR TITLE
feat: add deterministic Adaptive Diagnosis JSON export

### DIFF
--- a/tests/test_pr_quality_adaptive_diagnosis_json.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_json.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "export_pr_quality_adaptive_diagnosis_json.py"
+)
+SPEC = importlib.util.spec_from_file_location("adaptive_diagnosis_json", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+exporter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(exporter)
+
+
+def _card() -> dict[str, object]:
+    return {
+        "status": "review_first",
+        "failure_class": "test",
+        "diagnostic_completeness": "complete",
+        "confidence": "high",
+        "checks": {
+            "exact_failure_detail_present": True,
+            "authority_boundary_preserved": True,
+        },
+        "owner_files": ["docs/contracts/quality-truth-baseline.v1.json"],
+        "proof_commands": ["python -m pytest -q tests/test_quality_truth_baseline.py -o addopts="],
+        "evidence_gaps": [],
+        "next_human_action": "Run the focused proof.",
+        "review_first": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_export_normalizes_machine_readable_contract() -> None:
+    payload = exporter.export_from_model({"adaptive_diagnosis": _card()})
+
+    assert payload["schema_version"] == "sdetkit.adaptive_diagnosis_export.v1"
+    assert payload["diagnosis"] == {
+        "status": "review_first",
+        "failure_class": "test",
+        "diagnostic_completeness": "complete",
+        "confidence": "high",
+        "review_first": True,
+    }
+    assert payload["evidence"]["owner_files"] == ["docs/contracts/quality-truth-baseline.v1.json"]
+    assert payload["evidence"]["checks"]["authority_boundary_preserved"] is True
+    assert payload["authority"]["reporting_only"] is True
+    assert payload["authority"]["automation_allowed"] is False
+    assert payload["authority"]["merge_authorized"] is False
+
+
+def test_export_is_deterministic() -> None:
+    payload = exporter.export_from_model({"adaptive_diagnosis": _card()})
+    first = exporter.serialize_export(payload)
+    second = exporter.serialize_export(payload)
+
+    assert first == second
+    assert first.endswith("\n")
+
+
+def test_export_reads_nested_card() -> None:
+    payload = exporter.export_from_model({"primary_failure": {"adaptive_diagnosis": _card()}})
+    assert payload["diagnosis"]["confidence"] == "high"
+
+
+def test_export_rejects_missing_card() -> None:
+    with pytest.raises(ValueError, match="no adaptive diagnosis card"):
+        exporter.export_from_model({})
+
+
+def test_export_cli_writes_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    model = tmp_path / "model.json"
+    out = tmp_path / "adaptive-diagnosis.json"
+    model.write_text(json.dumps({"adaptive_diagnosis": _card()}), encoding="utf-8")
+
+    assert exporter.main(["--review-model", str(model), "--out", str(out)]) == 0
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    stdout = capsys.readouterr().out
+    assert payload["diagnosis"]["failure_class"] == "test"
+    assert "adaptive_diagnosis_json_export=passed" in stdout
+    assert "reporting_only=true" in stdout
+    assert "automation_allowed=false" in stdout

--- a/tools/export_pr_quality_adaptive_diagnosis_json.py
+++ b/tools/export_pr_quality_adaptive_diagnosis_json.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_export.v1"
+AUTHORITY_FIELDS = (
+    "reporting_only",
+    "automation_allowed",
+    "patch_application_allowed",
+    "security_dismissal_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _as_dict(value: object) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    rendered = str(value).strip()
+    return rendered or default
+
+
+def adaptive_diagnosis_card(model: JsonObject) -> JsonObject:
+    card = _as_dict(model.get("adaptive_diagnosis"))
+    if card:
+        return card
+    return _as_dict(_as_dict(model.get("primary_failure")).get("adaptive_diagnosis"))
+
+
+def build_export(card: JsonObject) -> JsonObject:
+    checks = {
+        _text(name): bool(value)
+        for name, value in _as_dict(card.get("checks")).items()
+        if _text(name)
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnosis": {
+            "status": _text(card.get("status"), "review_first"),
+            "failure_class": _text(card.get("failure_class"), "unknown"),
+            "diagnostic_completeness": _text(card.get("diagnostic_completeness"), "insufficient"),
+            "confidence": _text(card.get("confidence"), "low"),
+            "review_first": bool(card.get("review_first", True)),
+        },
+        "evidence": {
+            "checks": checks,
+            "owner_files": [
+                _text(item) for item in _as_list(card.get("owner_files")) if _text(item)
+            ],
+            "proof_commands": [
+                _text(item) for item in _as_list(card.get("proof_commands")) if _text(item)
+            ],
+            "evidence_gaps": [
+                _text(item) for item in _as_list(card.get("evidence_gaps")) if _text(item)
+            ],
+            "next_human_action": _text(
+                card.get("next_human_action"),
+                "Collect exact failure evidence before changing code.",
+            ),
+        },
+        "authority": {field: bool(card.get(field, False)) for field in AUTHORITY_FIELDS},
+    }
+
+
+def export_from_model(model: JsonObject) -> JsonObject:
+    card = adaptive_diagnosis_card(model)
+    if not card:
+        raise ValueError("review model has no adaptive diagnosis card")
+    return build_export(card)
+
+
+def serialize_export(payload: JsonObject) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Export the Adaptive Diagnosis contract as deterministic JSON."
+    )
+    parser.add_argument("--review-model", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    model = json.loads(args.review_model.read_text(encoding="utf-8"))
+    if not isinstance(model, dict):
+        raise ValueError("review model must be a JSON object")
+    payload = export_from_model(model)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(serialize_export(payload), encoding="utf-8", newline="\n")
+    print("adaptive_diagnosis_json_export=passed")
+    print(f"out={args.out.as_posix()}")
+    print("reporting_only=true")
+    print("automation_allowed=false")
+    print("merge_authorized=false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- normalize the existing Adaptive Diagnosis evidence into a deterministic JSON contract
- separate diagnosis, evidence, checks, and authority fields
- preserve review-first and reporting-only boundaries

## Verification
- `python -m pytest -q tests/test_pr_quality_adaptive_diagnosis_json.py -o addopts=` — 5 passed locally
- `python -m ruff format --check --line-length 100 tools/export_pr_quality_adaptive_diagnosis_json.py tests/test_pr_quality_adaptive_diagnosis_json.py`
- `python -m ruff check --line-length 100 tools/export_pr_quality_adaptive_diagnosis_json.py tests/test_pr_quality_adaptive_diagnosis_json.py`

## Risk
Low. Additive tool and tests only. Output is deterministic and does not authorize action. Rollback is a revert.

## Authority
- `reporting_only=true`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `security_dismissal_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`