### PR TITLE
feat: load FailureVector bundle in Doctor report CLI

### DIFF
--- a/docs/doctor-report-contract.md
+++ b/docs/doctor-report-contract.md
@@ -98,9 +98,12 @@ The main `sdetkit` CLI can project standard Doctor output into the report contra
 ```bash
 python -m sdetkit doctor --report-contract --format json
 python -m sdetkit doctor --report-contract --format md --ci --out build/sdetkit/doctor-report.md
+python -m sdetkit doctor --report-contract --failure-vector-bundle build/sdetkit/failure-vector.json
 ```
 
 `--report-contract` uses the same Doctor checks and exit status, but renders the advisory report contract as JSON or Markdown. The mode keeps automation, patch application, and merge authorization false.
+
+`--failure-vector-bundle` is only consumed by the report-contract route. It must point to a prebuilt `sdetkit.failure_vector.bundle.v1` JSON object. The CLI loads it as evidence and passes it to `build_doctor_report_contract(..., failure_vector_bundle=...)`.
 
 ## Artifact bundle
 
@@ -108,6 +111,7 @@ Use `--report-artifact-dir` when CI or an operator needs both machine-readable a
 
 ```bash
 python -m sdetkit doctor --report-contract --report-artifact-dir build/sdetkit
+python -m sdetkit doctor --report-contract --failure-vector-bundle build/sdetkit/failure-vector.json --report-artifact-dir build/sdetkit
 ```
 
 The artifact bundle writes:

--- a/src/sdetkit/cli/__init__.py
+++ b/src/sdetkit/cli/__init__.py
@@ -29,11 +29,12 @@ def _normalize_professional_command_aliases(argv: list[str]) -> list[str]:
 
 def _split_doctor_report_contract_args(
     argv: list[str],
-) -> tuple[bool, str, str | None, str | None, list[str]]:
+) -> tuple[bool, str, str | None, str | None, str | None, list[str]]:
     enabled = False
     output_format = "text"
     out_path: str | None = None
     artifact_dir: str | None = None
+    failure_vector_bundle_path: str | None = None
     inner: list[str] = []
 
     index = 0
