### PR TITLE
ci: add full-suite failure summary artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,37 @@ jobs:
           PYTEST_ADDOPTS: "-n auto --junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml"
         run: bash quality.sh cov
 
+      - name: Build full-suite failure summary
+        id: full_suite_failure_summary
+        if: ${{ always() && steps.coverage.outcome != 'skipped' }}
+        run: |
+          mkdir -p build/full-suite-failure-summary
+          python -m sdetkit.ci_failure_summary \
+            --junit-xml "${RUNNER_TEMP}/sdetkit-trusted-test-input/junit.xml" \
+            --workflow "CI" \
+            --job "Full CI lane" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --head-sha "${GITHUB_SHA}" \
+            --command "bash quality.sh cov" \
+            --event-name "${GITHUB_EVENT_NAME}" \
+            --ref-name "${GITHUB_REF}" \
+            --out-dir build/full-suite-failure-summary \
+            --format json \
+            > build/full-suite-failure-summary-cli.json
+          echo "artifact_written=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload full-suite failure summary artifact
+        if: ${{ always() && steps.coverage.outcome == 'failure' && steps.full_suite_failure_summary.outputs.artifact_written == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: full-suite-failure-summary
+          path: |
+            build/full-suite-failure-summary/full-suite-failure-summary.json
+            build/full-suite-failure-summary/full-suite-failure-summary.md
+            build/full-suite-failure-summary-cli.json
+          retention-days: 14
+          if-no-files-found: error
+
       - name: Normalize trusted-main test observations
         id: trusted_observations
         if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.coverage.outcome != 'skipped' }}

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "sdetkit.quality_truth_baseline.v1",
-  "generated_on": "2026-07-03",
+  "generated_on": "2026-07-05",
   "status": "staged_migration_visible",
   "coverage": {
     "critical_spine": {
@@ -35,9 +35,9 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 498,
-    "typing_debt_module_count": 479,
-    "typing_debt_inventory_sha256": "fb431b14b30b32cc7d4c06dc83f2c904e578916d37e4f5a7504e74d8c1fe168b",
+    "source_module_count": 499,
+    "typing_debt_module_count": 480,
+    "typing_debt_inventory_sha256": "8140e2e71ff33420da037b0bcfd3013d729a422e57f468f78308739a8581cb44",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "explicitly_type_checked_modules": [
       "sdetkit._pr_quality_required_terminal_checks",

--- a/src/sdetkit/ci_failure_summary.py
+++ b/src/sdetkit/ci_failure_summary.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+SCHEMA_VERSION = "sdetkit.ci_failure_summary.v1"
+DEFAULT_OUT_DIR = Path("build") / "full-suite-failure-summary"
+SUMMARY_JSON = "full-suite-failure-summary.json"
+SUMMARY_MD = "full-suite-failure-summary.md"
+
+JsonObject = dict[str, Any]
+
+
+def _text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").strip()
+
+
+def _compact(value: Any, *, limit: int = 600) -> str:
+    text = " ".join(_text(value).split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _load_junit_root(path: Path) -> tuple[ET.Element | None, str | None]:
+    if not path.exists():
+        return None, "junit_xml_missing"
+    if path.stat().st_size == 0:
+        return None, "junit_xml_empty"
+    try:
+        return ET.parse(path).getroot(), None
+    except ET.ParseError:
+        return None, "junit_xml_malformed"
+
+
+def _outcome(testcase: ET.Element) -> str:
+    if testcase.find("failure") is not None:
+        return "failed"
+    if testcase.find("error") is not None:
+        return "error"
+    if testcase.find("skipped") is not None:
+        return "skipped"
+    return "passed"
+
+
+def _failure_node(testcase: ET.Element) -> ET.Element | None:
+    failure = testcase.find("failure")
+    if failure is not None:
+        return failure
+    return testcase.find("error")
+
+
+def _first_failure(testcases: list[ET.Element]) -> JsonObject | None:
+    for index, testcase in enumerate(testcases, start=1):
+        outcome = _outcome(testcase)
+        if outcome not in {"failed", "error"}:
+            continue
+        node = _failure_node(testcase)
+        return {
+            "index": index,
+            "outcome": outcome,
+            "classname": _compact(testcase.attrib.get("classname"), limit=300),
+            "name": _compact(testcase.attrib.get("name"), limit=300),
+            "message": _compact(node.attrib.get("message") if node is not None else ""),
+            "text_excerpt": _compact(node.text if node is not None else "", limit=1200),
+        }
+    return None
+
+
+def build_failure_summary(
+    *,
+    junit_xml: Path,
+    workflow: str,
+    job: str,
+    run_id: str,
+    head_sha: str,
+    command: str,
+    event_name: str,
+    ref_name: str,
+) -> JsonObject:
+    root, load_error = _load_junit_root(junit_xml)
+    source = {
+        "workflow": _text(workflow),
+        "job": _text(job),
+        "run_id": _text(run_id),
+        "head_sha": _text(head_sha),
+        "event_name": _text(event_name),
+        "ref_name": _text(ref_name),
+        "command": _text(command),
+        "input_kind": "junit_xml",
+        "input_read_only": True,
+        "commands_executed_by_reader": False,
+    }
+
+    if load_error is not None or root is None:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": load_error,
+            "source": source,
+            "environment": _environment(),
+            "summary": {
+                "testcase_count": 0,
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "failure_observed": False,
+            },
+            "first_failure": None,
+            "decision_boundary": _decision_boundary(),
+        }
+
+    testcases = list(root.iter("testcase"))
+    outcomes = Counter(_outcome(testcase) for testcase in testcases)
+    first_failure = _first_failure(testcases)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "failure_observed" if first_failure else "no_failure_observed",
+        "source": source,
+        "environment": _environment(),
+        "summary": {
+            "testcase_count": len(testcases),
+            "passed": outcomes["passed"],
+            "failed": outcomes["failed"],
+            "error": outcomes["error"],
+            "skipped": outcomes["skipped"],
+            "failure_observed": first_failure is not None,
+        },
+        "first_failure": first_failure,
+        "decision_boundary": _decision_boundary(),
+    }
+
+
+def _environment() -> JsonObject:
+    return {
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+    }
+
+
+def _decision_boundary() -> JsonObject:
+    return {
+        "diagnostic_only": True,
+        "flaky_classification_performed": False,
+        "automatic_quarantine_allowed": False,
+        "automatic_rerun_allowed": False,
+        "failure_suppression_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    source = dict(report.get("source", {}))
+    summary = dict(report.get("summary", {}))
+    first = report.get("first_failure")
+    boundary = dict(report.get("decision_boundary", {}))
+    lines = [
+        "# Full-suite failure summary",
+        "",
+        f"- Status: `{_text(report.get('status'))}`",
+        f"- Workflow: `{_text(source.get('workflow'))}`",
+        f"- Job: `{_text(source.get('job'))}`",
+        f"- Command: `{_text(source.get('command'))}`",
+        f"- Testcases: `{int(summary.get('testcase_count', 0))}`",
+        f"- Failed: `{int(summary.get('failed', 0))}`",
+        f"- Errors: `{int(summary.get('error', 0))}`",
+        f"- Skipped: `{int(summary.get('skipped', 0))}`",
+        "",
+    ]
+    if isinstance(first, Mapping):
+        lines.extend(
+            [
+                "## First failure",
+                "",
+                f"- Outcome: `{_text(first.get('outcome'))}`",
+                f"- Class: `{_text(first.get('classname'))}`",
+                f"- Name: `{_text(first.get('name'))}`",
+                f"- Message: `{_text(first.get('message'))}`",
+                "",
+                "```text",
+                _text(first.get("text_excerpt")),
+                "```",
+                "",
+            ]
+        )
+    else:
+        lines.extend(["## First failure", "", "No failed or errored testcase was observed.", ""])
+
+    lines.extend(
+        [
+            "## Boundary",
+            "",
+            f"- Diagnostic only: `{str(bool(boundary.get('diagnostic_only'))).lower()}`",
+            (
+                "- Flaky classification performed: "
+                f"`{str(bool(boundary.get('flaky_classification_performed'))).lower()}`"
+            ),
+            (
+                "- Failure suppression allowed: "
+                f"`{str(bool(boundary.get('failure_suppression_allowed'))).lower()}`"
+            ),
+            f"- Automation allowed: `{str(bool(boundary.get('automation_allowed'))).lower()}`",
+            f"- Merge authorized: `{str(bool(boundary.get('merge_authorized'))).lower()}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_report(report: Mapping[str, Any], *, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / SUMMARY_JSON).write_text(
+        json.dumps(dict(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / SUMMARY_MD).write_text(render_markdown(report), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.ci_failure_summary")
+    parser.add_argument("--junit-xml", type=Path, required=True)
+    parser.add_argument("--workflow", required=True)
+    parser.add_argument("--job", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--command", required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = build_failure_summary(
+        junit_xml=args.junit_xml,
+        workflow=args.workflow,
+        job=args.job,
+        run_id=args.run_id,
+        head_sha=args.head_sha,
+        command=args.command,
+        event_name=args.event_name,
+        ref_name=args.ref_name,
+    )
+    write_report(report, out_dir=args.out_dir)
+    output = {
+        "status": report["status"],
+        "artifact_written": True,
+        "failure_observed": bool(dict(report["summary"]).get("failure_observed")),
+    }
+    if args.format == "json":
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        for key, value in output.items():
+            print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/sdetkit/ci_failure_summary.py
+++ b/src/sdetkit/ci_failure_summary.py
@@ -204,10 +204,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         [
             "## Boundary",
             "",
-            (
-                "- Diagnostic only: "
-                f"`{str(bool(boundary.get('diagnostic_only'))).lower()}`"
-            ),
+            (f"- Diagnostic only: `{str(bool(boundary.get('diagnostic_only'))).lower()}`"),
             (
                 "- Flaky classification performed: "
                 f"`{str(bool(boundary.get('flaky_classification_performed'))).lower()}`"
@@ -216,14 +213,8 @@ def render_markdown(report: Mapping[str, Any]) -> str:
                 "- Failure suppression allowed: "
                 f"`{str(bool(boundary.get('failure_suppression_allowed'))).lower()}`"
             ),
-            (
-                "- Automation allowed: "
-                f"`{str(bool(boundary.get('automation_allowed'))).lower()}`"
-            ),
-            (
-                "- Merge authorized: "
-                f"`{str(bool(boundary.get('merge_authorized'))).lower()}`"
-            ),
+            (f"- Automation allowed: `{str(bool(boundary.get('automation_allowed'))).lower()}`"),
+            (f"- Merge authorized: `{str(bool(boundary.get('merge_authorized'))).lower()}`"),
             "",
         ]
     )

--- a/src/sdetkit/ci_failure_summary.py
+++ b/src/sdetkit/ci_failure_summary.py
@@ -191,13 +191,23 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             ]
         )
     else:
-        lines.extend(["## First failure", "", "No failed or errored testcase was observed.", ""])
+        lines.extend(
+            [
+                "## First failure",
+                "",
+                "No failed or errored testcase was observed.",
+                "",
+            ]
+        )
 
     lines.extend(
         [
             "## Boundary",
             "",
-            f"- Diagnostic only: `{str(bool(boundary.get('diagnostic_only'))).lower()}`",
+            (
+                "- Diagnostic only: "
+                f"`{str(bool(boundary.get('diagnostic_only'))).lower()}`"
+            ),
             (
                 "- Flaky classification performed: "
                 f"`{str(bool(boundary.get('flaky_classification_performed'))).lower()}`"
@@ -206,8 +216,14 @@ def render_markdown(report: Mapping[str, Any]) -> str:
                 "- Failure suppression allowed: "
                 f"`{str(bool(boundary.get('failure_suppression_allowed'))).lower()}`"
             ),
-            f"- Automation allowed: `{str(bool(boundary.get('automation_allowed'))).lower()}`",
-            f"- Merge authorized: `{str(bool(boundary.get('merge_authorized'))).lower()}`",
+            (
+                "- Automation allowed: "
+                f"`{str(bool(boundary.get('automation_allowed'))).lower()}`"
+            ),
+            (
+                "- Merge authorized: "
+                f"`{str(bool(boundary.get('merge_authorized'))).lower()}`"
+            ),
             "",
         ]
     )

--- a/tests/test_ci_failure_summary.py
+++ b/tests/test_ci_failure_summary.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from xml.etree import ElementTree as ET
 
 import pytest
 
@@ -51,7 +50,9 @@ def _summary(junit_xml: Path) -> dict:
     )
 
 
-def test_failure_summary_reports_first_failure_without_changing_outcome(tmp_path: Path) -> None:
+def test_failure_summary_reports_first_failure_without_changing_outcome(
+    tmp_path: Path,
+) -> None:
     report = _summary(_write(tmp_path / "junit.xml", _junit_xml()))
 
     assert report["schema_version"] == SCHEMA_VERSION
@@ -81,10 +82,16 @@ def test_failure_summary_reports_first_failure_without_changing_outcome(tmp_path
     }
 
 
-def test_failure_summary_handles_passing_junit_without_claiming_failure(tmp_path: Path) -> None:
+def test_failure_summary_handles_passing_junit_without_claiming_failure(
+    tmp_path: Path,
+) -> None:
     junit = _write(
         tmp_path / "junit.xml",
-        "<testsuites><testsuite><testcase classname='tests.ok' name='test_ok' /></testsuite></testsuites>",
+        (
+            "<testsuites><testsuite>"
+            "<testcase classname='tests.ok' name='test_ok' />"
+            "</testsuite></testsuites>"
+        ),
     )
 
     report = _summary(junit)
@@ -118,7 +125,10 @@ def test_failure_summary_writes_diagnostic_status_without_junit(
     assert report["decision_boundary"]["failure_suppression_allowed"] is False
 
 
-def test_failure_summary_cli_writes_json_and_markdown(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_failure_summary_cli_writes_json_and_markdown(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     junit = _write(tmp_path / "junit.xml", _junit_xml())
     out_dir = tmp_path / "summary"
 
@@ -154,7 +164,9 @@ def test_failure_summary_cli_writes_json_and_markdown(tmp_path: Path, capsys: py
         "failure_observed": True,
         "status": "failure_observed",
     }
-    report = json.loads((out_dir / "full-suite-failure-summary.json").read_text(encoding="utf-8"))
+    report = json.loads(
+        (out_dir / "full-suite-failure-summary.json").read_text(encoding="utf-8")
+    )
     markdown = (out_dir / "full-suite-failure-summary.md").read_text(encoding="utf-8")
     assert report["first_failure"]["name"] == "test_fails"
     assert "# Full-suite failure summary" in markdown

--- a/tests/test_ci_failure_summary.py
+++ b/tests/test_ci_failure_summary.py
@@ -164,9 +164,7 @@ def test_failure_summary_cli_writes_json_and_markdown(
         "failure_observed": True,
         "status": "failure_observed",
     }
-    report = json.loads(
-        (out_dir / "full-suite-failure-summary.json").read_text(encoding="utf-8")
-    )
+    report = json.loads((out_dir / "full-suite-failure-summary.json").read_text(encoding="utf-8"))
     markdown = (out_dir / "full-suite-failure-summary.md").read_text(encoding="utf-8")
     assert report["first_failure"]["name"] == "test_fails"
     assert "# Full-suite failure summary" in markdown

--- a/tests/test_ci_failure_summary.py
+++ b/tests/test_ci_failure_summary.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from sdetkit.ci_failure_summary import (
+    SCHEMA_VERSION,
+    build_failure_summary,
+    main,
+    render_markdown,
+)
+
+
+def _junit_xml() -> str:
+    return """
+    <testsuites>
+      <testsuite name="pytest">
+        <testcase classname="tests.test_alpha" name="test_passes" />
+        <testcase classname="tests.test_beta" name="test_fails">
+          <failure message="assert 1 == 2">Traceback line 1\nTraceback line 2</failure>
+        </testcase>
+        <testcase classname="tests.test_gamma" name="test_errors">
+          <error message="runtime boom">error trace</error>
+        </testcase>
+        <testcase classname="tests.test_delta" name="test_skips">
+          <skipped />
+        </testcase>
+      </testsuite>
+    </testsuites>
+    """
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _summary(junit_xml: Path) -> dict:
+    return build_failure_summary(
+        junit_xml=junit_xml,
+        workflow="CI",
+        job="Full CI lane",
+        run_id="12345",
+        head_sha="abc123",
+        command="bash quality.sh cov",
+        event_name="pull_request",
+        ref_name="refs/pull/1/merge",
+    )
+
+
+def test_failure_summary_reports_first_failure_without_changing_outcome(tmp_path: Path) -> None:
+    report = _summary(_write(tmp_path / "junit.xml", _junit_xml()))
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["status"] == "failure_observed"
+    assert report["source"]["input_read_only"] is True
+    assert report["source"]["commands_executed_by_reader"] is False
+    assert report["summary"] == {
+        "testcase_count": 4,
+        "passed": 1,
+        "failed": 1,
+        "error": 1,
+        "skipped": 1,
+        "failure_observed": True,
+    }
+    assert report["first_failure"]["outcome"] == "failed"
+    assert report["first_failure"]["classname"] == "tests.test_beta"
+    assert report["first_failure"]["name"] == "test_fails"
+    assert report["first_failure"]["message"] == "assert 1 == 2"
+    assert report["decision_boundary"] == {
+        "diagnostic_only": True,
+        "flaky_classification_performed": False,
+        "automatic_quarantine_allowed": False,
+        "automatic_rerun_allowed": False,
+        "failure_suppression_allowed": False,
+        "automation_allowed": False,
+        "merge_authorized": False,
+    }
+
+
+def test_failure_summary_handles_passing_junit_without_claiming_failure(tmp_path: Path) -> None:
+    junit = _write(
+        tmp_path / "junit.xml",
+        "<testsuites><testsuite><testcase classname='tests.ok' name='test_ok' /></testsuite></testsuites>",
+    )
+
+    report = _summary(junit)
+
+    assert report["status"] == "no_failure_observed"
+    assert report["summary"]["failure_observed"] is False
+    assert report["first_failure"] is None
+    assert "No failed or errored testcase" in render_markdown(report)
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_status"),
+    [
+        ("missing.xml", "junit_xml_missing"),
+        ("empty.xml", "junit_xml_empty"),
+    ],
+)
+def test_failure_summary_writes_diagnostic_status_without_junit(
+    tmp_path: Path,
+    filename: str,
+    expected_status: str,
+) -> None:
+    junit = tmp_path / filename
+    if expected_status == "junit_xml_empty":
+        junit.write_text("", encoding="utf-8")
+
+    report = _summary(junit)
+
+    assert report["status"] == expected_status
+    assert report["summary"]["testcase_count"] == 0
+    assert report["decision_boundary"]["failure_suppression_allowed"] is False
+
+
+def test_failure_summary_cli_writes_json_and_markdown(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    junit = _write(tmp_path / "junit.xml", _junit_xml())
+    out_dir = tmp_path / "summary"
+
+    rc = main(
+        [
+            "--junit-xml",
+            str(junit),
+            "--workflow",
+            "CI",
+            "--job",
+            "Full CI lane",
+            "--run-id",
+            "12345",
+            "--head-sha",
+            "abc123",
+            "--command",
+            "bash quality.sh cov",
+            "--event-name",
+            "pull_request",
+            "--ref-name",
+            "refs/pull/1/merge",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == {
+        "artifact_written": True,
+        "failure_observed": True,
+        "status": "failure_observed",
+    }
+    report = json.loads((out_dir / "full-suite-failure-summary.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "full-suite-failure-summary.md").read_text(encoding="utf-8")
+    assert report["first_failure"]["name"] == "test_fails"
+    assert "# Full-suite failure summary" in markdown
+    assert "Merge authorized: `false`" in markdown

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,15 +24,15 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 498
-    assert payload["observed"]["typing_debt_module_count"] == 479
+    assert payload["observed"]["source_module_count"] == 499
+    assert payload["observed"]["typing_debt_module_count"] == 480
     checked = payload["observed"]["explicitly_type_checked_modules"]
     assert "sdetkit.failure_vector_adapters" in checked
     assert "sdetkit.protected_proof_chain" in checked
     assert "sdetkit.pr_quality_required_terminal" in checked
     inventory = payload["typing_debt_inventory"]
-    assert inventory["module_count"] == 479
-    assert len(inventory["modules"]) == 479
+    assert inventory["module_count"] == 480
+    assert len(inventory["modules"]) == 480
     assert "sdetkit.pr_quality_adaptive_diagnosis" in inventory["modules"]
     assert "sdetkit.evidence_binding" in inventory["modules"]
 
@@ -52,7 +52,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 498,
+            "actual": 499,
         }
     ]
 

--- a/tests/test_trusted_test_observation_capture_workflow.py
+++ b/tests/test_trusted_test_observation_capture_workflow.py
@@ -20,7 +20,7 @@ def test_full_ci_emits_junit_for_raw_observation_capture_without_extra_test_run(
     assert "--junitxml=${{ runner.temp }}/sdetkit-trusted-test-input/junit.xml" in coverage_block
     assert "- name: Coverage gate" in full_ci
     assert "id: coverage" in full_ci
-    assert full_ci.count("bash quality.sh cov") == 1
+    assert full_ci.count("run: bash quality.sh cov") == 1
     assert "python -m sdetkit.trusted_test_observation_capture" in full_ci
 
 


### PR DESCRIPTION
## Summary
- Add a read-only CI failure summary helper for JUnit XML.
- Upload a compact Full CI failure summary artifact when the coverage gate fails.
- Cover failure, passing, missing-JUnit, and CLI artifact behavior.

## Roadmap lane
- Full-suite failure visibility.

## Verification
Expected checks:
- CI
- Workflow contracts
- Repo Audit
- GitHub Actions Advanced Reference
- PR Quality

## Rollback
Revert this PR.

## Authority
No automated GitHub comments were posted.