### PR TITLE
feat: connect Doctor report to FailureVector evidence

### DIFF
--- a/docs/doctor-report-contract.md
+++ b/docs/doctor-report-contract.md
@@ -24,6 +24,7 @@ The contract is intentionally advisory. It does not authorize automation, patch 
   "summary": {},
   "primary_finding": {},
   "findings": [],
+  "failure_vector_evidence": {},
   "safety_decision": {},
   "roadmap_alignment": {},
   "proof_commands": []
@@ -48,6 +49,20 @@ Every Doctor report preserves the authority boundary:
 
 This keeps Doctor useful without making unsafe claims. Future remediation work can consume the report, but separate SafetyGate, verifier, proof, and trajectory records must still decide whether any action is allowed.
 
+## Failure vector evidence
+
+`build_doctor_report_contract()` accepts an optional `failure_vector_bundle` payload. This lets Doctor summarize existing `sdetkit.failure_vector.bundle.v1` evidence without parsing logs inside the Doctor report layer.
+
+When evidence is supplied, the report includes:
+
+- `failure_vector_count`
+- counts by failure class and risk
+- safe-fix candidate and review-first counts
+- the highest-risk top failure signal
+- the `failure_diagnosis` roadmap lane
+
+Supplying failure-vector evidence can raise a green Doctor payload to `review_required`, because active failure vectors mean the repository still has unresolved diagnosis evidence. The report remains advisory and review-first.
+
 ## Markdown rendering
 
 The Markdown renderer produces these sections:
@@ -55,6 +70,7 @@ The Markdown renderer produces these sections:
 - Status
 - Primary Finding
 - Findings
+- Failure Vector Evidence
 - Safety Decision
 - Roadmap Alignment
 - Proof Commands
@@ -68,6 +84,11 @@ from sdetkit.doctor_report import build_doctor_report_contract, render_doctor_re
 
 contract = build_doctor_report_contract(doctor_payload)
 markdown = render_doctor_report_markdown(contract)
