### PR TITLE
fix(release): parse Doctor v2 readiness evidence

### DIFF
--- a/.github/workflows/release-readiness-radar-bot.yml
+++ b/.github/workflows/release-readiness-radar-bot.yml
@@ -44,6 +44,8 @@ jobs:
           import subprocess
           from pathlib import Path
 
+          from tools.release_readiness_doctor import evaluate_doctor_evidence
+
           repo_root = Path('.')
           build = repo_root / 'build'
 
@@ -106,19 +108,11 @@ jobs:
               for path in release_assets
           ]
 
-          doctor_checks = doctor.get('checks', [])
-          doctor_evidence_available = (
-              bool(doctor)
-              and 'raw' not in doctor
-              and isinstance(doctor_checks, list)
-          )
-          if not isinstance(doctor_checks, list):
-              doctor_checks = []
+          doctor_evidence = evaluate_doctor_evidence(doctor)
+          doctor_status = str(doctor_evidence['status'])
+          doctor_evidence_available = bool(doctor_evidence['evidence_available'])
           failing_doctor_checks = [
-              item.get('name') or item.get('id') or item.get('key')
-              for item in doctor_checks
-              if isinstance(item, dict)
-              and not item.get('ok', item.get('passed', True))
+              str(item) for item in doctor_evidence['failing_checks']
           ]
           automation = maintenance.get('checks', {}).get('github_automation_check', {})
           automation_details = automation.get('details', {}) if isinstance(automation, dict) else {}
@@ -137,13 +131,7 @@ jobs:
 
           missing_release_workflows = [item['path'] for item in workflows if not item['present']]
           missing_release_assets = [item['path'] for item in assets if not item['present']]
