### PR TITLE
refactor: centralize Adaptive Diagnosis artifact contracts

### DIFF
--- a/src/sdetkit/pr_quality_adaptive_diagnosis.py
+++ b/src/sdetkit/pr_quality_adaptive_diagnosis.py
@@ -7,9 +7,7 @@ from typing import Any
 JsonObject = dict[str, Any]
 ADAPTIVE_DIAGNOSIS_SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_card.v1"
 ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_export.v1"
-ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION = (
-    "sdetkit.adaptive_diagnosis_bundle_manifest.v1"
-)
+ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_bundle_manifest.v1"
 AUTHORITY_FIELDS = (
     "reporting_only",
     "automation_allowed",
@@ -72,9 +70,7 @@ def validate_authority(card: Mapping[str, object]) -> None:
         if card.get(field) is not expected
     ]
     if mismatches:
-        raise ValueError(
-            "unsafe adaptive diagnosis authority: " + "; ".join(mismatches)
-        )
+        raise ValueError("unsafe adaptive diagnosis authority: " + "; ".join(mismatches))
 
 
 def build_export(card: Mapping[str, object]) -> JsonObject:
@@ -88,9 +84,7 @@ def build_export(card: Mapping[str, object]) -> JsonObject:
         "diagnosis": {
             "status": _text(card.get("status"), "review_first"),
             "failure_class": _text(card.get("failure_class"), "unknown"),
-            "diagnostic_completeness": _text(
-                card.get("diagnostic_completeness"), "insufficient"
-            ),
+            "diagnostic_completeness": _text(card.get("diagnostic_completeness"), "insufficient"),
             "confidence": _text(card.get("confidence"), "low"),
             "review_first": bool(card.get("review_first", True)),
         },
@@ -100,23 +94,17 @@ def build_export(card: Mapping[str, object]) -> JsonObject:
                 _text(item) for item in _as_list(card.get("owner_files")) if _text(item)
             ],
             "proof_commands": [
-                _text(item)
-                for item in _as_list(card.get("proof_commands"))
-                if _text(item)
+                _text(item) for item in _as_list(card.get("proof_commands")) if _text(item)
             ],
             "evidence_gaps": [
-                _text(item)
-                for item in _as_list(card.get("evidence_gaps"))
-                if _text(item)
+                _text(item) for item in _as_list(card.get("evidence_gaps")) if _text(item)
             ],
             "next_human_action": _text(
                 card.get("next_human_action"),
                 "Collect exact failure evidence before changing code.",
             ),
         },
-        "authority": {
-            field: bool(card.get(field, False)) for field in AUTHORITY_FIELDS
-        },
+        "authority": {field: bool(card.get(field, False)) for field in AUTHORITY_FIELDS},
     }
 
 
@@ -137,15 +125,11 @@ def _family_score(value: object) -> tuple[int, int, int]:
     return (
         1 if _text(family.get("test_node")) else 0,
         1 if _text(family.get("message")) else 0,
-        1
-        if code and code not in {"UNKNOWN_REVIEW_REQUIRED", "RELEASE_ARTIFACT_INVALID"}
-        else 0,
+        1 if code and code not in {"UNKNOWN_REVIEW_REQUIRED", "RELEASE_ARTIFACT_INVALID"} else 0,
     )
 
 
