### PR TITLE
feat(adoption): surface NuGet audit evidence

### DIFF
--- a/src/sdetkit/adoption_surface/java_workspaces.py
+++ b/src/sdetkit/adoption_surface/java_workspaces.py
@@ -362,11 +362,15 @@ def _is_dotnet_vulnerability_report(payload: object) -> bool:
         for framework in frameworks:
             if not isinstance(framework, dict) or not str(framework.get("framework", "")).strip():
                 continue
-            if any(
-                isinstance(framework.get(field), list)
-                for field in ("topLevelPackages", "transitivePackages")
-            ):
-                return True
+            for field in ("topLevelPackages", "transitivePackages"):
+                packages = framework.get(field)
+                if not isinstance(packages, list):
+                    continue
+                if any(
+                    isinstance(package, dict) and isinstance(package.get("vulnerabilities"), list)
+                    for package in packages
+                ):
+                    return True
     return False
 
 

--- a/src/sdetkit/adoption_surface/java_workspaces.py
+++ b/src/sdetkit/adoption_surface/java_workspaces.py
@@ -238,17 +238,21 @@ def _dotnet_audit_config_state(text: str) -> tuple[bool, bool]:
     except ET.ParseError:
         return False, False
 
-    enabled = False
-    disabled = False
+    explicit_values: set[str] = set()
+    audit_setting_detected = False
     for element in root.iter():
         name = _local_name(str(element.tag))
         value = (element.text or "").strip().lower()
-        if name == "nugetaudit":
-            enabled = enabled or value == "true"
-            disabled = disabled or value == "false"
+        if name == "nugetaudit" and value in {"true", "false"}:
+            explicit_values.add(value)
         elif name in _DOTNET_AUDIT_ELEMENTS:
