### PR TITLE
feat(diagnosis): add read-only Rust failure-vector adapters

### DIFF
--- a/src/sdetkit/failure_vector_adapters.py
+++ b/src/sdetkit/failure_vector_adapters.py
@@ -18,9 +18,11 @@ GO_TEST = re.compile(r"---\s+FAIL:\s+(?P<check>[\w./-]+)")
 JAVA_LOCATION = re.compile(
     r"(?P<path>[\w./-]+\.java)(?::\d+|:\[\d+(?:,\d+)?\])(?::\s*(?P<check>.+))?"
 )
+RUST_LOCATION = re.compile(r"(?:-->\s+|at\s+)?(?P<path>[\w./-]+\.rs):\d+:\d+")
+RUST_TEST = re.compile(r"^test\s+(?P<check>[\w:./-]+)\s+\.\.\.\s+FAILED$", re.MULTILINE)
 COMMAND = re.compile(r"^(?:Run|\$)\s+(?P<command>.+)$", re.MULTILINE)
 EXIT_CODE = re.compile(r"Process completed with exit code (?P<code>\d+)")
-SUPPORTED = frozenset({"auto", "python", "javascript_typescript", "go", "java"})
+SUPPORTED = frozenset({"auto", "python", "javascript_typescript", "go", "java", "rust"})
 
 
 @dataclass(frozen=True)
@@ -218,6 +220,8 @@ def extract_ecosystem_failure_vector(
         return _go_result(log_text, check, log_url, environment)
     if selected == "java":
         return _java_result(log_text, check, log_url, environment)
+    if selected == "rust":
+        return _rust_result(log_text, check, log_url, environment)
     return _unknown(log_text, "unknown", check, log_url, environment, "ecosystem_not_identified")
 
 
@@ -227,6 +231,8 @@ def _detect(log_text: str) -> str:
         return "javascript_typescript"
     if any(token in lower for token in ("jest", "vitest", "eslint", "tsc --noemit")):
         return "javascript_typescript"
+    if _looks_like_rust(log_text):
+        return "rust"
     if GO_LOCATION.search(log_text) or GO_TEST.search(log_text):
         return "go"
     if any(token in lower for token in ("go test", "go vet")):
@@ -356,6 +362,55 @@ def _java_result(
     return _unknown(log_text, "java", check, log_url, environment, "java_failure_not_classified")
 
 
+def _rust_result(
+    log_text: str,
+    check: str,
+    log_url: str | None,
+    environment: str,
+) -> FailureVectorAdapterResult:
+    lower = log_text.lower()
+    location = RUST_LOCATION.search(log_text)
+    if _looks_like_cargo_clippy(lower):
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location,
+            "lint",
+            "cargo_clippy",
+            "cargo clippy --all-targets --all-features",
+            ecosystem="rust",
+        )
+    test = RUST_TEST.search(log_text)
+    if test or _looks_like_cargo_test(lower):
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location or test,
+            "test",
+            "cargo_test",
+            "cargo test",
+            ecosystem="rust",
+        )
+    if location:
+        return _result(
+            log_text,
+            check,
+            log_url,
+            environment,
+            location,
+            "unknown",
+            "cargo_toolchain",
+            "cargo test",
+            ("rust_failure_class_not_proven",),
+            ecosystem="rust",
+        )
+    return _unknown(log_text, "rust", check, log_url, environment, "rust_failure_not_classified")
+
+
 def _result(
     log_text: str,
     check: str,
@@ -453,6 +508,41 @@ def _looks_like_gradle_test(lower: str) -> bool:
             "$ ./gradlew test",
             "> task :test failed",
             "gradle test executor",
+        )
+    )
+
+
+def _looks_like_rust(log_text: str) -> bool:
+    lower = log_text.lower()
+    return (
+        RUST_LOCATION.search(log_text) is not None
+        or RUST_TEST.search(log_text) is not None
+        or _looks_like_cargo_test(lower)
+        or _looks_like_cargo_clippy(lower)
+    )
+
+
+def _looks_like_cargo_test(lower: str) -> bool:
+    return any(
+        token in lower
+        for token in (
+            "run cargo test",
+            "$ cargo test",
+            "test result: failed",
+            "running unittests",
+            "panicked at",
+        )
+    )
+
+
+def _looks_like_cargo_clippy(lower: str) -> bool:
+    return any(
+        token in lower
+        for token in (
+            "run cargo clippy",
+            "$ cargo clippy",
+            "cargo clippy --all-targets --all-features",
+            "clippy::",
         )
     )
 

