### PR TITLE
chore(adoption): sync main into .NET adoption branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
           name: release-distributions
           path: release-candidate
       - name: Create GitHub Release after PyPI verification
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
           tag_name: ${{ needs.build.outputs.tag }}
           name: ${{ needs.build.outputs.tag }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.15.21
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -24,7 +24,7 @@ repos:
         additional_dependencies: [tomli]
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         args: [src]

--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -1,17 +1,17 @@
 # Frozen CI/tested dependency baseline used to keep `pip install -e .[...]`
 # reproducible across workflows while preserving flexible ranges in pyproject.toml.
 httpx==0.28.1
-build==1.5.0
+build==1.5.1
 check-wheel-contents==0.6.3
-hypothesis==6.156.1
+hypothesis==6.156.6
 mkdocs==1.6.1
 mkdocs-material==9.7.6
-mypy==2.1.0
+mypy==2.3.0
 pre-commit==4.6.0
 pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
-ruff==0.15.20
+ruff==0.15.21
 twine==6.2.0
 pytest-xdist==3.8.0
 psutil==7.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,14 @@ Changelog = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CHANGELOG.m
 
 [project.optional-dependencies]
 dev = [
-  "build==1.5.0",
-  "mypy==2.1.0",
+  "build==1.5.1",
+  "mypy==2.3.0",
   "pre-commit==4.6.0",
-  "ruff==0.15.20",
+  "ruff==0.15.21",
   "twine==6.2.0"
 ]
 test = [
-  "hypothesis==6.156.1",
+  "hypothesis==6.156.6",
   "pre-commit==4.6.0",
   "PyYAML",
   "pytest",
@@ -63,7 +63,7 @@ docs = [
   "mkdocs-material==9.7.6"
 ]
 packaging = [
-  "build==1.5.0",
+  "build==1.5.1",
   "check-wheel-contents==0.6.3",
   "twine==6.2.0"
 ]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,14 +3,14 @@ pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.4.0
 pytest-xdist[psutil]==3.8.0
-hypothesis==6.156.1
+hypothesis==6.156.6
 PyYAML==6.0.3
 httpx==0.28.1
-ruff==0.15.20
-mypy==2.1.0
+ruff==0.15.21
+mypy==2.3.0
 pre-commit==4.6.0
 mutmut==3.6.0
 
 # Security scanner transitive dependency floors
 idna==3.18
-filelock==3.29.5
+filelock==3.29.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,19 @@
 
 # Runtime dependency
 httpx==0.28.1
-filelock==3.29.5
+filelock==3.29.7
 
 # Dev + QA tooling
-ruff==0.15.20
-mypy==2.1.0
+ruff==0.15.21
+mypy==2.3.0
 pre-commit==4.6.0
 pytest==9.1.1
 pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.4.0
-hypothesis==6.156.1
+hypothesis==6.156.6
 mutmut==3.6.0
-build==1.5.0
+build==1.5.1
 twine==6.2.0
 
 # Security/compliance tooling used in workflows


### PR DESCRIPTION
## Summary
- Merge the current `main` branch into `agent/dotnet-adoption-proof`.
- Preserve the reviewed .NET adoption commits while bringing in the merged release-action and dependency updates.

## Why
- Branch protection requires proof on the current merge state.
- This sync is intentionally non-product work; it exists only to make PR #2062 current with `main` before its final verification and merge.

## Verification
- PR #2062 workflows will rerun on the resulting head.

## Risk
- Low.
- Rollback: revert this merge commit on the feature branch if needed.