### PR TITLE
fix(security): normalize GHAS digest metrics

### DIFF
--- a/.github/workflows/ghas-review-bot.yml
+++ b/.github/workflows/ghas-review-bot.yml
@@ -32,8 +32,7 @@ jobs:
             const {
               collectedAlerts,
               unavailableAlerts,
-              metricOrUnknown,
-              countOrUnknown,
+              digestAlertMetrics,
             } = require(`${process.env.GITHUB_WORKSPACE}/scripts/ghas_tracker_state.js`);
             const weekOf = new Date().toISOString().slice(0, 10);
             const labels = [
@@ -137,10 +136,7 @@ jobs:
             const codeScanning = await fetchAlerts('/repos/{owner}/{repo}/code-scanning/alerts', 'Code scanning');
             const dependabot = await fetchAlerts('/repos/{owner}/{repo}/dependabot/alerts', 'Dependabot alerts');
             const secretScanning = await fetchAlerts('/repos/{owner}/{repo}/secret-scanning/alerts', 'Secret scanning alerts');
-            const pushProtectionBypassed = metricOrUnknown(
-              secretScanning,
-              (alerts) => alerts.filter((alert) => alert.push_protection_bypassed === true).length
-            );
+            const digestMetrics = digestAlertMetrics(codeScanning, dependabot, secretScanning);
 
             for (const result of [codeScanning, dependabot, secretScanning]) {
               if (result.note) {
@@ -155,10 +151,10 @@ jobs:
               'This issue is auto-generated to keep GitHub Advanced Security review visible and actionable.',
               '',
               '## Alert totals',
-              `- Open code scanning alerts: **${codeScanning.count}**`,
-              `- Open Dependabot alerts: **${dependabot.count}**`,
-              `- Open secret scanning alerts: **${secretScanning.count}**`,
-              `- Secret scanning review queue (push-protection/bypass follow-up): **${pushProtectionBypassed.count}**`,
+              `- Open code scanning alerts: **${digestMetrics.codeScanning}**`,
+              `- Open Dependabot alerts: **${digestMetrics.dependabot}**`,
+              `- Open secret scanning alerts: **${digestMetrics.secretScanning}**`,
+              `- Secret scanning review queue (push-protection/bypass follow-up): **${digestMetrics.pushProtectionBypassed}**`,
               '',
               '## Collection status',
               `- Code scanning: **${codeScanning.status}**`,

--- a/scripts/ghas_tracker_state.js
+++ b/scripts/ghas_tracker_state.js
@@ -66,6 +66,20 @@ function formatMetric(value) {
   return value;
 }
 
+function digestAlertMetrics(codeScanning, dependabot, secretScanning) {
+  return {
+    codeScanning: countOrUnknown(codeScanning),
+    dependabot: countOrUnknown(dependabot),
+    secretScanning: countOrUnknown(secretScanning),
+    pushProtectionBypassed: formatMetric(
+      metricOrUnknown(
+        secretScanning,
+        (alerts) => alerts.filter((alert) => alert.push_protection_bypassed === true).length,
+      ),
+    ),
+  };
+}
+
 module.exports = {
   collectedAlerts,
   unavailableAlerts,
@@ -73,4 +87,5 @@ module.exports = {
   metricOrUnknown,
   countOrUnknown,
   formatMetric,
+  digestAlertMetrics,
 };

--- a/tests/test_ghas_tracker_state_contract.py
+++ b/tests/test_ghas_tracker_state_contract.py
@@ -90,18 +90,85 @@ def test_derived_metrics_remain_unknown_when_collection_is_unknown() -> None:
     )
 
 
+def test_digest_metrics_preserve_authoritative_zero() -> None:
+    result = _node_json(
+        "helper.digestAlertMetrics("
+        "helper.collectedAlerts([], 'Code scanning'), "
+        "helper.collectedAlerts([], 'Dependabot'), "
+        "helper.collectedAlerts([], 'Secret scanning'))"
+    )
+
+    assert result == {
+        "codeScanning": 0,
+        "dependabot": 0,
+        "secretScanning": 0,
+        "pushProtectionBypassed": 0,
+    }
+
+
+def test_digest_metrics_never_leak_null_or_undefined() -> None:
+    result = _node_json(
+        "helper.digestAlertMetrics("
+        "helper.collectedAlerts([{number: 1}, {number: 2}], 'Code scanning'), "
+        "helper.unavailableAlerts('Dependabot', new Error('forbidden')), "
+        "helper.collectedAlerts(null, 'Secret scanning'))"
+    )
+
+    assert result == {
+        "codeScanning": 2,
+        "dependabot": "unknown",
+        "secretScanning": "unknown",
+        "pushProtectionBypassed": "unknown",
+    }
+
+
+def test_digest_metrics_preserve_collected_bypass_count() -> None:
+    result = _node_json(
+        "helper.digestAlertMetrics("
+        "helper.collectedAlerts([], 'Code scanning'), "
+        "helper.collectedAlerts([], 'Dependabot'), "
+        "helper.collectedAlerts(["
+        "{push_protection_bypassed: true}, "
+        "{push_protection_bypassed: false}, "
+        "{push_protection_bypassed: true}], 'Secret scanning'))"
+    )
+
+    assert result == {
+        "codeScanning": 0,
+        "dependabot": 0,
+        "secretScanning": 3,
+        "pushProtectionBypassed": 2,
+    }
+
+
 def test_workflows_use_shared_state_contract() -> None:
     texts = {key: path.read_text(encoding="utf-8") for key, path in WORKFLOWS.items()}
 
     for text in texts.values():
         assert "scripts/ghas_tracker_state.js" in text
-        assert "countOrUnknown" in text
         assert "Collection status" in text
         assert "process.env.GHAS_TOKEN || github.token" in text
 
+    assert "countOrUnknown" in texts["sla"]
+    assert "countOrUnknown" in texts["configuration"]
+    assert "digestAlertMetrics" in texts["review"]
     assert "return [];" not in texts["sla"]
     assert "Array.isArray(response.data) ? response.data.length : 0" not in texts["review"]
     assert "Array.isArray(response.data) ? response.data.length : 0" not in texts["configuration"]
+
+
+def test_review_bot_renders_only_normalized_digest_metrics() -> None:
+    text = WORKFLOWS["review"].read_text(encoding="utf-8")
+
+    assert "const digestMetrics = digestAlertMetrics(" in text
+    assert "${digestMetrics.codeScanning}" in text
+    assert "${digestMetrics.dependabot}" in text
+    assert "${digestMetrics.secretScanning}" in text
+    assert "${digestMetrics.pushProtectionBypassed}" in text
+    assert "${codeScanning.count}" not in text
+    assert "${dependabot.count}" not in text
+    assert "${secretScanning.count}" not in text
+    assert "${pushProtectionBypassed.count}" not in text
 
 
 def test_review_bot_uses_cadence_aware_workflow_freshness() -> None:


### PR DESCRIPTION
## Summary

I fixed the GHAS weekly digest so unavailable or invalid alert evidence renders as `unknown` instead of leaking `null` or `undefined` into the generated issue.

Closes #2080.

## What I changed

- I added one shared `digestAlertMetrics()` contract for code-scanning, Dependabot, secret-scanning, and push-protection bypass totals.
- I preserve authoritative numeric `0` only when the relevant API returned a valid empty alert array.
- I preserve exact nonzero counts for collected evidence.
- I keep every derived secret-scanning metric `unknown` when its source collection is unavailable or invalid.
- I changed the weekly digest to render only normalized metrics rather than raw nullable fields.

## Regression coverage

- collected empty evidence renders four numeric zeroes;
- collected non-empty evidence preserves exact totals and bypass counts;
- unavailable and invalid evidence renders `unknown` and never `0`, `null`, or `undefined`;
- the workflow no longer interpolates raw alert `.count` values or dereferences `.count` on a scalar metric;
- source-specific collection status and fallback notes remain visible;
- permissions and pinned actions remain unchanged;
- security mutation and alert-dismissal APIs remain forbidden.

## Safety boundary

- I do not dismiss alerts, mutate security configuration, rerun workflows, or create remediation patches.
- I do not treat unavailable evidence as an empty queue.
- I do not add merge, issue-closing, security-dismissal, or semantic-equivalence authority.

## Verification

```bash
python -m pytest -q tests/test_ghas_tracker_state_contract.py -o addopts=
python -m pre_commit run -a
```

The complete repository gate is delegated to CI, including workflow contracts, supported Python versions, full coverage, strict documentation, packaging, isolated wheel installation, dependency review, security, and quality evidence publication.

## Risk

Low. The change only normalizes reporting values through the existing documented GHAS state contract. API collection, issue lifecycle, workflow freshness, permissions, and security authority remain unchanged.

## Rollback

Revert this pull request. No migration, token, secret, persisted-state, or workflow-permission rollback is required.