--- a/tests/fixtures/ci_failures/cargo_clippy/ci_log.txt
+++ b/tests/fixtures/ci_failures/cargo_clippy/ci_log.txt
@@ -1,0 +1,16 @@
+Run cargo clippy --all-targets --all-features
+    Checking calculator v0.1.0 (/home/runner/work/calculator/calculator)
+error: this `if` statement can be collapsed
+ --> src/main.rs:8:5
+  |
+8 | /     if ready {
+9 | |         if enabled {
+10| |             run();
+11| |         }
+12| |     }
+  | |_____^
+  |
+  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
+  = note: `-D clippy::collapsible-if` implied by `-D warnings`
+error: could not compile `calculator` (bin "calculator" test) due to 1 previous error
+Process completed with exit code 101

--- a/tests/fixtures/ci_failures/cargo_test/ci_log.txt
+++ b/tests/fixtures/ci_failures/cargo_test/ci_log.txt
@@ -1,0 +1,19 @@
+Run cargo test
+   Compiling calculator v0.1.0 (/home/runner/work/calculator/calculator)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.71s
+     Running unittests src/lib.rs (target/debug/deps/calculator-7c18a7f9)
+
+running 1 test
+test tests::adds_numbers ... FAILED
+
+failures:
+
+---- tests::adds_numbers stdout ----
+thread 'tests::adds_numbers' panicked at src/lib.rs:14:9:
+assertion `left == right` failed
+  left: 3
+ right: 4
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+error: test failed, to rerun pass `--lib`
+Process completed with exit code 101

--- a/tests/test_cross_ecosystem_failure_vector_adapters.py
+++ b/tests/test_cross_ecosystem_failure_vector_adapters.py
@@ -45,6 +45,15 @@ def _fixture(name: str) -> str:
             "./gradlew test",
             1,
         ),
+        ("cargo_test", "cargo_test", "test", "src/lib.rs", "cargo test", 101),
+        (
+            "cargo_clippy",
+            "cargo_clippy",
+            "lint",
+            "src/main.rs",
+            "cargo clippy --all-targets --all-features",
+            101,
+        ),
     ],
 )
 def test_cross_ecosystem_adapter_extracts_review_first_failure_vectors(
@@ -118,6 +127,29 @@ def test_unknown_java_signal_remains_review_first() -> None:
     assert result.uncertainty == ("java_failure_not_classified",)
     assert result.vector.failure_class == "unknown"
     assert evaluate_failure_vector(result.vector).review_first is True
+
+
+def test_unknown_rust_signal_remains_review_first() -> None:
+    result = extract_ecosystem_failure_vector(
+        "Rust build stopped without Cargo test or Clippy markers",
+        ecosystem="rust",
+        check="rust-build",
+    )
+
+    assert result.ecosystem == "rust"
+    assert result.tool == "unknown"
+    assert result.confidence == "low"
+    assert result.uncertainty == ("rust_failure_not_classified",)
+    assert result.vector.failure_class == "unknown"
+    assert evaluate_failure_vector(result.vector).review_first is True
+
+
+def test_cargo_test_is_not_misclassified_as_go_test() -> None:
+    result = extract_ecosystem_failure_vector(_fixture("cargo_test"), check="cargo-test")
+
+    assert result.ecosystem == "rust"
+    assert result.tool == "cargo_test"
+    assert result.vector.local_repro_command == "cargo test"
 
 
 def test_adapter_rejects_unsupported_ecosystem() -> None:


### PR DESCRIPTION
## Summary
- accept `rust` as an explicit and auto-detected failure-vector ecosystem
- normalize saved `cargo test` failures as review-first `cargo_test` vectors
- normalize saved `cargo clippy` diagnostics as review-first `cargo_clippy` vectors
- extract `.rs` owner paths and GitHub Actions exit codes when present
- add realistic fixture coverage and an explicit regression test preventing `cargo test` from being misclassified as `go test`

Closes #1937.

Related: #1928, #1946, #2045.

## Product value
This is the diagnosis component of the first complete post-1.1 ecosystem vertical. It reuses the shared `FailureVector` and `SafetyGate` contracts instead of creating a Rust-specific subsystem.

## Safety boundary
- saved logs only; no target repository execution
- no Cargo installation
- no patch application
- no dependency mutation
- no merge or semantic-equivalence authority
- unknown Rust output remains low-confidence and review-first

## Verification
Private parser/syntax checks completed against the exact proposed source and fixtures, including detection precedence for the `cargo test` / `go test` substring overlap.

Expected CI proof:

- `python -m pytest -q tests/test_cross_ecosystem_failure_vector_adapters.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low/medium: one shared read-only adapter module plus fixture tests
- Existing Python, JavaScript/TypeScript, Go, and Java branches are preserved
- Rollback: revert the four focused commits

## Release boundary
This PR is post-1.1 feature work. It does not modify the frozen 1.1.0 release candidate, release files, package metadata, or publishing configuration.