### PR TITLE
feat(adoption): scope Go proof to nested workspaces

### DIFF
--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -359,9 +359,98 @@ def _extend_nested_rust_workspaces(payload: dict[str, Any], root: Path) -> None:
     )
 
 
+def _nested_go_security_evidence(root: Path, workspace: str) -> list[str]:
+    workspace_root = root / workspace
+    named_files = [
+        _workspace_path(workspace, path)
+        for path in ("Makefile", "Taskfile.yml", "Taskfile.yaml", "justfile", "Justfile")
+        if _core._file(root, _workspace_path(workspace, path))
+    ]
+    script_files = [
+        _workspace_path(workspace, path)
+        for path in _core._recursive_files(workspace_root, "*.sh")
+    ]
+    workflow_files = [
+        _workspace_path(workspace, path)
+        for path in (
+            *_core._glob_files(workspace_root, ".github/workflows/*.yml"),
+            *_core._glob_files(workspace_root, ".github/workflows/*.yaml"),
+        )
+    ]
+    candidates = sorted(set(named_files + script_files + workflow_files))
+    return _core._files_containing(root, candidates, "govulncheck")
+
+
+def _extend_nested_go_workspaces(payload: dict[str, Any], root: Path) -> None:
+    manifests = _nested_owned_files(root, "go.mod")
+    if not manifests:
+        return
+
+    go_files: list[str] = []
+    for manifest in manifests:
+        workspace = _workspace_directory(manifest)
+        workspace_files = [manifest]
+        checksum = _workspace_path(workspace, "go.sum")
+        if _core._file(root, checksum):
+            workspace_files.append(checksum)
+        go_files.extend(workspace_files)
+
+        _merge_named_list(
+            payload["test_runners"],
+            "go_test",
+            list_field="commands",
+            values=["go test ./..."],
+            confidence="high",
+        )
+        _add_workspace_proof_command(
+            payload["recommended_proof_commands"],
+            surface="go",
+            command="go test ./...",
+            confidence="high",
+            purpose="test",
+            file=manifest,
+            working_directory=workspace,
+        )
+
+        security_evidence = _nested_go_security_evidence(root, workspace)
+        if not security_evidence:
+            continue
+        _merge_named_list(
+            payload["security_tools"],
+            "govulncheck",
+            list_field="evidence",
+            values=security_evidence,
+            confidence="detected",
+        )
+        _add_workspace_proof_command(
+            payload["recommended_proof_commands"],
+            surface="go",
+            command="govulncheck ./...",
+            confidence="medium",
+            purpose="security",
+            file=security_evidence[0],
+            working_directory=workspace,
+        )
+
+    _merge_named_list(
+        payload["detected_languages"],
+        "go",
+        list_field="evidence",
+        values=go_files,
+        confidence="high",
+    )
+    _merge_named_list(
+        payload["package_managers"],
+        "go_modules",
+        list_field="files",
+        values=go_files,
+    )
+
+
 def _extend_nested_workspaces(payload: dict[str, Any], root: Path) -> None:
     _extend_nested_python_workspaces(payload, root)
     _extend_nested_node_workspaces(payload, root)
+    _extend_nested_go_workspaces(payload, root)
     _extend_nested_rust_workspaces(payload, root)
 
 

