### PR TITLE
feat: add portable Adaptive Diagnosis evidence bundle

### DIFF
--- a/tests/test_pr_quality_adaptive_diagnosis_bundle.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_bundle.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "build_pr_quality_adaptive_diagnosis_bundle.py"
+)
+SPEC = importlib.util.spec_from_file_location("adaptive_diagnosis_bundle", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+builder = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(builder)
+
+
+def _card() -> dict[str, object]:
+    return {
+        "status": "review_first",
+        "failure_class": "test",
+        "diagnostic_completeness": "complete",
+        "confidence": "high",
+        "checks": {
+            "exact_failure_detail_present": True,
+            "authority_boundary_preserved": True,
+        },
+        "owner_files": ["docs/contracts/quality-truth-baseline.v1.json"],
+        "proof_commands": ["python -m pytest -q tests/test_quality_truth_baseline.py -o addopts="],
+        "evidence_gaps": [],
+        "next_human_action": "Run focused proof and inspect the owner file.",
+        "review_first": True,
+        "reporting_only": True,
+        "automation_allowed": False,
+        "patch_application_allowed": False,
+        "security_dismissal_allowed": False,
+        "merge_authorized": False,
+        "semantic_equivalence_proven": False,
+    }
+
+
+def test_bundle_writes_portable_operator_artifacts(tmp_path: Path) -> None:
+    manifest = builder.build_bundle({"adaptive_diagnosis": _card()}, tmp_path)
+
+    assert manifest["status"] == "passed"
+    assert manifest["authority_validated"] is True
+    assert {item["path"] for item in manifest["artifacts"]} == {
+        "adaptive-diagnosis.html",
+        "adaptive-diagnosis.md",
+        "adaptive-diagnosis.json",
+    }
+    assert (tmp_path / "manifest.json").is_file()
+    assert "<h1>Adaptive Diagnosis</h1>" in (tmp_path / "adaptive-diagnosis.html").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        (tmp_path / "adaptive-diagnosis.md")
+        .read_text(encoding="utf-8")
+        .startswith("# Adaptive Diagnosis")
+    )
+    payload = json.loads((tmp_path / "adaptive-diagnosis.json").read_text(encoding="utf-8"))
+    assert payload["diagnosis"]["failure_class"] == "test"
+
+
+def test_manifest_hashes_match_artifact_bytes(tmp_path: Path) -> None:
+    manifest = builder.build_bundle({"adaptive_diagnosis": _card()}, tmp_path)
+
+    for record in manifest["artifacts"]:
+        content = (tmp_path / record["path"]).read_bytes()
+        assert record["size_bytes"] == len(content)
+        assert record["sha256"] == hashlib.sha256(content).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("field", "unsafe_value"),
+    [
+        ("reporting_only", False),
+        ("automation_allowed", True),
+        ("patch_application_allowed", True),
+        ("security_dismissal_allowed", True),
+        ("merge_authorized", True),
+        ("semantic_equivalence_proven", True),
+    ],
+)
+def test_bundle_fails_closed_for_unsafe_authority(
+    tmp_path: Path,
+    field: str,
+    unsafe_value: bool,
+) -> None:
+    card = _card()
+    card[field] = unsafe_value
+
+    with pytest.raises(ValueError, match="unsafe adaptive diagnosis authority"):
+        builder.build_bundle({"adaptive_diagnosis": card}, tmp_path)
+
+    assert not list(tmp_path.iterdir())
+
+
+def test_bundle_rejects_missing_card(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no adaptive diagnosis card"):
+        builder.build_bundle({}, tmp_path)
+
+
+def test_bundle_cli_writes_manifest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    model = tmp_path / "model.json"
+    out_dir = tmp_path / "bundle"
+    model.write_text(json.dumps({"adaptive_diagnosis": _card()}), encoding="utf-8")
+
+    assert builder.main(["--review-model", str(model), "--out-dir", str(out_dir)]) == 0
+
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    stdout = capsys.readouterr().out
+    assert manifest["authority_validated"] is True
+    assert "adaptive_diagnosis_bundle=passed" in stdout
+    assert "artifact_count=3" in stdout
+    assert "automation_allowed=false" in stdout

--- a/tools/build_pr_quality_adaptive_diagnosis_bundle.py
+++ b/tools/build_pr_quality_adaptive_diagnosis_bundle.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+JsonObject = dict[str, Any]
+AUTHORITY_EXPECTATIONS = {
+    "reporting_only": True,
+    "automation_allowed": False,
+    "patch_application_allowed": False,
+    "security_dismissal_allowed": False,
+    "merge_authorized": False,
+    "semantic_equivalence_proven": False,
+}
+ARTIFACT_NAMES = (
+    "adaptive-diagnosis.html",
+    "adaptive-diagnosis.md",
+    "adaptive-diagnosis.json",
+)
+
+
+def _load_sibling(name: str, filename: str) -> ModuleType:
+    path = Path(__file__).with_name(filename)
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load renderer: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+HTML_RENDERER = _load_sibling(
+    "adaptive_diagnosis_html_renderer",
+    "render_pr_quality_adaptive_diagnosis.py",
+)
+MARKDOWN_RENDERER = _load_sibling(
+    "adaptive_diagnosis_markdown_renderer",
+    "render_pr_quality_adaptive_diagnosis_markdown.py",
+)
+JSON_EXPORTER = _load_sibling(
+    "adaptive_diagnosis_json_exporter",
+    "export_pr_quality_adaptive_diagnosis_json.py",
+)
+
+
+def _as_dict(value: object) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def adaptive_diagnosis_card(model: JsonObject) -> JsonObject:
+    card = _as_dict(model.get("adaptive_diagnosis"))
+    if card:
+        return card
+    return _as_dict(_as_dict(model.get("primary_failure")).get("adaptive_diagnosis"))
+
+
+def validate_authority(card: JsonObject) -> None:
+    mismatches = [
+        f"{field} expected {expected!r}, observed {card.get(field)!r}"
+        for field, expected in AUTHORITY_EXPECTATIONS.items()
+        if card.get(field) is not expected
+    ]
+    if mismatches:
+        raise ValueError("unsafe adaptive diagnosis authority: " + "; ".join(mismatches))
+
+
+def _artifact_record(path: Path) -> JsonObject:
+    content = path.read_bytes()
+    return {
+        "path": path.name,
+        "size_bytes": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+def build_bundle(model: JsonObject, out_dir: Path) -> JsonObject:
+    card = adaptive_diagnosis_card(model)
+    if not card:
+        raise ValueError("review model has no adaptive diagnosis card")
+    validate_authority(card)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    html_path = out_dir / ARTIFACT_NAMES[0]
+    markdown_path = out_dir / ARTIFACT_NAMES[1]
+    json_path = out_dir / ARTIFACT_NAMES[2]
+
+    html_path.write_text(
+        HTML_RENDERER.render_adaptive_diagnosis_html(card),
+        encoding="utf-8",
+        newline="\n",
+    )
+    markdown_path.write_text(
+        MARKDOWN_RENDERER.render_adaptive_diagnosis_markdown(card),
+        encoding="utf-8",
+        newline="\n",
+    )
+    exported = JSON_EXPORTER.build_export(card)
+    json_path.write_text(
+        JSON_EXPORTER.serialize_export(exported),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    manifest = {
+        "schema_version": "sdetkit.adaptive_diagnosis_bundle_manifest.v1",
+        "status": "passed",
+        "authority_validated": True,
+        "authority": dict(AUTHORITY_EXPECTATIONS),
+        "artifacts": [_artifact_record(out_dir / name) for name in ARTIFACT_NAMES],
+    }
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return manifest
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the portable Adaptive Diagnosis evidence bundle."
+    )
+    parser.add_argument("--review-model", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    model = json.loads(args.review_model.read_text(encoding="utf-8"))
+    if not isinstance(model, dict):
+        raise ValueError("review model must be a JSON object")
+    manifest = build_bundle(model, args.out_dir)
+    print("adaptive_diagnosis_bundle=passed")
+    print(f"artifact_count={len(manifest['artifacts'])}")
+    print(f"out_dir={args.out_dir.as_posix()}")
+    print("authority_validated=true")
+    print("reporting_only=true")
+    print("automation_allowed=false")
+    print("merge_authorized=false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- build HTML, Markdown, and deterministic JSON Adaptive Diagnosis artifacts in one command
- emit a deterministic SHA-256 manifest with artifact sizes and authority state
- fail closed before writing artifacts when any reporting-only authority boundary is escalated

## Verification
- `python -m pytest -q tests/test_pr_quality_adaptive_diagnosis_bundle.py -o addopts=` — 10 passed locally
- `python -m ruff format --check --line-length 100 tools/build_pr_quality_adaptive_diagnosis_bundle.py tests/test_pr_quality_adaptive_diagnosis_bundle.py`
- `python -m ruff check --line-length 100 tools/build_pr_quality_adaptive_diagnosis_bundle.py tests/test_pr_quality_adaptive_diagnosis_bundle.py`

## Real-world output
A single command writes:
- `adaptive-diagnosis.html`
- `adaptive-diagnosis.md`
- `adaptive-diagnosis.json`
- `manifest.json` with SHA-256 and byte size for every evidence artifact

## Risk
Low. Additive tool and tests only. No workflow, dependency, package, security scanner, or public import change. Rollback is a revert.

## Authority
- `reporting_only=true`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `security_dismissal_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`