### PR TITLE
feat: surface Adaptive Diagnosis in live PR quality views

### DIFF
--- a/src/sdetkit/pr_quality_live_dashboard.py
+++ b/src/sdetkit/pr_quality_live_dashboard.py
@@ -346,5 +346,13 @@ def render_live_evidence_html(snapshot: JsonObject) -> str:
     return _inject_adaptive_html(_core.render_live_evidence_html(snapshot), snapshot)
 
 
-def render_live_product_dashboard(snapshot: JsonObject) -> str:
-    return _inject_adaptive_html(_core.render_live_product_dashboard(snapshot), snapshot)
+def render_live_product_dashboard(
+    model: JsonObject,
+    *,
+    embedded_artifacts: JsonObject | None = None,
+) -> str:
+    rendered = _core.render_live_product_dashboard(
+        model,
+        embedded_artifacts=embedded_artifacts,
+    )
+    return _inject_adaptive_html(rendered, _as_dict(model.get("live_evidence")))

--- a/src/sdetkit/pr_quality_live_dashboard.py
+++ b/src/sdetkit/pr_quality_live_dashboard.py
@@ -3,12 +3,21 @@ from __future__ import annotations
 import ast
 import re
 from collections.abc import Mapping
+from html import escape
 from typing import Any
 
 from . import _pr_quality_live_dashboard_core as _core
 from .pr_quality_adaptive_diagnosis import attach_adaptive_diagnosis
 
 JsonObject = dict[str, Any]
