### PR TITLE
feat(adoption): scope Rust proof to nested workspaces

### DIFF
--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -285,9 +285,84 @@ def _extend_nested_node_workspaces(payload: dict[str, Any], root: Path) -> None:
             )
 
 
+def _nested_rust_audit_evidence(root: Path, workspace: str) -> list[str]:
+    return [
+        _workspace_path(workspace, path)
+        for path in (".cargo/audit.toml", "audit.toml")
+        if _core._file(root, _workspace_path(workspace, path))
+    ]
+
+
+def _extend_nested_rust_workspaces(payload: dict[str, Any], root: Path) -> None:
+    manifests = _nested_owned_files(root, "Cargo.toml")
+    if not manifests:
+        return
+
+    cargo_files: list[str] = []
+    for manifest in manifests:
+        workspace = _workspace_directory(manifest)
+        workspace_files = [manifest]
+        lockfile = _workspace_path(workspace, "Cargo.lock")
+        if _core._file(root, lockfile):
+            workspace_files.append(lockfile)
+        cargo_files.extend(workspace_files)
+
+        _merge_named_list(
+            payload["test_runners"],
+            "cargo_test",
+            list_field="commands",
+            values=["cargo test"],
+            confidence="high",
+        )
+        _add_workspace_proof_command(
+            payload["recommended_proof_commands"],
+            surface="rust",
+            command="cargo test",
+            confidence="high",
+            purpose="test",
+            file=manifest,
+            working_directory=workspace,
+        )
+
+        audit_evidence = _nested_rust_audit_evidence(root, workspace)
+        if not audit_evidence:
+            continue
+        _merge_named_list(
+            payload["security_tools"],
+            "cargo_audit",
+            list_field="evidence",
+            values=audit_evidence,
+            confidence="detected",
+        )
+        _add_workspace_proof_command(
+            payload["recommended_proof_commands"],
+            surface="rust",
+            command="cargo audit",
+            confidence="medium",
+            purpose="security",
+            file=audit_evidence[0],
+            working_directory=workspace,
+        )
+
+    _merge_named_list(
+        payload["detected_languages"],
+        "rust",
+        list_field="evidence",
+        values=cargo_files,
+        confidence="high",
+    )
+    _merge_named_list(
+        payload["package_managers"],
+        "cargo",
+        list_field="files",
+        values=cargo_files,
+    )
+
+
 def _extend_nested_workspaces(payload: dict[str, Any], root: Path) -> None:
     _extend_nested_python_workspaces(payload, root)
     _extend_nested_node_workspaces(payload, root)
+    _extend_nested_rust_workspaces(payload, root)
 
 
 def _extend_jenkins_pipeline(payload: dict[str, Any], root: Path) -> None:
@@ -327,11 +402,12 @@ def _extend_cargo_audit(payload: dict[str, Any], root: Path) -> None:
     if not evidence:
         return
 
