### PR TITLE
feat: validate evidence revision binding

### DIFF
--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "sdetkit.quality_truth_baseline.v1",
-  "generated_on": "2026-07-02",
+  "generated_on": "2026-07-03",
   "status": "staged_migration_visible",
   "coverage": {
     "critical_spine": {
@@ -35,9 +35,9 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 497,
-    "typing_debt_module_count": 478,
-    "typing_debt_inventory_sha256": "17724720314e09ed03953dea8a6982404a1402a6d4c94bac14a77140617f7d14",
+    "source_module_count": 498,
+    "typing_debt_module_count": 479,
+    "typing_debt_inventory_sha256": "fb431b14b30b32cc7d4c06dc83f2c904e578916d37e4f5a7504e74d8c1fe168b",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "explicitly_type_checked_modules": [
       "sdetkit._pr_quality_required_terminal_checks",

--- a/docs/quality-truth-baseline.md
+++ b/docs/quality-truth-baseline.md
@@ -32,14 +32,14 @@ The repository must not describe the whole package as 95% covered. The 95% state
 
 ## Typing truth
 
-The repository still has a broad `sdetkit.*` mypy suppression. Twelve diagnostic, safety, trajectory, and adoption modules explicitly opt back into error checking.
+The repository still has a broad `sdetkit.*` mypy suppression. Nineteen diagnostic, safety, trajectory, adoption, and proof modules explicitly opt back into error checking.
 
-Fresh inventory evidence records:
+The reviewed inventory after adding the evidence-binding module records:
 
 ```text
-source_module_count=486
-explicitly_type_checked_module_count=12
-typing_debt_module_count=474
+source_module_count=498
+explicitly_type_checked_module_count=19
+typing_debt_module_count=479
 ```
 
 The complete debt module list is emitted to:
@@ -64,7 +64,7 @@ The package metadata declares Python 3.10, 3.11, and 3.12. Canonical fast and sm
 
 ## Required next steps
 
-1. Reduce the hashed 474-module typing-debt inventory through behavior-focused ratchets.
+1. Reduce the hashed 479-module typing-debt inventory through behavior-focused ratchets.
 2. Keep whole-package coverage at or above the reviewed 87.89% baseline.
 3. Keep the critical reliability spine at or above 95%.
 4. Add Python 3.10 to the exact-wheel qualification route.

--- a/src/sdetkit/evidence_binding.py
+++ b/src/sdetkit/evidence_binding.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from .protected_proof_chain import COMMIT_RE, JSON_STAGES, STAGE_ORDER, build_protected_proof_chain
+
+SCHEMA_VERSION = "sdetkit.evidence_binding.v1"
+REPOSITORY_KEYS = ("repository_full_name", "repo_full_name", "repository")
+REVISION_KEYS = ("current_head_sha", "source_head_sha", "head_sha", "commit_sha")
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _revision_matches(claim: str, expected: str) -> bool:
+    normalized = claim.lower()
+    if not COMMIT_RE.fullmatch(normalized):
+        return False
+    return (
+        normalized == expected or normalized.startswith(expected) or expected.startswith(normalized)
+    )
+
+
+def _conflicts(
+    payload: Mapping[str, object],
+    *,
+    repository: str,
+    revision: str,
+) -> list[str]:
+    conflicts: list[str] = []
+    for key in REPOSITORY_KEYS:
+        claim = _text(payload.get(key))
+        if claim and claim != repository:
+            conflicts.append(f"{key}={claim}")
+    for key in REVISION_KEYS:
+        claim = _text(payload.get(key))
+        if claim and not _revision_matches(claim, revision):
+            conflicts.append(f"{key}={claim}")
+    return conflicts
+
+
+def validate_evidence_binding(
+    *,
+    repository: str,
+    revision: str,
+    artifacts: Mapping[str, str | Path],
+) -> dict[str, object]:
+    repository_text = repository.strip()
+    revision_text = revision.strip().lower()
+    conflicts: list[str] = []
+    checked_stages: list[str] = []
+    claim_count = 0
+
+    for stage in STAGE_ORDER:
+        if stage not in JSON_STAGES:
+            continue
+        path = Path(artifacts[stage])
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object: {path}")
+        checked_stages.append(stage)
+        claim_count += sum(
+            1 for key in (*REPOSITORY_KEYS, *REVISION_KEYS) if _text(payload.get(key))
+        )
+        conflicts.extend(
+            f"{stage}:{item}"
+            for item in _conflicts(
+                payload,
+                repository=repository_text,
+                revision=revision_text,
+            )
+        )
+
+    if conflicts:
+        raise ValueError("evidence binding conflict: " + ", ".join(conflicts))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "passed",
+        "repository": repository_text,
+        "revision": revision_text,
+        "checked_stages": checked_stages,
+        "claim_count": claim_count,
+    }
+
+
+def build_bound_proof_chain(
+    *,
+    repository: str,
+    revision: str,
+    artifacts: Mapping[str, str | Path],
+) -> dict[str, object]:
+    validate_evidence_binding(
+        repository=repository,
+        revision=revision,
+        artifacts=artifacts,
+    )
+    return build_protected_proof_chain(
+        repository=repository,
+        commit_sha=revision,
+        artifacts=artifacts,
+    )

--- a/src/sdetkit/protected_proof_chain.py
+++ b/src/sdetkit/protected_proof_chain.py
@@ -54,17 +54,6 @@ MARKDOWN_AUTHORITY_RE = re.compile(
     rf"(?im)^\s*(?:[-*]\s*)?(?P<key>{'|'.join(sorted(AUTHORITY_KEYS))})"
     r"\s*[:=]\s*(?P<value>[^\n]+)$"
 )
-REPOSITORY_IDENTITY_KEYS = (
-    "repository_full_name",
-    "repo_full_name",
-    "repository",
-)
-COMMIT_IDENTITY_KEYS = (
-    "current_head_sha",
-    "source_head_sha",
-    "head_sha",
-    "commit_sha",
-)
 
 DECISION_BOUNDARY: dict[str, bool] = {
     "automation_allowed": False,
@@ -156,46 +145,7 @@ def _identity(repository: str, commit_sha: str) -> tuple[str, str]:
     return repository_text, commit_text.lower()
 
 
-def _identity_claim(value: object) -> str:
-    return value.strip() if isinstance(value, str) else ""
-
-
-def _commit_claim_matches(claim: str, expected: str) -> bool:
-    normalized = claim.lower()
-    if not COMMIT_RE.fullmatch(normalized):
-        return False
-    return (
-        normalized == expected
-        or normalized.startswith(expected)
-        or expected.startswith(normalized)
-    )
-
-
-def _embedded_identity_violations(
-    payload: Mapping[str, object],
-    *,
-    expected_repository: str,
-    expected_commit_sha: str,
-) -> list[str]:
-    violations: list[str] = []
-    for key in REPOSITORY_IDENTITY_KEYS:
-        claim = _identity_claim(payload.get(key))
-        if claim and claim != expected_repository:
-            violations.append(f"{key}={claim}")
-    for key in COMMIT_IDENTITY_KEYS:
-        claim = _identity_claim(payload.get(key))
-        if claim and not _commit_claim_matches(claim, expected_commit_sha):
-            violations.append(f"{key}={claim}")
-    return violations
-
-
-def _entry(
-    stage: str,
-    path: Path,
-    *,
-    expected_repository: str,
-    expected_commit_sha: str,
-) -> tuple[dict[str, object], list[str], list[str]]:
+def _entry(stage: str, path: Path) -> tuple[dict[str, object], list[str]]:
     data = path.read_bytes()
     entry: dict[str, object] = {
         "stage": stage,
@@ -204,29 +154,17 @@ def _entry(
         "size_bytes": len(data),
         "media_type": "application/json" if stage in JSON_STAGES else "text/markdown",
     }
-    identity_violations: list[str] = []
     if stage in JSON_STAGES:
         payload = json.loads(data)
         if not isinstance(payload, dict):
-            raise ValueError(
-                f"expected JSON object for protected proof artifact: {path}"
-            )
-        entry["artifact_schema_version"] = str(
-            payload.get("schema_version") or "unknown"
-        )
-        authority_violations = _json_violations(payload)
-        identity_violations = _embedded_identity_violations(
-            payload,
-            expected_repository=expected_repository,
-            expected_commit_sha=expected_commit_sha,
-        )
+            raise ValueError(f"expected JSON object for protected proof artifact: {path}")
+        entry["artifact_schema_version"] = str(payload.get("schema_version") or "unknown")
+        violations = _json_violations(payload)
     else:
         entry["artifact_schema_version"] = "markdown"
-        authority_violations = _markdown_violations(
-            data.decode("utf-8", errors="replace")
-        )
-    entry["authority_violation_count"] = len(authority_violations)
-    return entry, authority_violations, identity_violations
+        violations = _markdown_violations(data.decode("utf-8", errors="replace"))
+    entry["authority_violation_count"] = len(violations)
+    return entry, violations
 
 
 def _material(
@@ -255,27 +193,14 @@ def build_protected_proof_chain(
     repository_text, commit_text = _identity(repository, commit_sha)
     normalized = _normalize_artifacts(artifacts)
     entries: list[dict[str, object]] = []
-    authority_violations: list[str] = []
-    identity_violations: list[str] = []
+    violations: list[str] = []
     for stage in STAGE_ORDER:
-        entry, stage_authority, stage_identity = _entry(
-            stage,
-            normalized[stage],
-            expected_repository=repository_text,
-            expected_commit_sha=commit_text,
-        )
+        entry, stage_violations = _entry(stage, normalized[stage])
         entries.append(entry)
-        authority_violations.extend(f"{stage}:{item}" for item in stage_authority)
-        identity_violations.extend(f"{stage}:{item}" for item in stage_identity)
-    if authority_violations:
+        violations.extend(f"{stage}:{item}" for item in stage_violations)
+    if violations:
         raise ValueError(
-            "protected proof artifacts attempted to expand authority: "
-            + ", ".join(authority_violations)
-        )
-    if identity_violations:
-        raise ValueError(
-            "protected proof artifact identity mismatch: "
-            + ", ".join(identity_violations)
+            "protected proof artifacts attempted to expand authority: " + ", ".join(violations)
         )
     material = _material(repository_text, commit_text, entries)
     return {**material, "chain_id": _sha256(_canonical_json(material))}

--- a/src/sdetkit/protected_proof_chain.py
+++ b/src/sdetkit/protected_proof_chain.py
@@ -54,6 +54,17 @@ MARKDOWN_AUTHORITY_RE = re.compile(
     rf"(?im)^\s*(?:[-*]\s*)?(?P<key>{'|'.join(sorted(AUTHORITY_KEYS))})"
     r"\s*[:=]\s*(?P<value>[^\n]+)$"
 )
+REPOSITORY_IDENTITY_KEYS = (
+    "repository_full_name",
+    "repo_full_name",
+    "repository",
+)
+COMMIT_IDENTITY_KEYS = (
+    "current_head_sha",
+    "source_head_sha",
+    "head_sha",
+    "commit_sha",
+)
 
 DECISION_BOUNDARY: dict[str, bool] = {
     "automation_allowed": False,
@@ -145,7 +156,46 @@ def _identity(repository: str, commit_sha: str) -> tuple[str, str]:
     return repository_text, commit_text.lower()
 
 
-def _entry(stage: str, path: Path) -> tuple[dict[str, object], list[str]]:
+def _identity_claim(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _commit_claim_matches(claim: str, expected: str) -> bool:
+    normalized = claim.lower()
+    if not COMMIT_RE.fullmatch(normalized):
+        return False
+    return (
+        normalized == expected
+        or normalized.startswith(expected)
+        or expected.startswith(normalized)
+    )
+
+
+def _embedded_identity_violations(
+    payload: Mapping[str, object],
+    *,
+    expected_repository: str,
+    expected_commit_sha: str,
+) -> list[str]:
+    violations: list[str] = []
+    for key in REPOSITORY_IDENTITY_KEYS:
+        claim = _identity_claim(payload.get(key))
+        if claim and claim != expected_repository:
+            violations.append(f"{key}={claim}")
+    for key in COMMIT_IDENTITY_KEYS:
+        claim = _identity_claim(payload.get(key))
+        if claim and not _commit_claim_matches(claim, expected_commit_sha):
+            violations.append(f"{key}={claim}")
+    return violations
+
+
+def _entry(
+    stage: str,
+    path: Path,
+    *,
+    expected_repository: str,
+    expected_commit_sha: str,
+) -> tuple[dict[str, object], list[str], list[str]]:
     data = path.read_bytes()
     entry: dict[str, object] = {
         "stage": stage,
@@ -154,17 +204,29 @@ def _entry(stage: str, path: Path) -> tuple[dict[str, object], list[str]]:
         "size_bytes": len(data),
         "media_type": "application/json" if stage in JSON_STAGES else "text/markdown",
     }
+    identity_violations: list[str] = []
     if stage in JSON_STAGES:
         payload = json.loads(data)
         if not isinstance(payload, dict):
-            raise ValueError(f"expected JSON object for protected proof artifact: {path}")
-        entry["artifact_schema_version"] = str(payload.get("schema_version") or "unknown")
-        violations = _json_violations(payload)
+            raise ValueError(
+                f"expected JSON object for protected proof artifact: {path}"
+            )
+        entry["artifact_schema_version"] = str(
+            payload.get("schema_version") or "unknown"
+        )
+        authority_violations = _json_violations(payload)
+        identity_violations = _embedded_identity_violations(
+            payload,
+            expected_repository=expected_repository,
+            expected_commit_sha=expected_commit_sha,
+        )
     else:
         entry["artifact_schema_version"] = "markdown"
-        violations = _markdown_violations(data.decode("utf-8", errors="replace"))
-    entry["authority_violation_count"] = len(violations)
-    return entry, violations
+        authority_violations = _markdown_violations(
+            data.decode("utf-8", errors="replace")
+        )
+    entry["authority_violation_count"] = len(authority_violations)
+    return entry, authority_violations, identity_violations
 
 
 def _material(
@@ -193,14 +255,27 @@ def build_protected_proof_chain(
     repository_text, commit_text = _identity(repository, commit_sha)
     normalized = _normalize_artifacts(artifacts)
     entries: list[dict[str, object]] = []
-    violations: list[str] = []
+    authority_violations: list[str] = []
+    identity_violations: list[str] = []
     for stage in STAGE_ORDER:
-        entry, stage_violations = _entry(stage, normalized[stage])
+        entry, stage_authority, stage_identity = _entry(
+            stage,
+            normalized[stage],
+            expected_repository=repository_text,
+            expected_commit_sha=commit_text,
+        )
         entries.append(entry)
-        violations.extend(f"{stage}:{item}" for item in stage_violations)
-    if violations:
+        authority_violations.extend(f"{stage}:{item}" for item in stage_authority)
+        identity_violations.extend(f"{stage}:{item}" for item in stage_identity)
+    if authority_violations:
         raise ValueError(
-            "protected proof artifacts attempted to expand authority: " + ", ".join(violations)
+            "protected proof artifacts attempted to expand authority: "
+            + ", ".join(authority_violations)
+        )
+    if identity_violations:
+        raise ValueError(
+            "protected proof artifact identity mismatch: "
+            + ", ".join(identity_violations)
         )
     material = _material(repository_text, commit_text, entries)
     return {**material, "chain_id": _sha256(_canonical_json(material))}

--- a/tests/test_protected_proof_chain_identity.py
+++ b/tests/test_protected_proof_chain_identity.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.protected_proof_chain import STAGE_ORDER, build_protected_proof_chain
+
+REPOSITORY = "owner/repo"
+COMMIT_SHA = "a" * 40
+
+
+def _artifacts(root: Path) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for stage in STAGE_ORDER:
+        path = root / (f"{stage}.md" if stage == "pr_report" else f"{stage}.json")
+        if stage == "pr_report":
+            path.write_text("# PR report\n\nReview required.\n", encoding="utf-8")
+        else:
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": f"test.{stage}.v1",
+                        "automation_allowed": False,
+                        "patch_application_allowed": False,
+                        "merge_authorized": False,
+                        "semantic_equivalence_proven": False,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        result[stage] = path
+    return result
+
+
+def _write_claim(path: Path, **claims: object) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload.update(claims)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _build(artifacts: dict[str, Path]) -> dict[str, object]:
+    return build_protected_proof_chain(
+        repository=REPOSITORY,
+        commit_sha=COMMIT_SHA,
+        artifacts=artifacts,
+    )
+
+
+def test_proof_chain_accepts_matching_embedded_identity(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    _write_claim(
+        artifacts["proof_result"],
+        repository_full_name=REPOSITORY,
+        current_head_sha=COMMIT_SHA,
+    )
+    _write_claim(
+        artifacts["verifier_result"],
+        repo_full_name=REPOSITORY,
+        head_sha=COMMIT_SHA[:12],
+    )
+
+    manifest = _build(artifacts)
+
+    assert manifest["repository"] == REPOSITORY
+    assert manifest["commit_sha"] == COMMIT_SHA
+
+
+@pytest.mark.parametrize(
+    "claim",
+    [
+        {"repository_full_name": "different/repository"},
+        {"current_head_sha": "b" * 40},
+        {"head_sha": "invalid-sha-value"},
+    ],
+)
+def test_proof_chain_rejects_conflicting_embedded_identity(
+    tmp_path: Path,
+    claim: dict[str, object],
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    _write_claim(artifacts["proof_result"], **claim)
+
+    with pytest.raises(ValueError, match="identity mismatch"):
+        _build(artifacts)
+
+
+def test_proof_chain_ignores_nested_historical_identity(tmp_path: Path) -> None:
+    artifacts = _artifacts(tmp_path)
+    _write_claim(
+        artifacts["trajectory"],
+        historical_record={
+            "repository_full_name": "different/repository",
+            "head_sha": "b" * 40,
+        },
+    )
+
+    assert _build(artifacts)["status"] == "bound_review_first"

--- a/tests/test_protected_proof_chain_identity.py
+++ b/tests/test_protected_proof_chain_identity.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from sdetkit.protected_proof_chain import STAGE_ORDER, build_protected_proof_chain
+from sdetkit.evidence_binding import build_bound_proof_chain, validate_evidence_binding
+from sdetkit.protected_proof_chain import STAGE_ORDER
 
 REPOSITORY = "owner/repo"
-COMMIT_SHA = "a" * 40
+REVISION = "a" * 40
 
 
 def _artifacts(root: Path) -> dict[str, Path]:
@@ -41,31 +42,34 @@ def _write_claim(path: Path, **claims: object) -> None:
     path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
 
-def _build(artifacts: dict[str, Path]) -> dict[str, object]:
-    return build_protected_proof_chain(
-        repository=REPOSITORY,
-        commit_sha=COMMIT_SHA,
-        artifacts=artifacts,
-    )
-
-
-def test_proof_chain_accepts_matching_embedded_identity(tmp_path: Path) -> None:
+def test_binding_accepts_matching_claims(tmp_path: Path) -> None:
     artifacts = _artifacts(tmp_path)
     _write_claim(
         artifacts["proof_result"],
         repository_full_name=REPOSITORY,
-        current_head_sha=COMMIT_SHA,
+        current_head_sha=REVISION,
     )
     _write_claim(
         artifacts["verifier_result"],
         repo_full_name=REPOSITORY,
-        head_sha=COMMIT_SHA[:12],
+        head_sha=REVISION[:12],
     )
 
-    manifest = _build(artifacts)
+    validation = validate_evidence_binding(
+        repository=REPOSITORY,
+        revision=REVISION,
+        artifacts=artifacts,
+    )
+    manifest = build_bound_proof_chain(
+        repository=REPOSITORY,
+        revision=REVISION,
+        artifacts=artifacts,
+    )
 
+    assert validation["status"] == "passed"
+    assert validation["claim_count"] == 4
     assert manifest["repository"] == REPOSITORY
-    assert manifest["commit_sha"] == COMMIT_SHA
+    assert manifest["commit_sha"] == REVISION
 
 
 @pytest.mark.parametrize(
@@ -76,18 +80,22 @@ def test_proof_chain_accepts_matching_embedded_identity(tmp_path: Path) -> None:
         {"head_sha": "invalid-sha-value"},
     ],
 )
-def test_proof_chain_rejects_conflicting_embedded_identity(
+def test_binding_rejects_conflicting_claims(
     tmp_path: Path,
     claim: dict[str, object],
 ) -> None:
     artifacts = _artifacts(tmp_path)
     _write_claim(artifacts["proof_result"], **claim)
 
-    with pytest.raises(ValueError, match="identity mismatch"):
-        _build(artifacts)
+    with pytest.raises(ValueError, match="binding conflict"):
+        build_bound_proof_chain(
+            repository=REPOSITORY,
+            revision=REVISION,
+            artifacts=artifacts,
+        )
 
 
-def test_proof_chain_ignores_nested_historical_identity(tmp_path: Path) -> None:
+def test_binding_ignores_nested_historical_claims(tmp_path: Path) -> None:
     artifacts = _artifacts(tmp_path)
     _write_claim(
         artifacts["trajectory"],
@@ -97,4 +105,11 @@ def test_proof_chain_ignores_nested_historical_identity(tmp_path: Path) -> None:
         },
     )
 
-    assert _build(artifacts)["status"] == "bound_review_first"
+    validation = validate_evidence_binding(
+        repository=REPOSITORY,
+        revision=REVISION,
+        artifacts=artifacts,
+    )
+
+    assert validation["status"] == "passed"
+    assert validation["claim_count"] == 0

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,16 +24,17 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 497
-    assert payload["observed"]["typing_debt_module_count"] == 478
+    assert payload["observed"]["source_module_count"] == 498
+    assert payload["observed"]["typing_debt_module_count"] == 479
     checked = payload["observed"]["explicitly_type_checked_modules"]
     assert "sdetkit.failure_vector_adapters" in checked
     assert "sdetkit.protected_proof_chain" in checked
     assert "sdetkit.pr_quality_required_terminal" in checked
     inventory = payload["typing_debt_inventory"]
-    assert inventory["module_count"] == 478
-    assert len(inventory["modules"]) == 478
+    assert inventory["module_count"] == 479
+    assert len(inventory["modules"]) == 479
     assert "sdetkit.pr_quality_adaptive_diagnosis" in inventory["modules"]
+    assert "sdetkit.evidence_binding" in inventory["modules"]
 
 
 def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Path) -> None:
@@ -51,7 +52,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 497,
+            "actual": 498,
         }
     ]
 


### PR DESCRIPTION
## Summary
- add a package-owned validator for repository and revision declarations in evidence files
- accept exact or unambiguous abbreviated revision matches
- reject conflicting top-level current declarations
- preserve nested historical records and the existing chain output

## Verification
- focused unit tests cover matching, conflicting, malformed, and historical declarations
- Ruff check and repository-config formatting pass locally
- exact-head CI will run the full regression suite

## Compatibility
This is additive. Existing chain functions, schemas, workflows, and artifacts are unchanged. Evidence without declarations remains valid.