### PR TITLE
fix(adoption): require Python evidence under src

### DIFF
--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from sdetkit.adoption_surface import _base
+from sdetkit.adoption_surface import core as _core
 from sdetkit.adoption_surface.java_security import extend_java_dependency_security
 from sdetkit.adoption_surface.java_workspaces import (
     extend_dotnet_workspaces,
@@ -38,10 +39,54 @@ __all__ = (
     "write_adoption_surface_artifact",
 )
 
+_PYTHON_TEST_UNKNOWN = "Python project detected but test command is not proven"
+
+
+def _src_contains_python_files(root: Path) -> bool:
+    src_root = root / "src"
+    return bool(
+        _core._recursive_files(src_root, "*.py")
+        or _core._recursive_files(src_root, "*.pyi")
+    )
+
+
+def _remove_unproven_src_python(payload: dict[str, Any], root: Path) -> None:
+    if _src_contains_python_files(root):
+        return
+
+    languages = payload.get("detected_languages")
+    if not isinstance(languages, list):
+        return
+
+    src_only = any(
+        isinstance(item, dict)
+        and item.get("name") == "python"
+        and item.get("evidence") == ["src/"]
+        for item in languages
+    )
+    if not src_only:
+        return
+
+    payload["detected_languages"] = [
+        item
+        for item in languages
+        if not (
+            isinstance(item, dict)
+            and item.get("name") == "python"
+            and item.get("evidence") == ["src/"]
+        )
+    ]
+    unknowns = payload.get("review_first_unknowns")
+    if isinstance(unknowns, list):
+        payload["review_first_unknowns"] = [
+            item for item in unknowns if item != _PYTHON_TEST_UNKNOWN
+        ]
+
 
 def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root)
     payload = _base.discover_adoption_surface(root)
+    _remove_unproven_src_python(payload, root)
     extend_javascript_package_security(payload, root)
     extend_nested_java_workspaces(payload, root)
     extend_java_dependency_security(payload, root)

--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -45,8 +45,7 @@ _PYTHON_TEST_UNKNOWN = "Python project detected but test command is not proven"
 def _src_contains_python_files(root: Path) -> bool:
     src_root = root / "src"
     return bool(
-        _core._recursive_files(src_root, "*.py")
-        or _core._recursive_files(src_root, "*.pyi")
+        _core._recursive_files(src_root, "*.py") or _core._recursive_files(src_root, "*.pyi")
     )
 
 