-    _core._add_named(
+    _merge_named_list(
         payload["security_tools"],
         "cargo_audit",
+        list_field="evidence",
+        values=evidence,
         confidence="detected",
-        evidence=evidence,
     )
     _core._add_proof_command(
         payload["recommended_proof_commands"],
@@ -357,9 +433,9 @@ def _proof_sort_key(item: dict[str, Any]) -> tuple[str, str, str, str]:
 def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root)
     payload = _core.discover_adoption_surface(root)
+    _extend_cargo_audit(payload, root)
     _extend_nested_workspaces(payload, root)
     _extend_jenkins_pipeline(payload, root)
-    _extend_cargo_audit(payload, root)
 
     for field in ("detected_languages", "package_managers", "test_runners", "security_tools"):
         payload[field] = sorted(payload[field], key=lambda item: item["name"])

--- a/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/core/.cargo/audit.toml
+++ b/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/core/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[advisories]
+ignore = []

--- a/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/core/Cargo.lock
+++ b/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/core/Cargo.lock
@@ -1,0 +1,1 @@
+version = 3

--- a/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/core/Cargo.toml
+++ b/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "core-service"
+version = "0.1.0"
+edition = "2021"

--- a/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/worker/Cargo.lock
+++ b/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/worker/Cargo.lock
@@ -1,0 +1,1 @@
+version = 3

--- a/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/worker/Cargo.toml
+++ b/tests/fixtures/adoption_repos/mixed_nested_rust_workspaces/services/worker/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "worker-service"
+version = "0.1.0"
+edition = "2021"

--- a/tests/test_adoption_surface_nested_rust_workspaces.py
+++ b/tests/test_adoption_surface_nested_rust_workspaces.py
@@ -103,9 +103,7 @@ def test_nested_rust_workspaces_emit_scoped_test_and_explicit_security_proof() -
     assert payload["merge_authorized"] is False
     assert payload["semantic_equivalence_proven"] is False
     assert all(
-        item["auto_run_allowed"] is False
-        for items in scoped.values()
-        for item in items
+        item["auto_run_allowed"] is False for items in scoped.values() for item in items
     )
 
 
@@ -142,9 +140,7 @@ def test_nested_rust_scope_survives_recommendations_and_reports() -> None:
         for item in items
     )
     assert all(
-        item["auto_run_allowed"] is False
-        for items in scoped.values()
-        for item in items
+        item["auto_run_allowed"] is False for items in scoped.values() for item in items
     )
 
     proof_text = render_proof_recommendations_text(recommendations)