-def _richest_family(
-    primary_failure: JsonObject, review_model: JsonObject
-) -> JsonObject:
+def _richest_family(primary_failure: JsonObject, review_model: JsonObject) -> JsonObject:
     families = [
         _as_dict(item)
         for item in _as_list(
@@ -163,9 +147,7 @@ def _test_source_path(test_node: str) -> str:
 
 def _generic_observation(value: str) -> bool:
     normalized = " ".join(value.lower().split())
-    return normalized in _GENERIC_OBSERVED or normalized.startswith(
-        "assert false is true"
-    )
+    return normalized in _GENERIC_OBSERVED or normalized.startswith("assert false is true")
 
 
 def _failure_class(primary_failure: JsonObject, detail: JsonObject) -> str:
@@ -224,8 +206,7 @@ def attach_adaptive_diagnosis(review_model: JsonObject) -> None:
     proof_commands = _proof_commands(primary_failure)
 
     checks = {
-        "exact_failure_detail_present": bool(message)
-        and not _generic_observation(observed),
+        "exact_failure_detail_present": bool(message) and not _generic_observation(observed),
         "expected_observed_specific": bool(expected)
         and expected != "check completes successfully"
         and bool(observed)
@@ -240,18 +221,14 @@ def attach_adaptive_diagnosis(review_model: JsonObject) -> None:
         "authority_boundary_preserved": _authority_boundary_preserved(primary_failure),
     }
     existing_gaps = [
-        _text(item)
-        for item in _as_list(primary_failure.get("evidence_gaps"))
-        if _text(item)
+        _text(item) for item in _as_list(primary_failure.get("evidence_gaps")) if _text(item)
     ]
     evidence_gaps = list(existing_gaps)
     for check, passed in checks.items():
         if not passed and check not in evidence_gaps:
             evidence_gaps.append(check)
 
-    diagnostic_checks = [
-        name for name in checks if name != "authority_boundary_preserved"
-    ]
+    diagnostic_checks = [name for name in checks if name != "authority_boundary_preserved"]
     passed_count = sum(1 for name in diagnostic_checks if checks[name])
     if passed_count == len(diagnostic_checks):
         completeness = "complete"

--- a/src/sdetkit/pr_quality_adaptive_diagnosis.py
+++ b/src/sdetkit/pr_quality_adaptive_diagnosis.py
@@ -72,7 +72,9 @@ def validate_authority(card: Mapping[str, object]) -> None:
         if card.get(field) is not expected
     ]
     if mismatches:
-        raise ValueError("unsafe adaptive diagnosis authority: " + "; ".join(mismatches))
+        raise ValueError(
+            "unsafe adaptive diagnosis authority: " + "; ".join(mismatches)
+        )
 
 
 def build_export(card: Mapping[str, object]) -> JsonObject:
@@ -98,17 +100,23 @@ def build_export(card: Mapping[str, object]) -> JsonObject:
                 _text(item) for item in _as_list(card.get("owner_files")) if _text(item)
             ],
             "proof_commands": [
-                _text(item) for item in _as_list(card.get("proof_commands")) if _text(item)
+                _text(item)
+                for item in _as_list(card.get("proof_commands"))
+                if _text(item)
             ],
             "evidence_gaps": [
-                _text(item) for item in _as_list(card.get("evidence_gaps")) if _text(item)
+                _text(item)
+                for item in _as_list(card.get("evidence_gaps"))
+                if _text(item)
             ],
             "next_human_action": _text(
                 card.get("next_human_action"),
                 "Collect exact failure evidence before changing code.",
             ),
         },
-        "authority": {field: bool(card.get(field, False)) for field in AUTHORITY_FIELDS},
+        "authority": {
+            field: bool(card.get(field, False)) for field in AUTHORITY_FIELDS
+        },
     }
 
 
@@ -129,11 +137,15 @@ def _family_score(value: object) -> tuple[int, int, int]:
     return (
         1 if _text(family.get("test_node")) else 0,
         1 if _text(family.get("message")) else 0,
-        1 if code and code not in {"UNKNOWN_REVIEW_REQUIRED", "RELEASE_ARTIFACT_INVALID"} else 0,
+        1
+        if code and code not in {"UNKNOWN_REVIEW_REQUIRED", "RELEASE_ARTIFACT_INVALID"}
+        else 0,
     )
 
 