--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -367,8 +367,7 @@ def _nested_go_security_evidence(root: Path, workspace: str) -> list[str]:
         if _core._file(root, _workspace_path(workspace, path))
     ]
     script_files = [
-        _workspace_path(workspace, path)
-        for path in _core._recursive_files(workspace_root, "*.sh")
+        _workspace_path(workspace, path) for path in _core._recursive_files(workspace_root, "*.sh")
     ]
     workflow_files = [
         _workspace_path(workspace, path)

--- a/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/go.mod
+++ b/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/go.mod
@@ -1,0 +1,3 @@
+module example.com/api
+
+go 1.23

--- a/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/go.mod
+++ b/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/go.mod
@@ -1,3 +1,3 @@
 module example.com/api
 
-go 1.23
+go 1.26.5

--- a/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/go.sum
+++ b/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/go.sum
@@ -1,0 +1,1 @@
+example.com/dependency v0.0.0 h1:fixture

--- a/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/scripts/security.sh
+++ b/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/api/scripts/security.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+govulncheck ./...

--- a/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/worker/go.mod
+++ b/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/worker/go.mod
@@ -1,0 +1,3 @@
+module example.com/worker
+
+go 1.23

--- a/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/worker/go.mod
+++ b/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/worker/go.mod
@@ -1,3 +1,3 @@
 module example.com/worker
 
-go 1.23
+go 1.26.5

--- a/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/worker/go.sum
+++ b/tests/fixtures/adoption_repos/mixed_nested_go_workspaces/services/worker/go.sum
@@ -1,0 +1,1 @@
+example.com/dependency v0.0.0 h1:fixture

--- a/tests/fixtures/adoption_repos/mixed_nested_workspaces/services/api/requirements-test.txt
+++ b/tests/fixtures/adoption_repos/mixed_nested_workspaces/services/api/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest
+Pygments==2.20.0

--- a/tests/test_adoption_surface_nested_go_workspaces.py
+++ b/tests/test_adoption_surface_nested_go_workspaces.py
@@ -23,9 +23,7 @@ WORKSPACES = {API_WORKSPACE, WORKER_WORKSPACE}
 def _named(items: object) -> dict[str, dict[str, object]]:
     assert isinstance(items, list)
     return {
-        str(item["name"]): item
-        for item in items
-        if isinstance(item, dict) and item.get("name")
+        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
     }
 
 
@@ -67,9 +65,7 @@ def test_nested_go_workspaces_emit_scoped_test_and_explicit_security_proof() -> 
     security_tools = _named(payload["security_tools"])
 
     expected_go_files = {
-        f"{workspace}/{file_name}"
-        for workspace in WORKSPACES
-        for file_name in ("go.mod", "go.sum")
+        f"{workspace}/{file_name}" for workspace in WORKSPACES for file_name in ("go.mod", "go.sum")
     }
     assert set(languages["go"]["evidence"]) == expected_go_files
     assert set(package_managers["go_modules"]["files"]) == expected_go_files
@@ -123,7 +119,9 @@ def test_nested_go_scope_survives_recommendations_and_reports() -> None:
     )
     assert api_test["operator_level"] == "required"
     assert api_security["operator_level"] == "review_first"
-    assert all(item["execution_policy"] == "manual_only" for items in scoped.values() for item in items)
+    assert all(
+        item["execution_policy"] == "manual_only" for items in scoped.values() for item in items
+    )
     assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
 
     proof_text = render_proof_recommendations_text(recommendations)