--- a/tests/test_adoption_surface_nested_rust_workspaces.py
+++ b/tests/test_adoption_surface_nested_rust_workspaces.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.adoption_proof_recommendations import (
+    build_proof_recommendations_payload,
+    render_proof_recommendations_text,
+)
+from sdetkit.adoption_surface import (
+    discover_adoption_surface,
+    render_adoption_surface_report,
+    validate_adoption_surface_payload,
+)
+
+FIXTURE = Path("tests/fixtures/adoption_repos/mixed_nested_rust_workspaces")
+CORE_WORKSPACE = Path("services", "core").as_posix()
+WORKER_WORKSPACE = Path("services", "worker").as_posix()
+WORKSPACES = {CORE_WORKSPACE, WORKER_WORKSPACE}
+
+
+def _named(items: object) -> dict[str, dict[str, object]]:
+    assert isinstance(items, list)
+    return {
+        str(item["name"]): item
+        for item in items
+        if isinstance(item, dict) and item.get("name")
+    }
+
+
+def _scoped_commands(payload: dict[str, object]) -> dict[str, list[dict[str, object]]]:
+    raw_commands = payload["recommended_proof_commands"]
+    assert isinstance(raw_commands, list)
+    scoped: dict[str, list[dict[str, object]]] = {}
+    for item in raw_commands:
+        if not isinstance(item, dict):
+            continue
+        source = item.get("source")
+        if not isinstance(source, dict):
+            continue
+        workspace = str(source.get("working_directory", ""))
+        if workspace:
+            scoped.setdefault(workspace, []).append(item)
+    return scoped
+
+
+def _command_names(items: list[dict[str, object]]) -> set[str]:
+    return {str(item["command"]) for item in items}
+
+
+def _source(workspace: str, file_name: str) -> dict[str, str]:
+    return {
+        "scope": "nested_workspace",
+        "file": f"{workspace}/{file_name}",
+        "working_directory": workspace,
+    }
+
+
+def test_nested_rust_workspaces_emit_scoped_test_and_explicit_security_proof() -> None:
+    payload = discover_adoption_surface(FIXTURE)
+
+    assert validate_adoption_surface_payload(payload) == []
+    languages = _named(payload["detected_languages"])
+    package_managers = _named(payload["package_managers"])
+    test_runners = _named(payload["test_runners"])
+    security_tools = _named(payload["security_tools"])
+
+    assert "rust" in languages
+    assert "cargo" in package_managers
+    assert "cargo_test" in test_runners
+    assert "cargo_audit" in security_tools
+
+    expected_cargo_files = {
+        f"{workspace}/{file_name}"
+        for workspace in WORKSPACES
+        for file_name in ("Cargo.toml", "Cargo.lock")
+    }
+    assert set(package_managers["cargo"]["files"]) == expected_cargo_files
+
+    audit_file = f"{CORE_WORKSPACE}/.cargo/audit.toml"
+    assert security_tools["cargo_audit"]["evidence"] == [audit_file]
+
+    scoped = _scoped_commands(payload)
+    assert set(scoped) == WORKSPACES
+    assert _command_names(scoped[CORE_WORKSPACE]) == {"cargo test", "cargo audit"}
+    assert _command_names(scoped[WORKER_WORKSPACE]) == {"cargo test"}
+
+    core_test = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test")
+    core_audit = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit")
+    worker_test = scoped[WORKER_WORKSPACE][0]
+    assert core_test["source"] == _source(CORE_WORKSPACE, "Cargo.toml")
+    assert core_audit["source"] == _source(CORE_WORKSPACE, ".cargo/audit.toml")
+    assert worker_test["source"] == _source(WORKER_WORKSPACE, "Cargo.toml")
+
+    assert payload["review_first_unknowns"] == []
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
+
+
+def test_nested_rust_scope_survives_recommendations_and_reports() -> None:
+    surface = discover_adoption_surface(FIXTURE)
+    recommendations = build_proof_recommendations_payload(FIXTURE, surface_payload=surface)
+    raw_items = recommendations["proof_recommendations"]
+    assert isinstance(raw_items, list)
+
+    scoped = {
+        workspace: [
+            item
+            for item in raw_items
+            if isinstance(item, dict) and item.get("working_directory") == workspace
+        ]
+        for workspace in WORKSPACES
+    }
+    assert _command_names(scoped[CORE_WORKSPACE]) == {"cargo test", "cargo audit"}
+    assert _command_names(scoped[WORKER_WORKSPACE]) == {"cargo test"}
+
+    core_test = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test")
+    core_audit = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit")
+    assert core_test["operator_level"] == "required"
+    assert core_audit["operator_level"] == "review_first"
+    assert all(item["execution_policy"] == "manual_only" for items in scoped.values() for item in items)
+    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
+
+    proof_text = render_proof_recommendations_text(recommendations)
+    surface_report = render_adoption_surface_report(surface)
+    for workspace in WORKSPACES:
+        scope = f"working_directory={workspace}"
+        assert scope in proof_text
+        assert scope in surface_report
+
+
+def test_nested_rust_manifest_alone_does_not_infer_cargo_audit(tmp_path: Path) -> None:
+    workspace = tmp_path / "services" / "api"
+    workspace.mkdir(parents=True)
+    (workspace / "Cargo.toml").write_text(
+        '[package]\nname = "api"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    security_tools = _named(payload["security_tools"])
+    scoped = _scoped_commands(payload)
+    workspace_name = Path("services", "api").as_posix()
+
+    assert "cargo_audit" not in security_tools
+    assert _command_names(scoped[workspace_name]) == {"cargo test"}
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False

--- a/tests/test_adoption_surface_nested_rust_workspaces.py
+++ b/tests/test_adoption_surface_nested_rust_workspaces.py
@@ -21,9 +21,7 @@ WORKSPACES = {CORE_WORKSPACE, WORKER_WORKSPACE}
 def _named(items: object) -> dict[str, dict[str, object]]:
     assert isinstance(items, list)
     return {
-        str(item["name"]): item
-        for item in items
-        if isinstance(item, dict) and item.get("name")
+        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
     }
 
 
@@ -86,12 +84,8 @@ def test_nested_rust_workspaces_emit_scoped_test_and_explicit_security_proof() -
     assert _command_names(scoped[CORE_WORKSPACE]) == {"cargo test", "cargo audit"}
     assert _command_names(scoped[WORKER_WORKSPACE]) == {"cargo test"}
 
-    core_test = next(
-        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test"
-    )
-    core_audit = next(
-        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit"
-    )
+    core_test = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test")
+    core_audit = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit")
     worker_test = scoped[WORKER_WORKSPACE][0]
     assert core_test["source"] == _source(CORE_WORKSPACE, "Cargo.toml")
     assert core_audit["source"] == _source(CORE_WORKSPACE, ".cargo/audit.toml")
@@ -102,16 +96,12 @@ def test_nested_rust_workspaces_emit_scoped_test_and_explicit_security_proof() -
     assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False
     assert payload["semantic_equivalence_proven"] is False
-    assert all(
-        item["auto_run_allowed"] is False for items in scoped.values() for item in items
-    )
+    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
 
 
 def test_nested_rust_scope_survives_recommendations_and_reports() -> None:
     surface = discover_adoption_surface(FIXTURE)
-    recommendations = build_proof_recommendations_payload(
-        FIXTURE, surface_payload=surface
-    )
+    recommendations = build_proof_recommendations_payload(FIXTURE, surface_payload=surface)
     raw_items = recommendations["proof_recommendations"]
     assert isinstance(raw_items, list)
 
@@ -126,22 +116,14 @@ def test_nested_rust_scope_survives_recommendations_and_reports() -> None:
     assert _command_names(scoped[CORE_WORKSPACE]) == {"cargo test", "cargo audit"}
     assert _command_names(scoped[WORKER_WORKSPACE]) == {"cargo test"}
 
-    core_test = next(
-        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test"
-    )
-    core_audit = next(
-        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit"
-    )
+    core_test = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test")
+    core_audit = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit")
     assert core_test["operator_level"] == "required"
     assert core_audit["operator_level"] == "review_first"
     assert all(
-        item["execution_policy"] == "manual_only"
-        for items in scoped.values()
-        for item in items
+        item["execution_policy"] == "manual_only" for items in scoped.values() for item in items
     )
-    assert all(
-        item["auto_run_allowed"] is False for items in scoped.values() for item in items
-    )
+    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
 
     proof_text = render_proof_recommendations_text(recommendations)
     surface_report = render_adoption_surface_report(surface)

--- a/tests/test_adoption_surface_nested_rust_workspaces.py
+++ b/tests/test_adoption_surface_nested_rust_workspaces.py
@@ -27,7 +27,9 @@ def _named(items: object) -> dict[str, dict[str, object]]:
     }
 
 
