### PR TITLE
feat(adoption): extract Jenkins proof commands

### DIFF
--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "sdetkit.quality_truth_baseline.v1",
-  "generated_on": "2026-07-12",
+  "generated_on": "2026-07-13",
   "status": "staged_migration_visible",
   "coverage": {
     "critical_spine": {
@@ -35,7 +35,7 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 503,
+    "source_module_count": 504,
     "typing_debt_module_count": 484,
     "typing_debt_inventory_sha256": "b118d6ed853b73f7b5a551e98b684484a3d63ddc65d3b3aa348f926c37cd3998",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
@@ -50,6 +50,7 @@
       "sdetkit.adoption_proof_recommendations",
       "sdetkit.adoption_public_repo_trial_matrix_report",
       "sdetkit.adoption_repo_topology",
+      "sdetkit.adoption_surface.jenkins",
       "sdetkit.diagnostic_execution_plan",
       "sdetkit.diagnostic_job",
       "sdetkit.diagnostic_worker_trajectory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ ignore_errors = false
 module = [
   "sdetkit.adoption_proof_recommendations",
   "sdetkit.adoption_repo_topology",
+  "sdetkit.adoption_surface.jenkins",
 ]
 ignore_errors = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,8 +151,11 @@ ignore_errors = false
 module = [
   "sdetkit.adoption_proof_recommendations",
   "sdetkit.adoption_repo_topology",
-  "sdetkit.adoption_surface.jenkins",
 ]
+ignore_errors = false
+
+[[tool.mypy.overrides]]
+module = "sdetkit.adoption_surface.jenkins"
 ignore_errors = false
 
 [[tool.mypy.overrides]]

--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -17,6 +17,7 @@ from sdetkit.adoption_surface.core import (
     validate_adoption_surface_artifact,
     validate_adoption_surface_payload,
 )
+from sdetkit.adoption_surface.jenkins import extract_jenkins_pipeline
 
 __all__ = (
     "REQUIRED_FALSE_FIELDS",
@@ -50,11 +51,46 @@ def _cargo_audit_evidence(root: Path) -> list[str]:
     return sorted(set(config_files + command_files))
 
 
-def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
-    payload = _core.discover_adoption_surface(repo_root)
-    evidence = _cargo_audit_evidence(Path(repo_root))
+def _jenkins_context(stage: str) -> str:
+    return f"stage {stage}" if stage else "pipeline"
+
+
+def _extend_jenkins_pipeline(payload: dict[str, Any], root: Path) -> None:
+    extracted, unknowns = extract_jenkins_pipeline(root)
+    payload["review_first_unknowns"].extend(unknowns)
+
+    for item in extracted:
+        command = str(item.get("command", "")).strip()
+        stage = str(item.get("stage", "")).strip()
+        if not command or _core._command_is_shell_message(command):
+            continue
+        if _core._command_is_dynamic(command):
+            payload["review_first_unknowns"].append(
+                f"Jenkins {_jenkins_context(stage)} has dynamic shell command that was not guessed"
+            )
+            continue
+
+        source: dict[str, Any] = {
+            "ci_system": "jenkins",
+            "file": str(item.get("file", "Jenkinsfile")),
+        }
+        if stage:
+            source["stage"] = stage
+        _core._add_proof_command(
+            payload["recommended_proof_commands"],
+            surface="jenkins",
+            command=command,
+            confidence="medium",
+            purpose=_core._classify_proof_purpose(command),
+            evidence=[str(item.get("file", "Jenkinsfile"))],
+            source=source,
+        )
+
+
+def _extend_cargo_audit(payload: dict[str, Any], root: Path) -> None:
+    evidence = _cargo_audit_evidence(root)
     if not evidence:
-        return payload
+        return
 
     _core._add_named(
         payload["security_tools"],
@@ -70,11 +106,20 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
         purpose="security",
         evidence=evidence,
     )
+
+
+def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
+    root = Path(repo_root)
+    payload = _core.discover_adoption_surface(root)
+    _extend_jenkins_pipeline(payload, root)
+    _extend_cargo_audit(payload, root)
+
     payload["security_tools"] = sorted(payload["security_tools"], key=lambda item: item["name"])
     payload["recommended_proof_commands"] = sorted(
         payload["recommended_proof_commands"],
         key=lambda item: (item["surface"], item["command"]),
     )
+    payload["review_first_unknowns"] = sorted(set(payload["review_first_unknowns"]))
     return payload
 
 

--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -37,7 +37,9 @@ def _cargo_audit_evidence(root: Path) -> list[str]:
     if not _core._file(root, "Cargo.toml"):
         return []
 
-    config_files = [path for path in (".cargo/audit.toml", "audit.toml") if _core._file(root, path)]
+    config_files = [
+        path for path in (".cargo/audit.toml", "audit.toml") if _core._file(root, path)
+    ]
     workflow_files = _core._workflow_files(root)
     script_files = _core._owned_script_files(root)
     command_files = sorted(
@@ -114,7 +116,9 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     _extend_jenkins_pipeline(payload, root)
     _extend_cargo_audit(payload, root)
 
-    payload["security_tools"] = sorted(payload["security_tools"], key=lambda item: item["name"])
+    payload["security_tools"] = sorted(
+        payload["security_tools"], key=lambda item: item["name"]
+    )
     payload["recommended_proof_commands"] = sorted(
         payload["recommended_proof_commands"],
         key=lambda item: (item["surface"], item["command"]),
@@ -131,7 +135,9 @@ def write_adoption_surface_artifact(
     payload = discover_adoption_surface(repo_root)
     out_path = Path(out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return {
         "schema_version": payload["schema_version"],
         "adoption_surface_json": out_path.as_posix(),
@@ -155,15 +161,21 @@ def main(argv: Sequence[str] | None = None) -> int:
     if ns.format == "json":
         sys.stdout.write(json.dumps(summary, indent=2, sort_keys=True) + "\n")
     elif ns.format == "report":
-        payload = json.loads(Path(summary["adoption_surface_json"]).read_text(encoding="utf-8"))
+        payload = json.loads(
+            Path(summary["adoption_surface_json"]).read_text(encoding="utf-8")
+        )
         sys.stdout.write(render_adoption_surface_report(payload) + "\n")
     else:
         sys.stdout.write(f"adoption_surface_json={summary['adoption_surface_json']}\n")
-        sys.stdout.write(f"automation_allowed={str(summary['automation_allowed']).lower()}\n")
+        sys.stdout.write(
+            f"automation_allowed={str(summary['automation_allowed']).lower()}\n"
+        )
         sys.stdout.write(
             f"patch_application_allowed={str(summary['patch_application_allowed']).lower()}\n"
         )
-        sys.stdout.write(f"merge_authorized={str(summary['merge_authorized']).lower()}\n")
+        sys.stdout.write(
+            f"merge_authorized={str(summary['merge_authorized']).lower()}\n"
+        )
         sys.stdout.write(
             f"semantic_equivalence_proven={str(summary['semantic_equivalence_proven']).lower()}\n"
         )

--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -37,9 +37,7 @@ def _cargo_audit_evidence(root: Path) -> list[str]:
     if not _core._file(root, "Cargo.toml"):
         return []
 
-    config_files = [
-        path for path in (".cargo/audit.toml", "audit.toml") if _core._file(root, path)
-    ]
+    config_files = [path for path in (".cargo/audit.toml", "audit.toml") if _core._file(root, path)]
     workflow_files = _core._workflow_files(root)
     script_files = _core._owned_script_files(root)
     command_files = sorted(
@@ -116,9 +114,7 @@ def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     _extend_jenkins_pipeline(payload, root)
     _extend_cargo_audit(payload, root)
 
-    payload["security_tools"] = sorted(
-        payload["security_tools"], key=lambda item: item["name"]
-    )
+    payload["security_tools"] = sorted(payload["security_tools"], key=lambda item: item["name"])
     payload["recommended_proof_commands"] = sorted(
         payload["recommended_proof_commands"],
         key=lambda item: (item["surface"], item["command"]),
@@ -135,9 +131,7 @@ def write_adoption_surface_artifact(
     payload = discover_adoption_surface(repo_root)
     out_path = Path(out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return {
         "schema_version": payload["schema_version"],
         "adoption_surface_json": out_path.as_posix(),
@@ -161,21 +155,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     if ns.format == "json":
         sys.stdout.write(json.dumps(summary, indent=2, sort_keys=True) + "\n")
     elif ns.format == "report":
-        payload = json.loads(
-            Path(summary["adoption_surface_json"]).read_text(encoding="utf-8")
-        )
+        payload = json.loads(Path(summary["adoption_surface_json"]).read_text(encoding="utf-8"))
         sys.stdout.write(render_adoption_surface_report(payload) + "\n")
     else:
         sys.stdout.write(f"adoption_surface_json={summary['adoption_surface_json']}\n")
-        sys.stdout.write(
-            f"automation_allowed={str(summary['automation_allowed']).lower()}\n"
-        )
+        sys.stdout.write(f"automation_allowed={str(summary['automation_allowed']).lower()}\n")
         sys.stdout.write(
             f"patch_application_allowed={str(summary['patch_application_allowed']).lower()}\n"
         )
-        sys.stdout.write(
-            f"merge_authorized={str(summary['merge_authorized']).lower()}\n"
-        )
+        sys.stdout.write(f"merge_authorized={str(summary['merge_authorized']).lower()}\n")
         sys.stdout.write(
             f"semantic_equivalence_proven={str(summary['semantic_equivalence_proven']).lower()}\n"
         )

--- a/src/sdetkit/adoption_surface/jenkins.py
+++ b/src/sdetkit/adoption_surface/jenkins.py
@@ -21,7 +21,7 @@ def _brace_delta(raw_line: str) -> int:
     while index < len(raw_line):
         if not quote and raw_line.startswith("//", index):
             break
-        if not quote and raw_line.startswith(("'''", '\"\"\"'), index):
+        if not quote and raw_line.startswith(("'''", '"""'), index):
             marker = raw_line[index : index + 3]
             closing = raw_line.find(marker, index + 3)
             if closing < 0:
@@ -60,7 +60,7 @@ def _parse_literal_sh_step(raw_line: str) -> tuple[str | None, str | None]:
     if parenthesized:
         rest = rest[1:].lstrip()
 
-    if rest.startswith(("'''", '\"\"\"')):
+    if rest.startswith(("'''", '"""')):
         return None, "multiline"
     if not rest or rest[0] not in {"'", '"'}:
         return None, "dynamic_or_unsupported"
@@ -127,7 +127,9 @@ def extract_jenkins_pipeline(root: Path) -> tuple[list[dict[str, Any]], list[str
             current_stage = stage_match.group(2).strip()
             stage_depth = brace_depth + max(1, _brace_delta(raw_line))
         elif _STAGE_CALL_RE.match(raw_line):
-            unknowns.add("Jenkins pipeline uses a dynamic stage declaration that was not resolved")
+            unknowns.add(
+                "Jenkins pipeline uses a dynamic stage declaration that was not resolved"
+            )
 
         if _LIBRARY_RE.match(raw_line):
             unknowns.add(

--- a/src/sdetkit/adoption_surface/jenkins.py
+++ b/src/sdetkit/adoption_surface/jenkins.py
@@ -127,9 +127,7 @@ def extract_jenkins_pipeline(root: Path) -> tuple[list[dict[str, Any]], list[str
             current_stage = stage_match.group(2).strip()
             stage_depth = brace_depth + max(1, _brace_delta(raw_line))
         elif _STAGE_CALL_RE.match(raw_line):
-            unknowns.add(
-                "Jenkins pipeline uses a dynamic stage declaration that was not resolved"
-            )
+            unknowns.add("Jenkins pipeline uses a dynamic stage declaration that was not resolved")
 
         if _LIBRARY_RE.match(raw_line):
             unknowns.add(
@@ -140,9 +138,7 @@ def extract_jenkins_pipeline(root: Path) -> tuple[list[dict[str, Any]], list[str
                 f"Jenkins {_context(current_stage)} uses a script block; Groovy behavior was not evaluated"
             )
         if _NODE_BLOCK_RE.match(raw_line):
-            unknowns.add(
-                "Jenkins scripted node block detected; Groovy behavior was not evaluated"
-            )
+            unknowns.add("Jenkins scripted node block detected; Groovy behavior was not evaluated")
 
         command, unresolved = _parse_literal_sh_step(raw_line)
         if command is not None:

--- a/src/sdetkit/adoption_surface/jenkins.py
+++ b/src/sdetkit/adoption_surface/jenkins.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+JENKINSFILE = "Jenkinsfile"
+_STAGE_RE = re.compile(r"^\s*stage\s*\(\s*(['\"])(.*?)\1\s*\)\s*\{")
+_STAGE_CALL_RE = re.compile(r"^\s*stage\s*\(")
+_SH_CALL_RE = re.compile(r"^\s*sh(?:\s|\()")
+_SCRIPT_BLOCK_RE = re.compile(r"^\s*script\s*\{")
+_NODE_BLOCK_RE = re.compile(r"^\s*node\s*\{")
+_LIBRARY_RE = re.compile(r"^\s*(?:@Library\b|library(?:\s|\())")
+
+
+def _brace_delta(raw_line: str) -> int:
+    delta = 0
+    quote = ""
+    escaped = False
+    index = 0
+    while index < len(raw_line):
+        if not quote and raw_line.startswith("//", index):
+            break
+        if not quote and raw_line.startswith(("'''", '\"\"\"'), index):
+            marker = raw_line[index : index + 3]
+            closing = raw_line.find(marker, index + 3)
+            if closing < 0:
+                break
+            index = closing + 3
+            continue
+
+        char = raw_line[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = ""
+            index += 1
+            continue
+
+        if char in {"'", '"'}:
+            quote = char
+        elif char == "{":
+            delta += 1
+        elif char == "}":
+            delta -= 1
+        index += 1
+    return delta
+
+
+def _parse_literal_sh_step(raw_line: str) -> tuple[str | None, str | None]:
+    stripped = raw_line.strip()
+    if not _SH_CALL_RE.match(stripped):
+        return None, None
+
+    rest = stripped[2:].lstrip()
+    parenthesized = rest.startswith("(")
+    if parenthesized:
+        rest = rest[1:].lstrip()
+
+    if rest.startswith(("'''", '\"\"\"')):
+        return None, "multiline"
+    if not rest or rest[0] not in {"'", '"'}:
+        return None, "dynamic_or_unsupported"
+
+    quote = rest[0]
+    escaped = False
+    closing = -1
+    for index, char in enumerate(rest[1:], start=1):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == quote:
+            closing = index
+            break
+    if closing < 0:
+        return None, "dynamic_or_unsupported"
+
+    command = rest[1:closing].strip()
+    tail = rest[closing + 1 :].strip()
+    if parenthesized:
+        if not tail.startswith(")"):
+            return None, "dynamic_or_unsupported"
+        tail = tail[1:].strip()
+    if tail.startswith(";"):
+        tail = tail[1:].strip()
+    if tail and not tail.startswith("//"):
+        return None, "dynamic_or_unsupported"
+    if not command:
+        return None, "dynamic_or_unsupported"
+    return command, None
+
+
+def _context(stage: str) -> str:
+    return f"stage {stage}" if stage else "pipeline"
+
+
+def extract_jenkins_pipeline(root: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    path = root / JENKINSFILE
+    if not path.is_file():
+        return [], []
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return [], []
+
+    commands: list[dict[str, Any]] = []
+    unknowns: set[str] = set()
+    current_stage = ""
+    stage_depth = -1
+    brace_depth = 0
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("//"):
+            brace_depth += _brace_delta(raw_line)
+            continue
+
+        stage_match = _STAGE_RE.match(raw_line)
+        if stage_match:
+            current_stage = stage_match.group(2).strip()
+            stage_depth = brace_depth + max(1, _brace_delta(raw_line))
+        elif _STAGE_CALL_RE.match(raw_line):
+            unknowns.add("Jenkins pipeline uses a dynamic stage declaration that was not resolved")
+
+        if _LIBRARY_RE.match(raw_line):
+            unknowns.add(
+                "Jenkins shared library detected; external pipeline behavior was not resolved"
+            )
+        if _SCRIPT_BLOCK_RE.match(raw_line):
+            unknowns.add(
+                f"Jenkins {_context(current_stage)} uses a script block; Groovy behavior was not evaluated"
+            )
+        if _NODE_BLOCK_RE.match(raw_line):
+            unknowns.add(
+                "Jenkins scripted node block detected; Groovy behavior was not evaluated"
+            )
+
+        command, unresolved = _parse_literal_sh_step(raw_line)
+        if command is not None:
+            item: dict[str, Any] = {"command": command, "file": JENKINSFILE}
+            if current_stage:
+                item["stage"] = current_stage
+            commands.append(item)
+        elif unresolved == "multiline":
+            unknowns.add(
+                f"Jenkins {_context(current_stage)} has multiline sh content that was not guessed"
+            )
+        elif unresolved == "dynamic_or_unsupported":
+            unknowns.add(
+                f"Jenkins {_context(current_stage)} has dynamic or unsupported sh content that was not guessed"
+            )
+
+        brace_depth += _brace_delta(raw_line)
+        if current_stage and brace_depth < stage_depth:
+            current_stage = ""
+            stage_depth = -1
+
+    return commands, sorted(unknowns)

--- a/tests/fixtures/adoption_repos/jenkins_java/Jenkinsfile
+++ b/tests/fixtures/adoption_repos/jenkins_java/Jenkinsfile
@@ -1,1 +1,10 @@
-pipeline { agent any }
+pipeline {
+  agent any
+  stages {
+    stage('Test') {
+      steps {
+        sh 'mvn test'
+      }
+    }
+  }
+}

--- a/tests/test_adoption_surface_jenkins.py
+++ b/tests/test_adoption_surface_jenkins.py
@@ -11,9 +11,7 @@ def _write(path: Path, text: str) -> None:
 
 
 def _proof_commands(payload: dict) -> dict[str, dict]:
-    return {
-        str(item["command"]): item for item in payload["recommended_proof_commands"]
-    }
+    return {str(item["command"]): item for item in payload["recommended_proof_commands"]}
 
 
 def test_adoption_surface_extracts_literal_jenkins_sh_commands_with_stage_context(
@@ -77,9 +75,7 @@ pipeline {
     assert commands["python -m ruff check ."]["source"]["stage"] == "Quality"
     assert commands["pip-audit"]["source"]["stage"] == "Security"
     assert all(command["auto_run_allowed"] is False for command in commands.values())
-    assert all(
-        command["executes_untrusted_code"] is True for command in commands.values()
-    )
+    assert all(command["executes_untrusted_code"] is True for command in commands.values())
     assert payload["review_first_unknowns"] == []
     assert payload["automation_allowed"] is False
     assert payload["patch_application_allowed"] is False
@@ -125,37 +121,20 @@ pipeline {
 
     assert commands == {}
     assert (
-        "Jenkins shared library detected; external pipeline behavior was not resolved"
-        in unknowns
+        "Jenkins shared library detected; external pipeline behavior was not resolved" in unknowns
     )
+    assert "Jenkins scripted node block detected; Groovy behavior was not evaluated" in unknowns
+    assert "Jenkins pipeline uses a dynamic stage declaration that was not resolved" in unknowns
+    assert "Jenkins pipeline has dynamic or unsupported sh content that was not guessed" in unknowns
     assert (
-        "Jenkins scripted node block detected; Groovy behavior was not evaluated"
-        in unknowns
+        "Jenkins stage Dynamic uses a script block; Groovy behavior was not evaluated" in unknowns
     )
-    assert (
-        "Jenkins pipeline uses a dynamic stage declaration that was not resolved"
-        in unknowns
-    )
-    assert (
-        "Jenkins pipeline has dynamic or unsupported sh content that was not guessed"
-        in unknowns
-    )
-    assert (
-        "Jenkins stage Dynamic uses a script block; Groovy behavior was not evaluated"
-        in unknowns
-    )
-    assert (
-        "Jenkins stage Dynamic has dynamic shell command that was not guessed"
-        in unknowns
-    )
+    assert "Jenkins stage Dynamic has dynamic shell command that was not guessed" in unknowns
     assert (
         "Jenkins stage Dynamic has dynamic or unsupported sh content that was not guessed"
         in unknowns
     )
-    assert (
-        "Jenkins stage Dynamic has multiline sh content that was not guessed"
-        in unknowns
-    )
+    assert "Jenkins stage Dynamic has multiline sh content that was not guessed" in unknowns
     assert payload["automation_allowed"] is False
     assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False

--- a/tests/test_adoption_surface_jenkins.py
+++ b/tests/test_adoption_surface_jenkins.py
@@ -11,7 +11,9 @@ def _write(path: Path, text: str) -> None:
 
 
 def _proof_commands(payload: dict) -> dict[str, dict]:
-    return {str(item["command"]): item for item in payload["recommended_proof_commands"]}
+    return {
+        str(item["command"]): item for item in payload["recommended_proof_commands"]
+    }
 
 
 def test_adoption_surface_extracts_literal_jenkins_sh_commands_with_stage_context(
@@ -75,7 +77,9 @@ pipeline {
     assert commands["python -m ruff check ."]["source"]["stage"] == "Quality"
     assert commands["pip-audit"]["source"]["stage"] == "Security"
     assert all(command["auto_run_allowed"] is False for command in commands.values())
-    assert all(command["executes_untrusted_code"] is True for command in commands.values())
+    assert all(
+        command["executes_untrusted_code"] is True for command in commands.values()
+    )
     assert payload["review_first_unknowns"] == []
     assert payload["automation_allowed"] is False
     assert payload["patch_application_allowed"] is False
@@ -120,21 +124,38 @@ pipeline {
     unknowns = set(payload["review_first_unknowns"])
 
     assert commands == {}
-    assert "Jenkins shared library detected; external pipeline behavior was not resolved" in unknowns
-    assert "Jenkins scripted node block detected; Groovy behavior was not evaluated" in unknowns
-    assert "Jenkins pipeline uses a dynamic stage declaration that was not resolved" in unknowns
     assert (
-        "Jenkins pipeline has dynamic or unsupported sh content that was not guessed" in unknowns
+        "Jenkins shared library detected; external pipeline behavior was not resolved"
+        in unknowns
     )
     assert (
-        "Jenkins stage Dynamic uses a script block; Groovy behavior was not evaluated" in unknowns
+        "Jenkins scripted node block detected; Groovy behavior was not evaluated"
+        in unknowns
     )
-    assert "Jenkins stage Dynamic has dynamic shell command that was not guessed" in unknowns
+    assert (
+        "Jenkins pipeline uses a dynamic stage declaration that was not resolved"
+        in unknowns
+    )
+    assert (
+        "Jenkins pipeline has dynamic or unsupported sh content that was not guessed"
+        in unknowns
+    )
+    assert (
+        "Jenkins stage Dynamic uses a script block; Groovy behavior was not evaluated"
+        in unknowns
+    )
+    assert (
+        "Jenkins stage Dynamic has dynamic shell command that was not guessed"
+        in unknowns
+    )
     assert (
         "Jenkins stage Dynamic has dynamic or unsupported sh content that was not guessed"
         in unknowns
     )
-    assert "Jenkins stage Dynamic has multiline sh content that was not guessed" in unknowns
+    assert (
+        "Jenkins stage Dynamic has multiline sh content that was not guessed"
+        in unknowns
+    )
     assert payload["automation_allowed"] is False
     assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False

--- a/tests/test_adoption_surface_jenkins.py
+++ b/tests/test_adoption_surface_jenkins.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.adoption_surface import discover_adoption_surface
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _proof_commands(payload: dict) -> dict[str, dict]:
+    return {str(item["command"]): item for item in payload["recommended_proof_commands"]}
+
+
+def test_adoption_surface_extracts_literal_jenkins_sh_commands_with_stage_context(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "Jenkinsfile",
+        """
+pipeline {
+  agent any
+  stages {
+    stage('Test') {
+      steps {
+        sh 'python -m pytest -q'
+      }
+    }
+    stage("Quality") {
+      steps {
+        sh("python -m ruff check .")
+        sh ('mypy src')
+      }
+    }
+    stage('Security') {
+      steps {
+        sh "pip-audit"
+      }
+    }
+    stage('Docs') {
+      steps {
+        sh('mkdocs build --strict')
+      }
+    }
+    stage('Build') {
+      steps {
+        sh 'python -m compileall src'
+        sh 'echo smoke only'
+      }
+    }
+  }
+}
+""".lstrip(),
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = _proof_commands(payload)
+    ci_systems = {str(item["name"]) for item in payload["ci_systems"]}
+
+    assert "jenkins" in ci_systems
+    assert commands["python -m pytest -q"]["purpose"] == "test"
+    assert commands["python -m ruff check ."]["purpose"] == "lint"
+    assert commands["mypy src"]["purpose"] == "type"
+    assert commands["pip-audit"]["purpose"] == "security"
+    assert commands["mkdocs build --strict"]["purpose"] == "docs"
+    assert commands["python -m compileall src"]["purpose"] == "unknown"
+    assert "echo smoke only" not in commands
+    assert commands["python -m pytest -q"]["source"] == {
+        "ci_system": "jenkins",
+        "file": "Jenkinsfile",
+        "stage": "Test",
+    }
+    assert commands["python -m ruff check ."]["source"]["stage"] == "Quality"
+    assert commands["pip-audit"]["source"]["stage"] == "Security"
+    assert all(command["auto_run_allowed"] is False for command in commands.values())
+    assert all(command["executes_untrusted_code"] is True for command in commands.values())
+    assert payload["review_first_unknowns"] == []
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_adoption_surface_reports_dynamic_jenkins_behavior_review_first(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "Jenkinsfile",
+        """
+@Library('shared-ci') _
+node {
+  echo 'scripted pipeline'
+}
+pipeline {
+  agent any
+  stages {
+    stage(STAGE_NAME) {
+      steps {
+        sh buildCommand()
+      }
+    }
+    stage('Dynamic') {
+      steps {
+        script {
+          sh "${TEST_COMMAND}"
+        }
+        sh(script: env.TEST_COMMAND)
+        sh '''python -m pytest -q'''
+      }
+    }
+  }
+}
+""".lstrip(),
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = _proof_commands(payload)
+    unknowns = set(payload["review_first_unknowns"])
+
+    assert commands == {}
+    assert "Jenkins shared library detected; external pipeline behavior was not resolved" in unknowns
+    assert "Jenkins scripted node block detected; Groovy behavior was not evaluated" in unknowns
+    assert "Jenkins pipeline uses a dynamic stage declaration that was not resolved" in unknowns
+    assert (
+        "Jenkins pipeline has dynamic or unsupported sh content that was not guessed" in unknowns
+    )
+    assert (
+        "Jenkins stage Dynamic uses a script block; Groovy behavior was not evaluated" in unknowns
+    )
+    assert "Jenkins stage Dynamic has dynamic shell command that was not guessed" in unknowns
+    assert (
+        "Jenkins stage Dynamic has dynamic or unsupported sh content that was not guessed"
+        in unknowns
+    )
+    assert "Jenkins stage Dynamic has multiline sh content that was not guessed" in unknowns
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_jenkins_extraction_preserves_existing_github_and_gitlab_ci_behavior(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", "name: CI\n")
+    _write(
+        tmp_path / ".gitlab-ci.yml",
+        "gitlab_test:\n  script:\n    - python -m pytest -q\n",
+    )
+    _write(
+        tmp_path / "Jenkinsfile",
+        "pipeline {\n  stages {\n    stage('Lint') {\n      steps {\n        sh 'ruff check .'\n      }\n    }\n  }\n}\n",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = _proof_commands(payload)
+    ci_systems = {str(item["name"]) for item in payload["ci_systems"]}
+
+    assert ci_systems == {"github_actions", "gitlab_ci", "jenkins"}
+    assert commands["python -m pytest -q"]["source"] == {
+        "ci_system": "gitlab_ci",
+        "file": ".gitlab-ci.yml",
+        "job": "gitlab_test",
+    }
+    assert commands["ruff check ."]["source"] == {
+        "ci_system": "jenkins",
+        "file": "Jenkinsfile",
+        "stage": "Lint",
+    }

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,13 +24,15 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 503
+    assert payload["observed"]["source_module_count"] == 504
     assert payload["observed"]["typing_debt_module_count"] == 484
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 19
+    assert len(checked) == 20
+    assert "sdetkit.adoption_surface.jenkins" in checked
     inventory = payload["typing_debt_inventory"]
     assert inventory["module_count"] == 484
     assert len(inventory["modules"]) == 484
+    assert "sdetkit.adoption_surface.jenkins" not in inventory["modules"]
 
 
 def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Path) -> None:
@@ -48,7 +50,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 503,
+            "actual": 504,
         }
     ]
 


### PR DESCRIPTION
## Summary
- add conservative, read-only extraction for literal Jenkins declarative-pipeline `sh` steps
- support simple `sh '...'`, `sh "..."`, `sh('...')`, and `sh("...")` forms
- preserve Jenkinsfile and literal stage context in proof-command source metadata
- classify extracted commands through the existing shared test/lint/type/security/docs/unknown classifier
- route interpolation, multiline shell, shared-library, scripted-node, script-block, and dynamic stage behavior to review-first unknowns
- replace the placeholder Jenkins fixture with a minimal declarative pipeline and add focused regression coverage

Closes #1945.

## Safety boundary
- reads `Jenkinsfile` as text only
- does not execute Jenkins, Groovy, shell, or extracted commands
- does not load shared libraries or resolve environment interpolation
- does not evaluate scripted pipelines or dynamically constructed commands
- every recommendation keeps `executes_untrusted_code=true` and `auto_run_allowed=false`
- repository-level `automation_allowed=false`, `patch_application_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false` remain unchanged

## Verification
Expected CI proof:

```bash
python -m pytest -q \
  tests/test_adoption_surface_jenkins.py \
  tests/test_adoption_surface_gitlab_ci.py \
  tests/test_adoption_surface.py \
  tests/test_adoption_surface_fixture_matrix.py \
  -o addopts=
python -m mypy src
python -m pre_commit run -a
```

## Risk
Low-to-medium. The parser is intentionally line-oriented and conservative; unsupported forms become review-first unknowns instead of guessed commands. GitHub Actions and GitLab CI behavior are covered by regression tests.

## Rollback
Revert the Jenkins parser, package-level enrichment, focused tests, and fixture update. No schema, migration, workflow, or persisted-data change is required.