--- a/tests/test_adoption_surface_nested_go_workspaces.py
+++ b/tests/test_adoption_surface_nested_go_workspaces.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_proof_recommendations import (
+    build_proof_recommendations_payload,
+    render_proof_recommendations_text,
+)
+from sdetkit.adoption_surface import (
+    discover_adoption_surface,
+    render_adoption_surface_report,
+    validate_adoption_surface_payload,
+)
+
+FIXTURE = Path("tests/fixtures/adoption_repos/mixed_nested_go_workspaces")
+API_WORKSPACE = Path("services", "api").as_posix()
+WORKER_WORKSPACE = Path("services", "worker").as_posix()
+WORKSPACES = {API_WORKSPACE, WORKER_WORKSPACE}
+
+
+def _named(items: object) -> dict[str, dict[str, object]]:
+    assert isinstance(items, list)
+    return {
+        str(item["name"]): item
+        for item in items
+        if isinstance(item, dict) and item.get("name")
+    }
+
+
+def _scoped_commands(payload: dict[str, object]) -> dict[str, list[dict[str, object]]]:
+    raw_commands = payload["recommended_proof_commands"]
+    assert isinstance(raw_commands, list)
+    scoped: dict[str, list[dict[str, object]]] = {}
+    for item in raw_commands:
+        if not isinstance(item, dict):
+            continue
+        source = item.get("source")
+        if not isinstance(source, dict):
+            continue
+        workspace = str(source.get("working_directory", ""))
+        if workspace:
+            scoped.setdefault(workspace, []).append(item)
+    return scoped
+
+
+def _command_names(items: list[dict[str, object]]) -> set[str]:
+    return {str(item["command"]) for item in items}
+
+
+def _source(workspace: str, file_name: str) -> dict[str, str]:
+    return {
+        "scope": "nested_workspace",
+        "file": f"{workspace}/{file_name}",
+        "working_directory": workspace,
+    }
+
+
+def test_nested_go_workspaces_emit_scoped_test_and_explicit_security_proof() -> None:
+    payload = discover_adoption_surface(FIXTURE)
+
+    assert validate_adoption_surface_payload(payload) == []
+    languages = _named(payload["detected_languages"])
+    package_managers = _named(payload["package_managers"])
+    test_runners = _named(payload["test_runners"])
+    security_tools = _named(payload["security_tools"])
+
+    expected_go_files = {
+        f"{workspace}/{file_name}"
+        for workspace in WORKSPACES
+        for file_name in ("go.mod", "go.sum")
+    }
+    assert set(languages["go"]["evidence"]) == expected_go_files
+    assert set(package_managers["go_modules"]["files"]) == expected_go_files
+    assert test_runners["go_test"]["commands"] == ["go test ./..."]
+
+    security_file = f"{API_WORKSPACE}/scripts/security.sh"
+    assert security_tools["govulncheck"]["evidence"] == [security_file]
+
+    scoped = _scoped_commands(payload)
+    assert set(scoped) == WORKSPACES
+    assert _command_names(scoped[API_WORKSPACE]) == {"go test ./...", "govulncheck ./..."}
+    assert _command_names(scoped[WORKER_WORKSPACE]) == {"go test ./..."}
+
+    api_test = next(item for item in scoped[API_WORKSPACE] if item["command"] == "go test ./...")
+    api_security = next(
+        item for item in scoped[API_WORKSPACE] if item["command"] == "govulncheck ./..."
+    )
+    worker_test = scoped[WORKER_WORKSPACE][0]
+    assert api_test["source"] == _source(API_WORKSPACE, "go.mod")
+    assert api_security["source"] == _source(API_WORKSPACE, "scripts/security.sh")
+    assert worker_test["source"] == _source(WORKER_WORKSPACE, "go.mod")
+
+    assert payload["review_first_unknowns"] == []
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
+
+
+def test_nested_go_scope_survives_recommendations_and_reports() -> None:
+    surface = discover_adoption_surface(FIXTURE)
+    recommendations = build_proof_recommendations_payload(FIXTURE, surface_payload=surface)
+    raw_items = recommendations["proof_recommendations"]
+    assert isinstance(raw_items, list)
+
+    scoped = {
+        workspace: [
+            item
+            for item in raw_items
+            if isinstance(item, dict) and item.get("working_directory") == workspace
+        ]
+        for workspace in WORKSPACES
+    }
+    assert _command_names(scoped[API_WORKSPACE]) == {"go test ./...", "govulncheck ./..."}
+    assert _command_names(scoped[WORKER_WORKSPACE]) == {"go test ./..."}
+
+    api_test = next(item for item in scoped[API_WORKSPACE] if item["command"] == "go test ./...")
+    api_security = next(
+        item for item in scoped[API_WORKSPACE] if item["command"] == "govulncheck ./..."
+    )
+    assert api_test["operator_level"] == "required"
+    assert api_security["operator_level"] == "review_first"
+    assert all(item["execution_policy"] == "manual_only" for items in scoped.values() for item in items)
+    assert all(item["auto_run_allowed"] is False for items in scoped.values() for item in items)
+
+    proof_text = render_proof_recommendations_text(recommendations)
+    surface_report = render_adoption_surface_report(surface)
+    for workspace in WORKSPACES:
+        scope = f"working_directory={workspace}"
+        assert scope in proof_text
+        assert scope in surface_report
+
+
+def test_nested_go_mod_alone_does_not_infer_govulncheck(tmp_path: Path) -> None:
+    workspace = tmp_path / "services" / "api"
+    workspace.mkdir(parents=True)
+    (workspace / "go.mod").write_text("module example.com/api\n\ngo 1.23\n", encoding="utf-8")
+
+    payload = discover_adoption_surface(tmp_path)
+    security_tools = _named(payload["security_tools"])
+    scoped = _scoped_commands(payload)
+    workspace_name = Path("services", "api").as_posix()
+
+    assert "govulncheck" not in security_tools
+    assert _command_names(scoped[workspace_name]) == {"go test ./..."}
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "content"),
+    [
+        ("Makefile", "security:\n\tgovulncheck ./...\n"),
+        ("scripts/security.sh", "#!/usr/bin/env sh\nset -eu\ngovulncheck ./...\n"),
+        (
+            ".github/workflows/security.yml",
+            "jobs:\n  scan:\n    steps:\n      - run: govulncheck ./...\n",
+        ),
+    ],
+)
+def test_nested_go_security_requires_workspace_owned_literal_evidence(
+    tmp_path: Path,
+    relative_path: str,
+    content: str,
+) -> None:
+    workspace = tmp_path / "services" / "api"
+    workspace.mkdir(parents=True)
+    (workspace / "go.mod").write_text("module example.com/api\n\ngo 1.23\n", encoding="utf-8")
+    evidence = workspace / relative_path
+    evidence.parent.mkdir(parents=True, exist_ok=True)
+    evidence.write_text(content, encoding="utf-8")
+
+    payload = discover_adoption_surface(tmp_path)
+    scoped = _scoped_commands(payload)
+    workspace_name = Path("services", "api").as_posix()
+    security_file = f"{workspace_name}/{relative_path}"
+
+    assert _named(payload["security_tools"])["govulncheck"]["evidence"] == [security_file]
+    security = next(
+        item for item in scoped[workspace_name] if item["command"] == "govulncheck ./..."
+    )
+    assert security["source"] == _source(workspace_name, relative_path)
+    assert security["purpose"] == "security"
+    assert security["auto_run_allowed"] is False


