### PR TITLE
feat(ci): adapt full-suite summaries into failure vectors

### DIFF
--- a/src/sdetkit/failure_vector_adapters.py
+++ b/src/sdetkit/failure_vector_adapters.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
 
 from sdetkit.failure_vector import FailureVector, extract_failure_vector
 
@@ -36,6 +38,145 @@ class FailureVectorAdapterResult:
             "target_code_execution": False,
         }
         return payload
+
+
+def extract_ci_failure_summary_vector(
+    report: Mapping[str, Any],
+    *,
+    log_url: str | None = None,
+    environment: str = "github_actions",
+) -> FailureVectorAdapterResult:
+    """Convert a read-only full-suite summary artifact into a FailureVector."""
+
+    source = _summary_mapping(report.get("source"))
+    first_failure = _summary_mapping(report.get("first_failure"))
+    workflow = _summary_text(source.get("workflow")) or "unknown"
+    job = _summary_text(source.get("job")) or "unknown"
+    command = _summary_text(source.get("command")) or "unknown"
+    status = _summary_text(report.get("status")) or "unknown"
+    check = _summary_check_name(workflow, job)
+
+    if not first_failure:
+        vector = FailureVector(
+            check=check,
+            command=command,
+            exit_code=None,
+            failure_class="unknown",
+            risk="high",
+            scope="unknown",
+            reproducible_locally="not_run",
+            safe_fix_candidate=False,
+            first_failing_line=f"{status}: no failed junit testcase observed",
+            affected_files=(),
+            log_url=log_url,
+            local_repro_command=command if command != "unknown" else None,
+            environment=environment,
+            headline_signal=f"{check}: unknown",
+            actual_failure=status,
+            failure_type="unknown",
+            failing_command=command,
+            failing_test_or_check=check,
+            owner_hint=check,
+            safe_fix_allowed=False,
+        )
+        return FailureVectorAdapterResult(
+            vector=vector,
+            ecosystem="python",
+            tool="pytest",
+            confidence="low",
+            uncertainty=(f"ci_failure_summary_status_{status}",),
+        )
+
+    classname = _summary_text(first_failure.get("classname"))
+    name = _summary_text(first_failure.get("name"))
+    message = _summary_text(first_failure.get("message"))
+    text_excerpt = _summary_text(first_failure.get("text_excerpt"))
+    path = _junit_classname_to_path(classname)
+    node = _pytest_node(path, classname, name)
+    first_line = _summary_failure_line(node, message, text_excerpt)
+    vector = FailureVector(
+        check=check,
+        command=command,
+        exit_code=None,
+        failure_class="test",
+        risk="medium",
+        scope="pr_owned_only" if path else "unknown",
+        reproducible_locally="not_run",
+        safe_fix_candidate=False,
+        first_failing_line=first_line,
+        affected_files=(path,) if path else (),
+        log_url=log_url,
+        local_repro_command=_pytest_repro_command(path, name),
+        environment=environment,
+        headline_signal=f"{check}: test",
+        actual_failure=message or _first_summary_line(text_excerpt) or first_line,
+        failure_type="test",
+        failing_command=command,
+        failing_test_or_check=node or check,
+        owner_hint=path or check,
+        safe_fix_allowed=False,
+    )
+    return FailureVectorAdapterResult(
+        vector=vector,
+        ecosystem="python",
+        tool="pytest",
+        confidence="high",
+        uncertainty=(),
+    )
+
+
+def _summary_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _summary_text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").strip()
+
+
+def _summary_check_name(workflow: str, job: str) -> str:
+    if workflow == "unknown" and job == "unknown":
+        return "full_suite"
+    return f"{workflow}/{job}"
+
+
+def _junit_classname_to_path(classname: str) -> str:
+    if not classname:
+        return ""
+    path = classname.replace(".", "/") + ".py"
+    if path.startswith(("src/", "tests/")):
+        return path
+    return ""
+
+
+def _pytest_node(path: str, classname: str, name: str) -> str:
+    if path and name:
+        return f"{path}::{name}"
+    if name:
+        return name
+    return classname
+
+
+def _summary_failure_line(node: str, message: str, text_excerpt: str) -> str:
+    detail = message or _first_summary_line(text_excerpt)
+    if node and detail:
+        return f"FAILED {node} - {detail}"
+    if node:
+        return f"FAILED {node}"
+    return detail or "FAILED unknown junit testcase"
+
+
+def _first_summary_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _pytest_repro_command(path: str, name: str) -> str | None:
+    if path and name:
+        return f"PYTHONPATH=src python -m pytest -q {path}::{name} -o addopts="
+    return None
 
 
 def extract_ecosystem_failure_vector(

--- a/tests/test_ci_failure_summary_failure_vector_adapter.py
+++ b/tests/test_ci_failure_summary_failure_vector_adapter.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.ci_failure_summary import build_failure_summary
+from sdetkit.failure_vector_adapters import extract_ci_failure_summary_vector
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _summary(junit_xml: Path) -> dict:
+    return build_failure_summary(
+        junit_xml=junit_xml,
+        workflow="CI",
+        job="Full CI lane",
+        run_id="12345",
+        head_sha="abc123",
+        command="bash quality.sh cov",
+        event_name="pull_request",
+        ref_name="refs/pull/1/merge",
+    )
+
+
+def test_ci_failure_summary_vector_preserves_first_junit_failure_and_boundaries(
+    tmp_path: Path,
+) -> None:
+    junit = _write(
+        tmp_path / "junit.xml",
+        """
+        <testsuites>
+          <testsuite name="pytest">
+            <testcase classname="tests.test_beta" name="test_fails">
+              <failure message="assert 1 == 2">Traceback line 1</failure>
+            </testcase>
+          </testsuite>
+        </testsuites>
+        """,
+    )
+
+    result = extract_ci_failure_summary_vector(_summary(junit), log_url="artifact://summary")
+    payload = result.to_dict()
+
+    assert result.ecosystem == "python"
+    assert result.tool == "pytest"
+    assert result.confidence == "high"
+    assert result.uncertainty == ()
+    assert payload["failure_class"] == "test"
+    assert payload["command"] == "bash quality.sh cov"
+    assert payload["first_failing_line"] == (
+        "FAILED tests/test_beta.py::test_fails - assert 1 == 2"
+    )
+    assert payload["affected_files"] == ["tests/test_beta.py"]
+    assert payload["local_repro_command"] == (
+        "PYTHONPATH=src python -m pytest -q tests/test_beta.py::test_fails -o addopts="
+    )
+    assert payload["safe_fix_candidate"] is False
+    assert payload["safe_fix_allowed"] is False
+    assert payload["contract"]["reporting_only"] is True
+    assert payload["contract"]["automation_allowed"] is False
+    assert payload["contract"]["patch_application_allowed"] is False
+    assert payload["contract"]["merge_authorized"] is False
+    assert payload["adapter"]["target_code_execution"] is False
+
+
+def test_ci_failure_summary_vector_keeps_missing_failure_review_first(
+    tmp_path: Path,
+) -> None:
+    junit = _write(
+        tmp_path / "junit.xml",
+        "<testsuites><testsuite><testcase classname='tests.ok' name='test_ok' /></testsuite></testsuites>",
+    )
+
+    result = extract_ci_failure_summary_vector(_summary(junit))
+    payload = result.to_dict()
+
+    assert result.confidence == "low"
+    assert result.uncertainty == ("ci_failure_summary_status_no_failure_observed",)
+    assert payload["failure_class"] == "unknown"
+    assert payload["risk"] == "high"
+    assert payload["scope"] == "unknown"
+    assert payload["safe_fix_candidate"] is False
+    assert payload["safe_fix_allowed"] is False
+    assert payload["first_failing_line"] == (
+        "no_failure_observed: no failed junit testcase observed"
+    )
+    assert payload["contract"]["automation_allowed"] is False
+    assert payload["contract"]["patch_application_allowed"] is False
+    assert payload["adapter"]["target_code_execution"] is False


### PR DESCRIPTION
## Summary
- Add a read-only adapter that converts full-suite failure summary payloads into existing FailureVector records.
- Preserve pytest/JUnit first-failure evidence, affected file hints, and local repro command guidance.
- Keep no-failure or missing-failure summaries review-first with low confidence and no automation authority.

## Why
- The previous upgrade made Full CI failures visible as compact artifacts.
- This upgrade connects that artifact to the existing FailureVector model so future reporter, safety-gate, and trajectory-store work can reuse the same structured evidence.

## Verification
Expected checks:
- `python -m pytest -q tests/test_ci_failure_summary_failure_vector_adapter.py -o addopts=`
- `python -m pre_commit run -a`
- CI

## Risk
- Low/Medium: adapter-only behavior with focused tests.
- Rollback: revert this PR.

## Authority
No automated GitHub comments were posted.
Automation, patch application, semantic-equivalence, and merge authorization remain false in the normalized contract.