### PR TITLE
feat: include FailureVector evidence in Doctor artifact bundle

### DIFF
--- a/docs/doctor-report-contract.md
+++ b/docs/doctor-report-contract.md
@@ -107,17 +107,21 @@ python -m sdetkit doctor --report-contract --failure-vector-bundle build/sdetkit
 
 ## Artifact bundle
 
-Use `--report-artifact-dir` when CI or an operator needs both machine-readable and human-readable report files in one deterministic directory:
+Use `--report-artifact-dir` when CI or an operator needs machine-readable, human-readable, and evidence files in one deterministic directory:
 
 ```bash
 python -m sdetkit doctor --report-contract --report-artifact-dir build/sdetkit
 python -m sdetkit doctor --report-contract --failure-vector-bundle build/sdetkit/failure-vector.json --report-artifact-dir build/sdetkit
 ```
 
-The artifact bundle writes:
+The artifact bundle always writes:
 
 - `doctor-report.json`
 - `doctor-report.md`
 - `doctor-report-manifest.json`
 
-The manifest schema is `sdetkit.doctor_report_artifact_bundle.v1`. It records the report schema version, report status, output paths, and SHA-256 digests for the JSON and Markdown report files.
+When `--failure-vector-bundle` is also supplied, the artifact bundle also writes a deterministic copy:
+
+- `failure-vector.json`
+
+The manifest schema is `sdetkit.doctor_report_artifact_bundle.v1`. It records the report schema version, report status, output paths, and SHA-256 digests for the JSON, Markdown, and optional FailureVector evidence files. This keeps the `build/sdetkit` evidence directory self-contained while preserving review-first authority boundaries.

--- a/src/sdetkit/cli/__init__.py
+++ b/src/sdetkit/cli/__init__.py
@@ -98,6 +98,10 @@ def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _json_dumps_pretty(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, indent=2) + "\n"
+
+
 def _load_failure_vector_bundle(path: str) -> dict[str, Any]:
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -110,6 +114,7 @@ def _write_doctor_report_artifact_bundle(
     contract: dict[str, Any],
     json_output: str,
     markdown_output: str,
+    failure_vector_bundle: dict[str, Any] | None = None,
 ) -> None:
     target = Path(artifact_dir)
     target.mkdir(parents=True, exist_ok=True)
@@ -124,16 +129,26 @@ def _write_doctor_report_artifact_bundle(
             "sha256": _sha256_text(markdown_output),
         },
     }
+    failure_vector_output = None
+    if failure_vector_bundle is not None:
+        failure_vector_output = _json_dumps_pretty(failure_vector_bundle)
+        outputs["failure_vector"] = {
+            "path": "failure-vector.json",
+            "sha256": _sha256_text(failure_vector_output),
+        }
+
     manifest = {
         "schema_version": "sdetkit.doctor_report_artifact_bundle.v1",
         "report_schema_version": str(contract.get("schema_version", "")),
         "status": str(contract.get("status", "")),
         "outputs": outputs,
     }
-    manifest_output = json.dumps(manifest, sort_keys=True, indent=2) + "\n"
+    manifest_output = _json_dumps_pretty(manifest)
 
     (target / "doctor-report.json").write_text(json_output, encoding="utf-8")
     (target / "doctor-report.md").write_text(markdown_output, encoding="utf-8")
+    if failure_vector_output is not None:
+        (target / "failure-vector.json").write_text(failure_vector_output, encoding="utf-8")
     (target / "doctor-report-manifest.json").write_text(manifest_output, encoding="utf-8")
 
 
@@ -201,6 +216,7 @@ def _run_doctor_report_contract(argv: list[str]) -> int | None:
             contract,
             json_output,
             markdown_output,
+            failure_vector_bundle=failure_vector_bundle,
         )
     if out_path:
         Path(out_path).write_text(output, encoding="utf-8")