-def _scoped_commands(payload: dict[str, object]) -> dict[str, list[dict[str, object]]]:
+def _scoped_commands(
+    payload: dict[str, object],
+) -> dict[str, list[dict[str, object]]]:
     raw_commands = payload["recommended_proof_commands"]
     assert isinstance(raw_commands, list)
     scoped: dict[str, list[dict[str, object]]] = {}
@@ -84,8 +86,12 @@ def test_nested_rust_workspaces_emit_scoped_test_and_explicit_security_proof() -
     assert _command_names(scoped[CORE_WORKSPACE]) == {"cargo test", "cargo audit"}
     assert _command_names(scoped[WORKER_WORKSPACE]) == {"cargo test"}
 
-    core_test = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test")
-    core_audit = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit")
+    core_test = next(
+        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test"
+    )
+    core_audit = next(
+        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit"
+    )
     worker_test = scoped[WORKER_WORKSPACE][0]
     assert core_test["source"] == _source(CORE_WORKSPACE, "Cargo.toml")
     assert core_audit["source"] == _source(CORE_WORKSPACE, ".cargo/audit.toml")
@@ -96,12 +102,18 @@ def test_nested_rust_workspaces_emit_scoped_test_and_explicit_security_proof() -
     assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False
     assert payload["semantic_equivalence_proven"] is False
-    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
+    assert all(
+        item["auto_run_allowed"] is False
+        for items in scoped.values()
+        for item in items
+    )
 
 
 def test_nested_rust_scope_survives_recommendations_and_reports() -> None:
     surface = discover_adoption_surface(FIXTURE)
