### PR TITLE
feat: write Doctor report artifact bundle

### DIFF
--- a/docs/doctor-report-contract.md
+++ b/docs/doctor-report-contract.md
@@ -80,3 +80,19 @@ python -m sdetkit doctor --report-contract --format md --ci --out build/sdetkit/
 ```
 
 `--report-contract` uses the same Doctor checks and exit status, but renders the advisory report contract as JSON or Markdown. The mode keeps automation, patch application, and merge authorization false.
+
+## Artifact bundle
+
+Use `--report-artifact-dir` when CI or an operator needs both machine-readable and human-readable report files in one deterministic directory:
+
+```bash
+python -m sdetkit doctor --report-contract --report-artifact-dir build/sdetkit
+```
+
+The artifact bundle writes:
+
+- `doctor-report.json`
+- `doctor-report.md`
+- `doctor-report-manifest.json`
+
+The manifest schema is `sdetkit.doctor_report_artifact_bundle.v1`. It records the report schema version, report status, output paths, and SHA-256 digests for the JSON and Markdown report files.

--- a/src/sdetkit/cli/__init__.py
+++ b/src/sdetkit/cli/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import io
 import json
@@ -28,10 +29,11 @@ def _normalize_professional_command_aliases(argv: list[str]) -> list[str]:
 
 def _split_doctor_report_contract_args(
     argv: list[str],
-) -> tuple[bool, str, str | None, list[str]]:
+) -> tuple[bool, str, str | None, str | None, list[str]]:
     enabled = False
     output_format = "text"
     out_path: str | None = None
+    artifact_dir: str | None = None
     inner: list[str] = []
 
     index = 0
@@ -65,17 +67,63 @@ def _split_doctor_report_contract_args(
             out_path = token.split("=", 1)[1]
             index += 1
             continue
+        if token == "--report-artifact-dir":
+            if index + 1 >= len(argv):
+                raise SystemExit(2)
+            artifact_dir = argv[index + 1]
+            index += 2
+            continue
+        if token.startswith("--report-artifact-dir="):
+            artifact_dir = token.split("=", 1)[1]
+            index += 1
+            continue
         inner.append(token)
         index += 1
 
-    return enabled, output_format, out_path, inner
+    return enabled, output_format, out_path, artifact_dir, inner
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _write_doctor_report_artifact_bundle(
+    artifact_dir: str,
+    contract: dict[str, Any],
+    json_output: str,
+    markdown_output: str,
+) -> None:
+    target = Path(artifact_dir)
+    target.mkdir(parents=True, exist_ok=True)
+
+    outputs = {
+        "json": {
+            "path": "doctor-report.json",
+            "sha256": _sha256_text(json_output),
+        },
+        "markdown": {
+            "path": "doctor-report.md",
+            "sha256": _sha256_text(markdown_output),
+        },
+    }
+    manifest = {
+        "schema_version": "sdetkit.doctor_report_artifact_bundle.v1",
+        "report_schema_version": str(contract.get("schema_version", "")),
+        "status": str(contract.get("status", "")),
+        "outputs": outputs,
+    }
+    manifest_output = json.dumps(manifest, sort_keys=True, indent=2) + "\n"
+
+    (target / "doctor-report.json").write_text(json_output, encoding="utf-8")
+    (target / "doctor-report.md").write_text(markdown_output, encoding="utf-8")
+    (target / "doctor-report-manifest.json").write_text(manifest_output, encoding="utf-8")
 
 
 def _run_doctor_report_contract(argv: list[str]) -> int | None:
     if not argv or argv[0] != "doctor":
         return None
 
-    enabled, output_format, out_path, inner = _split_doctor_report_contract_args(argv[1:])
+    enabled, output_format, out_path, artifact_dir, inner = _split_doctor_report_contract_args(argv[1:])
     if not enabled:
         return None
 
@@ -107,11 +155,17 @@ def _run_doctor_report_contract(argv: list[str]) -> int | None:
         return rc if rc else 2
 
     contract = build_doctor_report_contract(doctor_payload)
-    if output_format == "json":
-        output = json.dumps(contract, sort_keys=True) + "\n"
-    else:
-        output = render_doctor_report_markdown(contract)
+    json_output = json.dumps(contract, sort_keys=True) + "\n"
+    markdown_output = render_doctor_report_markdown(contract)
+    output = json_output if output_format == "json" else markdown_output
 
+    if artifact_dir:
+        _write_doctor_report_artifact_bundle(
+            artifact_dir,
+            contract,
+            json_output,
+            markdown_output,
+        )
     if out_path:
         Path(out_path).write_text(output, encoding="utf-8")
     sys.stdout.write(output)

--- a/src/sdetkit/cli/__init__.py
+++ b/src/sdetkit/cli/__init__.py
@@ -123,7 +123,9 @@ def _run_doctor_report_contract(argv: list[str]) -> int | None:
     if not argv or argv[0] != "doctor":
         return None
 
-    enabled, output_format, out_path, artifact_dir, inner = _split_doctor_report_contract_args(argv[1:])
+    enabled, output_format, out_path, artifact_dir, inner = _split_doctor_report_contract_args(
+        argv[1:]
+    )
     if not enabled:
         return None
 

--- a/tests/test_doctor_report_cli_contract.py
+++ b/tests/test_doctor_report_cli_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -18,6 +19,10 @@ def _run_sdetkit(repo_root: Path, cwd: Path, *args: str) -> subprocess.Completed
         capture_output=True,
         check=False,
     )
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def test_sdetkit_doctor_report_contract_json_is_review_first(tmp_path: Path) -> None:
@@ -69,3 +74,44 @@ def test_sdetkit_doctor_report_contract_markdown_respects_out_path(tmp_path: Pat
     assert "patch_application_allowed: `false`" in proc.stdout
     assert "merge_authorized: `false`" in proc.stdout
     assert out_path.read_text(encoding="utf-8") == proc.stdout
+
+
+def test_sdetkit_doctor_report_contract_writes_artifact_bundle(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    artifact_dir = tmp_path / "doctor-artifacts"
+
+    proc = _run_sdetkit(
+        repo_root,
+        tmp_path,
+        "doctor",
+        "--report-contract",
+        "--format",
+        "json",
+        "--report-artifact-dir",
+        str(artifact_dir),
+        "--no-workspace",
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    json_path = artifact_dir / "doctor-report.json"
+    markdown_path = artifact_dir / "doctor-report.md"
+    manifest_path = artifact_dir / "doctor-report-manifest.json"
+    assert json_path.read_text(encoding="utf-8") == proc.stdout
+    assert markdown_path.read_text(encoding="utf-8").startswith("# SDETKit Doctor Report")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest == {
+        "outputs": {
+            "json": {
+                "path": "doctor-report.json",
+                "sha256": _sha256_text(json_path.read_text(encoding="utf-8")),
+            },
+            "markdown": {
+                "path": "doctor-report.md",
+                "sha256": _sha256_text(markdown_path.read_text(encoding="utf-8")),
+            },
+        },
+        "report_schema_version": "sdetkit.doctor_report.v1",
+        "schema_version": "sdetkit.doctor_report_artifact_bundle.v1",
+        "status": "green",
+    }


### PR DESCRIPTION
## Summary
- add `sdetkit doctor --report-contract --report-artifact-dir <dir>`
- write `doctor-report.json`, `doctor-report.md`, and `doctor-report-manifest.json`
- record deterministic SHA-256 digests for JSON and Markdown report outputs
- document the artifact bundle and add focused subprocess coverage

## Why
- Makes the Doctor report contract usable as a CI artifact bundle, not only stdout or a single `--out` file.
- Keeps default Doctor behavior unchanged unless `--report-contract` is requested.
- Preserves review-first boundaries: automation, patch application, merge authorization, and semantic-equivalence claims remain false.

## Verification
Expected checks:
- `python -m pytest -q tests/test_doctor_report_cli_contract.py -o addopts=`
- `python -m pre_commit run -a`
- CI

## Risk
- Low/medium: existing CLI compatibility-layer path, deterministic file writes, focused tests.
- Rollback: revert this PR.

## Authority
No automated GitHub comments or reviews were posted.
Automation, patch application, security dismissal, semantic-equivalence, and merge authorization remain false/review-first.