### PR TITLE
feat: add Java failure vector adapters

### DIFF
--- a/src/sdetkit/failure_vector_adapters.py
+++ b/src/sdetkit/failure_vector_adapters.py
@@ -15,9 +15,12 @@ JS_TEST = re.compile(
 )
 GO_LOCATION = re.compile(r"(?P<path>[\w./-]+\.go):\d+(?::\d+)?:\s*(?P<check>.+)")
 GO_TEST = re.compile(r"---\s+FAIL:\s+(?P<check>[\w./-]+)")
+JAVA_LOCATION = re.compile(
+    r"(?P<path>[\w./-]+\.java)(?::\d+|:\[\d+(?:,\d+)?\])(?::\s*(?P<check>.+))?"
+)
 COMMAND = re.compile(r"^(?:Run|\$)\s+(?P<command>.+)$", re.MULTILINE)
 EXIT_CODE = re.compile(r"Process completed with exit code (?P<code>\d+)")
-SUPPORTED = frozenset({"auto", "python", "javascript_typescript", "go"})
+SUPPORTED = frozenset({"auto", "python", "javascript_typescript", "go", "java"})
 
 
 @dataclass(frozen=True)
@@ -213,6 +216,8 @@ def extract_ecosystem_failure_vector(
         return _javascript_result(log_text, check, log_url, environment)
     if selected == "go":
         return _go_result(log_text, check, log_url, environment)
+    if selected == "java":
+        return _java_result(log_text, check, log_url, environment)
     return _unknown(log_text, "unknown", check, log_url, environment, "ecosystem_not_identified")
 
 
@@ -226,6 +231,8 @@ def _detect(log_text: str) -> str:
         return "go"
     if any(token in lower for token in ("go test", "go vet")):
         return "go"
+    if _looks_like_java(log_text):
+        return "java"
     if any(token in lower for token in ("pytest", "mypy", "ruff", ".py:")):
         return "python"
     return "unknown"
@@ -301,6 +308,54 @@ def _go_result(
     return _unknown(log_text, "go", check, log_url, environment, "go_failure_not_classified")
 
 
+def _java_result(
+    log_text: str,
+    check: str,
+    log_url: str | None,
+    environment: str,
+) -> FailureVectorAdapterResult:
+    lower = log_text.lower()
+    location = JAVA_LOCATION.search(log_text)
+    if _looks_like_maven_test(lower):
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location,
+            "test",
+            "maven_test",
+            "mvn test",
+            ecosystem="java",
+        )
+    if _looks_like_gradle_test(lower):
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location,
+            "test",
+            "gradle_test",
+            "./gradlew test",
+            ecosystem="java",
+        )
+    if location:
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location,
+            "unknown",
+            "java_toolchain",
+            "mvn test",
+            ("java_failure_class_not_proven",),
+            ecosystem="java",
+        )
+    return _unknown(log_text, "java", check, log_url, environment, "java_failure_not_classified")
+
+
 def _result(
     log_text: str,
     check: str,
@@ -311,6 +366,7 @@ def _result(
     tool: str,
     repro: str,
     uncertainty: tuple[str, ...] = (),
+    ecosystem: str | None = None,
 ) -> FailureVectorAdapterResult:
     path = match.groupdict().get("path", "") if match else ""
     detail = match.groupdict().get("check", "") if match else ""
@@ -340,9 +396,10 @@ def _result(
         owner_hint=path or check,
         safe_fix_allowed=False,
     )
+    inferred_ecosystem = "go" if tool.startswith("go_") else "javascript_typescript"
     return FailureVectorAdapterResult(
         vector=vector,
-        ecosystem="go" if tool.startswith("go_") else "javascript_typescript",
+        ecosystem=ecosystem or inferred_ecosystem,
         tool=tool,
         confidence="medium" if uncertainty else "high",
         uncertainty=uncertainty,
@@ -364,6 +421,40 @@ def _unknown(
         environment=environment,
     )
     return FailureVectorAdapterResult(vector, ecosystem, "unknown", "low", (uncertainty,))
+
+
+def _looks_like_java(log_text: str) -> bool:
+    lower = log_text.lower()
+    return (
+        JAVA_LOCATION.search(log_text) is not None
+        or _looks_like_maven_test(lower)
+        or _looks_like_gradle_test(lower)
+    )
+
+
+def _looks_like_maven_test(lower: str) -> bool:
+    return any(
+        token in lower
+        for token in (
+            "run mvn test",
+            "$ mvn test",
+            "maven-surefire-plugin",
+            "surefire-reports",
+            "tests run:",
+        )
+    )
+
+
+def _looks_like_gradle_test(lower: str) -> bool:
+    return any(
+        token in lower
+        for token in (
+            "run ./gradlew test",
+            "$ ./gradlew test",
+            "> task :test failed",
+            "gradle test executor",
+        )
+    )
 
 
 def _first_failure_line(log_text: str) -> str:

--- a/tests/fixtures/ci_failures/gradle_test/ci_log.txt
+++ b/tests/fixtures/ci_failures/gradle_test/ci_log.txt
@@ -1,0 +1,14 @@
+Run ./gradlew test
+> Task :compileJava UP-TO-DATE
+> Task :test FAILED
+
+Gradle Test Executor 1 finished executing tests.
+
+com.example.CalculatorTest > addsTwoNumbers FAILED
+    java.lang.AssertionError: expected:<4> but was:<5>
+    at src/test/java/com/example/CalculatorTest.java:22
+
+1 test completed, 1 failed
+
+FAILURE: Build failed with an exception.
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/maven_test/ci_log.txt
+++ b/tests/fixtures/ci_failures/maven_test/ci_log.txt
@@ -1,0 +1,10 @@
+Run mvn test
+[INFO] --- maven-surefire-plugin:3.2.5:test (default-test) @ calculator ---
+[INFO] Running com.example.CalculatorTest
+[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.021 s <<< FAILURE! -- in com.example.CalculatorTest
+[ERROR] src/test/java/com/example/CalculatorTest.java:16: expected:<4> but was:<5>
+[ERROR]   at com.example.CalculatorTest.addsTwoNumbers(CalculatorTest.java:16)
+[ERROR] Failures:
+[ERROR]   CalculatorTest.addsTwoNumbers:16 expected:<4> but was:<5>
+[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
+Process completed with exit code 1

--- a/tests/test_cross_ecosystem_failure_vector_adapters.py
+++ b/tests/test_cross_ecosystem_failure_vector_adapters.py
@@ -29,6 +29,22 @@ def _fixture(name: str) -> str:
             1,
         ),
         ("go_vet", "go_vet", "lint", "internal/logging/logging.go", "go vet ./...", 1),
+        (
+            "maven_test",
+            "maven_test",
+            "test",
+            "src/test/java/com/example/CalculatorTest.java",
+            "mvn test",
+            1,
+        ),
+        (
+            "gradle_test",
+            "gradle_test",
+            "test",
+            "src/test/java/com/example/CalculatorTest.java",
+            "./gradlew test",
+            1,
+        ),
     ],
 )
 def test_cross_ecosystem_adapter_extracts_review_first_failure_vectors(
@@ -85,6 +101,21 @@ def test_unknown_cross_ecosystem_signal_remains_review_first() -> None:
     assert result.tool == "unknown"
     assert result.confidence == "low"
     assert result.uncertainty == ("javascript_failure_not_classified",)
+    assert result.vector.failure_class == "unknown"
+    assert evaluate_failure_vector(result.vector).review_first is True
+
+
+def test_unknown_java_signal_remains_review_first() -> None:
+    result = extract_ecosystem_failure_vector(
+        "Java build stopped without Maven or Gradle test markers",
+        ecosystem="java",
+        check="java-build",
+    )
+
+    assert result.ecosystem == "java"
+    assert result.tool == "unknown"
+    assert result.confidence == "low"
+    assert result.uncertainty == ("java_failure_not_classified",)
     assert result.vector.failure_class == "unknown"
     assert evaluate_failure_vector(result.vector).review_first is True
 


### PR DESCRIPTION
## Summary
- add read-only Java failure-vector extraction for saved Maven and Gradle test logs
- retain Java source/test paths and exit codes when present in the saved log
- keep unknown Java output low-confidence and review-first

## Why
- Extends the cross-ecosystem FailureVector path from Python, JavaScript/TypeScript, and Go into Java.
- Aligns with the multi-language diagnosis roadmap while keeping target repository code execution disabled.

## Verification
Expected checks:
- `python -m pytest -q tests/test_cross_ecosystem_failure_vector_adapters.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- CI

## Risk
- Low/Medium: read-only adapter and fixture-test coverage only.
- Rollback: revert this PR.

## Authority
No automated GitHub comments or reviews were posted.
Automation, patch application, security dismissal, semantic-equivalence, and merge authorization remain false/review-first.

Resolves #1939