@@ -77,14 +78,31 @@ def _split_doctor_report_contract_args(
             artifact_dir = token.split("=", 1)[1]
             index += 1
             continue
+        if token == "--failure-vector-bundle":
+            if index + 1 >= len(argv):
+                raise SystemExit(2)
+            failure_vector_bundle_path = argv[index + 1]
+            index += 2
+            continue
+        if token.startswith("--failure-vector-bundle="):
+            failure_vector_bundle_path = token.split("=", 1)[1]
+            index += 1
+            continue
         inner.append(token)
         index += 1
 
-    return enabled, output_format, out_path, artifact_dir, inner
+    return enabled, output_format, out_path, artifact_dir, failure_vector_bundle_path, inner
 
 
 def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _load_failure_vector_bundle(path: str) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("FailureVector bundle must be a JSON object")
+    return payload
 
 
 def _write_doctor_report_artifact_bundle(
@@ -123,9 +141,14 @@ def _run_doctor_report_contract(argv: list[str]) -> int | None:
     if not argv or argv[0] != "doctor":
         return None
 
-    enabled, output_format, out_path, artifact_dir, inner = _split_doctor_report_contract_args(
-        argv[1:]
-    )
+    (
+        enabled,
+        output_format,
+        out_path,
+        artifact_dir,
+        failure_vector_bundle_path,
+        inner,
+    ) = _split_doctor_report_contract_args(argv[1:])
     if not enabled:
         return None
 
@@ -156,7 +179,18 @@ def _run_doctor_report_contract(argv: list[str]) -> int | None:
         print("doctor: error: could not build report contract from doctor JSON", file=sys.stderr)
         return rc if rc else 2
 
-    contract = build_doctor_report_contract(doctor_payload)
+    failure_vector_bundle = None
+    if failure_vector_bundle_path:
+        try:
+            failure_vector_bundle = _load_failure_vector_bundle(failure_vector_bundle_path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"doctor: error: could not load FailureVector bundle: {exc}", file=sys.stderr)
+            return 2
+
+    contract = build_doctor_report_contract(
+        doctor_payload,
+        failure_vector_bundle=failure_vector_bundle,
+    )
     json_output = json.dumps(contract, sort_keys=True) + "\n"
     markdown_output = render_doctor_report_markdown(contract)
     output = json_output if output_format == "json" else markdown_output

--- a/tests/test_doctor_report_cli_contract.py
+++ b/tests/test_doctor_report_cli_contract.py
@@ -8,9 +8,7 @@ import sys
 from pathlib import Path
 
 
-def _run_sdetkit(
-    repo_root: Path, cwd: Path, *args: str
-) -> subprocess.CompletedProcess[str]:
+def _run_sdetkit(repo_root: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(repo_root / "src")
     return subprocess.run(
@@ -131,9 +129,7 @@ def test_sdetkit_doctor_report_contract_writes_artifact_bundle(tmp_path: Path) -
     markdown_path = artifact_dir / "doctor-report.md"
     manifest_path = artifact_dir / "doctor-report-manifest.json"
     assert json_path.read_text(encoding="utf-8") == proc.stdout
-    assert markdown_path.read_text(encoding="utf-8").startswith(
-        "# SDETKit Doctor Report"
-    )
+    assert markdown_path.read_text(encoding="utf-8").startswith("# SDETKit Doctor Report")
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest == {
@@ -185,9 +181,7 @@ def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(
         "check": "ruff_format",
         "failure_type": "format",
         "headline_signal": "ruff format would reformat one file",
-        "local_repro_command": (
-            "python -m ruff format --check src/sdetkit/cli/__init__.py"
-        ),
+        "local_repro_command": ("python -m ruff format --check src/sdetkit/cli/__init__.py"),
         "risk": "low",
     }
     assert payload["safety_decision"]["automation_allowed"] is False

--- a/tests/test_doctor_report_cli_contract.py
+++ b/tests/test_doctor_report_cli_contract.py
@@ -44,7 +44,9 @@ def _write_failure_vector_bundle(path: Path) -> None:
                 "failure_type": "format",
                 "risk": "low",
                 "headline_signal": "ruff format would reformat one file",
-                "local_repro_command": "python -m ruff format --check src/sdetkit/cli/__init__.py",
+                "local_repro_command": (
+                    "python -m ruff format --check src/sdetkit/cli/__init__.py"
+                ),
                 "safe_fix_candidate": True,
                 "safe_fix_allowed": False,
             }
@@ -175,7 +177,9 @@ def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(tmp_path: Pa
         "check": "ruff_format",
         "failure_type": "format",
         "headline_signal": "ruff format would reformat one file",
-        "local_repro_command": "python -m ruff format --check src/sdetkit/cli/__init__.py",
+        "local_repro_command": (
+            "python -m ruff format --check src/sdetkit/cli/__init__.py"
+        ),
         "risk": "low",
     }
     assert payload["safety_decision"]["automation_allowed"] is False
@@ -187,5 +191,7 @@ def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(tmp_path: Pa
     assert "failure_vector_count: `1`" in markdown
     assert "top_failure_type: `format`" in markdown
 
-    manifest = json.loads((artifact_dir / "doctor-report-manifest.json").read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (artifact_dir / "doctor-report-manifest.json").read_text(encoding="utf-8")
+    )
     assert manifest["status"] == "review_required"

--- a/tests/test_doctor_report_cli_contract.py
+++ b/tests/test_doctor_report_cli_contract.py
@@ -25,6 +25,34 @@ def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _write_failure_vector_bundle(path: Path) -> None:
+    payload = {
+        "schema_version": "sdetkit.failure_vector.bundle.v1",
+        "vector_schema_version": "sdetkit.failure_vector.v1",
+        "environment": "ci",
+        "failure_vector_count": 1,
+        "summary": {
+            "by_failure_class": {"format": 1},
+            "by_risk": {"low": 1},
+            "safe_fix_candidate_count": 1,
+            "review_first_count": 0,
+        },
+        "failure_vectors": [
+            {
+                "check": "ruff_format",
+                "failure_class": "format",
+                "failure_type": "format",
+                "risk": "low",
+                "headline_signal": "ruff format would reformat one file",
+                "local_repro_command": "python -m ruff format --check src/sdetkit/cli/__init__.py",
+                "safe_fix_candidate": True,
+                "safe_fix_allowed": False,
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def test_sdetkit_doctor_report_contract_json_is_review_first(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
 
@@ -115,3 +143,49 @@ def test_sdetkit_doctor_report_contract_writes_artifact_bundle(tmp_path: Path) -
         "schema_version": "sdetkit.doctor_report_artifact_bundle.v1",
         "status": "green",
     }
+
+
+def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    bundle_path = tmp_path / "failure-vector.json"
+    artifact_dir = tmp_path / "doctor-artifacts"
+    _write_failure_vector_bundle(bundle_path)
+
+    proc = _run_sdetkit(
+        repo_root,
+        tmp_path,
+        "doctor",
+        "--report-contract",
+        "--format",
+        "json",
+        "--failure-vector-bundle",
+        str(bundle_path),
+        "--report-artifact-dir",
+        str(artifact_dir),
+        "--no-workspace",
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "review_required"
+    assert payload["summary"]["failure_vector_count"] == 1
+    assert payload["failure_vector_evidence"]["available"] is True
+    assert payload["failure_vector_evidence"]["failure_vector_count"] == 1
+    assert payload["failure_vector_evidence"]["top_failure"] == {
+        "check": "ruff_format",
+        "failure_type": "format",
+        "headline_signal": "ruff format would reformat one file",
+        "local_repro_command": "python -m ruff format --check src/sdetkit/cli/__init__.py",
+        "risk": "low",
+    }
+    assert payload["safety_decision"]["automation_allowed"] is False
+    assert payload["safety_decision"]["patch_application_allowed"] is False
+    assert payload["safety_decision"]["merge_authorized"] is False
+
+    markdown = (artifact_dir / "doctor-report.md").read_text(encoding="utf-8")
+    assert "## Failure Vector Evidence" in markdown
+    assert "failure_vector_count: `1`" in markdown
+    assert "top_failure_type: `format`" in markdown
+
+    manifest = json.loads((artifact_dir / "doctor-report-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["status"] == "review_required"

--- a/tests/test_doctor_report_cli_contract.py
+++ b/tests/test_doctor_report_cli_contract.py
@@ -8,7 +8,9 @@ import sys
 from pathlib import Path
 
 
-def _run_sdetkit(repo_root: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run_sdetkit(
+    repo_root: Path, cwd: Path, *args: str
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(repo_root / "src")
     return subprocess.run(
@@ -79,7 +81,9 @@ def test_sdetkit_doctor_report_contract_json_is_review_first(tmp_path: Path) -> 
     assert payload["proof_commands"] == ["python -m sdetkit doctor --all --format json"]
 
 
-def test_sdetkit_doctor_report_contract_markdown_respects_out_path(tmp_path: Path) -> None:
+def test_sdetkit_doctor_report_contract_markdown_respects_out_path(
+    tmp_path: Path,
+) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     out_path = tmp_path / "doctor-report.md"
 
@@ -127,7 +131,9 @@ def test_sdetkit_doctor_report_contract_writes_artifact_bundle(tmp_path: Path) -
     markdown_path = artifact_dir / "doctor-report.md"
     manifest_path = artifact_dir / "doctor-report-manifest.json"
     assert json_path.read_text(encoding="utf-8") == proc.stdout
-    assert markdown_path.read_text(encoding="utf-8").startswith("# SDETKit Doctor Report")
+    assert markdown_path.read_text(encoding="utf-8").startswith(
+        "# SDETKit Doctor Report"
+    )
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest == {
@@ -147,7 +153,9 @@ def test_sdetkit_doctor_report_contract_writes_artifact_bundle(tmp_path: Path) -
     }
 
 
-def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(tmp_path: Path) -> None:
+def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(
+    tmp_path: Path,
+) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     bundle_path = tmp_path / "failure-vector.json"
     artifact_dir = tmp_path / "doctor-artifacts"


### PR DESCRIPTION
## Summary
- add `--failure-vector-bundle <path>` to `sdetkit doctor --report-contract`
- load a prebuilt `sdetkit.failure_vector.bundle.v1` JSON object into the Doctor report contract
- preserve the underlying Doctor exit status and existing stdout/`--out`/artifact bundle behavior
- add subprocess coverage and docs for the evidence path

## Why
- Follows #2022 by making the new FailureVector evidence contract reachable from the operator CLI.
- Keeps log parsing outside the Doctor report layer; the CLI only loads an already-built bundle.
- Keeps default Doctor behavior unchanged unless `--report-contract` and `--failure-vector-bundle` are explicitly requested.

## Verification
Expected checks:
- `python -m pytest -q tests/test_doctor_report_cli_contract.py -o addopts=`
- `python -m pre_commit run -a`
- CI

## Risk
- Low/medium: report-contract CLI path only; no default Doctor behavior change.
- Rollback: revert this PR.

## Authority
No automated GitHub comments or reviews were posted.
Automation, patch application, security dismissal, semantic-equivalence, and merge authorization remain false/review-first.