### PR TITLE
feat: validate proof artifact identity claims

### DIFF
--- a/src/sdetkit/protected_proof_chain.py
+++ b/src/sdetkit/protected_proof_chain.py
@@ -54,6 +54,17 @@ MARKDOWN_AUTHORITY_RE = re.compile(
     rf"(?im)^\s*(?:[-*]\s*)?(?P<key>{'|'.join(sorted(AUTHORITY_KEYS))})"
     r"\s*[:=]\s*(?P<value>[^\n]+)$"
 )
+REPOSITORY_IDENTITY_KEYS = (
+    "repository_full_name",
+    "repo_full_name",
+    "repository",
+)
+COMMIT_IDENTITY_KEYS = (
+    "current_head_sha",
+    "source_head_sha",
+    "head_sha",
+    "commit_sha",
+)
 
 DECISION_BOUNDARY: dict[str, bool] = {
     "automation_allowed": False,
@@ -145,7 +156,46 @@ def _identity(repository: str, commit_sha: str) -> tuple[str, str]:
     return repository_text, commit_text.lower()
 
 
-def _entry(stage: str, path: Path) -> tuple[dict[str, object], list[str]]:
+def _identity_claim(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _commit_claim_matches(claim: str, expected: str) -> bool:
+    normalized = claim.lower()
+    if not COMMIT_RE.fullmatch(normalized):
+        return False
+    return (
+        normalized == expected
+        or normalized.startswith(expected)
+        or expected.startswith(normalized)
+    )
+
+
+def _embedded_identity_violations(
+    payload: Mapping[str, object],
+    *,
+    expected_repository: str,
+    expected_commit_sha: str,
+) -> list[str]:
+    violations: list[str] = []
+    for key in REPOSITORY_IDENTITY_KEYS:
+        claim = _identity_claim(payload.get(key))
+        if claim and claim != expected_repository:
+            violations.append(f"{key}={claim}")
+    for key in COMMIT_IDENTITY_KEYS:
+        claim = _identity_claim(payload.get(key))
+        if claim and not _commit_claim_matches(claim, expected_commit_sha):
+            violations.append(f"{key}={claim}")
+    return violations
+
+
+def _entry(
+    stage: str,
+    path: Path,
+    *,
+    expected_repository: str,
+    expected_commit_sha: str,
+) -> tuple[dict[str, object], list[str], list[str]]:
     data = path.read_bytes()
     entry: dict[str, object] = {
         "stage": stage,
@@ -154,17 +204,29 @@ def _entry(stage: str, path: Path) -> tuple[dict[str, object], list[str]]:
         "size_bytes": len(data),
         "media_type": "application/json" if stage in JSON_STAGES else "text/markdown",
     }
+    identity_violations: list[str] = []
     if stage in JSON_STAGES:
         payload = json.loads(data)
         if not isinstance(payload, dict):
-            raise ValueError(f"expected JSON object for protected proof artifact: {path}")
-        entry["artifact_schema_version"] = str(payload.get("schema_version") or "unknown")
-        violations = _json_violations(payload)
+            raise ValueError(
+                f"expected JSON object for protected proof artifact: {path}"
+            )
+        entry["artifact_schema_version"] = str(
+            payload.get("schema_version") or "unknown"
+        )
+        authority_violations = _json_violations(payload)
+        identity_violations = _embedded_identity_violations(
+            payload,
+            expected_repository=expected_repository,
+            expected_commit_sha=expected_commit_sha,
+        )
     else:
         entry["artifact_schema_version"] = "markdown"
-        violations = _markdown_violations(data.decode("utf-8", errors="replace"))
-    entry["authority_violation_count"] = len(violations)
-    return entry, violations
+        authority_violations = _markdown_violations(
+            data.decode("utf-8", errors="replace")
+        )
+    entry["authority_violation_count"] = len(authority_violations)
+    return entry, authority_violations, identity_violations
 
 
 def _material(
@@ -193,14 +255,27 @@ def build_protected_proof_chain(
     repository_text, commit_text = _identity(repository, commit_sha)
     normalized = _normalize_artifacts(artifacts)
     entries: list[dict[str, object]] = []
-    violations: list[str] = []
+    authority_violations: list[str] = []
+    identity_violations: list[str] = []
     for stage in STAGE_ORDER:
-        entry, stage_violations = _entry(stage, normalized[stage])
+        entry, stage_authority, stage_identity = _entry(
+            stage,
+            normalized[stage],
+            expected_repository=repository_text,
+            expected_commit_sha=commit_text,
+        )
         entries.append(entry)
-        violations.extend(f"{stage}:{item}" for item in stage_violations)
-    if violations:
+        authority_violations.extend(f"{stage}:{item}" for item in stage_authority)
+        identity_violations.extend(f"{stage}:{item}" for item in stage_identity)
+    if authority_violations:
         raise ValueError(
-            "protected proof artifacts attempted to expand authority: " + ", ".join(violations)
+            "protected proof artifacts attempted to expand authority: "
+            + ", ".join(authority_violations)
+        )
+    if identity_violations:
+        raise ValueError(
+            "protected proof artifact identity mismatch: "
+            + ", ".join(identity_violations)
         )
     material = _material(repository_text, commit_text, entries)
     return {**material, "chain_id": _sha256(_canonical_json(material))}

--- a/tests/test_protected_proof_chain_identity.py
+++ b/tests/test_protected_proof_chain_identity.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.protected_proof_chain import STAGE_ORDER, build_protected_proof_chain
+
+REPOSITORY = "owner/repo"
+COMMIT_SHA = "a" * 40
+
+
+def _artifacts(root: Path) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for stage in STAGE_ORDER:
+        path = root / (f"{stage}.md" if stage == "pr_report" else f"{stage}.json")
+        if stage == "pr_report":
+            path.write_text("# PR report\n\nReview required.\n", encoding="utf-8")
+        else:
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": f"test.{stage}.v1",
+                        "automation_allowed": False,
+                        "patch_application_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_proven": False,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        result[stage] = path
+    return result
+
+
+def _write_claim(path: Path, **claims: object) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload.update(claims)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _build(artifacts: dict[str, Path]) -> dict[str, object]:
+    return build_protected_proof_chain(
+        repository=REPOSITORY,
+        commit_sha=COMMIT_SHA,
+        artifacts=artifacts,
+    )
+
+
+def test_proof_chain_accepts_matching_embedded_identity(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    _write_claim(
+        artifacts["proof_result"],
+        repository_full_name=REPOSITORY,
+        current_head_sha=COMMIT_SHA,
+    )
+    _write_claim(
+        artifacts["verifier_result"],
+        repo_full_name=REPOSITORY,
+        head_sha=COMMIT_SHA[:12],
+    )
+
+    manifest = _build(artifacts)
+
+    assert manifest["repository"] == REPOSITORY
+    assert manifest["commit_sha"] == COMMIT_SHA
+
+
+@pytest.mark.parametrize(
+    "claim",
+    [
+        {"repository_full_name": "different/repository"},
+        {"current_head_sha": "b" * 40},
+        {"head_sha": "invalid-sha-value"},
+    ],
+)
+def test_proof_chain_rejects_conflicting_embedded_identity(
+    tmp_path: Path,
+    claim: dict[str, object],
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    _write_claim(artifacts["proof_result"], **claim)
+
+    with pytest.raises(ValueError, match="identity mismatch"):
+        _build(artifacts)
+
+
+def test_proof_chain_ignores_nested_historical_identity(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    _write_claim(
+        artifacts["trajectory"],
+        historical_record={
+            "repository_full_name": "different/repository",
+            "head_sha": "b" * 40,
+        },
+    )
+
+    assert _build(artifacts)["status"] == "bound_review_first"


### PR DESCRIPTION
## Summary
- validate explicit top-level repository and head-SHA claims inside protected proof JSON artifacts
- accept exact or unambiguous abbreviated SHA matches
- reject malformed or conflicting declared identities before a proof chain is built
- keep nested historical repository/head records out of current-head identity enforcement

## Why
The protected proof chain already binds artifact bytes to an externally supplied repository and commit. It did not reject an artifact that explicitly declared a different repository or head, allowing stale or cross-head evidence to be rebound into a new chain. This closes that provenance gap without requiring identity fields in legacy artifacts.

## Verification
Focused local proof:
- `PYTHONPATH=<wheel-source> python -m pytest -q tests/test_protected_proof_chain_identity.py -o addopts=` → `5 passed`
- `python -m ruff check src/sdetkit/protected_proof_chain.py tests/test_protected_proof_chain_identity.py` → passed
- `python -m ruff format --check src/sdetkit/protected_proof_chain.py tests/test_protected_proof_chain_identity.py` → passed

Regression proof for exact-head CI:
- `python -m pytest -q tests/test_protected_proof_chain.py tests/test_protected_proof_chain_identity.py -o addopts=`
- `python -m pre_commit run -a`

## Compatibility
- artifacts without repository/head declarations remain valid
- validation applies only to top-level current-artifact claims
- nested trajectory/history identity is preserved as historical context
- output schema and manifest fields are unchanged

## Risk
- Low to medium: stricter fail-closed validation for artifacts that declare conflicting current identity
- no workflow, dependency, patch application, security dismissal, or merge behavior changes
- rollback: revert this PR

## Authority
- `automation_allowed=false`
- `patch_application_allowed=false`
- `security_dismissal_allowed=false`
- `merge_authorized=false`
- `semantic_equivalence_proven=false`