### PR TITLE
feat: recommend JavaScript proof commands by package manager

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -145,6 +145,14 @@ def _package_json_has_test(root: Path) -> bool:
     return bool(str(scripts.get("test", "")).strip())
 
 
+def _javascript_test_command(root: Path) -> str:
+    if _file(root, "pnpm-lock.yaml"):
+        return "pnpm test"
+    if _file(root, "yarn.lock"):
+        return "yarn test"
+    return "npm test"
+
+
 def _make_target_exists(root: Path, target: str) -> bool:
     makefile = root / "Makefile"
     if not makefile.is_file():
@@ -364,16 +372,17 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     if _file(root, "yarn.lock"):
         _add_named(package_managers, "yarn", files=["yarn.lock"])
     if _file(root, "package.json") and _package_json_has_test(root):
+        node_test_command = _javascript_test_command(root)
         _add_named(
             test_runners,
             "node_test_script",
             confidence="medium",
-            commands=["npm test"],
+            commands=[node_test_command],
         )
         _add_proof_command(
             recommended_proof_commands,
             surface="javascript_typescript",
-            command="npm test",
+            command=node_test_command,
             confidence="medium",
             purpose="test",
         )

--- a/tests/test_adoption_surface_js_package_managers.py
+++ b/tests/test_adoption_surface_js_package_managers.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_surface import discover_adoption_surface
+
+
+def _write(path: Path, text: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _commands(payload: dict) -> dict[str, dict]:
+    return {str(item["command"]): item for item in payload["recommended_proof_commands"]}
+
+
+@pytest.mark.parametrize(
+    ("lockfile", "expected_manager", "expected_command"),
+    [
+        ("package-lock.json", "npm", "npm test"),
+        ("pnpm-lock.yaml", "pnpm", "pnpm test"),
+        ("yarn.lock", "yarn", "yarn test"),
+    ],
+)
+def test_adoption_surface_recommends_javascript_test_command_for_detected_package_manager(
+    tmp_path: Path,
+    lockfile: str,
+    expected_manager: str,
+    expected_command: str,
+) -> None:
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "demo", "scripts": {"test": "vitest"}}),
+    )
+    _write(tmp_path / lockfile, "# lockfile evidence\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    managers = {str(item["name"]) for item in payload["package_managers"]}
+    runners = {str(item["name"]): item for item in payload["test_runners"]}
+    commands = _commands(payload)
+
+    assert expected_manager in managers
+    assert runners["node_test_script"]["commands"] == [expected_command]
+    assert expected_command in commands
+    assert commands[expected_command]["surface"] == "javascript_typescript"
+    assert commands[expected_command]["purpose"] == "test"
+    assert commands[expected_command]["executes_untrusted_code"] is True
+    assert commands[expected_command]["auto_run_allowed"] is False
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_adoption_surface_preserves_npm_fallback_when_package_json_has_test_without_lockfile(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "demo", "scripts": {"test": "node --test"}}),
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = _commands(payload)
+    runners = {str(item["name"]): item for item in payload["test_runners"]}
+
+    assert payload["package_managers"] == []
+    assert runners["node_test_script"]["commands"] == ["npm test"]
+    assert commands["npm test"]["auto_run_allowed"] is False
+    assert commands["npm test"]["executes_untrusted_code"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False


### PR DESCRIPTION
## Summary
- choose the JavaScript test proof command from the detected lockfile: `pnpm test`, `yarn test`, or `npm test`
- preserve the conservative `npm test` fallback when `package.json` has a test script but no lockfile
- add focused adoption-surface coverage for npm, pnpm, Yarn, and manifest-only fallback behavior

## Why
- resolves #1943
- improves multi-ecosystem adoption guidance without installing dependencies or executing target repository code
- keeps the recommendation review-first: proof commands still have `auto_run_allowed=false` and `executes_untrusted_code=true`

## Verification
Expected focused proof:
- `python -m pytest -q tests/test_adoption_surface.py tests/test_adoption_surface_js_package_managers.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low
- Rollback: revert this PR