-def _richest_family(primary_failure: JsonObject, review_model: JsonObject) -> JsonObject:
+def _richest_family(
+    primary_failure: JsonObject, review_model: JsonObject
+) -> JsonObject:
     families = [
         _as_dict(item)
         for item in _as_list(
@@ -151,7 +163,9 @@ def _test_source_path(test_node: str) -> str:
 
 def _generic_observation(value: str) -> bool:
     normalized = " ".join(value.lower().split())
-    return normalized in _GENERIC_OBSERVED or normalized.startswith("assert false is true")
+    return normalized in _GENERIC_OBSERVED or normalized.startswith(
+        "assert false is true"
+    )
 
 
 def _failure_class(primary_failure: JsonObject, detail: JsonObject) -> str:
@@ -210,7 +224,8 @@ def attach_adaptive_diagnosis(review_model: JsonObject) -> None:
     proof_commands = _proof_commands(primary_failure)
 
     checks = {
-        "exact_failure_detail_present": bool(message) and not _generic_observation(observed),
+        "exact_failure_detail_present": bool(message)
+        and not _generic_observation(observed),
         "expected_observed_specific": bool(expected)
         and expected != "check completes successfully"
         and bool(observed)
@@ -225,14 +240,18 @@ def attach_adaptive_diagnosis(review_model: JsonObject) -> None:
         "authority_boundary_preserved": _authority_boundary_preserved(primary_failure),
     }
     existing_gaps = [
-        _text(item) for item in _as_list(primary_failure.get("evidence_gaps")) if _text(item)
+        _text(item)
+        for item in _as_list(primary_failure.get("evidence_gaps"))
+        if _text(item)
     ]
     evidence_gaps = list(existing_gaps)
     for check, passed in checks.items():
         if not passed and check not in evidence_gaps:
             evidence_gaps.append(check)
 
-    diagnostic_checks = [name for name in checks if name != "authority_boundary_preserved"]
+    diagnostic_checks = [
+        name for name in checks if name != "authority_boundary_preserved"
+    ]
     passed_count = sum(1 for name in diagnostic_checks if checks[name])
     if passed_count == len(diagnostic_checks):
         completeness = "complete"

--- a/src/sdetkit/pr_quality_adaptive_diagnosis.py
+++ b/src/sdetkit/pr_quality_adaptive_diagnosis.py
@@ -1,9 +1,31 @@
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from typing import Any
 
 JsonObject = dict[str, Any]
 ADAPTIVE_DIAGNOSIS_SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_card.v1"
+ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_export.v1"
+ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION = (
+    "sdetkit.adaptive_diagnosis_bundle_manifest.v1"
+)
+AUTHORITY_FIELDS = (
+    "reporting_only",
+    "automation_allowed",
+    "patch_application_allowed",
+    "security_dismissal_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+AUTHORITY_EXPECTATIONS = {
+    "reporting_only": True,
+    "automation_allowed": False,
+    "patch_application_allowed": False,
+    "security_dismissal_allowed": False,
+    "merge_authorized": False,
+    "semantic_equivalence_proven": False,
+}
 
 _FAILURE_CLASS_BY_CODE = {
     "PYTEST_ASSERTION_FAILURE": "test",
@@ -34,6 +56,71 @@ def _text(value: object, default: str = "") -> str:
         return default
     rendered = str(value).strip()
     return rendered or default
+
+
+def adaptive_diagnosis_card(model: Mapping[str, object]) -> JsonObject:
+    card = _as_dict(model.get("adaptive_diagnosis"))
+    if card:
+        return card
+    return _as_dict(_as_dict(model.get("primary_failure")).get("adaptive_diagnosis"))
+
+
+def validate_authority(card: Mapping[str, object]) -> None:
+    mismatches = [
+        f"{field} expected {expected!r}, observed {card.get(field)!r}"
+        for field, expected in AUTHORITY_EXPECTATIONS.items()
+        if card.get(field) is not expected
+    ]
+    if mismatches:
+        raise ValueError("unsafe adaptive diagnosis authority: " + "; ".join(mismatches))
+
+
+def build_export(card: Mapping[str, object]) -> JsonObject:
+    checks = {
+        _text(name): bool(value)
+        for name, value in _as_dict(card.get("checks")).items()
+        if _text(name)
+    }
+    return {
+        "schema_version": ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION,
+        "diagnosis": {
+            "status": _text(card.get("status"), "review_first"),
+            "failure_class": _text(card.get("failure_class"), "unknown"),
+            "diagnostic_completeness": _text(
+                card.get("diagnostic_completeness"), "insufficient"
+            ),
+            "confidence": _text(card.get("confidence"), "low"),
+            "review_first": bool(card.get("review_first", True)),
+        },
+        "evidence": {
+            "checks": checks,
+            "owner_files": [
+                _text(item) for item in _as_list(card.get("owner_files")) if _text(item)
+            ],
+            "proof_commands": [
+                _text(item) for item in _as_list(card.get("proof_commands")) if _text(item)
+            ],
+            "evidence_gaps": [
+                _text(item) for item in _as_list(card.get("evidence_gaps")) if _text(item)
+            ],
+            "next_human_action": _text(
+                card.get("next_human_action"),
+                "Collect exact failure evidence before changing code.",
+            ),
+        },
+        "authority": {field: bool(card.get(field, False)) for field in AUTHORITY_FIELDS},
+    }
+
+
+def export_from_model(model: Mapping[str, object]) -> JsonObject:
+    card = adaptive_diagnosis_card(model)
+    if not card:
+        raise ValueError("review model has no adaptive diagnosis card")
+    return build_export(card)
+
+
+def serialize_export(payload: Mapping[str, object]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
 
 def _family_score(value: object) -> tuple[int, int, int]:
@@ -105,13 +192,8 @@ def _proof_commands(primary_failure: JsonObject) -> list[str]:
 def _authority_boundary_preserved(primary_failure: JsonObject) -> bool:
     return bool(primary_failure.get("reporting_only", True)) and not any(
         bool(primary_failure.get(field, False))
-        for field in (
-            "automation_allowed",
-            "patch_application_allowed",
-            "security_dismissal_allowed",
-            "merge_authorized",
-            "semantic_equivalence_proven",
-        )
+        for field in AUTHORITY_FIELDS
+        if field != "reporting_only"
     )
 
 
@@ -197,12 +279,7 @@ def attach_adaptive_diagnosis(review_model: JsonObject) -> None:
         "proof_commands": proof_commands,
         "next_human_action": next_human_action,
         "review_first": review_first,
-        "reporting_only": True,
-        "automation_allowed": False,
-        "patch_application_allowed": False,
-        "security_dismissal_allowed": False,
-        "merge_authorized": False,
-        "semantic_equivalence_proven": False,
+        **AUTHORITY_EXPECTATIONS,
     }
     primary_failure["adaptive_diagnosis"] = card
     primary_failure["diagnostic_completeness"] = completeness

--- a/tests/test_pr_quality_adaptive_diagnosis_contract.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sdetkit.pr_quality_adaptive_diagnosis import (
+    ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION,
+    ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION,
+    AUTHORITY_EXPECTATIONS,
+    adaptive_diagnosis_card,
+    attach_adaptive_diagnosis,
+    build_export,
+    serialize_export,
+    validate_authority,
+)
+
+
+def _model() -> dict[str, object]:
+    return {
+        "primary_failure": {
+            "available": True,
+            "expected": "heavy_workflow_count <= 8",
+            "observed": "heavy_workflow_count = 9",
+            "message": "workflow budget regression",
+            "test_node": "tests/test_workflow_contracts.py::test_repository_workflow_contracts_pass",
+            "reproduction_command": (
+                "python -m pytest -q "
+                "tests/test_workflow_contracts.py::test_repository_workflow_contracts_pass "
+                "-o addopts="
+            ),
+            "mapping_confidence": "high",
+            "provenance_status": "confirmed",
+            "step_evidence_status": "confirmed",
+            "workflow_exact_head_verified": True,
+            "reporting_only": True,
+            "families": [{"failure_code": "PYTEST_ASSERTION_FAILURE"}],
+        }
+    }
+
+
+def test_export_uses_canonical_adaptive_diagnosis_contract() -> None:
+    model = _model()
+    attach_adaptive_diagnosis(model)
+    card = adaptive_diagnosis_card(model)
+
+    validate_authority(card)
+    payload = build_export(card)
+    serialized = serialize_export(payload)
+
+    assert payload["schema_version"] == ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION
+    assert payload["diagnosis"]["failure_class"] == "test"
+    assert payload["authority"] == AUTHORITY_EXPECTATIONS
+    assert json.loads(serialized) == payload
+    assert serialized.endswith("\n")
+    assert ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION.endswith(".v1")
+
+
+@pytest.mark.parametrize(
+    ("field", "expanded_value"),
+    [
+        ("reporting_only", False),
+        ("automation_allowed", True),
+        ("patch_application_allowed", True),
+        ("security_dismissal_allowed", True),
+        ("merge_authorized", True),
+        ("semantic_equivalence_proven", True),
+    ],
+)
+def test_authority_validation_rejects_expansion(
+    field: str,
+    expanded_value: bool,
+) -> None:
+    card = dict(AUTHORITY_EXPECTATIONS)
+    card[field] = expanded_value
+
+    with pytest.raises(ValueError, match="adaptive diagnosis authority"):
+        validate_authority(card)

--- a/tools/build_pr_quality_adaptive_diagnosis_bundle.py
+++ b/tools/build_pr_quality_adaptive_diagnosis_bundle.py
@@ -8,15 +8,16 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from sdetkit.pr_quality_adaptive_diagnosis import (
+    ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION,
+    AUTHORITY_EXPECTATIONS,
+    adaptive_diagnosis_card,
+    build_export,
+    serialize_export,
+    validate_authority,
+)
+
 JsonObject = dict[str, Any]
-AUTHORITY_EXPECTATIONS = {
-    "reporting_only": True,
-    "automation_allowed": False,
-    "patch_application_allowed": False,
-    "security_dismissal_allowed": False,
-    "merge_authorized": False,
-    "semantic_equivalence_proven": False,
-}
 ARTIFACT_NAMES = (
     "adaptive-diagnosis.html",
     "adaptive-diagnosis.md",
@@ -42,31 +43,6 @@ MARKDOWN_RENDERER = _load_sibling(
     "adaptive_diagnosis_markdown_renderer",
     "render_pr_quality_adaptive_diagnosis_markdown.py",
 )
-JSON_EXPORTER = _load_sibling(
-    "adaptive_diagnosis_json_exporter",
-    "export_pr_quality_adaptive_diagnosis_json.py",
-)
-
-
-def _as_dict(value: object) -> JsonObject:
-    return value if isinstance(value, dict) else {}
-
-
-def adaptive_diagnosis_card(model: JsonObject) -> JsonObject:
-    card = _as_dict(model.get("adaptive_diagnosis"))
-    if card:
-        return card
-    return _as_dict(_as_dict(model.get("primary_failure")).get("adaptive_diagnosis"))
-
-
-def validate_authority(card: JsonObject) -> None:
-    mismatches = [
-        f"{field} expected {expected!r}, observed {card.get(field)!r}"
-        for field, expected in AUTHORITY_EXPECTATIONS.items()
-        if card.get(field) is not expected
-    ]
-    if mismatches:
-        raise ValueError("unsafe adaptive diagnosis authority: " + "; ".join(mismatches))
 
 
 def _artifact_record(path: Path) -> JsonObject:
@@ -99,15 +75,14 @@ def build_bundle(model: JsonObject, out_dir: Path) -> JsonObject:
         encoding="utf-8",
         newline="\n",
     )
-    exported = JSON_EXPORTER.build_export(card)
     json_path.write_text(
-        JSON_EXPORTER.serialize_export(exported),
+        serialize_export(build_export(card)),
         encoding="utf-8",
         newline="\n",
     )
 
     manifest = {
-        "schema_version": "sdetkit.adaptive_diagnosis_bundle_manifest.v1",
+        "schema_version": ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION,
         "status": "passed",
         "authority_validated": True,
         "authority": dict(AUTHORITY_EXPECTATIONS),

--- a/tools/export_pr_quality_adaptive_diagnosis_json.py
+++ b/tools/export_pr_quality_adaptive_diagnosis_json.py
@@ -3,86 +3,15 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any
 
-JsonObject = dict[str, Any]
-SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_export.v1"
-AUTHORITY_FIELDS = (
-    "reporting_only",
-    "automation_allowed",
-    "patch_application_allowed",
-    "security_dismissal_allowed",
-    "merge_authorized",
-    "semantic_equivalence_proven",
+from sdetkit.pr_quality_adaptive_diagnosis import (
+    ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION,
+    build_export,
+    export_from_model,
+    serialize_export,
 )
 
-
-def _as_dict(value: object) -> JsonObject:
-    return value if isinstance(value, dict) else {}
-
-
-def _as_list(value: object) -> list[object]:
-    return value if isinstance(value, list) else []
-
-
-def _text(value: object, default: str = "") -> str:
-    if value is None:
-        return default
-    rendered = str(value).strip()
-    return rendered or default
-
-
-def adaptive_diagnosis_card(model: JsonObject) -> JsonObject:
-    card = _as_dict(model.get("adaptive_diagnosis"))
-    if card:
-        return card
-    return _as_dict(_as_dict(model.get("primary_failure")).get("adaptive_diagnosis"))
-
-
-def build_export(card: JsonObject) -> JsonObject:
-    checks = {
-        _text(name): bool(value)
-        for name, value in _as_dict(card.get("checks")).items()
-        if _text(name)
-    }
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "diagnosis": {
-            "status": _text(card.get("status"), "review_first"),
-            "failure_class": _text(card.get("failure_class"), "unknown"),
-            "diagnostic_completeness": _text(card.get("diagnostic_completeness"), "insufficient"),
-            "confidence": _text(card.get("confidence"), "low"),
-            "review_first": bool(card.get("review_first", True)),
-        },
-        "evidence": {
-            "checks": checks,
-            "owner_files": [
-                _text(item) for item in _as_list(card.get("owner_files")) if _text(item)
-            ],
-            "proof_commands": [
-                _text(item) for item in _as_list(card.get("proof_commands")) if _text(item)
-            ],
-            "evidence_gaps": [
-                _text(item) for item in _as_list(card.get("evidence_gaps")) if _text(item)
-            ],
-            "next_human_action": _text(
-                card.get("next_human_action"),
-                "Collect exact failure evidence before changing code.",
-            ),
-        },
-        "authority": {field: bool(card.get(field, False)) for field in AUTHORITY_FIELDS},
-    }
-
-
-def export_from_model(model: JsonObject) -> JsonObject:
-    card = adaptive_diagnosis_card(model)
-    if not card:
-        raise ValueError("review model has no adaptive diagnosis card")
-    return build_export(card)
-
-
-def serialize_export(payload: JsonObject) -> str:
-    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+SCHEMA_VERSION = ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tools/export_pr_quality_adaptive_diagnosis_json.py
+++ b/tools/export_pr_quality_adaptive_diagnosis_json.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from sdetkit.pr_quality_adaptive_diagnosis import (
     ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION,
-    build_export,
     export_from_model,
     serialize_export,
 )


### PR DESCRIPTION
## Summary
- move Adaptive Diagnosis export schemas, authority expectations, extraction, validation, and deterministic JSON serialization into the package module
- make the existing JSON exporter and portable bundle builder consume the canonical package contract
- add focused tests for schema parity, deterministic serialization, and fail-closed authority validation

## Why
Adaptive Diagnosis is now rendered in live PR Quality views and exported as a portable evidence bundle, but schema and authority rules were duplicated between package code and tools. A single package-owned contract prevents drift before the artifacts are registered more broadly or consumed by verifier/reporting integrations.

## Verification
Focused:
- `python -m pytest -q tests/test_pr_quality_adaptive_diagnosis.py tests/test_pr_quality_adaptive_diagnosis_contract.py tests/test_pr_quality_adaptive_diagnosis_bundle.py -o addopts=`

Quality:
- `python -m ruff check src/sdetkit/pr_quality_adaptive_diagnosis.py tools/export_pr_quality_adaptive_diagnosis_json.py tools/build_pr_quality_adaptive_diagnosis_bundle.py tests/test_pr_quality_adaptive_diagnosis_contract.py`
- `python -m ruff format --check src/sdetkit/pr_quality_adaptive_diagnosis.py tools/export_pr_quality_adaptive_diagnosis_json.py tools/build_pr_quality_adaptive_diagnosis_bundle.py tests/test_pr_quality_adaptive_diagnosis_contract.py`
- `python -m pre_commit run -a`

The connector runtime cannot execute the repository environment, so exact-head CI is the source of truth for these commands.

## Risk
- Low: internal contract consolidation with compatibility aliases preserved in the existing tool
- no CLI arguments, artifact filenames, JSON shape, workflow, dependency, patching, or merge behavior changes
- rollback: revert this PR

## Authority
- `reporting_only=true`
- `automation_allowed=false`
- `patch_application_allowed=false`
- `security_dismissal_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`