-          actionable_reasons = []
-          if not doctor_evidence_available:
-              actionable_reasons.append('doctor evidence unavailable or malformed')
-          if failing_doctor_checks:
-              actionable_reasons.append(
-                  f"failing doctor checks: {len(failing_doctor_checks)}"
-              )
+          actionable_reasons = list(doctor_evidence['actionable_reasons'])
           if missing_release_workflows:
               actionable_reasons.append(
                   'missing release workflows: ' + ', '.join(missing_release_workflows)
@@ -166,7 +154,7 @@ jobs:
 
           report = {
               'summary': {
-                  'doctor_status': doctor.get('status') or doctor.get('summary') or 'unknown',
+                  'doctor_status': doctor_status,
                   'doctor_evidence_available': doctor_evidence_available,
                   'automation_evidence_available': automation_evidence_available,
                   'failing_doctor_checks': len(failing_doctor_checks),

--- a/tests/test_release_readiness_radar.py
+++ b/tests/test_release_readiness_radar.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.release_readiness_doctor import (
+    MALFORMED_DOCTOR_REASON,
+    evaluate_doctor_evidence,
+)
+
+
+def test_current_doctor_v2_mapping_is_healthy_evidence() -> None:
+    result = evaluate_doctor_evidence(
+        {
+            "schema_version": "sdetkit.doctor.v2",
+            "ok": True,
+            "score": 100,
+            "quality": {"failed_checks": 0},
+            "checks": {
+                "pyproject": {"ok": True},
+                "release_meta": {"ok": True},
+            },
+        }
+    )
+
+    assert result == {
+        "status": "green",
+        "evidence_available": True,
+        "failing_checks": [],
+        "actionable_reasons": [],
+    }
+
+
+def test_current_doctor_v2_mapping_reports_sorted_failing_ids() -> None:
+    result = evaluate_doctor_evidence(
+        {
+            "schema_version": "sdetkit.doctor.v2",
+            "ok": False,
+            "summary": {"failed": 2},
+            "checks": {
+                "release_meta": {"ok": False},
+                "pyproject": {"passed": True},
+                "ci_workflows": {"passed": False},
+            },
+        }
+    )
+
+    assert result["status"] == "blocked"
+    assert result["evidence_available"] is True
+    assert result["failing_checks"] == ["ci_workflows", "release_meta"]
+    assert result["actionable_reasons"] == ["failing doctor checks: 2"]
+    assert isinstance(result["status"], str)
+
+
+def test_legacy_list_checks_remain_supported_without_invented_ids() -> None:
+    result = evaluate_doctor_evidence(
+        {
+            "schema_version": "sdetkit.doctor.v1",
+            "quality": {"failed_checks": 2},
+            "checks": [
+                {"name": "deps", "ok": False},
+                {"id": "ci_workflows", "passed": True},
+                {"ok": False},
+            ],
+        }
+    )
+
+    assert result["status"] == "review_required"
+    assert result["evidence_available"] is True
+    assert result["failing_checks"] == ["deps"]
+    assert result["actionable_reasons"] == ["failing doctor checks: 1"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {"raw": "not-json"},
+        {"schema_version": "sdetkit.doctor.v2", "checks": []},
+        {"schema_version": "sdetkit.doctor.v99", "checks": {}},
+        {"schema_version": "sdetkit.doctor.v1", "checks": {}},
+    ],
+)
+def test_malformed_or_unknown_doctor_evidence_stays_actionable(payload: object) -> None:
+    assert evaluate_doctor_evidence(payload) == {
+        "status": "unknown",
+        "evidence_available": False,
+        "failing_checks": [],
+        "actionable_reasons": [MALFORMED_DOCTOR_REASON],
+    }
+
+
+def test_explicit_scalar_status_is_preserved() -> None:
+    result = evaluate_doctor_evidence(
+        {
+            "schema_version": "sdetkit.doctor.v2",
+            "status": "review_required",
+            "summary": {"nested": "object"},
+            "checks": {},
+        }
+    )
+
+    assert result["status"] == "review_required"
+    assert isinstance(result["status"], str)

--- a/tests/test_release_readiness_zero_signal_policy.py
+++ b/tests/test_release_readiness_zero_signal_policy.py
@@ -55,7 +55,9 @@ def test_release_readiness_requires_complete_evidence_before_suppressing_tracker
 def test_generated_build_outputs_do_not_create_release_readiness_issue() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    policy_start = workflow.index("actionable_reasons = list(doctor_evidence['actionable_reasons'])")
+    policy_start = workflow.index(
+        "actionable_reasons = list(doctor_evidence['actionable_reasons'])"
+    )
     policy_end = workflow.index("actionable = bool(actionable_reasons)")
     policy_block = workflow[policy_start:policy_end]
 

--- a/tests/test_release_readiness_zero_signal_policy.py
+++ b/tests/test_release_readiness_zero_signal_policy.py
@@ -38,9 +38,13 @@ def test_release_readiness_uses_one_bot_managed_rolling_tracker() -> None:
 def test_release_readiness_requires_complete_evidence_before_suppressing_tracker() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
+    assert "from tools.release_readiness_doctor import evaluate_doctor_evidence" in workflow
+    assert "doctor_evidence = evaluate_doctor_evidence(doctor)" in workflow
+    assert "actionable_reasons = list(doctor_evidence['actionable_reasons'])" in workflow
     assert "doctor_evidence_available" in workflow
     assert "automation_evidence_available" in workflow
-    assert "doctor evidence unavailable or malformed" in workflow
+    assert "doctor evidence unavailable or malformed" not in workflow
+    assert "isinstance(doctor_checks, list)" not in workflow
     assert "automation evidence unavailable or malformed" in workflow
     assert "missing_release_workflows" in workflow
     assert "missing_release_assets" in workflow
@@ -51,7 +55,7 @@ def test_release_readiness_requires_complete_evidence_before_suppressing_tracker
 def test_generated_build_outputs_do_not_create_release_readiness_issue() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    policy_start = workflow.index("actionable_reasons = []")
+    policy_start = workflow.index("actionable_reasons = list(doctor_evidence['actionable_reasons'])")
     policy_end = workflow.index("actionable = bool(actionable_reasons)")
     policy_block = workflow[policy_start:policy_end]
 

--- a/tools/release_readiness_doctor.py
+++ b/tools/release_readiness_doctor.py
@@ -70,10 +70,12 @@ def evaluate_doctor_evidence(payload: object) -> dict[str, Any]:
     schema_version = payload.get("schema_version")
     checks = payload.get("checks")
     current_shape = schema_version == DOCTOR_SCHEMA_VERSION and isinstance(checks, dict)
-    legacy_shape = (
-        schema_version in {None, "", LEGACY_DOCTOR_SCHEMA_VERSION, DOCTOR_SCHEMA_VERSION}
-        and isinstance(checks, list)
-    )
+    legacy_shape = schema_version in {
+        None,
+        "",
+        LEGACY_DOCTOR_SCHEMA_VERSION,
+        DOCTOR_SCHEMA_VERSION,
+    } and isinstance(checks, list)
     evidence_available = current_shape or legacy_shape
     if not evidence_available:
         return {
@@ -84,9 +86,7 @@ def evaluate_doctor_evidence(payload: object) -> dict[str, Any]:
         }
 
     failing_checks = _failing_check_ids(checks)
-    actionable_reasons = (
-        [f"failing doctor checks: {len(failing_checks)}"] if failing_checks else []
-    )
+    actionable_reasons = [f"failing doctor checks: {len(failing_checks)}"] if failing_checks else []
     return {
         "status": _doctor_status(payload, failing_checks),
         "evidence_available": True,

--- a/tools/release_readiness_doctor.py
+++ b/tools/release_readiness_doctor.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+
+DOCTOR_SCHEMA_VERSION = "sdetkit.doctor.v2"
+LEGACY_DOCTOR_SCHEMA_VERSION = "sdetkit.doctor.v1"
+MALFORMED_DOCTOR_REASON = "doctor evidence unavailable or malformed"
+
+
+def _check_failed(item: dict[str, Any]) -> bool:
+    ok = item.get("ok")
+    if isinstance(ok, bool):
+        return not ok
+    passed = item.get("passed")
+    if isinstance(passed, bool):
+        return not passed
+    return False
+
+
+def _failing_check_ids(checks: object) -> list[str]:
+    failing: list[str] = []
+    if isinstance(checks, dict):
+        for check_id, item in checks.items():
+            if isinstance(item, dict) and _check_failed(item):
+                normalized = str(check_id).strip()
+                if normalized:
+                    failing.append(normalized)
+        return sorted(set(failing))
+
+    if isinstance(checks, list):
+        for item in checks:
+            if not isinstance(item, dict) or not _check_failed(item):
+                continue
+            check_id = item.get("name") or item.get("id") or item.get("key")
+            normalized = str(check_id).strip() if check_id is not None else ""
+            if normalized:
+                failing.append(normalized)
+        return sorted(set(failing))
+
+    return []
+
+
+def _doctor_status(payload: dict[str, Any], failing_checks: list[str]) -> str:
+    status = payload.get("status")
+    if isinstance(status, str) and status.strip():
+        return status.strip()
+
+    ok = payload.get("ok")
+    if isinstance(ok, bool):
+        return "green" if ok else "blocked"
+
+    quality = payload.get("quality")
+    if isinstance(quality, dict):
+        failed = quality.get("failed_checks")
+        if isinstance(failed, int):
+            return "green" if failed == 0 else "review_required"
+
+    return "review_required" if failing_checks else "unknown"
+
+
+def evaluate_doctor_evidence(payload: object) -> dict[str, Any]:
+    if not isinstance(payload, dict) or "raw" in payload:
+        return {
+            "status": "unknown",
+            "evidence_available": False,
+            "failing_checks": [],
+            "actionable_reasons": [MALFORMED_DOCTOR_REASON],
+        }
+
+    schema_version = payload.get("schema_version")
+    checks = payload.get("checks")
+    current_shape = schema_version == DOCTOR_SCHEMA_VERSION and isinstance(checks, dict)
+    legacy_shape = (
+        schema_version in {None, "", LEGACY_DOCTOR_SCHEMA_VERSION, DOCTOR_SCHEMA_VERSION}
+        and isinstance(checks, list)
+    )
+    evidence_available = current_shape or legacy_shape
+    if not evidence_available:
+        return {
+            "status": "unknown",
+            "evidence_available": False,
+            "failing_checks": [],
+            "actionable_reasons": [MALFORMED_DOCTOR_REASON],
+        }
+
+    failing_checks = _failing_check_ids(checks)
+    actionable_reasons = (
+        [f"failing doctor checks: {len(failing_checks)}"] if failing_checks else []
+    )
+    return {
+        "status": _doctor_status(payload, failing_checks),
+        "evidence_available": True,
+        "failing_checks": failing_checks,
+        "actionable_reasons": actionable_reasons,
+    }

--- a/tools/release_readiness_doctor.py
+++ b/tools/release_readiness_doctor.py
@@ -74,7 +74,6 @@ def evaluate_doctor_evidence(payload: object) -> dict[str, Any]:
         None,
         "",
         LEGACY_DOCTOR_SCHEMA_VERSION,
-        DOCTOR_SCHEMA_VERSION,
     } and isinstance(checks, list)
     evidence_available = current_shape or legacy_shape
     if not evidence_available:


### PR DESCRIPTION
## Summary

I fixed the release-readiness radar so current `sdetkit.doctor.v2` output is treated as valid evidence instead of being rejected because its `checks` field is a keyed object.

Closes #2078.

## What I changed

- I added a pure Doctor evidence parser for the release-readiness policy.
- I accept the current keyed Doctor v2 checks contract.
- I retain compatibility with legacy list-shaped checks.
- I derive deterministic failing check IDs without inventing IDs for anonymous legacy rows.
- I emit a stable scalar Doctor status from explicit status, overall `ok`, quality counts, or active failures.
- I keep malformed, raw, unknown-schema, and shape-mismatched evidence review-first and actionable.
- I wired the workflow to seed actionable reasons directly from the tested parser.

## Behavior

- Healthy Doctor v2 evidence no longer adds `doctor evidence unavailable or malformed`.
- Failed keyed Doctor checks still keep the rolling tracker actionable.
- Zero-signal runs remain artifact-only and close an existing bot-managed tracker.
- Workflow permissions, schedule, artifacts, release assets, automation checks, and issue reconciliation remain unchanged.

## Safety boundary

- I do not run release or publishing actions.
- I do not close non-bot issues or change the rolling tracker authority model.
- I do not authorize remediation, patch application, merge, security dismissal, or semantic-equivalence claims.
- Unknown or malformed evidence remains review-first rather than being guessed as healthy.

## Verification

```bash
python -m pytest -q tests/test_release_readiness_radar.py tests/test_release_readiness_zero_signal_policy.py -o addopts=
python -m ruff check tools/release_readiness_doctor.py tests/test_release_readiness_radar.py tests/test_release_readiness_zero_signal_policy.py
python -m ruff format --check tools/release_readiness_doctor.py tests/test_release_readiness_radar.py tests/test_release_readiness_zero_signal_policy.py
python -m pre_commit run -a
```

The complete repository gate is delegated to CI, including workflow contracts, supported Python versions, full coverage, strict documentation, packaging, isolated wheel installation, security, dependency review, and quality evidence publication.

## Risk

Low. The change narrows a false actionable signal while preserving conservative handling for malformed evidence and all existing release-readiness authority boundaries.

## Rollback

Revert this pull request. No migration, persisted-state conversion, release rollback, or workflow-secret change is required.