### PR TITLE
feat(adoption): discover JavaScript audit commands

### DIFF
--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "sdetkit.quality_truth_baseline.v1",
-  "generated_on": "2026-07-13",
+  "generated_on": "2026-07-15",
   "status": "staged_migration_visible",
   "coverage": {
     "critical_spine": {
@@ -35,7 +35,7 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 506,
+    "source_module_count": 507,
     "typing_debt_module_count": 486,
     "typing_debt_inventory_sha256": "13994dc80de2613e43b325a5cf39b6f22d0cff18c4ac8d4047ed99f57f20609a",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
@@ -50,6 +50,7 @@
       "sdetkit.adoption_proof_recommendations",
       "sdetkit.adoption_public_repo_trial_matrix_report",
       "sdetkit.adoption_repo_topology",
+      "sdetkit.adoption_surface.javascript_security",
       "sdetkit.adoption_surface.jenkins",
       "sdetkit.diagnostic_execution_plan",
       "sdetkit.diagnostic_job",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,10 @@ module = "sdetkit.adoption_surface.jenkins"
 ignore_errors = false
 
 [[tool.mypy.overrides]]
+module = "sdetkit.adoption_surface.javascript_security"
+ignore_errors = false
+
+[[tool.mypy.overrides]]
 module = [
   "sdetkit.adoption_evidence_bundle",
   "sdetkit.adoption_external_integration",

--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -12,6 +12,9 @@ from sdetkit.adoption_surface.java_workspaces import (
     extend_dotnet_workspaces,
     extend_nested_java_workspaces,
 )
+from sdetkit.adoption_surface.javascript_security import (
+    extend_javascript_package_security,
+)
 
 REQUIRED_FALSE_FIELDS = _base.REQUIRED_FALSE_FIELDS
 REQUIRED_LIST_FIELDS = _base.REQUIRED_LIST_FIELDS
@@ -38,6 +41,7 @@ __all__ = (
 def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root)
     payload = _base.discover_adoption_surface(root)
+    extend_javascript_package_security(payload, root)
     extend_nested_java_workspaces(payload, root)
     extend_dotnet_workspaces(payload, root)
 

--- a/src/sdetkit/adoption_surface/javascript_security.py
+++ b/src/sdetkit/adoption_surface/javascript_security.py
@@ -35,7 +35,8 @@ _ALLOWED_LINE_PREFIXES = {
     "powershell",
     "pwsh",
 }
-_IGNORED_LINE_PREFIXES = ("name:", "description:", "if:", "echo ", "printf ", "write-output ")
+_METADATA_PREFIXES = ("name:", "description:", "if:")
+_SHELL_MESSAGE_COMMANDS = ("echo", "printf", "write-output")
 
 
 def _is_repository_owned(path: str) -> bool:
@@ -67,6 +68,18 @@ def _owned_command_files(root: Path) -> list[str]:
 
 def _clean_line_prefix(prefix: str) -> str:
     return prefix.strip().lower().rstrip("'\"(").strip()
+
+
+def _line_prefix_is_descriptive(prefix: str) -> bool:
+    normalized = prefix.lstrip("- ").strip()
+    if normalized.startswith(_METADATA_PREFIXES):
+        return True
+    return any(
+        normalized == command
+        or normalized.startswith(f"{command} ")
+        or normalized.endswith(f" {command}")
+        for command in _SHELL_MESSAGE_COMMANDS
+    )
 
 
 def _strip_command_suffix(command: str) -> str:
@@ -102,7 +115,7 @@ def _literal_security_command(raw_value: str) -> tuple[str, str, str] | None:
 
     index, _prefix, manager = min(matches, key=lambda item: item[0])
     line_prefix = _clean_line_prefix(stripped[:index])
-    if any(line_prefix.startswith(prefix) for prefix in _IGNORED_LINE_PREFIXES):
+    if _line_prefix_is_descriptive(line_prefix):
         return None
     if line_prefix not in _ALLOWED_LINE_PREFIXES:
         return manager, "", "unresolved"
@@ -132,15 +145,18 @@ def _append_unknown(
     source = _source_label(path, script)
     if reason == "dynamic":
         unknowns.append(
-            f"JavaScript package security command for {manager} in {source} is dynamic and was not guessed"
+            f"JavaScript package security command for {manager} in {source} "
+            "is dynamic and was not guessed"
         )
     elif reason == "mutation":
         unknowns.append(
-            f"JavaScript package security command for {manager} in {source} requests dependency mutation and was not recommended"
+            f"JavaScript package security command for {manager} in {source} "
+            "requests dependency mutation and was not recommended"
         )
     else:
         unknowns.append(
-            f"JavaScript package security command for {manager} in {source} has unresolved command context and was not guessed"
+            f"JavaScript package security command for {manager} in {source} "
+            "has unresolved command context and was not guessed"
         )
 
 
@@ -163,7 +179,8 @@ def _extract_package_script_commands(
                     manager in raw_value.lower() for manager in ("npm", "pnpm", "yarn")
                 ):
                     unknowns.append(
-                        f"JavaScript package security script {script_name} in {manifest} was not a literal supported audit command"
+                        f"JavaScript package security script {script_name} in {manifest} "
+                        "was not a literal supported audit command"
                     )
                 continue
             manager, command, reason = extracted

--- a/src/sdetkit/adoption_surface/javascript_security.py
+++ b/src/sdetkit/adoption_surface/javascript_security.py
@@ -96,7 +96,12 @@ def _is_dynamic_or_composite(command: str) -> bool:
 
 def _requests_mutation(command: str) -> bool:
     normalized = " ".join(command.lower().split())
-    return normalized.startswith("npm audit fix") or "--fix" in normalized.split()
+    return (
+        normalized.startswith(
+            ("npm audit fix", "pnpm audit fix", "yarn audit fix", "yarn npm audit fix")
+        )
+        or "--fix" in normalized.split()
+    )
 
 
 def _literal_security_command(raw_value: str) -> tuple[str, str, str] | None:
@@ -205,7 +210,9 @@ def _extract_package_script_commands(
     return commands, unknowns
 
 
-def _extract_command_file_commands(root: Path) -> tuple[list[dict[str, str]], list[str]]:
+def _extract_command_file_commands(
+    root: Path,
+) -> tuple[list[dict[str, str]], list[str]]:
     commands: list[dict[str, str]] = []
     unknowns: list[str] = []
     for path in _owned_command_files(root):
@@ -247,7 +254,9 @@ def _merge_security_tool(
         )
         return
     current = existing.get("evidence", [])
-    current_values = [str(value) for value in current] if isinstance(current, list) else []
+    current_values = (
+        [str(value) for value in current] if isinstance(current, list) else []
+    )
     existing["evidence"] = sorted(set(current_values + values))
 
 
@@ -274,7 +283,9 @@ def _add_security_proof_command(payload: dict[str, Any], item: dict[str, str]) -
             source_payload["package_manager"] = item["manager"]
             existing["source"] = source_payload
             evidence = existing.get("evidence", [])
-            current = [str(value) for value in evidence] if isinstance(evidence, list) else []
+            current = (
+                [str(value) for value in evidence] if isinstance(evidence, list) else []
+            )
             existing["evidence"] = sorted(set(current + [item["file"]]))
             return
 

--- a/src/sdetkit/adoption_surface/javascript_security.py
+++ b/src/sdetkit/adoption_surface/javascript_security.py
@@ -50,9 +50,7 @@ def _is_repository_owned(path: str) -> bool:
 
 def _owned_package_manifests(root: Path) -> list[str]:
     return [
-        path
-        for path in _core._recursive_files(root, "package.json")
-        if _is_repository_owned(path)
+        path for path in _core._recursive_files(root, "package.json") if _is_repository_owned(path)
     ]
 
 
@@ -254,9 +252,7 @@ def _merge_security_tool(
         )
         return
     current = existing.get("evidence", [])
-    current_values = (
-        [str(value) for value in current] if isinstance(current, list) else []
-    )
+    current_values = [str(value) for value in current] if isinstance(current, list) else []
     existing["evidence"] = sorted(set(current_values + values))
 
 
@@ -283,9 +279,7 @@ def _add_security_proof_command(payload: dict[str, Any], item: dict[str, str]) -
             source_payload["package_manager"] = item["manager"]
             existing["source"] = source_payload
             evidence = existing.get("evidence", [])
-            current = (
-                [str(value) for value in evidence] if isinstance(evidence, list) else []
-            )
+            current = [str(value) for value in evidence] if isinstance(evidence, list) else []
             existing["evidence"] = sorted(set(current + [item["file"]]))
             return
 

--- a/src/sdetkit/adoption_surface/javascript_security.py
+++ b/src/sdetkit/adoption_surface/javascript_security.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from sdetkit.adoption_surface import core as _core
+
+_COMMAND_PATTERNS = ("*.sh", "*.ps1", "*.cmd", "*.bat")
+_IGNORED_TOP_LEVEL = {
+    ".github",
+    "build",
+    "dist",
+    "docs",
+    "examples",
+    "site",
+    "templates",
+    "test",
+    "tests",
+}
+_SECURITY_PREFIXES = (
+    ("yarn npm audit", "yarn"),
+    ("pnpm audit", "pnpm"),
+    ("npm audit", "npm"),
+    ("yarn audit", "yarn"),
+)
+_ALLOWED_LINE_PREFIXES = {
+    "",
+    "-",
+    "run:",
+    "- run:",
+    "script:",
+    "- script:",
+    "sh",
+    "bat",
+    "powershell",
+    "pwsh",
+}
+_IGNORED_LINE_PREFIXES = ("name:", "description:", "if:", "echo ", "printf ", "write-output ")
+
+
+def _is_repository_owned(path: str) -> bool:
+    parts = Path(path).parts
+    if not parts:
+        return False
+    if parts[:2] == (".github", "workflows"):
+        return True
+    return len(parts) == 1 or parts[0] not in _IGNORED_TOP_LEVEL
+
+
+def _owned_package_manifests(root: Path) -> list[str]:
+    return [
+        path
+        for path in _core._recursive_files(root, "package.json")
+        if _is_repository_owned(path)
+    ]
+
+
+def _owned_command_files(root: Path) -> list[str]:
+    files = set(_core._workflow_files(root) + _core._owned_script_files(root))
+    for path in (".gitlab-ci.yml", "Jenkinsfile"):
+        if _core._file(root, path):
+            files.add(path)
+    for pattern in _COMMAND_PATTERNS:
+        files.update(_core._recursive_files(root, pattern))
+    return sorted(path for path in files if _is_repository_owned(path))
+
+
+def _clean_line_prefix(prefix: str) -> str:
+    return prefix.strip().lower().rstrip("'\"(").strip()
+
+
+def _strip_command_suffix(command: str) -> str:
+    if " #" in command:
+        command = command.split(" #", 1)[0].rstrip()
+    return command.rstrip("'\"),").strip()
+
+
+def _is_dynamic_or_composite(command: str) -> bool:
+    return _core._command_is_dynamic(command) or any(
+        token in command for token in ("${{", "||", ";", "|")
+    )
+
+
+def _requests_mutation(command: str) -> bool:
+    normalized = " ".join(command.lower().split())
+    return normalized.startswith("npm audit fix") or "--fix" in normalized.split()
+
+
+def _literal_security_command(raw_value: str) -> tuple[str, str, str] | None:
+    stripped = raw_value.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+
+    lowered = stripped.lower()
+    matches = [
+        (lowered.find(prefix), prefix, manager)
+        for prefix, manager in _SECURITY_PREFIXES
+        if lowered.find(prefix) >= 0
+    ]
+    if not matches:
+        return None
+
+    index, _prefix, manager = min(matches, key=lambda item: item[0])
+    line_prefix = _clean_line_prefix(stripped[:index])
+    if any(line_prefix.startswith(prefix) for prefix in _IGNORED_LINE_PREFIXES):
+        return None
+    if line_prefix not in _ALLOWED_LINE_PREFIXES:
+        return manager, "", "unresolved"
+
+    command = _strip_command_suffix(stripped[index:])
+    if not command:
+        return manager, "", "unresolved"
+    if _requests_mutation(command):
+        return manager, "", "mutation"
+    if _is_dynamic_or_composite(command):
+        return manager, "", "dynamic"
+    return manager, command, ""
+
+
+def _source_label(path: str, script: str = "") -> str:
+    return f"{path} script {script}" if script else path
+
+
+def _append_unknown(
+    unknowns: list[str],
+    *,
+    manager: str,
+    path: str,
+    reason: str,
+    script: str = "",
+) -> None:
+    source = _source_label(path, script)
+    if reason == "dynamic":
+        unknowns.append(
+            f"JavaScript package security command for {manager} in {source} is dynamic and was not guessed"
+        )
+    elif reason == "mutation":
+        unknowns.append(
+            f"JavaScript package security command for {manager} in {source} requests dependency mutation and was not recommended"
+        )
+    else:
+        unknowns.append(
+            f"JavaScript package security command for {manager} in {source} has unresolved command context and was not guessed"
+        )
+
+
+def _extract_package_script_commands(
+    root: Path,
+) -> tuple[list[dict[str, str]], list[str]]:
+    commands: list[dict[str, str]] = []
+    unknowns: list[str] = []
+    for manifest in _owned_package_manifests(root):
+        scripts = _core._read_json(root, manifest).get("scripts")
+        if not isinstance(scripts, dict):
+            continue
+        working_directory = Path(manifest).parent.as_posix()
+        for script_name, raw_value in sorted(scripts.items()):
+            if not isinstance(raw_value, str):
+                continue
+            extracted = _literal_security_command(raw_value)
+            if extracted is None:
+                if "audit" in str(script_name).lower() and any(
+                    manager in raw_value.lower() for manager in ("npm", "pnpm", "yarn")
+                ):
+                    unknowns.append(
+                        f"JavaScript package security script {script_name} in {manifest} was not a literal supported audit command"
+                    )
+                continue
+            manager, command, reason = extracted
+            if reason:
+                _append_unknown(
+                    unknowns,
+                    manager=manager,
+                    path=manifest,
+                    reason=reason,
+                    script=str(script_name),
+                )
+                continue
+            commands.append(
+                {
+                    "manager": manager,
+                    "command": command,
+                    "file": manifest,
+                    "script": str(script_name),
+                    "working_directory": working_directory,
+                }
+            )
+    return commands, unknowns
+
+
+def _extract_command_file_commands(root: Path) -> tuple[list[dict[str, str]], list[str]]:
+    commands: list[dict[str, str]] = []
+    unknowns: list[str] = []
+    for path in _owned_command_files(root):
+        for raw_line in _core._read_text(root, path).splitlines():
+            extracted = _literal_security_command(raw_line)
+            if extracted is None:
+                continue
+            manager, command, reason = extracted
+            if reason:
+                _append_unknown(unknowns, manager=manager, path=path, reason=reason)
+                continue
+            commands.append(
+                {
+                    "manager": manager,
+                    "command": command,
+                    "file": path,
+                    "script": "",
+                    "working_directory": ".",
+                }
+            )
+    return commands, unknowns
+
+
+def _merge_security_tool(
+    payload: dict[str, Any],
+    *,
+    manager: str,
+    evidence: list[str],
+) -> None:
+    name = f"{manager}_audit"
+    existing = next(
+        (item for item in payload["security_tools"] if item.get("name") == name),
+        None,
+    )
+    values = sorted(set(evidence))
+    if existing is None:
+        payload["security_tools"].append(
+            {"name": name, "confidence": "detected", "evidence": values}
+        )
+        return
+    current = existing.get("evidence", [])
+    current_values = [str(value) for value in current] if isinstance(current, list) else []
+    existing["evidence"] = sorted(set(current_values + values))
+
+
+def _add_security_proof_command(payload: dict[str, Any], item: dict[str, str]) -> None:
+    source: dict[str, str] = {
+        "scope": "repository_command",
+        "file": item["file"],
+        "package_manager": item["manager"],
+    }
+    if item["script"]:
+        source["script"] = item["script"]
+    if item["working_directory"] != ".":
+        source["working_directory"] = item["working_directory"]
+
+    for existing in payload["recommended_proof_commands"]:
+        existing_source = existing.get("source")
+        source_payload = existing_source if isinstance(existing_source, dict) else {}
+        if (
+            existing.get("command") == item["command"]
+            and source_payload.get("file") == item["file"]
+            and source_payload.get("script", "") == item["script"]
+        ):
+            existing["purpose"] = "security"
+            source_payload["package_manager"] = item["manager"]
+            existing["source"] = source_payload
+            evidence = existing.get("evidence", [])
+            current = [str(value) for value in evidence] if isinstance(evidence, list) else []
+            existing["evidence"] = sorted(set(current + [item["file"]]))
+            return
+
+    payload["recommended_proof_commands"].append(
+        {
+            "surface": "javascript_typescript",
+            "command": item["command"],
+            "confidence": "medium",
+            "purpose": "security",
+            "executes_untrusted_code": True,
+            "auto_run_allowed": False,
+            "evidence": [item["file"]],
+            "source": source,
+        }
+    )
+
+
+def extend_javascript_package_security(payload: dict[str, Any], root: Path) -> None:
+    package_commands, package_unknowns = _extract_package_script_commands(root)
+    file_commands, file_unknowns = _extract_command_file_commands(root)
+    commands = package_commands + file_commands
+
+    seen: set[tuple[str, str, str, str]] = set()
+    grouped_evidence: dict[str, list[str]] = {}
+    for item in commands:
+        key = (item["manager"], item["command"], item["file"], item["script"])
+        if key in seen:
+            continue
+        seen.add(key)
+        grouped_evidence.setdefault(item["manager"], []).append(item["file"])
+        _add_security_proof_command(payload, item)
+
+    for manager, evidence in grouped_evidence.items():
+        _merge_security_tool(payload, manager=manager, evidence=evidence)
+
+    payload["review_first_unknowns"].extend(package_unknowns)
+    payload["review_first_unknowns"].extend(file_unknowns)

--- a/tests/test_adoption_surface_js_security.py
+++ b/tests/test_adoption_surface_js_security.py
@@ -14,7 +14,9 @@ def _write(path: Path, text: str = "") -> None:
 def _named(items: object) -> dict[str, dict[str, object]]:
     assert isinstance(items, list)
     return {
-        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
+        str(item["name"]): item
+        for item in items
+        if isinstance(item, dict) and item.get("name")
     }
 
 
@@ -83,7 +85,9 @@ def test_pnpm_audit_shell_command_preserves_exact_text(tmp_path: Path) -> None:
     assert commands[command]["auto_run_allowed"] is False
 
 
-def test_nested_yarn_audit_package_script_preserves_workspace_context(tmp_path: Path) -> None:
+def test_nested_yarn_audit_package_script_preserves_workspace_context(
+    tmp_path: Path,
+) -> None:
     manifest = tmp_path / "apps" / "web" / "package.json"
     command = "yarn npm audit --all --recursive"
     _write(
@@ -151,7 +155,7 @@ def test_dynamic_and_mutating_javascript_audit_commands_are_review_first(
         "  audit:\n"
         "    steps:\n"
         '      - run: npm audit --audit-level="$AUDIT_LEVEL"\n'
-        "      - run: pnpm audit --fix\n",
+        "      - run: pnpm audit fix\n",
     )
 
     payload = discover_adoption_surface(tmp_path)
@@ -176,7 +180,9 @@ def test_dynamic_and_mutating_javascript_audit_commands_are_review_first(
     )
 
 
-def test_descriptive_or_echoed_audit_text_is_not_a_security_command(tmp_path: Path) -> None:
+def test_descriptive_or_echoed_audit_text_is_not_a_security_command(
+    tmp_path: Path,
+) -> None:
     _write(tmp_path / "package.json", json.dumps({"name": "demo"}))
     workflow = tmp_path / ".github" / "workflows" / "security.yml"
     _write(

--- a/tests/test_adoption_surface_js_security.py
+++ b/tests/test_adoption_surface_js_security.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_surface import discover_adoption_surface
+
+
+def _write(path: Path, text: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _named(items: object) -> dict[str, dict[str, object]]:
+    assert isinstance(items, list)
+    return {
+        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
+    }
+
+
+def _commands(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    items = payload["recommended_proof_commands"]
+    assert isinstance(items, list)
+    return {
+        str(item["command"]): item
+        for item in items
+        if isinstance(item, dict) and item.get("command")
+    }
+
+
+def test_npm_audit_workflow_command_is_source_grounded(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "demo", "scripts": {"test": "vitest"}}),
+    )
+    _write(tmp_path / "package-lock.json", "{}\n")
+    workflow = tmp_path / ".github" / "workflows" / "security.yml"
+    command = "npm audit --audit-level=high --omit=dev"
+    _write(workflow, f"jobs:\n  audit:\n    steps:\n      - run: {command}\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    commands = _commands(payload)
+
+    assert security["npm_audit"]["evidence"] == [".github/workflows/security.yml"]
+    assert command in commands
+    assert commands[command]["purpose"] == "security"
+    assert commands[command]["evidence"] == [".github/workflows/security.yml"]
+    assert commands[command]["source"] == {
+        "scope": "repository_command",
+        "file": ".github/workflows/security.yml",
+        "package_manager": "npm",
+    }
+    assert commands[command]["executes_untrusted_code"] is True
+    assert commands[command]["auto_run_allowed"] is False
+    assert "npm test" in commands
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_pnpm_audit_shell_command_preserves_exact_text(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "demo", "scripts": {"test": "vitest"}}),
+    )
+    _write(tmp_path / "pnpm-lock.yaml", "lockfileVersion: '9.0'\n")
+    command = "pnpm audit --prod --audit-level high"
+    _write(tmp_path / "scripts" / "security.sh", f"#!/usr/bin/env sh\n{command}\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    commands = _commands(payload)
+
+    assert security["pnpm_audit"]["evidence"] == ["scripts/security.sh"]
+    assert commands[command]["source"] == {
+        "scope": "repository_command",
+        "file": "scripts/security.sh",
+        "package_manager": "pnpm",
+    }
+    assert commands[command]["purpose"] == "security"
+    assert commands[command]["auto_run_allowed"] is False
+
+
+def test_nested_yarn_audit_package_script_preserves_workspace_context(tmp_path: Path) -> None:
+    manifest = tmp_path / "apps" / "web" / "package.json"
+    command = "yarn npm audit --all --recursive"
+    _write(
+        manifest,
+        json.dumps(
+            {
+                "name": "web",
+                "scripts": {
+                    "test": "vitest",
+                    "dependencies:audit": command,
+                },
+            }
+        ),
+    )
+    _write(tmp_path / "apps" / "web" / "yarn.lock", "# yarn lock\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    commands = _commands(payload)
+
+    assert security["yarn_audit"]["evidence"] == ["apps/web/package.json"]
+    assert commands[command]["source"] == {
+        "scope": "repository_command",
+        "file": "apps/web/package.json",
+        "package_manager": "yarn",
+        "script": "dependencies:audit",
+        "working_directory": "apps/web",
+    }
+    assert commands[command]["purpose"] == "security"
+    assert commands[command]["executes_untrusted_code"] is True
+    assert commands[command]["auto_run_allowed"] is False
+
+
+def test_javascript_lockfiles_do_not_invent_security_proof(tmp_path: Path) -> None:
+    _write(tmp_path / "package.json", json.dumps({"name": "demo"}))
+    _write(tmp_path / "package-lock.json", "{}\n")
+    _write(tmp_path / "pnpm-lock.yaml", "lockfileVersion: '9.0'\n")
+    _write(tmp_path / "yarn.lock", "# yarn lock\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    security_commands = [
+        item
+        for item in payload["recommended_proof_commands"]
+        if isinstance(item, dict)
+        and item.get("surface") == "javascript_typescript"
+        and item.get("purpose") == "security"
+    ]
+
+    assert "npm_audit" not in security
+    assert "pnpm_audit" not in security
+    assert "yarn_audit" not in security
+    assert security_commands == []
+
+
+def test_dynamic_and_mutating_javascript_audit_commands_are_review_first(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "package.json", json.dumps({"name": "demo"}))
+    _write(tmp_path / "package-lock.json", "{}\n")
+    workflow = tmp_path / ".github" / "workflows" / "security.yml"
+    _write(
+        workflow,
+        "jobs:\n"
+        "  audit:\n"
+        "    steps:\n"
+        '      - run: npm audit --audit-level="$AUDIT_LEVEL"\n'
+        "      - run: pnpm audit --fix\n",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    security = _named(payload["security_tools"])
+    security_commands = [
+        item
+        for item in payload["recommended_proof_commands"]
+        if isinstance(item, dict) and item.get("purpose") == "security"
+    ]
+
+    assert "npm_audit" not in security
+    assert "pnpm_audit" not in security
+    assert security_commands == []
+    assert (
+        "JavaScript package security command for npm in .github/workflows/security.yml "
+        "is dynamic and was not guessed" in payload["review_first_unknowns"]
+    )
+    assert (
+        "JavaScript package security command for pnpm in .github/workflows/security.yml "
+        "requests dependency mutation and was not recommended"
+        in payload["review_first_unknowns"]
+    )
+
+
+def test_descriptive_or_echoed_audit_text_is_not_a_security_command(tmp_path: Path) -> None:
+    _write(tmp_path / "package.json", json.dumps({"name": "demo"}))
+    workflow = tmp_path / ".github" / "workflows" / "security.yml"
+    _write(
+        workflow,
+        "jobs:\n"
+        "  audit:\n"
+        "    steps:\n"
+        "      - name: npm audit\n"
+        '      - run: echo "npm audit"\n',
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "npm_audit" not in _named(payload["security_tools"])
+    assert not any(
+        isinstance(item, dict) and item.get("purpose") == "security"
+        for item in payload["recommended_proof_commands"]
+    )
+    assert not any(
+        "JavaScript package security command" in item
+        for item in payload["review_first_unknowns"]
+    )

--- a/tests/test_adoption_surface_js_security.py
+++ b/tests/test_adoption_surface_js_security.py
@@ -14,7 +14,9 @@ def _write(path: Path, text: str = "") -> None:
 def _named(items: object) -> dict[str, dict[str, object]]:
     assert isinstance(items, list)
     return {
-        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
+        str(item["name"]): item
+        for item in items
+        if isinstance(item, dict) and item.get("name")
     }
 
 
@@ -173,7 +175,8 @@ def test_dynamic_and_mutating_javascript_audit_commands_are_review_first(
     )
     assert (
         "JavaScript package security command for pnpm in .github/workflows/security.yml "
-        "requests dependency mutation and was not recommended" in payload["review_first_unknowns"]
+        "requests dependency mutation and was not recommended"
+        in payload["review_first_unknowns"]
     )
 
 

--- a/tests/test_adoption_surface_js_security.py
+++ b/tests/test_adoption_surface_js_security.py
@@ -14,9 +14,7 @@ def _write(path: Path, text: str = "") -> None:
 def _named(items: object) -> dict[str, dict[str, object]]:
     assert isinstance(items, list)
     return {
-        str(item["name"]): item
-        for item in items
-        if isinstance(item, dict) and item.get("name")
+        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
     }
 
 
@@ -175,8 +173,7 @@ def test_dynamic_and_mutating_javascript_audit_commands_are_review_first(
     )
     assert (
         "JavaScript package security command for pnpm in .github/workflows/security.yml "
-        "requests dependency mutation and was not recommended"
-        in payload["review_first_unknowns"]
+        "requests dependency mutation and was not recommended" in payload["review_first_unknowns"]
     )
 
 
@@ -187,11 +184,7 @@ def test_descriptive_or_echoed_audit_text_is_not_a_security_command(
     workflow = tmp_path / ".github" / "workflows" / "security.yml"
     _write(
         workflow,
-        "jobs:\n"
-        "  audit:\n"
-        "    steps:\n"
-        "      - name: npm audit\n"
-        '      - run: echo "npm audit"\n',
+        'jobs:\n  audit:\n    steps:\n      - name: npm audit\n      - run: echo "npm audit"\n',
     )
 
     payload = discover_adoption_surface(tmp_path)

--- a/tests/test_adoption_surface_js_security.py
+++ b/tests/test_adoption_surface_js_security.py
@@ -14,9 +14,7 @@ def _write(path: Path, text: str = "") -> None:
 def _named(items: object) -> dict[str, dict[str, object]]:
     assert isinstance(items, list)
     return {
-        str(item["name"]): item
-        for item in items
-        if isinstance(item, dict) and item.get("name")
+        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
     }
 
 
@@ -175,8 +173,7 @@ def test_dynamic_and_mutating_javascript_audit_commands_are_review_first(
     )
     assert (
         "JavaScript package security command for pnpm in .github/workflows/security.yml "
-        "requests dependency mutation and was not recommended"
-        in payload["review_first_unknowns"]
+        "requests dependency mutation and was not recommended" in payload["review_first_unknowns"]
     )
 
 
@@ -198,6 +195,5 @@ def test_descriptive_or_echoed_audit_text_is_not_a_security_command(
         for item in payload["recommended_proof_commands"]
     )
     assert not any(
-        "JavaScript package security command" in item
-        for item in payload["review_first_unknowns"]
+        "JavaScript package security command" in item for item in payload["review_first_unknowns"]
     )

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,14 +24,16 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 506
+    assert payload["observed"]["source_module_count"] == 507
     assert payload["observed"]["typing_debt_module_count"] == 486
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 20
+    assert len(checked) == 21
+    assert "sdetkit.adoption_surface.javascript_security" in checked
     assert "sdetkit.adoption_surface.jenkins" in checked
     inventory = payload["typing_debt_inventory"]
     assert inventory["module_count"] == 486
     assert len(inventory["modules"]) == 486
+    assert "sdetkit.adoption_surface.javascript_security" not in inventory["modules"]
     assert "sdetkit.adoption_surface.jenkins" not in inventory["modules"]
 
 
@@ -50,7 +52,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 506,
+            "actual": 507,
         }
     ]
 


### PR DESCRIPTION
## Summary
I added read-only discovery for explicit npm, pnpm, and Yarn package-security commands already owned by a repository.

Closes #1948.

## What I added
- I preserve exact literal audit commands from workflows, shell scripts, and package scripts.
- I retain package-manager identity and source context for each recommendation.
- I report npm, pnpm, and Yarn audit surfaces only when direct command evidence exists.
- I keep lockfile-only repositories security-neutral.
- I keep dynamic, composite, unresolved, and dependency-mutating audit commands review-first.
- I ignore descriptive step names, comments, and echoed command text.
- I preserve existing JavaScript test recommendations and existing CI-provider behavior.

## Safety boundary
- I do not install dependencies or package-manager tooling.
- I do not run audit, test, build, or target-code commands.
- I do not parse vulnerability findings or claim remediation.
- I do not modify dependencies, apply patches, dismiss security findings, publish, or merge automatically.
- Every recommendation remains advisory with execution and mutation authority disabled.

## Verification
```bash
python -m pytest -q tests/test_adoption_surface_js_security.py tests/test_adoption_surface_js_package_managers.py -o addopts=
python -m ruff check src/sdetkit/adoption_surface tests/test_adoption_surface_js_security.py
python -m ruff format --check src/sdetkit/adoption_surface tests/test_adoption_surface_js_security.py
python -m mypy src
python -m pre_commit run -a
```

The complete repository gate is delegated to CI, including supported Python versions, full coverage, strict documentation, packaging, isolated wheel installation, security, dependency review, and quality evidence publication.

## Risk
Medium-low. The parser is deliberately narrow and rejects unsupported command context instead of evaluating shell, YAML, JSON, or Groovy behavior.

## Rollback
Revert this pull request. No migration, dependency rollback, persisted-state conversion, or workflow restoration is required.