### PR TITLE
feat: detect Go security proof surface

### DIFF
--- a/src/sdetkit/adoption_surface.py
+++ b/src/sdetkit/adoption_surface.py
@@ -128,6 +128,15 @@ def _workflow_files(root: Path) -> list[str]:
     )
 
 
+def _owned_script_files(root: Path) -> list[str]:
+    named_scripts = [
+        path
+        for path in ["Makefile", "Taskfile.yml", "Taskfile.yaml", "justfile", "Justfile"]
+        if _file(root, path)
+    ]
+    return sorted(set(named_scripts + _recursive_files(root, "*.sh")))
+
+
 def _workflow_text(root: Path, files: list[str]) -> str:
     return "\n".join(_read_text(root, path).lower() for path in files)
 
@@ -234,6 +243,7 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root)
     requirements = _glob_files(root, "requirements*.txt")
     workflows = _workflow_files(root)
+    script_files = _owned_script_files(root)
 
     detected_languages: list[dict[str, Any]] = []
     package_managers: list[dict[str, Any]] = []
@@ -497,6 +507,27 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
             "pip_audit",
             confidence="detected",
             evidence=pip_audit_evidence,
+        )
+
+    govulncheck_evidence = sorted(
+        set(
+            _files_containing(root, workflows, "govulncheck")
+            + _files_containing(root, script_files, "govulncheck")
+        )
+    )
+    if _file(root, "go.mod") and govulncheck_evidence:
+        _add_named(
+            security_tools,
+            "govulncheck",
+            confidence="detected",
+            evidence=govulncheck_evidence,
+        )
+        _add_proof_command(
+            recommended_proof_commands,
+            surface="go",
+            command="govulncheck ./...",
+            confidence="medium",
+            purpose="security",
         )
 
     release_workflows = [

--- a/tests/test_adoption_surface_go_security.py
+++ b/tests/test_adoption_surface_go_security.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_surface import discover_adoption_surface
+
+
+def _write(path: Path, text: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _commands(payload: dict) -> dict[str, dict]:
+    return {str(item["command"]): item for item in payload["recommended_proof_commands"]}
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    [
+        (
+            ".github/workflows/security.yml",
+            "steps:\n  - run: govulncheck ./...\n",
+        ),
+        (
+            "scripts/security.sh",
+            "#!/usr/bin/env sh\nset -e\ngovulncheck ./...\n",
+        ),
+    ],
+)
+def test_adoption_surface_detects_govulncheck_security_surface_from_owned_evidence(
+    tmp_path: Path,
+    path: str,
+    content: str,
+) -> None:
+    _write(tmp_path / "go.mod", "module example.com/demo\n")
+    _write(tmp_path / path, content)
+
+    payload = discover_adoption_surface(tmp_path)
+    tools = {str(item["name"]): item for item in payload["security_tools"]}
+    commands = _commands(payload)
+
+    assert tools["govulncheck"]["confidence"] == "detected"
+    assert tools["govulncheck"]["evidence"] == [path]
+    assert "go test ./..." in commands
+    assert commands["govulncheck ./..."]["surface"] == "go"
+    assert commands["govulncheck ./..."]["purpose"] == "security"
+    assert commands["govulncheck ./..."]["auto_run_allowed"] is False
+    assert commands["govulncheck ./..."]["executes_untrusted_code"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_adoption_surface_does_not_infer_govulncheck_from_go_mod_only(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "go.mod", "module example.com/demo\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    tools = {str(item["name"]) for item in payload["security_tools"]}
+    commands = _commands(payload)
+
+    assert "govulncheck" not in tools
+    assert "go test ./..." in commands
+    assert "govulncheck ./..." not in commands
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False


### PR DESCRIPTION
## Summary
- detect explicit `govulncheck` evidence from repository-owned workflow and shell-script files
- report a `security_tools` entry named `govulncheck` when Go module evidence is present
- recommend `govulncheck ./...` as a review-first security proof command
- add positive workflow/script tests and a negative `go.mod`-only test

## Why
- resolves #1947
- improves Go adoption-surface security guidance without installing tools, running target code, or parsing vulnerability output
- keeps security proof recommendations review-first with `auto_run_allowed=false` and `executes_untrusted_code=true`

## Verification
Expected focused proof:
- `python -m pytest -q tests/test_adoption_surface.py tests/test_adoption_surface_go_security.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low
- Rollback: revert this PR