--- a/tests/test_adoption_surface_python_src_detection.py
+++ b/tests/test_adoption_surface_python_src_detection.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_surface import discover_adoption_surface
+
+
+def _write(path: Path, text: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _named(items: object) -> dict[str, dict[str, object]]:
+    assert isinstance(items, list)
+    return {
+        str(item["name"]): item
+        for item in items
+        if isinstance(item, dict) and item.get("name")
+    }
+
+
+def _commands(payload: dict[str, object]) -> set[str]:
+    items = payload["recommended_proof_commands"]
+    assert isinstance(items, list)
+    return {
+        str(item["command"])
+        for item in items
+        if isinstance(item, dict) and item.get("command")
+    }
+
+
+def _assert_authority_is_false(payload: dict[str, object]) -> None:
+    assert payload["automation_allowed"] is False
+    assert payload["patch_application_allowed"] is False
+    assert payload["merge_authorized"] is False
+    assert payload["semantic_equivalence_proven"] is False
+
+
+def test_java_src_tree_does_not_imply_python(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pom.xml",
+        """<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>demo</artifactId>
+  <version>1.0.0</version>
+</project>
+""",
+    )
+    _write(tmp_path / "src" / "main" / "java" / "example" / "App.java", "class App {}\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    languages = _named(payload["detected_languages"])
+
+    assert set(languages) == {"java"}
+    assert "mvn test" in _commands(payload)
+    assert not any("Python project detected" in str(item) for item in payload["review_first_unknowns"])
+    _assert_authority_is_false(payload)
+
+
+def test_typescript_src_tree_does_not_imply_python(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "demo", "scripts": {"test": "vitest run"}}),
+    )
+    _write(tmp_path / "src" / "index.ts", "export const value = 1;\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    languages = _named(payload["detected_languages"])
+
+    assert set(languages) == {"javascript_typescript"}
+    assert "npm test" in _commands(payload)
+    assert not any("Python project detected" in str(item) for item in payload["review_first_unknowns"])
+    _assert_authority_is_false(payload)
+
+
+def test_empty_or_vendor_only_src_tree_does_not_imply_python(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    _write(tmp_path / "src" / "node_modules" / "generated.py", "value = 1\n")
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert _named(payload["detected_languages"]) == {}
+    assert payload["review_first_unknowns"] == []
+    _assert_authority_is_false(payload)
+
+
+@pytest.mark.parametrize("suffix", [".py", ".pyi"])
+def test_python_source_or_stub_under_src_preserves_python_detection(
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    _write(tmp_path / "src" / "example" / f"module{suffix}", "value: int = 1\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    languages = _named(payload["detected_languages"])
+
+    assert languages["python"]["evidence"] == ["src/"]
+    assert payload["review_first_unknowns"] == [
+        "Python project detected but test command is not proven"
+    ]
+    _assert_authority_is_false(payload)
+
+
+def test_python_manifest_detection_is_unchanged_without_src_source(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        """[project]
+name = "demo"
+version = "0.1.0"
+dependencies = ["pytest"]
+""",
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    languages = _named(payload["detected_languages"])
+
+    assert languages["python"]["evidence"] == ["pyproject.toml"]
+    assert "python -m pytest -q -o addopts=" in _commands(payload)
+    assert payload["review_first_unknowns"] == []
+    _assert_authority_is_false(payload)

--- a/tests/test_adoption_surface_python_src_detection.py
+++ b/tests/test_adoption_surface_python_src_detection.py
@@ -16,9 +16,7 @@ def _write(path: Path, text: str = "") -> None:
 def _named(items: object) -> dict[str, dict[str, object]]:
     assert isinstance(items, list)
     return {
-        str(item["name"]): item
-        for item in items
-        if isinstance(item, dict) and item.get("name")
+        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
     }
 
 
@@ -57,7 +55,9 @@ def test_java_src_tree_does_not_imply_python(tmp_path: Path) -> None:
 
     assert set(languages) == {"java"}
     assert "mvn test" in _commands(payload)
-    assert not any("Python project detected" in str(item) for item in payload["review_first_unknowns"])
+    assert not any(
+        "Python project detected" in str(item) for item in payload["review_first_unknowns"]
+    )
     _assert_authority_is_false(payload)
 
 
@@ -73,7 +73,9 @@ def test_typescript_src_tree_does_not_imply_python(tmp_path: Path) -> None:
 
     assert set(languages) == {"javascript_typescript"}
     assert "npm test" in _commands(payload)
-    assert not any("Python project detected" in str(item) for item in payload["review_first_unknowns"])
+    assert not any(
+        "Python project detected" in str(item) for item in payload["review_first_unknowns"]
+    )
     _assert_authority_is_false(payload)
 
 


### PR DESCRIPTION
## Summary

I stopped a generic top-level `src/` directory from creating unsupported high-confidence Python adoption evidence.

Closes #2075.

## What I changed

- I keep `src/` as Python evidence only when it contains an owned `.py` or `.pyi` file.
- I remove the unsupported Python language classification when `src/` contains Java, TypeScript, an empty tree, or ignored vendor content only.
- I remove the corresponding unproven Python test-command warning when that directory name was the sole Python signal.
- I preserve Python detection from `pyproject.toml`, setup metadata, requirements, tox configuration, real Python source, and Python stubs.
- I preserve all Java, JavaScript/TypeScript, package-manager, proof-command, and authority behavior.

## Safety boundary

- I do not inspect or execute target repository code.
- I do not infer a Python test command from directory shape.
- I do not remove Python evidence backed by manifests, requirements, tox, `.py`, or `.pyi` files.
- Automatic command execution, patch application, merge authorization, and semantic-equivalence claims remain false.

## Verification

```bash
python -m pytest -q tests/test_adoption_surface_python_src_detection.py tests/test_java_adoption_vertical.py tests/test_adoption_surface_nested_java_workspaces.py -o addopts=
python -m ruff check src/sdetkit/adoption_surface/__init__.py tests/test_adoption_surface_python_src_detection.py
python -m ruff format --check src/sdetkit/adoption_surface/__init__.py tests/test_adoption_surface_python_src_detection.py
python -m mypy src
python -m pre_commit run -a
```

The complete repository gate is delegated to CI, including supported Python versions, full coverage, strict documentation, packaging, isolated wheel installation, security, dependency review, and quality evidence publication.

## Risk

Low. The correction only removes an unsupported language claim when `src/` is the sole Python evidence and contains no Python source or stub files.

## Rollback

Revert this pull request. No migration, dependency rollback, persisted-state conversion, or workflow restoration is required.