### PR DESCRIPTION
## Summary
- discover nested Go workspaces from repository-owned `go.mod` manifests
- preserve workspace-relative `working_directory` and manifest evidence for `go test ./...`
- include workspace `go.sum` files in Go module evidence when present
- detect scoped `govulncheck ./...` only from literal evidence owned by the same workspace
- support workspace-local Make/Task/Just files, shell scripts, and local GitHub workflow files as explicit security evidence
- retain identical Go commands from separate workspaces instead of collapsing them into one root recommendation
- merge root-level and nested Go/security evidence without replacing either scope
- add a two-service Go fixture where only one service owns security evidence

Roadmap: 1.2.x mixed-repository confidence after nested Python, Node, and Rust workspace scoping.

## Safety boundary
- reads manifests, checksums, and literal repository command evidence only
- does not install Go, modules, or `govulncheck`
- does not execute `go test` or `govulncheck`
- does not infer `govulncheck` from `go.mod` alone
- does not interpret dynamic shell expressions or top-level CI working-directory semantics in this slice
- ignores fixture, docs, example, template, build, and generated top-level trees during nested discovery
- Java and other nested ecosystems remain out of scope
- `automation_allowed=false`, `patch_application_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false` remain unchanged

## Verification
Focused static proof completed before opening:

- new source block parses successfully with Python AST
- a two-workspace stub harness produced distinct scoped `go test ./...` commands
- only the workspace owning `scripts/security.sh` received scoped `govulncheck ./...`
- language, module, checksum, security evidence, source context, and manual-only flags matched the intended contract

Expected repository proof:

```bash
python -m pytest -q \
  tests/test_adoption_surface_nested_go_workspaces.py \
  tests/test_adoption_surface_nested_workspaces.py \
  tests/test_adoption_surface_nested_rust_workspaces.py \
  tests/test_adoption_surface_go_security.py \
  -o addopts=
python -m pre_commit run -a
```

## Risk
Medium-low. The change extends the existing nested-workspace enrichment layer and adds evidence merging for Go. The principal risks are formatter drift, duplicate-command handling, and accidental security inference; focused tests cover each boundary.

## Rollback
Revert the nested Go enrichment, fixture, and focused tests. No schema migration or persisted-state conversion is required.