### PR TITLE
fix(adoption): require Python files under src

### DIFF
--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from sdetkit.adoption_surface import _base
+from sdetkit.adoption_surface import core as _core
 from sdetkit.adoption_surface.java_security import extend_java_dependency_security
 from sdetkit.adoption_surface.java_workspaces import (
     extend_dotnet_workspaces,
@@ -38,10 +39,49 @@ __all__ = (
     "write_adoption_surface_artifact",
 )
 
+_PYTHON_TEST_UNKNOWN = "Python project detected but test command is not proven"
+
+
+def _src_contains_python_sources(root: Path) -> bool:
+    src_root = root / "src"
+    if not src_root.is_dir():
+        return False
+    return bool(_core._recursive_files_for_patterns(src_root, ("*.py", "*.pyi")))
+
+
+def _refine_python_src_evidence(payload: dict[str, Any], root: Path) -> None:
+    if _src_contains_python_sources(root):
+        return
+
+    languages = payload.get("detected_languages")
+    if not isinstance(languages, list):
+        return
+
+    for index, item in enumerate(languages):
+        if not isinstance(item, dict) or item.get("name") != "python":
+            continue
+        evidence = item.get("evidence")
+        if not isinstance(evidence, list) or "src/" not in evidence:
+            return
+
+        filtered = sorted({str(value) for value in evidence if str(value) != "src/"})
+        if filtered:
+            item["evidence"] = filtered
+            return
+
+        del languages[index]
+        unknowns = payload.get("review_first_unknowns")
+        if isinstance(unknowns, list):
+            payload["review_first_unknowns"] = [
+                value for value in unknowns if value != _PYTHON_TEST_UNKNOWN
+            ]
+        return
+
 
 def discover_adoption_surface(repo_root: str | Path = ".") -> dict[str, Any]:
     root = Path(repo_root)
     payload = _base.discover_adoption_surface(root)
+    _refine_python_src_evidence(payload, root)
     extend_javascript_package_security(payload, root)
     extend_nested_java_workspaces(payload, root)
     extend_java_dependency_security(payload, root)

--- a/tests/test_adoption_surface_python_src_detection.py
+++ b/tests/test_adoption_surface_python_src_detection.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_surface import discover_adoption_surface
+
+PYTHON_TEST_UNKNOWN = "Python project detected but test command is not proven"
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+)
+
+
+def _write(path: Path, text: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _named(items: object) -> dict[str, dict[str, object]]:
+    assert isinstance(items, list)
+    return {
+        str(item["name"]): item for item in items if isinstance(item, dict) and item.get("name")
+    }
+
+
+def _commands(payload: dict[str, object]) -> list[dict[str, object]]:
+    commands = payload["recommended_proof_commands"]
+    assert isinstance(commands, list)
+    return [item for item in commands if isinstance(item, dict)]
+
+
+@pytest.mark.parametrize(
+    ("manifest", "manifest_text", "source", "expected_language"),
+    [
+        (
+            "pom.xml",
+            "<project />\n",
+            "src/main/java/com/example/Application.java",
+            "java",
+        ),
+        (
+            "package.json",
+            json.dumps({"name": "web", "scripts": {"test": "vitest"}}) + "\n",
+            "src/index.ts",
+            "javascript_typescript",
+        ),
+    ],
+)
+def test_non_python_src_trees_do_not_imply_python_adoption(
+    tmp_path: Path,
+    manifest: str,
+    manifest_text: str,
+    source: str,
+    expected_language: str,
+) -> None:
+    _write(tmp_path / manifest, manifest_text)
+    _write(tmp_path / source, "// repository-owned non-Python source\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    languages = _named(payload["detected_languages"])
+    runners = _named(payload["test_runners"])
+
+    assert expected_language in languages
+    assert "python" not in languages
+    assert "pytest" not in runners
+    assert PYTHON_TEST_UNKNOWN not in payload["review_first_unknowns"]
+    assert all(item.get("surface") != "python" for item in _commands(payload))
+    assert all(payload[field] is False for field in AUTHORITY_FIELDS)
+
+
+def test_empty_src_directory_does_not_imply_python_adoption(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+
+    payload = discover_adoption_surface(tmp_path)
+
+    assert "python" not in _named(payload["detected_languages"])
+    assert PYTHON_TEST_UNKNOWN not in payload["review_first_unknowns"]
+    assert all(payload[field] is False for field in AUTHORITY_FIELDS)
+
+
+@pytest.mark.parametrize("source_name", ["module.py", "types.pyi"])
+def test_python_files_under_src_remain_high_confidence_evidence(
+    tmp_path: Path,
+    source_name: str,
+) -> None:
+    _write(tmp_path / "src" / "example" / source_name, "VALUE = 1\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    python = _named(payload["detected_languages"])["python"]
+
+    assert python["confidence"] == "high"
+    assert python["evidence"] == ["src/"]
+    assert PYTHON_TEST_UNKNOWN in payload["review_first_unknowns"]
+    assert all(payload[field] is False for field in AUTHORITY_FIELDS)
+
+
+@pytest.mark.parametrize(
+    ("metadata_path", "metadata_text", "expected_unknown", "expected_command"),
+    [
+        ("pyproject.toml", "[project]\nname = 'example'\n", True, None),
+        ("setup.cfg", "[metadata]\nname = example\n", True, None),
+        ("setup.py", "from setuptools import setup\nsetup(name='example')\n", True, None),
+        ("requirements.txt", "requests==2.32.4\n", True, None),
+        ("tox.ini", "[tox]\nenvlist = py\n", False, "python -m tox"),
+    ],
+)
+def test_python_metadata_detection_is_preserved_without_python_src_files(
+    tmp_path: Path,
+    metadata_path: str,
+    metadata_text: str,
+    expected_unknown: bool,
+    expected_command: str | None,
+) -> None:
+    _write(tmp_path / metadata_path, metadata_text)
+    _write(tmp_path / "src" / "index.ts", "export const value = 1;\n")
+
+    payload = discover_adoption_surface(tmp_path)
+    python = _named(payload["detected_languages"])["python"]
+    commands = {str(item.get("command")) for item in _commands(payload)}
+
+    assert python["confidence"] == "high"
+    assert python["evidence"] == [metadata_path]
+    assert (PYTHON_TEST_UNKNOWN in payload["review_first_unknowns"]) is expected_unknown
+    if expected_command is not None:
+        assert expected_command in commands
+    assert all(payload[field] is False for field in AUTHORITY_FIELDS)


### PR DESCRIPTION
## Summary

I fixed a cross-ecosystem adoption false positive where any top-level `src/` directory was treated as high-confidence Python evidence.

Closes #2075.

## What I changed

- I keep `src/` as Python evidence only when it contains repository-owned `.py` or `.pyi` files.
- I remove the unsupported Python test-command warning when `src/` was the only Python signal.
- I preserve Python detection from `pyproject.toml`, `setup.cfg`, `setup.py`, requirements files, and tox configuration.
- I preserve the existing read-only authority boundary.

## Regression coverage

- Java repository with `src/main/java` remains Java-only.
- JavaScript/TypeScript repository with `src/` remains JavaScript/TypeScript-only.
- Empty `src/` does not imply Python.
- `.py` and `.pyi` files under `src/` still create high-confidence Python evidence.
- Manifest-only and tox-based Python detection remain unchanged.
- False Python classification does not create a Python proof command or review-first warning.

## Safety boundary

- I do not execute target repository code, tests, builds, or package managers.
- I do not install dependencies or infer behavior from generated output.
- Automation, patch application, merge authorization, and semantic-equivalence claims remain false.

## Verification

```bash
python -m pytest -q tests/test_adoption_surface_python_src_detection.py tests/test_java_adoption_vertical.py tests/test_adoption_surface_nested_java_workspaces.py -o addopts=
python -m ruff check src/sdetkit/adoption_surface/__init__.py tests/test_adoption_surface_python_src_detection.py
python -m ruff format --check src/sdetkit/adoption_surface/__init__.py tests/test_adoption_surface_python_src_detection.py
python -m pre_commit run -a
```

The complete repository gate is delegated to CI, including all supported Python versions, coverage, strict documentation, packaging, isolated wheel installation, dependency review, security, and quality evidence publication.

## Risk

Low. The change only removes unsupported Python evidence created by a generic directory name. Explicit Python metadata and real Python source evidence continue to behave as before.

## Rollback

Revert this pull request. No migration, dependency rollback, persisted-state conversion, or workflow restoration is required.