### PR TITLE
docs: link dependency review from first contribution guide

### DIFF
--- a/docs/first-contribution-quickstart.md
+++ b/docs/first-contribution-quickstart.md
@@ -33,6 +33,9 @@ Use `docs/starter-work-inventory.md` for concrete categories mapped to this repo
    - Resolve Ruff/mypy findings without behavior changes.
 4. **CLI/docs alignment**
    - Update docs when command names/options/output changed.
+5. **Dependency review support**
+   - Improve dependency-update review guidance without changing package pins.
+   - Start with the [dependency review playbook](dependency-review-playbook.md).
 
 ## 3) Validate locally before opening a PR
 


### PR DESCRIPTION
## Summary
- add dependency review support as a safe first-contribution category
- link first-time contributors to the dependency review playbook

## Verification
Docs-only change. Exact-head CI is the merge gate.