--- a/tests/test_doctor_report_cli_contract.py
+++ b/tests/test_doctor_report_cli_contract.py
@@ -25,8 +25,12 @@ def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def _write_failure_vector_bundle(path: Path) -> None:
-    payload = {
+def _json_dumps_pretty(value: dict[str, object]) -> str:
+    return json.dumps(value, sort_keys=True, indent=2) + "\n"
+
+
+def _failure_vector_bundle_payload() -> dict[str, object]:
+    return {
         "schema_version": "sdetkit.failure_vector.bundle.v1",
         "vector_schema_version": "sdetkit.failure_vector.v1",
         "environment": "ci",
@@ -52,7 +56,12 @@ def _write_failure_vector_bundle(path: Path) -> None:
             }
         ],
     }
+
+
+def _write_failure_vector_bundle(path: Path) -> dict[str, object]:
+    payload = _failure_vector_bundle_payload()
     path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
 
 
 def test_sdetkit_doctor_report_contract_json_is_review_first(tmp_path: Path) -> None:
@@ -130,6 +139,7 @@ def test_sdetkit_doctor_report_contract_writes_artifact_bundle(tmp_path: Path) -
     manifest_path = artifact_dir / "doctor-report-manifest.json"
     assert json_path.read_text(encoding="utf-8") == proc.stdout
     assert markdown_path.read_text(encoding="utf-8").startswith("# SDETKit Doctor Report")
+    assert not (artifact_dir / "failure-vector.json").exists()
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest == {
@@ -155,7 +165,7 @@ def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(
     repo_root = Path(__file__).resolve().parents[1]
     bundle_path = tmp_path / "failure-vector.json"
     artifact_dir = tmp_path / "doctor-artifacts"
-    _write_failure_vector_bundle(bundle_path)
+    bundle_payload = _write_failure_vector_bundle(bundle_path)
 
     proc = _run_sdetkit(
         repo_root,
@@ -193,7 +203,29 @@ def test_sdetkit_doctor_report_contract_loads_failure_vector_bundle(
     assert "failure_vector_count: `1`" in markdown
     assert "top_failure_type: `format`" in markdown
 
+    failure_vector_path = artifact_dir / "failure-vector.json"
+    failure_vector_output = _json_dumps_pretty(bundle_payload)
+    assert failure_vector_path.read_text(encoding="utf-8") == failure_vector_output
+
     manifest = json.loads(
         (artifact_dir / "doctor-report-manifest.json").read_text(encoding="utf-8")
     )
-    assert manifest["status"] == "review_required"
+    assert manifest == {
+        "outputs": {
+            "failure_vector": {
+                "path": "failure-vector.json",
+                "sha256": _sha256_text(failure_vector_output),
+            },
+            "json": {
+                "path": "doctor-report.json",
+                "sha256": _sha256_text(proc.stdout),
+            },
+            "markdown": {
+                "path": "doctor-report.md",
+                "sha256": _sha256_text(markdown),
+            },
+        },
+        "report_schema_version": "sdetkit.doctor_report.v1",
+        "schema_version": "sdetkit.doctor_report_artifact_bundle.v1",
+        "status": "review_required",
+    }


### PR DESCRIPTION
## Summary
- include a deterministic `failure-vector.json` copy in `--report-artifact-dir` when `--failure-vector-bundle` is supplied
- add a `failure_vector` output entry with SHA-256 digest to `doctor-report-manifest.json`
- keep artifact bundle behavior unchanged when no FailureVector bundle is supplied
- add subprocess coverage and docs for the self-contained evidence directory

## Why
- Follows #2023 by making the Doctor artifact directory self-contained for CI/operator evidence.
- Keeps Doctor report generation advisory and review-first.
- Avoids log parsing or remediation behavior in the report layer.

## Verification
Expected checks:
- `python -m pytest -q tests/test_doctor_report_cli_contract.py -o addopts=`
- `python -m pre_commit run -a`
- CI

## Risk
- Low/medium: report-contract artifact path only; no default Doctor behavior change.
- Rollback: revert this PR.

## Authority
No automated GitHub comments or reviews were posted.
Automation, patch application, security dismissal, semantic-equivalence, and merge authorization remain false/review-first.