-    recommendations = build_proof_recommendations_payload(FIXTURE, surface_payload=surface)
+    recommendations = build_proof_recommendations_payload(
+        FIXTURE, surface_payload=surface
+    )
     raw_items = recommendations["proof_recommendations"]
     assert isinstance(raw_items, list)
 
@@ -116,12 +128,24 @@ def test_nested_rust_scope_survives_recommendations_and_reports() -> None:
     assert _command_names(scoped[CORE_WORKSPACE]) == {"cargo test", "cargo audit"}
     assert _command_names(scoped[WORKER_WORKSPACE]) == {"cargo test"}
 
-    core_test = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test")
-    core_audit = next(item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit")
+    core_test = next(
+        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo test"
+    )
+    core_audit = next(
+        item for item in scoped[CORE_WORKSPACE] if item["command"] == "cargo audit"
+    )
     assert core_test["operator_level"] == "required"
     assert core_audit["operator_level"] == "review_first"
-    assert all(item["execution_policy"] == "manual_only" for items in scoped.values() for item in items)
-    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
+    assert all(
+        item["execution_policy"] == "manual_only"
+        for items in scoped.values()
+        for item in items
+    )
+    assert all(
+        item["auto_run_allowed"] is False
+        for items in scoped.values()
+        for item in items
+    )
 
     proof_text = render_proof_recommendations_text(recommendations)
     surface_report = render_adoption_surface_report(surface)
@@ -131,7 +155,9 @@ def test_nested_rust_scope_survives_recommendations_and_reports() -> None:
         assert scope in surface_report
 
 
-def test_nested_rust_manifest_alone_does_not_infer_cargo_audit(tmp_path: Path) -> None:
+def test_nested_rust_manifest_alone_does_not_infer_cargo_audit(
+    tmp_path: Path,
+) -> None:
     workspace = tmp_path / "services" / "api"
     workspace.mkdir(parents=True)
     (workspace / "Cargo.toml").write_text(


### PR DESCRIPTION
## Summary
- discover nested Rust workspaces from repository-owned `Cargo.toml` manifests
- preserve workspace-relative `working_directory` and manifest evidence for `cargo test`
- detect scoped `cargo audit` only when the same workspace owns `.cargo/audit.toml` or `audit.toml`
- retain identical Rust commands from separate workspaces instead of collapsing them into one root recommendation
- merge root-level and nested cargo-audit evidence without losing either scope
- carry workspace context through adoption proof recommendations and operator reports
- add a two-service Rust fixture where only one service has explicit audit evidence

Roadmap: 1.2.x mixed-repository confidence after the completed Rust vertical and nested Python/Node scoping.

## Safety boundary
- reads manifests, lockfiles, and audit configuration as repository evidence only
- does not install Rust, Cargo, cargo-audit, or target dependencies
- does not execute `cargo test` or `cargo audit`
- does not infer cargo-audit from a manifest alone
- ignores fixture, docs, example, template, build, and generated top-level trees during nested discovery
- Go, Java, and other nested ecosystems remain out of scope for this slice
- `automation_allowed=false`, `patch_application_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false` remain unchanged

## Verification
Focused local proof against the current package surface:

```bash
python -m pytest -q tests/test_adoption_surface_nested_rust_workspaces.py -o addopts=
```

Additional regression probes verified that root and nested `cargo test` / `cargo audit` recommendations coexist and that their evidence is merged rather than overwritten.

Expected repository proof:

```bash
python -m pytest -q \
  tests/test_adoption_surface_nested_rust_workspaces.py \
  tests/test_adoption_surface_nested_workspaces.py \
  tests/test_adoption_surface_cargo_audit.py \
  tests/test_rust_adoption_vertical.py \
  -o addopts=
python -m pre_commit run -a
```

## Risk
Medium-low. The change extends the existing scoped workspace contract to Rust and changes cargo-audit aggregation so root and nested evidence can coexist. It preserves the v1 schema and all authority boundaries.

## Rollback
Revert the nested Rust enrichment, cargo-audit evidence merge, fixture, and focused tests. No migration or persisted-state conversion is required.