### PR TITLE
feat: verify evidence bundle integrity

### DIFF
--- a/tests/test_pr_quality_adaptive_diagnosis_bundle_verifier.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_bundle_verifier.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+from sdetkit.pr_quality_adaptive_diagnosis import (
+    ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION,
+    AUTHORITY_EXPECTATIONS,
+    attach_adaptive_diagnosis,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_tool(name: str) -> ModuleType:
+    path = ROOT / "tools" / name
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+BUILDER = _load_tool("build_pr_quality_adaptive_diagnosis_bundle.py")
+VERIFIER = _load_tool("verify_pr_quality_adaptive_diagnosis_bundle.py")
+
+
+def _model() -> dict[str, object]:
+    model: dict[str, object] = {
+        "primary_failure": {
+            "available": True,
+            "expected": "heavy_workflow_count <= 8",
+            "observed": "heavy_workflow_count = 9",
+            "message": "workflow budget regression",
+            "test_node": "tests/test_workflow_contracts.py::test_repository_workflow_contracts_pass",
+            "reproduction_command": (
+                "python -m pytest -q "
+                "tests/test_workflow_contracts.py::test_repository_workflow_contracts_pass "
+                "-o addopts="
+            ),
+            "mapping_confidence": "high",
+            "provenance_status": "confirmed",
+            "step_evidence_status": "confirmed",
+            "workflow_exact_head_verified": True,
+            "reporting_only": True,
+            "families": [{"failure_code": "PYTEST_ASSERTION_FAILURE"}],
+        }
+    }
+    attach_adaptive_diagnosis(model)
+    return model
+
+
+def _bundle(tmp_path: Path) -> Path:
+    bundle_dir = tmp_path / "bundle"
+    BUILDER.build_bundle(_model(), bundle_dir)
+    return bundle_dir
+
+
+def test_verifier_accepts_builder_output(tmp_path: Path) -> None:
+    bundle_dir = _bundle(tmp_path)
+
+    report = VERIFIER.verify_bundle(bundle_dir)
+
+    assert report["ok"] is True
+    assert report["mismatch_count"] == 0
+    assert report["artifacts_checked"] == list(VERIFIER.EXPECTED_ARTIFACTS)
+    assert report["decision_boundary"] == VERIFIER.DECISION_BOUNDARY
+
+
+def test_verifier_detects_tampered_artifact(tmp_path: Path) -> None:
+    bundle_dir = _bundle(tmp_path)
+    path = bundle_dir / "adaptive-diagnosis.md"
+    path.write_text(path.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8")
+
+    report = VERIFIER.verify_bundle(bundle_dir)
+
+    assert report["ok"] is False
+    assert "artifact size mismatch: adaptive-diagnosis.md" in report["mismatches"]
+    assert "artifact sha256 mismatch: adaptive-diagnosis.md" in report["mismatches"]
+
+
+def test_verifier_detects_manifest_authority_expansion(tmp_path: Path) -> None:
+    bundle_dir = _bundle(tmp_path)
+    manifest_path = bundle_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["authority"]["merge_authorized"] = True
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = VERIFIER.verify_bundle(bundle_dir)
+
+    assert report["ok"] is False
+    assert "manifest authority boundary mismatch" in report["mismatches"]
+
+
+def test_verifier_detects_export_contract_drift(tmp_path: Path) -> None:
+    bundle_dir = _bundle(tmp_path)
+    export_path = bundle_dir / "adaptive-diagnosis.json"
+    export = json.loads(export_path.read_text(encoding="utf-8"))
+    export["schema_version"] = "unexpected.schema.v1"
+    export["authority"] = dict(AUTHORITY_EXPECTATIONS)
+    export_path.write_text(json.dumps(export), encoding="utf-8")
+
+    manifest_path = bundle_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    for record in manifest["artifacts"]:
+        if record["path"] == "adaptive-diagnosis.json":
+            content = export_path.read_bytes()
+            import hashlib
+
+            record["size_bytes"] = len(content)
+            record["sha256"] = hashlib.sha256(content).hexdigest()
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = VERIFIER.verify_bundle(bundle_dir)
+
+    assert report["ok"] is False
+    assert "adaptive diagnosis export schema_version mismatch" in report["mismatches"]
+    assert ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION != export["schema_version"]
+
+
+def test_verifier_detects_missing_and_unexpected_records(tmp_path: Path) -> None:
+    bundle_dir = _bundle(tmp_path)
+    manifest_path = bundle_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"] = [
+        record
+        for record in manifest["artifacts"]
+        if record["path"] != "adaptive-diagnosis.html"
+    ]
+    manifest["artifacts"].append(
+        {
+            "path": "unexpected.txt",
+            "size_bytes": 0,
+            "sha256": "0" * 64,
+        }
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = VERIFIER.verify_bundle(bundle_dir)
+
+    assert report["ok"] is False
+    assert "missing artifact record: adaptive-diagnosis.html" in report["mismatches"]
+    assert "unexpected artifact record: unexpected.txt" in report["mismatches"]

--- a/tests/test_pr_quality_adaptive_diagnosis_bundle_verifier.py
+++ b/tests/test_pr_quality_adaptive_diagnosis_bundle_verifier.py
@@ -126,9 +126,7 @@ def test_verifier_detects_missing_and_unexpected_records(tmp_path: Path) -> None
     manifest_path = bundle_dir / "manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["artifacts"] = [
-        record
-        for record in manifest["artifacts"]
-        if record["path"] != "adaptive-diagnosis.html"
+        record for record in manifest["artifacts"] if record["path"] != "adaptive-diagnosis.html"
     ]
     manifest["artifacts"].append(
         {

--- a/tools/verify_pr_quality_adaptive_diagnosis_bundle.py
+++ b/tools/verify_pr_quality_adaptive_diagnosis_bundle.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sdetkit.pr_quality_adaptive_diagnosis import (
+    ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION,
+    ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION,
+    AUTHORITY_EXPECTATIONS,
+)
+
+JsonObject = dict[str, Any]
+SCHEMA_VERSION = "sdetkit.adaptive_diagnosis_bundle_verification.v1"
+EXPECTED_ARTIFACTS = (
+    "adaptive-diagnosis.html",
+    "adaptive-diagnosis.md",
+    "adaptive-diagnosis.json",
+)
+DECISION_BOUNDARY = {
+    "automation_allowed": False,
+    "patch_application_allowed": False,
+    "security_dismissal_allowed": False,
+    "merge_authorized": False,
+    "semantic_equivalence_proven": False,
+}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _artifact_records(value: object) -> tuple[dict[str, JsonObject], list[str]]:
+    records: dict[str, JsonObject] = {}
+    mismatches: list[str] = []
+    if not isinstance(value, list):
+        return records, ["manifest.artifacts must be a list"]
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            mismatches.append(f"manifest.artifacts[{index}] must be an object")
+            continue
+        name = str(item.get("path") or "").strip()
+        if not name:
+            mismatches.append(f"manifest.artifacts[{index}].path is required")
+            continue
+        if name in records:
+            mismatches.append(f"duplicate artifact record: {name}")
+            continue
+        records[name] = item
+    return records, mismatches
+
+
+def verify_bundle(bundle_dir: Path, *, manifest_path: Path | None = None) -> JsonObject:
+    root = bundle_dir.resolve()
+    manifest_file = (manifest_path or bundle_dir / "manifest.json").resolve()
+    mismatches: list[str] = []
+
+    if not manifest_file.is_file():
+        mismatches.append("manifest.json is missing")
+        manifest: JsonObject = {}
+    else:
+        loaded = json.loads(manifest_file.read_text(encoding="utf-8"))
+        manifest = loaded if isinstance(loaded, dict) else {}
+        if not manifest:
+            mismatches.append("manifest.json must contain an object")
+
+    if manifest.get("schema_version") != ADAPTIVE_DIAGNOSIS_BUNDLE_MANIFEST_SCHEMA_VERSION:
+        mismatches.append("manifest schema_version mismatch")
+    if manifest.get("status") != "passed":
+        mismatches.append("manifest status must be passed")
+    if manifest.get("authority_validated") is not True:
+        mismatches.append("manifest authority_validated must be true")
+    if _mapping(manifest.get("authority")) != AUTHORITY_EXPECTATIONS:
+        mismatches.append("manifest authority boundary mismatch")
+
+    records, record_mismatches = _artifact_records(manifest.get("artifacts"))
+    mismatches.extend(record_mismatches)
+    expected = set(EXPECTED_ARTIFACTS)
+    observed = set(records)
+    for missing in sorted(expected - observed):
+        mismatches.append(f"missing artifact record: {missing}")
+    for unexpected in sorted(observed - expected):
+        mismatches.append(f"unexpected artifact record: {unexpected}")
+
+    checked: list[str] = []
+    for name in EXPECTED_ARTIFACTS:
+        record = records.get(name)
+        if record is None:
+            continue
+        if Path(name).name != name or Path(name).is_absolute():
+            mismatches.append(f"unsafe artifact path: {name}")
+            continue
+        artifact = (root / name).resolve()
+        if artifact.parent != root:
+            mismatches.append(f"artifact escapes bundle directory: {name}")
+            continue
+        if not artifact.is_file():
+            mismatches.append(f"artifact file is missing: {name}")
+            continue
+        checked.append(name)
+        actual_size = artifact.stat().st_size
+        if record.get("size_bytes") != actual_size:
+            mismatches.append(f"artifact size mismatch: {name}")
+        if record.get("sha256") != _sha256(artifact):
+            mismatches.append(f"artifact sha256 mismatch: {name}")
+
+    export_path = root / "adaptive-diagnosis.json"
+    if export_path.is_file():
+        loaded_export = json.loads(export_path.read_text(encoding="utf-8"))
+        export = loaded_export if isinstance(loaded_export, dict) else {}
+        if export.get("schema_version") != ADAPTIVE_DIAGNOSIS_EXPORT_SCHEMA_VERSION:
+            mismatches.append("adaptive diagnosis export schema_version mismatch")
+        if _mapping(export.get("authority")) != AUTHORITY_EXPECTATIONS:
+            mismatches.append("adaptive diagnosis export authority boundary mismatch")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not mismatches,
+        "bundle_dir": bundle_dir.as_posix(),
+        "manifest_path": manifest_file.as_posix(),
+        "artifact_count": len(records),
+        "artifacts_checked": checked,
+        "mismatch_count": len(mismatches),
+        "mismatches": mismatches,
+        "decision_boundary": dict(DECISION_BOUNDARY),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify the portable Adaptive Diagnosis evidence bundle."
+    )
+    parser.add_argument("--bundle-dir", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--out", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = verify_bundle(args.bundle_dir, manifest_path=args.manifest)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.out is None:
+        print(rendered, end="")
+    else:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered, encoding="utf-8", newline="\n")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- verify the portable evidence bundle manifest, artifact set, file sizes, hashes, and JSON schema
- detect modified files, missing records, unexpected records, and contract drift
- keep verification read-only and return a deterministic report

## Verification
Focused tests cover a valid bundle plus tampering, manifest drift, JSON schema drift, and record-set drift. Exact-head CI is the source of truth for repository-wide validation.

## Risk
Additive tool and tests only. No existing workflow, package API, or artifact producer is changed.