+
+contract_with_failure_vectors = build_doctor_report_contract(
+    doctor_payload,
+    failure_vector_bundle=failure_vector_bundle,
+)
 ```
 
 ## CLI usage

--- a/src/sdetkit/doctor_report.py
+++ b/src/sdetkit/doctor_report.py
@@ -82,21 +82,34 @@ def _severity_rank(severity: str) -> int:
     return {"high": 3, "medium": 2, "low": 1}.get(severity, 0)
 
 
-def _status(payload: Mapping[str, Any], findings: Sequence[Mapping[str, object]]) -> str:
+def _status(
+    payload: Mapping[str, Any],
+    findings: Sequence[Mapping[str, object]],
+    failure_vector_evidence: Mapping[str, object],
+) -> str:
     if findings:
         if any(_string(item.get("severity")) == "high" for item in findings):
             return "blocked"
+        return "review_required"
+    if _int(failure_vector_evidence.get("failure_vector_count")) > 0:
         return "review_required"
     if _bool(payload.get("ok")):
         return "green"
     return "review_required"
 
 
-def _confidence(payload: Mapping[str, Any], findings: Sequence[Mapping[str, object]]) -> str:
+def _confidence(
+    payload: Mapping[str, Any],
+    findings: Sequence[Mapping[str, object]],
+    failure_vector_evidence: Mapping[str, object],
+) -> str:
     quality = _as_mapping(payload.get("quality"))
     evidence_count = _int(quality.get("evidence_count"))
     selected_checks = _int(quality.get("selected_checks"))
+    failure_vector_count = _int(failure_vector_evidence.get("failure_vector_count"))
     if findings and evidence_count > 0:
+        return "high"
+    if failure_vector_count > 0:
         return "high"
     if selected_checks > 0 or findings:
         return "medium"
@@ -161,8 +174,76 @@ def _build_findings(payload: Mapping[str, Any]) -> list[dict[str, object]]:
     )
 
 
+def _dict_of_ints(value: object) -> dict[str, int]:
+    mapping = _as_mapping(value)
+    return {key: _int(raw) for key, raw in sorted(mapping.items()) if _string(key)}
+
+
+def _top_failure_vector(vector_payloads: Sequence[Mapping[str, Any]]) -> dict[str, object]:
+    if not vector_payloads:
+        return {
+            "check": "none",
+            "failure_type": "none",
+            "risk": "none",
+            "headline_signal": "No failure vector evidence supplied",
+            "local_repro_command": "none",
+        }
+
+    rank = {"high": 3, "medium": 2, "low": 1}
+    top = sorted(
+        vector_payloads,
+        key=lambda item: (
+            -rank.get(_string(item.get("risk")), 0),
+            _string(item.get("check")),
+        ),
+    )[0]
+    return {
+        "check": _string(top.get("check"), "unknown"),
+        "failure_type": _string(top.get("failure_type") or top.get("failure_class"), "unknown"),
+        "risk": _string(top.get("risk"), "unknown"),
+        "headline_signal": _string(top.get("headline_signal"), "unknown"),
+        "local_repro_command": _string(top.get("local_repro_command"), "none"),
+    }
+
+
+def _failure_vector_evidence(bundle: Mapping[str, Any] | None) -> dict[str, object]:
+    if not bundle:
+        return {
+            "available": False,
+            "schema_version": "none",
+            "vector_schema_version": "none",
+            "failure_vector_count": 0,
+            "by_failure_class": {},
+            "by_risk": {},
+            "safe_fix_candidate_count": 0,
+            "safe_fix_allowed_count": 0,
+            "review_first_count": 0,
+            "top_failure": _top_failure_vector(()),
+        }
+
+    summary = _as_mapping(bundle.get("summary"))
+    raw_vectors = _as_sequence(bundle.get("failure_vectors"))
+    vector_payloads = [_as_mapping(item) for item in raw_vectors if _as_mapping(item)]
+    return {
+        "available": True,
+        "schema_version": _string(bundle.get("schema_version"), "unknown"),
+        "vector_schema_version": _string(bundle.get("vector_schema_version"), "unknown"),
+        "failure_vector_count": _int(bundle.get("failure_vector_count"), len(vector_payloads)),
+        "by_failure_class": _dict_of_ints(summary.get("by_failure_class")),
+        "by_risk": _dict_of_ints(summary.get("by_risk")),
+        "safe_fix_candidate_count": _int(summary.get("safe_fix_candidate_count")),
+        "safe_fix_allowed_count": sum(
+            1 for vector_payload in vector_payloads if _bool(vector_payload.get("safe_fix_allowed"))
+        ),
+        "review_first_count": _int(summary.get("review_first_count")),
+        "top_failure": _top_failure_vector(vector_payloads),
+    }
+
+
 def _summary(
-    payload: Mapping[str, Any], findings: Sequence[Mapping[str, object]]
+    payload: Mapping[str, Any],
+    findings: Sequence[Mapping[str, object]],
+    failure_vector_evidence: Mapping[str, object],
 ) -> dict[str, object]:
     quality = _as_mapping(payload.get("quality"))
     return {
@@ -174,6 +255,7 @@ def _summary(
         "failed_checks": _int(quality.get("failed_checks")),
         "skipped_checks": _int(quality.get("skipped_checks")),
         "finding_count": len(findings),
+        "failure_vector_count": _int(failure_vector_evidence.get("failure_vector_count")),
     }
 
 
@@ -200,12 +282,18 @@ def _primary_finding(findings: Sequence[Mapping[str, object]]) -> dict[str, obje
     }
 
 
-def _roadmap_alignment(findings: Sequence[Mapping[str, object]]) -> dict[str, object]:
+def _roadmap_alignment(
+    findings: Sequence[Mapping[str, object]],
+    failure_vector_evidence: Mapping[str, object],
+) -> dict[str, object]:
     lanes = sorted(
         {_string(item.get("roadmap_lane")) for item in findings if item.get("roadmap_lane")}
     )
+    if _bool(failure_vector_evidence.get("available")):
+        lanes.append("failure_diagnosis")
     if not lanes:
         lanes = ["green_main"]
+    lanes = sorted(set(lanes))
     return {
         "lanes": lanes,
         "next_best_lane": lanes[0],
@@ -213,23 +301,28 @@ def _roadmap_alignment(findings: Sequence[Mapping[str, object]]) -> dict[str, ob
     }
 
 
-def build_doctor_report_contract(payload: Mapping[str, Any]) -> dict[str, object]:
+def build_doctor_report_contract(
+    payload: Mapping[str, Any],
+    failure_vector_bundle: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
     """Build the professional Doctor report contract from a standard Doctor payload."""
 
     findings = _build_findings(payload)
-    status = _status(payload, findings)
+    failure_vector_evidence = _failure_vector_evidence(failure_vector_bundle)
+    status = _status(payload, findings, failure_vector_evidence)
     contract = {
         "schema_version": SCHEMA_VERSION,
         "status": status,
-        "confidence": _confidence(payload, findings),
-        "summary": _summary(payload, findings),
+        "confidence": _confidence(payload, findings, failure_vector_evidence),
+        "summary": _summary(payload, findings, failure_vector_evidence),
         "primary_finding": _primary_finding(findings),
         "findings": findings,
+        "failure_vector_evidence": failure_vector_evidence,
         "safety_decision": {
             **AUTHORITY_BOUNDARY,
             "reason": "Doctor report is advisory and review-first until proof and verifier boundaries are implemented.",
         },
-        "roadmap_alignment": _roadmap_alignment(findings),
+        "roadmap_alignment": _roadmap_alignment(findings, failure_vector_evidence),
         "proof_commands": sorted(
             {_string(item.get("proof_command")) for item in findings if item.get("proof_command")}
         )
@@ -245,6 +338,8 @@ def render_doctor_report_markdown(contract: Mapping[str, object]) -> str:
     primary = _as_mapping(contract.get("primary_finding"))
     safety = _as_mapping(contract.get("safety_decision"))
     roadmap = _as_mapping(contract.get("roadmap_alignment"))
+    failure_vector_evidence = _as_mapping(contract.get("failure_vector_evidence"))
+    top_failure = _as_mapping(failure_vector_evidence.get("top_failure"))
     findings = [_as_mapping(item) for item in _as_sequence(contract.get("findings"))]
     proof_commands = [
         _string(item) for item in _as_sequence(contract.get("proof_commands")) if _string(item)
@@ -258,6 +353,7 @@ def render_doctor_report_markdown(contract: Mapping[str, object]) -> str:
         f"- confidence: `{_string(contract.get('confidence'), 'low')}`",
         f"- score: `{_int(summary.get('score'))}%`",
         f"- findings: `{_int(summary.get('finding_count'))}`",
+        f"- failure_vectors: `{_int(summary.get('failure_vector_count'))}`",
         "",
         "## Primary Finding",
         f"- title: `{_string(primary.get('title'), 'No finding')}`",
@@ -286,6 +382,17 @@ def render_doctor_report_markdown(contract: Mapping[str, object]) -> str:
 
     lines.extend(
         [
+            "## Failure Vector Evidence",
+            f"- available: `{str(_bool(failure_vector_evidence.get('available'))).lower()}`",
+            f"- schema_version: `{_string(failure_vector_evidence.get('schema_version'), 'none')}`",
+            f"- failure_vector_count: `{_int(failure_vector_evidence.get('failure_vector_count'))}`",
+            f"- safe_fix_candidate_count: `{_int(failure_vector_evidence.get('safe_fix_candidate_count'))}`",
+            f"- safe_fix_allowed_count: `{_int(failure_vector_evidence.get('safe_fix_allowed_count'))}`",
+            f"- review_first_count: `{_int(failure_vector_evidence.get('review_first_count'))}`",
+            f"- top_failure_type: `{_string(top_failure.get('failure_type'), 'none')}`",
+            f"- top_failure_risk: `{_string(top_failure.get('risk'), 'none')}`",
+            f"- top_failure_signal: `{_string(top_failure.get('headline_signal'), 'none')}`",
+            "",
             "## Safety Decision",
             f"- review_first: `{str(_bool(safety.get('review_first'))).lower()}`",
             f"- automation_allowed: `{str(_bool(safety.get('automation_allowed'))).lower()}`",

--- a/tests/test_doctor_report_contract.py
+++ b/tests/test_doctor_report_contract.py
@@ -60,7 +60,9 @@ def test_doctor_report_contract_prioritizes_blocking_findings() -> None:
         "failed_checks": 2,
         "skipped_checks": 1,
         "finding_count": 2,
+        "failure_vector_count": 0,
     }
+    assert report["failure_vector_evidence"]["available"] is False
     assert report["safety_decision"]["review_first"] is True
     assert report["safety_decision"]["automation_allowed"] is False
     assert report["safety_decision"]["patch_application_allowed"] is False
@@ -95,6 +97,7 @@ def test_doctor_report_markdown_is_professional_and_review_first() -> None:
 
     assert markdown.startswith("# SDETKit Doctor Report")
     assert "## Primary Finding" in markdown
+    assert "## Failure Vector Evidence" in markdown
     assert "## Safety Decision" in markdown
     assert "automation_allowed: `false`" in markdown
     assert "patch_application_allowed: `false`" in markdown
@@ -122,11 +125,83 @@ def test_green_doctor_report_keeps_next_action_roadmap_aligned() -> None:
 
     assert report["status"] == "green"
     assert report["confidence"] == "medium"
+    assert report["summary"]["failure_vector_count"] == 0
     assert report["primary_finding"]["roadmap_lane"] == "green_main"
     assert (
         report["primary_finding"]["proof_command"] == "python -m sdetkit doctor --all --format json"
     )
     assert report["proof_commands"] == ["python -m sdetkit doctor --all --format json"]
+
+
+def test_doctor_report_includes_failure_vector_evidence() -> None:
+    failure_vector_bundle = {
+        "schema_version": "sdetkit.failure_vector.bundle.v1",
+        "vector_schema_version": "sdetkit.failure_vector.v1",
+        "environment": "ci",
+        "failure_vector_count": 2,
+        "summary": {
+            "by_failure_class": {"format": 1, "test": 1},
+            "by_risk": {"low": 1, "medium": 1},
+            "safe_fix_candidate_count": 1,
+            "review_first_count": 1,
+        },
+        "failure_vectors": [
+            {
+                "check": "ruff_format",
+                "failure_class": "format",
+                "failure_type": "format",
+                "risk": "low",
+                "headline_signal": "ruff format would reformat one file",
+                "local_repro_command": "python -m ruff format --check src/sdetkit/cli/__init__.py",
+                "safe_fix_candidate": True,
+                "safe_fix_allowed": False,
+            },
+            {
+                "check": "pytest",
+                "failure_class": "test",
+                "failure_type": "test",
+                "risk": "medium",
+                "headline_signal": "FAILED tests/test_example.py::test_contract",
+                "local_repro_command": "python -m pytest tests/test_example.py::test_contract",
+                "safe_fix_candidate": False,
+                "safe_fix_allowed": False,
+            },
+        ],
+    }
+
+    report = build_doctor_report_contract(
+        {"ok": True, "score": 100, "quality": {"selected_checks": 1}, "next_actions": []},
+        failure_vector_bundle=failure_vector_bundle,
+    )
+
+    assert report["status"] == "review_required"
+    assert report["confidence"] == "high"
+    assert report["summary"]["failure_vector_count"] == 2
+    assert report["failure_vector_evidence"] == {
+        "available": True,
+        "schema_version": "sdetkit.failure_vector.bundle.v1",
+        "vector_schema_version": "sdetkit.failure_vector.v1",
+        "failure_vector_count": 2,
+        "by_failure_class": {"format": 1, "test": 1},
+        "by_risk": {"low": 1, "medium": 1},
+        "safe_fix_candidate_count": 1,
+        "safe_fix_allowed_count": 0,
+        "review_first_count": 1,
+        "top_failure": {
+            "check": "pytest",
+            "failure_type": "test",
+            "risk": "medium",
+            "headline_signal": "FAILED tests/test_example.py::test_contract",
+            "local_repro_command": "python -m pytest tests/test_example.py::test_contract",
+        },
+    }
+    assert "failure_diagnosis" in report["roadmap_alignment"]["lanes"]
+
+    markdown = render_doctor_report_markdown(report)
+    assert "## Failure Vector Evidence" in markdown
+    assert "failure_vector_count: `2`" in markdown
+    assert "top_failure_type: `test`" in markdown
+    assert "top_failure_signal: `FAILED tests/test_example.py::test_contract`" in markdown
 
 
 def test_doctor_report_contract_writes_deterministic_json(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- let `build_doctor_report_contract()` accept optional FailureVector bundle evidence
- add `failure_vector_evidence` to the Doctor report contract and Markdown output
- surface failure-vector counts, class/risk summaries, top failure signal, and `failure_diagnosis` roadmap alignment
- add focused contract tests and docs

## Why
- Continues the Doctor roadmap after the report CLI and artifact bundle work.
- Lets Doctor summarize existing `sdetkit.failure_vector.bundle.v1` evidence without parsing logs inside the report layer.
- Keeps the report advisory and review-first; automation, patch application, merge authorization, and semantic-equivalence claims remain false.

## Verification
Expected checks:
- `python -m pytest -q tests/test_doctor_report_contract.py -o addopts=`
- `python -m pre_commit run -a`
- CI

## Risk
- Low/medium: contract extension with default-compatible optional argument.
- Existing callers can keep calling `build_doctor_report_contract(payload)` unchanged.
- Rollback: revert this PR.

## Authority
No automated GitHub comments or reviews were posted.
Automation, patch application, security dismissal, semantic-equivalence, and merge authorization remain false/review-first.