-            enabled = True
-    return enabled, disabled and not enabled
+            audit_setting_detected = True
+
+    if "true" in explicit_values:
+        return True, False
+    if "false" in explicit_values:
+        return False, True
+    return audit_setting_detected, False
 
 
 def _dotnet_audit_config_evidence(
@@ -342,14 +346,27 @@ def _dotnet_security_commands(root: Path) -> tuple[list[tuple[str, str]], list[s
     return commands, sorted(set(unknowns))
 
 
-def _contains_vulnerability_shape(value: object) -> bool:
-    if isinstance(value, dict):
-        keys = {str(key).lower() for key in value}
-        if "vulnerabilities" in keys or {"severity", "advisoryurl"}.issubset(keys):
-            return True
-        return any(_contains_vulnerability_shape(item) for item in value.values())
-    if isinstance(value, list):
-        return any(_contains_vulnerability_shape(item) for item in value)
+def _is_dotnet_vulnerability_report(payload: object) -> bool:
+    if not isinstance(payload, dict) or "version" not in payload:
+        return False
+    projects = payload.get("projects")
+    if not isinstance(projects, list):
+        return False
+
+    for project in projects:
+        if not isinstance(project, dict) or not str(project.get("path", "")).strip():
+            continue
+        frameworks = project.get("frameworks")
+        if not isinstance(frameworks, list):
+            continue
+        for framework in frameworks:
+            if not isinstance(framework, dict) or not str(framework.get("framework", "")).strip():
+                continue
+            if any(
+                isinstance(framework.get(field), list)
+                for field in ("topLevelPackages", "transitivePackages")
+            ):
+                return True
     return False
 
 
@@ -362,9 +379,7 @@ def _dotnet_vulnerability_reports(root: Path) -> list[str]:
             payload = json.loads(_core._read_text(root, path))
         except json.JSONDecodeError:
             continue
-        if not isinstance(payload, dict) or not isinstance(payload.get("projects"), list):
-            continue
-        if _contains_vulnerability_shape(payload["projects"]):
+        if _is_dotnet_vulnerability_report(payload):
             reports.append(path)
     return sorted(reports)
 

--- a/src/sdetkit/adoption_surface/java_workspaces.py
+++ b/src/sdetkit/adoption_surface/java_workspaces.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,20 @@ _LANGUAGE_BY_SUFFIX = {
     ".vbproj": "visual_basic",
 }
 _CENTRAL_NUGET_FILES = ("Directory.Packages.props", "NuGet.config", "nuget.config")
+_DOTNET_AUDIT_CONFIG_FILES = (
+    "Directory.Build.props",
+    "Directory.Build.targets",
+    "Directory.Packages.props",
+    "NuGet.config",
+    "nuget.config",
+)
+_DOTNET_COMMAND_PATTERNS = ("*.sh", "*.ps1", "*.cmd", "*.bat")
+_DOTNET_AUDIT_ELEMENTS = {
+    "auditsources",
+    "nugetauditlevel",
+    "nugetauditmode",
+    "nugetauditsuppress",
+}
 
 
 def _maven_workspace_command(root: Path, workspace: str) -> tuple[str, str, list[str]]:
@@ -217,6 +232,197 @@ def _nuget_evidence(root: Path, workspace: str) -> list[str]:
     return sorted(set(evidence))
 
 
+def _dotnet_audit_config_state(text: str) -> tuple[bool, bool]:
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError:
+        return False, False
+
+    enabled = False
+    disabled = False
+    for element in root.iter():
+        name = _local_name(str(element.tag))
+        value = (element.text or "").strip().lower()
+        if name == "nugetaudit":
+            enabled = enabled or value == "true"
+            disabled = disabled or value == "false"
+        elif name in _DOTNET_AUDIT_ELEMENTS:
+            enabled = True
+    return enabled, disabled and not enabled
+
+
+def _dotnet_audit_config_evidence(
+    root: Path,
+    manifests: list[str],
+) -> tuple[list[str], list[str]]:
+    candidates = {name for name in _DOTNET_AUDIT_CONFIG_FILES if _core._file(root, name)}
+    candidates.update(manifests)
+    for manifest in manifests:
+        workspace = _base._workspace_directory(manifest)
+        for ancestor in _workspace_ancestors(workspace):
+            for name in _DOTNET_AUDIT_CONFIG_FILES:
+                path = _base._workspace_path(ancestor, name)
+                if _core._file(root, path):
+                    candidates.add(path)
+
+    enabled: list[str] = []
+    disabled: list[str] = []
+    for path in sorted(candidates):
+        is_enabled, is_disabled = _dotnet_audit_config_state(_core._read_text(root, path))
+        if is_enabled:
+            enabled.append(path)
+        elif is_disabled:
+            disabled.append(path)
+    return enabled, disabled
+
+
+def _is_repository_command_source(path: str) -> bool:
+    parts = Path(path).parts
+    if not parts:
+        return False
+    if parts[:2] == (".github", "workflows"):
+        return True
+    return len(parts) == 1 or parts[0] not in _base._WORKSPACE_IGNORED_TOP_LEVEL
+
+
+def _owned_dotnet_command_files(root: Path) -> list[str]:
+    files = set(_core._workflow_files(root) + _core._owned_script_files(root))
+    for path in (".gitlab-ci.yml", "Jenkinsfile"):
+        if _core._file(root, path):
+            files.add(path)
+    for pattern in _DOTNET_COMMAND_PATTERNS:
+        files.update(_core._recursive_files(root, pattern))
+    return sorted(path for path in files if _is_repository_command_source(path))
+
+
+def _literal_dotnet_security_command(raw_line: str) -> str:
+    lower = raw_line.lower()
+    index = lower.find("dotnet ")
+    if index < 0 or "echo " in lower[:index]:
+        return ""
+
+    command = raw_line[index:].strip()
+    if " #" in command:
+        command = command.split(" #", 1)[0].rstrip()
+    command = command.rstrip("'\"")
+    normalized = " ".join(command.lower().split())
+    vulnerable_list = (
+        normalized.startswith("dotnet package list")
+        or (normalized.startswith("dotnet list ") and " package " in normalized)
+    ) and "--vulnerable" in normalized
+    explicit_restore_audit = normalized.startswith("dotnet restore") and any(
+        token in normalized
+        for token in (
+            "nugetaudit=true",
+            "nugetauditmode=",
+            "nugetauditlevel=",
+        )
+    )
+    return command if vulnerable_list or explicit_restore_audit else ""
+
+
+def _dotnet_security_commands(root: Path) -> tuple[list[tuple[str, str]], list[str]]:
+    commands: list[tuple[str, str]] = []
+    unknowns: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for path in _owned_dotnet_command_files(root):
+        for raw_line in _core._read_text(root, path).splitlines():
+            command = _literal_dotnet_security_command(raw_line)
+            if not command:
+                continue
+            if _core._command_is_dynamic(command):
+                unknowns.append(
+                    f".NET dependency security command in {path} is dynamic and was not guessed"
+                )
+                continue
+            key = (path, command)
+            if key not in seen:
+                seen.add(key)
+                commands.append(key)
+    return commands, sorted(set(unknowns))
+
+
+def _contains_vulnerability_shape(value: object) -> bool:
+    if isinstance(value, dict):
+        keys = {str(key).lower() for key in value}
+        if "vulnerabilities" in keys or {"severity", "advisoryurl"}.issubset(keys):
+            return True
+        return any(_contains_vulnerability_shape(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_vulnerability_shape(item) for item in value)
+    return False
+
+
+def _dotnet_vulnerability_reports(root: Path) -> list[str]:
+    reports: list[str] = []
+    for path in _core._recursive_files(root, "*.json"):
+        if not _is_repository_owned(path):
+            continue
+        try:
+            payload = json.loads(_core._read_text(root, path))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict) or not isinstance(payload.get("projects"), list):
+            continue
+        if _contains_vulnerability_shape(payload["projects"]):
+            reports.append(path)
+    return sorted(reports)
+
+
+def _extend_dotnet_security_evidence(
+    payload: dict[str, Any],
+    root: Path,
+    manifests: list[str],
+) -> None:
+    config_evidence, disabled_evidence = _dotnet_audit_config_evidence(root, manifests)
+    commands, command_unknowns = _dotnet_security_commands(root)
+    reports = _dotnet_vulnerability_reports(root)
+    command_files = [path for path, _command in commands]
+    evidence = sorted(set([*config_evidence, *command_files, *reports]))
+
+    if evidence:
+        _base._merge_named_list(
+            payload["security_tools"],
+            "nuget_audit",
+            list_field="evidence",
+            values=evidence,
+            confidence="detected",
+        )
+    if reports:
+        _base._merge_named_list(
+            payload["artifact_surfaces"],
+            "nuget_vulnerability_report",
+            list_field="paths",
+            values=reports,
+            confidence="detected",
+        )
+        payload["artifact_surfaces"] = sorted(
+            payload["artifact_surfaces"], key=lambda item: item["name"]
+        )
+
+    for path, command in commands:
+        _core._add_proof_command(
+            payload["recommended_proof_commands"],
+            surface="dotnet",
+            command=command,
+            confidence="high",
+            purpose="security",
+            evidence=[path],
+            source={"scope": "repository_command", "file": path},
+        )
+
+    payload["review_first_unknowns"].extend(command_unknowns)
+    payload["review_first_unknowns"].extend(
+        f".NET NuGet audit is explicitly disabled in {path}; security posture requires review"
+        for path in disabled_evidence
+    )
+    if config_evidence and not commands and not reports:
+        payload["review_first_unknowns"].append(
+            ".NET NuGet audit configuration detected but a literal security proof command "
+            "or saved vulnerability report is not proven"
+        )
+
+
 def _add_root_dotnet_test_command(payload: dict[str, Any], *, manifest: str, command: str) -> None:
     for item in payload["recommended_proof_commands"]:
         if (
@@ -271,6 +477,8 @@ def extend_dotnet_workspaces(payload: dict[str, Any], root: Path) -> None:
     manifests = _owned_dotnet_project_manifests(root)
     solutions = _owned_dotnet_solutions(root)
     _normalize_base_dotnet_detection(payload, manifests=manifests, solutions=solutions)
+    if manifests or solutions:
+        _extend_dotnet_security_evidence(payload, root, manifests)
     if not manifests:
         return
 

--- a/tests/test_adoption_surface_dotnet_workspaces.py
+++ b/tests/test_adoption_surface_dotnet_workspaces.py
@@ -404,6 +404,23 @@ def test_generic_projects_json_is_not_a_nuget_report(tmp_path: Path) -> None:
     assert "nuget_vulnerability_report" not in _named(payload["artifact_surfaces"])
 
 
+def test_package_inventory_json_is_not_a_vulnerability_report(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "src" / "Api" / "Api.csproj")
+    report = tmp_path / "security" / "package-inventory.json"
+    report.parent.mkdir(parents=True)
+    report.write_text(
+        '{"version": 1, "projects": [{"path": "src/Api/Api.csproj", '
+        '"frameworks": [{"framework": "net8.0", "topLevelPackages": '
+        '[{"id": "Contoso.Runtime", "resolvedVersion": "1.0.0"}]}]}]}\n',
+        encoding="utf-8",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "nuget_audit" not in _named(payload["security_tools"])
+    assert "nuget_vulnerability_report" not in _named(payload["artifact_surfaces"])
+
+
 def test_solution_only_dotnet_repo_can_surface_explicit_audit_command(tmp_path: Path) -> None:
     (tmp_path / "Product.sln").write_text("\n", encoding="utf-8")
     script = tmp_path / "audit.ps1"

--- a/tests/test_adoption_surface_dotnet_workspaces.py
+++ b/tests/test_adoption_surface_dotnet_workspaces.py
@@ -372,6 +372,38 @@ def test_explicitly_disabled_nuget_audit_is_review_first(tmp_path: Path) -> None
     )
 
 
+def test_disabled_nuget_audit_overrides_mode_settings(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "src" / "Api" / "Api.csproj")
+    (tmp_path / "Directory.Build.props").write_text(
+        "<Project><PropertyGroup><NuGetAudit>false</NuGetAudit>"
+        "<NuGetAuditMode>all</NuGetAuditMode></PropertyGroup></Project>\n",
+        encoding="utf-8",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "nuget_audit" not in _named(payload["security_tools"])
+    assert (
+        ".NET NuGet audit is explicitly disabled in Directory.Build.props; "
+        "security posture requires review" in payload["review_first_unknowns"]
+    )
+
+
+def test_generic_projects_json_is_not_a_nuget_report(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "src" / "Api" / "Api.csproj")
+    report = tmp_path / "security" / "generic.json"
+    report.parent.mkdir(parents=True)
+    report.write_text(
+        '{"version": 1, "projects": [{"name": "other", "vulnerabilities": []}]}\n',
+        encoding="utf-8",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "nuget_audit" not in _named(payload["security_tools"])
+    assert "nuget_vulnerability_report" not in _named(payload["artifact_surfaces"])
+
+
 def test_solution_only_dotnet_repo_can_surface_explicit_audit_command(tmp_path: Path) -> None:
     (tmp_path / "Product.sln").write_text("\n", encoding="utf-8")
     script = tmp_path / "audit.ps1"

--- a/tests/test_adoption_surface_dotnet_workspaces.py
+++ b/tests/test_adoption_surface_dotnet_workspaces.py
@@ -224,3 +224,168 @@ def test_dotnet_discovery_ignores_non_owned_top_level_trees(tmp_path: Path) -> N
     assert "fsharp" not in languages
     assert "nuget" not in _named(payload["package_managers"])
     assert payload["recommended_proof_commands"] == []
+
+
+def _write_dotnet_project(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">'
+        "<PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>"
+        '<ItemGroup><PackageReference Include="Contoso.Runtime" Version="1.0.0" /></ItemGroup>'
+        "</Project>\n",
+        encoding="utf-8",
+    )
+
+
+def test_dotnet_package_reference_does_not_invent_security_proof(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "src" / "Api" / "Api.csproj")
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    commands = [
+        item
+        for item in payload["recommended_proof_commands"]
+        if item.get("surface") == "dotnet" and item.get("purpose") == "security"
+    ]
+
+    assert "nuget_audit" not in security
+    assert commands == []
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+
+
+def test_dotnet_audit_config_and_literal_command_are_source_grounded(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "src" / "Api" / "Api.csproj")
+    (tmp_path / "Directory.Build.props").write_text(
+        "<Project><PropertyGroup><NuGetAudit>true</NuGetAudit>"
+        "<NuGetAuditMode>all</NuGetAuditMode></PropertyGroup></Project>\n",
+        encoding="utf-8",
+    )
+    workflow = tmp_path / ".github" / "workflows" / "security.yml"
+    workflow.parent.mkdir(parents=True)
+    command = (
+        "dotnet list src/Api/Api.csproj package --vulnerable --include-transitive --format json"
+    )
+    workflow.write_text(f"jobs:\n  audit:\n    steps:\n      - run: {command}\n", encoding="utf-8")
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    proof = next(
+        item
+        for item in payload["recommended_proof_commands"]
+        if item.get("surface") == "dotnet" and item.get("purpose") == "security"
+    )
+
+    assert set(security["nuget_audit"]["evidence"]) == {
+        ".github/workflows/security.yml",
+        "Directory.Build.props",
+    }
+    assert proof["command"] == command
+    assert proof["confidence"] == "high"
+    assert proof["auto_run_allowed"] is False
+    assert proof["source"] == {
+        "scope": "repository_command",
+        "file": ".github/workflows/security.yml",
+    }
+
+
+def test_dotnet_noun_first_vulnerability_command_is_preserved(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "services" / "billing" / "Billing.csproj")
+    script = tmp_path / "scripts" / "nuget-audit.sh"
+    script.parent.mkdir(parents=True)
+    command = (
+        "dotnet package list --project services/billing/Billing.csproj "
+        "--include-transitive --vulnerable --format json > security/nuget-report.json"
+    )
+    script.write_text(f"#!/usr/bin/env sh\n{command}\n", encoding="utf-8")
+
+    payload = discover_adoption_surface(tmp_path)
+    commands = [
+        item
+        for item in payload["recommended_proof_commands"]
+        if item.get("surface") == "dotnet" and item.get("purpose") == "security"
+    ]
+
+    assert [item["command"] for item in commands] == [command]
+    assert commands[0]["evidence"] == ["scripts/nuget-audit.sh"]
+
+
+def test_dynamic_dotnet_security_command_remains_review_first(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "services" / "billing" / "Billing.csproj")
+    script = tmp_path / "scripts" / "nuget-audit.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        '#!/usr/bin/env sh\ndotnet package list --project "$PROJECT" --vulnerable\n',
+        encoding="utf-8",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert not any(
+        item.get("surface") == "dotnet" and item.get("purpose") == "security"
+        for item in payload["recommended_proof_commands"]
+    )
+    assert (
+        ".NET dependency security command in scripts/nuget-audit.sh is dynamic and was not guessed"
+        in payload["review_first_unknowns"]
+    )
+
+
+def test_saved_dotnet_vulnerability_report_is_an_artifact_surface(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "src" / "Api" / "Api.csproj")
+    report = tmp_path / "security" / "nuget-vulnerabilities.json"
+    report.parent.mkdir(parents=True)
+    report.write_text(
+        '{"version": 1, "projects": [{"path": "src/Api/Api.csproj", '
+        '"frameworks": [{"framework": "net8.0", "topLevelPackages": '
+        '[{"id": "Contoso.Runtime", "resolvedVersion": "1.0.0", '
+        '"vulnerabilities": [{"severity": "high", '
+        '"advisoryurl": "https://example.invalid/advisory"}]}]}]}]}\n',
+        encoding="utf-8",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    artifacts = _named(payload["artifact_surfaces"])
+
+    assert security["nuget_audit"]["evidence"] == ["security/nuget-vulnerabilities.json"]
+    assert artifacts["nuget_vulnerability_report"]["paths"] == [
+        "security/nuget-vulnerabilities.json"
+    ]
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_explicitly_disabled_nuget_audit_is_review_first(tmp_path: Path) -> None:
+    _write_dotnet_project(tmp_path / "src" / "Api" / "Api.csproj")
+    (tmp_path / "Directory.Build.props").write_text(
+        "<Project><PropertyGroup><NuGetAudit>false</NuGetAudit></PropertyGroup></Project>\n",
+        encoding="utf-8",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "nuget_audit" not in _named(payload["security_tools"])
+    assert (
+        ".NET NuGet audit is explicitly disabled in Directory.Build.props; "
+        "security posture requires review" in payload["review_first_unknowns"]
+    )
+
+
+def test_solution_only_dotnet_repo_can_surface_explicit_audit_command(tmp_path: Path) -> None:
+    (tmp_path / "Product.sln").write_text("\n", encoding="utf-8")
+    script = tmp_path / "audit.ps1"
+    command = "dotnet package list --project Product.sln --vulnerable --format json"
+    script.write_text(command + "\n", encoding="utf-8")
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    commands = [
+        item
+        for item in payload["recommended_proof_commands"]
+        if item.get("surface") == "dotnet" and item.get("purpose") == "security"
+    ]
+
+    assert security["nuget_audit"]["evidence"] == ["audit.ps1"]
+    assert [item["command"] for item in commands] == [command]
+    assert commands[0]["auto_run_allowed"] is False


### PR DESCRIPTION
## Summary
- detect explicit NuGet Audit configuration from repository-owned .NET and central MSBuild/NuGet files
- preserve literal `dotnet list ... package --vulnerable`, `dotnet package list ... --vulnerable`, and explicit restore-audit commands as manual-only security proof
- detect saved NuGet package-list JSON as a vulnerability artifact only when package entries include vulnerability data
- keep ordinary `PackageReference` usage and ordinary package-inventory JSON from creating unsupported security claims
- keep dynamic commands and explicitly disabled NuGet Audit settings review-first
- support explicit audit evidence for both project-based and solution-only .NET repositories

Related: #2061.

## Product and roadmap alignment
- source bundle: `11_dependency_hygiene.md`, `13_security_posture.md`, `20_roadmap_and_kpi_system.md`, and `24_master_prompt.md`
- roadmap lane: Stage 1 evidence foundation + Stage 3 adoption discovery
- .NET vertical: executable ladder step 4, dependency/security evidence
- KPI impact: improves source-grounded adoption coverage and security evidence precision without expanding automated authority

## Why
The .NET vertical can already discover explicit test projects and normalize saved `dotnet test` failures, but it cannot yet prove whether a repository has an owned NuGet vulnerability-checking surface. This PR adds that evidence layer conservatively: commands and reports must already exist in repository-owned files, and package references or generic package inventory alone are insufficient.

## Safety boundary
- no .NET SDK, NuGet, workload, tool, or dependency installation
- no restore, build, test, package-list, audit, or target-code execution
- no network requests or advisory lookup
- no dependency mutation, target-repository patching, security dismissal, or remediation
- dynamic commands are not evaluated or guessed
- explicit `NuGetAudit=false` remains review-first even when mode or level settings are present
- `automation_allowed=false`, `patch_application_allowed=false`, `merge_authorized=false`, and `semantic_equivalence_proven=false` remain unchanged

## Verification
```bash
python -m pytest -q tests/test_adoption_surface_dotnet_workspaces.py -o addopts=
python -m ruff check \
  src/sdetkit/adoption_surface/java_workspaces.py \
  tests/test_adoption_surface_dotnet_workspaces.py
python -m ruff format --check \
  src/sdetkit/adoption_surface/java_workspaces.py \
  tests/test_adoption_surface_dotnet_workspaces.py
python -m pre_commit run -a
```

Focused local proof completed before opening and hardening:
- 16 focused .NET adoption tests passed
- Ruff lint, formatting, and Python compilation checks passed for both changed files
- ordinary package references remained security-neutral
- literal old and new .NET vulnerability command forms were preserved exactly
- dynamic commands and `NuGetAudit=false` stayed review-first
- disabled audit overrides nearby mode settings rather than being masked by them
- saved JSON was surfaced only when .NET project/framework/package structure and package-level vulnerability data were present
- generic `projects` JSON and ordinary package-list inventory lookalikes were rejected

The broader fixture matrix is delegated to repository CI because the locally available source distribution does not include the complete fixture corpus or every test-only helper module.

## Risk
Medium-low. The change is additive and read-only. Primary risks are false-positive command extraction, overly broad JSON recognition, and accidental inference from ordinary package metadata; focused negative and positive contracts cover those boundaries.

## Rollback
Revert this PR. No schema migration, dependency rollback, workflow edit, source inventory refresh, or persisted-state conversion is required.

## Next recommended PR
Complete #2061 with one sanitized end-to-end .NET fixture proving adoption discovery → saved-log FailureVector → SafetyGate → Doctor/report integration.