+AUTHORITY_FIELDS = (
+    "reporting_only",
+    "automation_allowed",
+    "patch_application_allowed",
+    "security_dismissal_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
 
 
 def _as_dict(value: object) -> JsonObject:
@@ -24,6 +33,10 @@ def _text(value: object, default: str = "") -> str:
         return default
     rendered = str(value).strip()
     return rendered or default
+
+
+def _markdown_code(value: object, default: str = "") -> str:
+    return _text(value, default).replace("`", "'").replace("\n", " ")
 
 
 def _display_failure_literal(value: object) -> str:
@@ -125,6 +138,169 @@ def _enrich_primary_failure(review_model: JsonObject) -> None:
         primary_failure["test_node"] = test_node
 
 
+def _adaptive_diagnosis_card(value: JsonObject) -> JsonObject:
+    card = _as_dict(value.get("adaptive_diagnosis"))
+    if card:
+        return card
+    return _as_dict(_as_dict(value.get("primary_failure")).get("adaptive_diagnosis"))
+
+
+def _adaptive_diagnosis_markdown(snapshot: JsonObject) -> str:
+    card = _adaptive_diagnosis_card(snapshot)
+    if not card:
+        return ""
+
+    checks = _as_dict(card.get("checks"))
+    lines = [
+        "## Adaptive Diagnosis",
+        "",
+        "| Signal | Value |",
+        "|---|---|",
+        (
+            "| Completeness | "
+            f"`{_markdown_code(card.get('diagnostic_completeness'), 'insufficient')}` |"
+        ),
+        f"| Confidence | `{_markdown_code(card.get('confidence'), 'low')}` |",
+        f"| Failure class | `{_markdown_code(card.get('failure_class'), 'unknown')}` |",
+        (
+            "| Review first | "
+            f"`{'true' if bool(card.get('review_first', True)) else 'false'}` |"
+        ),
+        "",
+        "### Safeguards",
+        "",
+    ]
+    if checks:
+        lines.extend(
+            f"- `{_markdown_code(name)}`: "
+            f"`{'pass' if bool(passed) else 'missing'}`"
+            for name, passed in sorted(checks.items(), key=lambda item: _text(item[0]))
+        )
+    else:
+        lines.append("- No adaptive checks were emitted.")
+
+    for title, key, empty in (
+        ("Owner files", "owner_files", "No owner file was resolved."),
+        ("Focused proof", "proof_commands", "No focused proof command was resolved."),
+        ("Evidence gaps", "evidence_gaps", "No evidence gaps were reported."),
+    ):
+        lines.extend(("", f"### {title}", ""))
+        values = [_text(item) for item in _as_list(card.get(key)) if _text(item)]
+        lines.extend(f"- `{_markdown_code(item)}`" for item in values)
+        if not values:
+            lines.append(f"- {empty}")
+
+    lines.extend(
+        (
+            "",
+            "### Next human action",
+            "",
+            _text(
+                card.get("next_human_action"),
+                "Collect exact failure evidence before changing code.",
+            ),
+            "",
+            "### Authority boundary",
+            "",
+        )
+    )
+    lines.extend(
+        f"- `{field}={'true' if bool(card.get(field, False)) else 'false'}`"
+        for field in AUTHORITY_FIELDS
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _html_list(values: object, *, empty: str) -> str:
+    items = [_text(item) for item in _as_list(values) if _text(item)]
+    if not items:
+        return f"<p>{escape(empty)}</p>"
+    return "<ul>" + "".join(f"<li><code>{escape(item)}</code></li>" for item in items) + "</ul>"
+
+
+def _adaptive_diagnosis_html(snapshot: JsonObject) -> str:
+    card = _adaptive_diagnosis_card(snapshot)
+    if not card:
+        return ""
+
+    checks = _as_dict(card.get("checks"))
+    check_rows = "".join(
+        "<tr>"
+        f"<td><code>{escape(_text(name))}</code></td>"
+        f"<td>{'Pass' if bool(passed) else 'Missing'}</td>"
+        "</tr>"
+        for name, passed in sorted(checks.items(), key=lambda item: _text(item[0]))
+    )
+    if not check_rows:
+        check_rows = '<tr><td colspan="2">No adaptive checks were emitted.</td></tr>'
+
+    authority_rows = "".join(
+        "<tr>"
+        f"<td><code>{field}</code></td>"
+        f"<td>{'true' if bool(card.get(field, False)) else 'false'}</td>"
+        "</tr>"
+        for field in AUTHORITY_FIELDS
+    )
+    completeness = escape(_text(card.get("diagnostic_completeness"), "insufficient").title())
+    confidence = escape(_text(card.get("confidence"), "low").title())
+    failure_class = escape(
+        _text(card.get("failure_class"), "unknown").replace("_", " ").title()
+    )
+    review_first = "Yes" if bool(card.get("review_first", True)) else "No"
+    next_action = escape(
+        _text(
+            card.get("next_human_action"),
+            "Collect exact failure evidence before changing code.",
+        )
+    )
+
+    return "".join(
+        (
+            '<section id="adaptive-diagnosis" class="section adaptive-diagnosis">',
+            '<div class="section-heading"><div>',
+            '<div class="eyebrow">Contributor evidence</div>',
+            "<h2>Adaptive Diagnosis</h2>",
+            "</div><p>The first violated contract, evidence quality, and review-first action.</p>",
+            "</div>",
+            '<div class="review-grid">',
+            f'<article class="review-panel"><span>Completeness</span><h3>{completeness}</h3></article>',
+            f'<article class="review-panel"><span>Confidence</span><h3>{confidence}</h3></article>',
+            f'<article class="review-panel"><span>Failure class</span><h3>{failure_class}</h3></article>',
+            f'<article class="review-panel"><span>Review first</span><h3>{review_first}</h3></article>',
+            "</div>",
+            "<h3>Safeguards</h3>",
+            "<table><thead><tr><th>Check</th><th>Result</th></tr></thead>",
+            f"<tbody>{check_rows}</tbody></table>",
+            "<h3>Owner files</h3>",
+            _html_list(card.get("owner_files"), empty="No owner file was resolved."),
+            "<h3>Focused proof</h3>",
+            _html_list(
+                card.get("proof_commands"),
+                empty="No focused proof command was resolved.",
+            ),
+            "<h3>Evidence gaps</h3>",
+            _html_list(card.get("evidence_gaps"), empty="No evidence gaps were reported."),
+            "<h3>Next human action</h3>",
+            f"<p><strong>{next_action}</strong></p>",
+            "<h3>Authority boundary</h3>",
+            "<table><thead><tr><th>Field</th><th>Value</th></tr></thead>",
+            f"<tbody>{authority_rows}</tbody></table>",
+            "</section>",
+        )
+    )
+
+
+def _inject_adaptive_html(rendered: str, snapshot: JsonObject) -> str:
+    section = _adaptive_diagnosis_html(snapshot)
+    if not rendered or not section:
+        return rendered
+    for marker in ("</main>", "</body>"):
+        if marker in rendered:
+            return rendered.replace(marker, section + marker, 1)
+    return rendered + section
+
+
 def build_live_evidence_snapshot(
     *,
     pr_number: int,
@@ -139,7 +315,7 @@ def build_live_evidence_snapshot(
 ) -> JsonObject:
     _enrich_primary_failure(review_model)
     attach_adaptive_diagnosis(review_model)
-    return _core.build_live_evidence_snapshot(
+    snapshot = _core.build_live_evidence_snapshot(
         pr_number=pr_number,
         head_sha=head_sha,
         base_sha=base_sha,
@@ -150,8 +326,25 @@ def build_live_evidence_snapshot(
         environment=environment,
         generated_at=generated_at,
     )
+    card = _adaptive_diagnosis_card(review_model)
+    if card:
+        snapshot["adaptive_diagnosis"] = dict(card)
+    return snapshot
 
 
-render_live_evidence_markdown = _core.render_live_evidence_markdown
-render_live_evidence_html = _core.render_live_evidence_html
-render_live_product_dashboard = _core.render_live_product_dashboard
+def render_live_evidence_markdown(snapshot: JsonObject) -> str:
+    rendered = _core.render_live_evidence_markdown(snapshot)
+    section = _adaptive_diagnosis_markdown(snapshot)
+    if not rendered:
+        return section
+    if not section:
+        return rendered
+    return rendered.rstrip() + "\n\n" + section
+
+
+def render_live_evidence_html(snapshot: JsonObject) -> str:
+    return _inject_adaptive_html(_core.render_live_evidence_html(snapshot), snapshot)
+
+
+def render_live_product_dashboard(snapshot: JsonObject) -> str:
+    return _inject_adaptive_html(_core.render_live_product_dashboard(snapshot), snapshot)

--- a/src/sdetkit/pr_quality_live_dashboard.py
+++ b/src/sdetkit/pr_quality_live_dashboard.py
@@ -162,18 +162,14 @@ def _adaptive_diagnosis_markdown(snapshot: JsonObject) -> str:
         ),
         f"| Confidence | `{_markdown_code(card.get('confidence'), 'low')}` |",
         f"| Failure class | `{_markdown_code(card.get('failure_class'), 'unknown')}` |",
-        (
-            "| Review first | "
-            f"`{'true' if bool(card.get('review_first', True)) else 'false'}` |"
-        ),
+        (f"| Review first | `{'true' if bool(card.get('review_first', True)) else 'false'}` |"),
         "",
         "### Safeguards",
         "",
     ]
     if checks:
         lines.extend(
-            f"- `{_markdown_code(name)}`: "
-            f"`{'pass' if bool(passed) else 'missing'}`"
+            f"- `{_markdown_code(name)}`: `{'pass' if bool(passed) else 'missing'}`"
             for name, passed in sorted(checks.items(), key=lambda item: _text(item[0]))
         )
     else:
@@ -244,9 +240,7 @@ def _adaptive_diagnosis_html(snapshot: JsonObject) -> str:
     )
     completeness = escape(_text(card.get("diagnostic_completeness"), "insufficient").title())
     confidence = escape(_text(card.get("confidence"), "low").title())
-    failure_class = escape(
-        _text(card.get("failure_class"), "unknown").replace("_", " ").title()
-    )
+    failure_class = escape(_text(card.get("failure_class"), "unknown").replace("_", " ").title())
     review_first = "Yes" if bool(card.get("review_first", True)) else "No"
     next_action = escape(
         _text(

--- a/tests/test_pr_quality_live_adaptive_diagnosis.py
+++ b/tests/test_pr_quality_live_adaptive_diagnosis.py
@@ -58,11 +58,12 @@ def _review_model() -> dict[str, object]:
 
 
 def _snapshot(review_model: dict[str, object] | None = None) -> dict[str, object]:
+    model = review_model if review_model is not None else _review_model()
     return build_live_evidence_snapshot(
         pr_number=1984,
         head_sha="a" * 40,
         base_sha="b" * 40,
-        review_model=review_model or _review_model(),
+        review_model=model,
         check_intelligence={"current_head_sha": "a" * 40},
         runtime_proof_artifacts={},
         artifact_manifest={},
@@ -129,7 +130,10 @@ def test_live_html_renders_visible_adaptive_diagnosis() -> None:
 
 
 def test_live_product_dashboard_includes_adaptive_diagnosis() -> None:
-    html = render_live_product_dashboard(_snapshot())
+    model = _review_model()
+    model["live_evidence"] = _snapshot(model)
+
+    html = render_live_product_dashboard(model)
 
     assert html.count('<section id="adaptive-diagnosis"') == 1
     assert "The first violated contract, evidence quality, and review-first action." in html

--- a/tests/test_pr_quality_live_adaptive_diagnosis.py
+++ b/tests/test_pr_quality_live_adaptive_diagnosis.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from sdetkit.pr_quality_live_dashboard import (
+    build_live_evidence_snapshot,
+    render_live_evidence_html,
+    render_live_evidence_markdown,
+    render_live_product_dashboard,
+)
+
+
+def _review_model() -> dict[str, object]:
+    return {
+        "decision": {
+            "review_state": "blocked",
+            "failed_checks": 1,
+            "required_queued_checks": 0,
+            "required_startup_failures": 0,
+            "missing_required_contexts": 0,
+        },
+        "primary_failure": {
+            "available": True,
+            "check_name": "Quality truth baseline",
+            "diagnostic_failure_code": "PYTEST_ASSERTION_FAILURE",
+            "message": "source_module_count expected 497 but observed 498",
+            "expected": "source_module_count = 497",
+            "observed": "source_module_count = 498",
+            "test_node": (
+                "tests/test_quality_truth_baseline.py::"
+                "test_quality_truth_baseline_matches_current_repository_configuration"
+            ),
+            "source_path": "docs/contracts/quality-truth-baseline.v1.json",
+            "reproduction_command": (
+                "python -m pytest -q "
+                "tests/test_quality_truth_baseline.py::"
+                "test_quality_truth_baseline_matches_current_repository_configuration "
+                "-o addopts="
+            ),
+            "mapping_confidence": "high",
+            "provenance_status": "confirmed",
+            "step_evidence_status": "confirmed",
+            "workflow_exact_head_verified": True,
+            "reporting_only": True,
+            "automation_allowed": False,
+            "patch_application_allowed": False,
+            "security_dismissal_allowed": False,
+            "merge_authorized": False,
+            "semantic_equivalence_proven": False,
+        },
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+            "semantic_equivalence_claim": False,
+        },
+        "ghas_blocker_details": {"collected": True},
+    }
+
+
+def _snapshot(review_model: dict[str, object] | None = None) -> dict[str, object]:
+    return build_live_evidence_snapshot(
+        pr_number=1984,
+        head_sha="a" * 40,
+        base_sha="b" * 40,
+        review_model=review_model or _review_model(),
+        check_intelligence={"current_head_sha": "a" * 40},
+        runtime_proof_artifacts={},
+        artifact_manifest={},
+        environment={
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_REPOSITORY": "sherif69-sa/DevS69-sdetkit",
+            "GITHUB_RUN_ID": "28600000000",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_WORKFLOW": "PR Quality Comment",
+            "GITHUB_JOB": "quality",
+        },
+        generated_at="2026-07-03T08:00:00+00:00",
+    )
+
+
+def test_live_snapshot_exposes_complete_adaptive_diagnosis() -> None:
+    snapshot = _snapshot()
+
+    card = snapshot["adaptive_diagnosis"]
+    assert card["diagnostic_completeness"] == "complete"
+    assert card["confidence"] == "high"
+    assert card["failure_class"] == "test"
+    assert card["review_first"] is True
+    assert card["checks"]["authority_boundary_preserved"] is True
+    assert card["owner_files"] == [
+        "docs/contracts/quality-truth-baseline.v1.json",
+        "tests/test_quality_truth_baseline.py",
+    ]
+    assert card["reporting_only"] is True
+    assert card["automation_allowed"] is False
+    assert card["merge_authorized"] is False
+
+
+def test_live_markdown_renders_contributor_adaptive_diagnosis() -> None:
+    markdown = render_live_evidence_markdown(_snapshot())
+
+    assert "## Adaptive Diagnosis" in markdown
+    assert "| Completeness | `complete` |" in markdown
+    assert "| Confidence | `high` |" in markdown
+    assert "| Failure class | `test` |" in markdown
+    assert "`authority_boundary_preserved`: `pass`" in markdown
+    assert "docs/contracts/quality-truth-baseline.v1.json" in markdown
+    assert "python -m pytest -q" in markdown
+    assert "`automation_allowed=false`" in markdown
+    assert "`merge_authorized=false`" in markdown
+
+
+def test_live_html_renders_visible_adaptive_diagnosis() -> None:
+    html = render_live_evidence_html(_snapshot())
+
+    assert '<section id="adaptive-diagnosis"' in html
+    assert "<h2>Adaptive Diagnosis</h2>" in html
+    assert "Completeness" in html
+    assert "Confidence" in html
+    assert "Failure class" in html
+    assert "Safeguards" in html
+    assert "Owner files" in html
+    assert "Focused proof" in html
+    assert "Evidence gaps" in html
+    assert "Next human action" in html
+    assert "Authority boundary" in html
+    assert "automation_allowed" in html
+    assert ">false<" in html
+
+
+def test_live_product_dashboard_includes_adaptive_diagnosis() -> None:
+    html = render_live_product_dashboard(_snapshot())
+
+    assert html.count('<section id="adaptive-diagnosis"') == 1
+    assert "The first violated contract, evidence quality, and review-first action." in html
+
+
+def test_live_html_escapes_adaptive_diagnosis_evidence() -> None:
+    snapshot = _snapshot()
+    snapshot["adaptive_diagnosis"]["next_human_action"] = "<script>alert('unsafe')</script>"
+
+    html = render_live_evidence_html(snapshot)
+
+    assert "<script>alert" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_live_views_preserve_existing_output_without_adaptive_card() -> None:
+    review_model = {
+        "decision": {
+            "review_state": "ready",
+            "failed_checks": 0,
+            "required_queued_checks": 0,
+            "required_startup_failures": 0,
+            "missing_required_contexts": 0,
+        },
+        "authority_boundary": {
+            "boundary_mode": "reporting_only",
+            "patch_automation": False,
+            "security_dismissal": False,
+            "merge_authorization": False,
+        },
+        "ghas_blocker_details": {"collected": True},
+    }
+    snapshot = _snapshot(review_model)
+
+    assert "adaptive_diagnosis" not in snapshot
+    assert "## Adaptive Diagnosis" not in render_live_evidence_markdown(snapshot)
+    assert '<section id="adaptive-diagnosis"' not in render_live_evidence_html(snapshot)


### PR DESCRIPTION
## Summary
- attach the existing Adaptive Diagnosis card to the exact-head live evidence snapshot
- render contributor-facing Adaptive Diagnosis sections in Markdown, compact HTML, and the full product dashboard
- show completeness, confidence, failure class, safeguard results, owner files, focused proof, evidence gaps, next human action, and every authority field
- escape rendered evidence and preserve existing output when no adaptive card is available

## Why
The diagnosis model and portable evidence bundle are now merged, but the primary live PR quality views still hide that evidence. This PR closes the product integration gap so contributors can see the adaptive diagnosis directly in the report surfaces they already use.

## Verification
Focused contract:
- `python -m pytest -q tests/test_pr_quality_live_adaptive_diagnosis.py -o addopts=`

Regression surfaces:
- `python -m pytest -q tests/test_pr_quality_expected_observed_evidence.py tests/test_pr_quality_adaptive_diagnosis.py -o addopts=`
- `python -m pre_commit run -a`

The current connector runtime cannot execute the repository environment, so these commands are intentionally left for exact-head CI proof rather than reported as locally passed.

## Risk
- Medium: report rendering behavior changes when an Adaptive Diagnosis card exists
- Existing behavior remains unchanged when the card is absent
- No workflow, dependency, package, security scanner, patching, or merge semantics change
- Rollback: revert this PR

## Authority
- `reporting_only=true`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `security_dismissal_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`