### PR TITLE
fix(security): normalize GHAS SLA state metrics

### DIFF
--- a/.github/workflows/ghas-alert-sla-bot.yml
+++ b/.github/workflows/ghas-alert-sla-bot.yml
@@ -32,7 +32,7 @@ jobs:
               collectedAlerts,
               unavailableAlerts,
               metricOrUnknown,
-              countOrUnknown,
+              slaAlertMetrics,
             } = require(`${process.env.GITHUB_WORKSPACE}/scripts/ghas_tracker_state.js`);
             const weekOf = new Date().toISOString().slice(0, 10);
             const labels = [
@@ -85,10 +85,6 @@ jobs:
               return Math.max(0, Math.floor((Date.now() - createdMs) / dayMs));
             }
 
-            function countAtLeast(alerts, days) {
-              return alerts.filter((alert) => ageDays(alert) >= days).length;
-            }
-
             function summarizeSeverity(alerts, pickSeverity) {
               const counts = new Map();
               for (const alert of alerts) {
@@ -125,28 +121,7 @@ jobs:
             const codeAlerts = await fetchAlerts('/repos/{owner}/{repo}/code-scanning/alerts', 'Code scanning alerts');
             const dependabotAlerts = await fetchAlerts('/repos/{owner}/{repo}/dependabot/alerts', 'Dependabot alerts');
             const secretAlerts = await fetchAlerts('/repos/{owner}/{repo}/secret-scanning/alerts', 'Secret scanning alerts');
-
-            const codeAlertCount = countOrUnknown(codeAlerts);
-            const dependabotAlertCount = countOrUnknown(dependabotAlerts);
-            const secretAlertCount = countOrUnknown(secretAlerts);
-            const codeAged7 = metricOrUnknown(codeAlerts, (alerts) => countAtLeast(alerts, 7));
-            const codeAged14 = metricOrUnknown(codeAlerts, (alerts) => countAtLeast(alerts, 14));
-            const codeAged30 = metricOrUnknown(codeAlerts, (alerts) => countAtLeast(alerts, 30));
-            const dependabotAged7 = metricOrUnknown(
-              dependabotAlerts,
-              (alerts) => countAtLeast(alerts, 7)
-            );
-            const dependabotAged14 = metricOrUnknown(
-              dependabotAlerts,
-              (alerts) => countAtLeast(alerts, 14)
-            );
-            const dependabotAged30 = metricOrUnknown(
-              dependabotAlerts,
-              (alerts) => countAtLeast(alerts, 30)
-            );
-            const secretAged7 = metricOrUnknown(secretAlerts, (alerts) => countAtLeast(alerts, 7));
-            const secretAged14 = metricOrUnknown(secretAlerts, (alerts) => countAtLeast(alerts, 14));
-            const secretAged30 = metricOrUnknown(secretAlerts, (alerts) => countAtLeast(alerts, 30));
+            const slaMetrics = slaAlertMetrics(codeAlerts, dependabotAlerts, secretAlerts, ageDays);
 
             const codeSeverity = metricOrUnknown(
               codeAlerts,
@@ -162,26 +137,7 @@ jobs:
                 (alert) => alert.security_vulnerability?.severity || alert.severity || 'unknown'
               )
             );
-
-            const secretBypassed = metricOrUnknown(
-              secretAlerts,
-              (alerts) => alerts.filter((alert) => alert.push_protection_bypassed === true).length
-            );
-            const secretBypassedAged = metricOrUnknown(
-              secretAlerts,
-              (alerts) => alerts.filter(
-                (alert) => alert.push_protection_bypassed === true && ageDays(alert) >= 7
-              ).length
-            );
             const severityOrder = ['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'];
-            const highSeverityCodeAged = metricOrUnknown(codeAlerts, (alerts) => alerts.filter((alert) => {
-              const severity = alert.rule?.security_severity_level || alert.rule?.severity || 'unknown';
-              return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
-            }).length);
-            const criticalDependabotAged = metricOrUnknown(dependabotAlerts, (alerts) => alerts.filter((alert) => {
-              const severity = alert.security_vulnerability?.severity || alert.severity || 'unknown';
-              return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
-            }).length);
             const oldCodeRules = metricOrUnknown(codeAlerts, topOldCodeRules);
 
             const title = `⏱️ GHAS alert SLA tracker (${weekOf})`;
@@ -189,24 +145,24 @@ jobs:
               'This issue is auto-generated to force older GHAS backlog slices into a time-bound remediation lane.',
               '',
               '## SLA snapshot',
-              `- Open code scanning alerts: **${codeAlertCount}**`,
-              `- Open Dependabot alerts: **${dependabotAlertCount}**`,
-              `- Open secret scanning alerts: **${secretAlertCount}**`,
-              `- Secret-scanning alerts with push-protection bypass: **${secretBypassed}**`,
+              `- Open code scanning alerts: **${slaMetrics.codeScanning}**`,
+              `- Open Dependabot alerts: **${slaMetrics.dependabot}**`,
+              `- Open secret scanning alerts: **${slaMetrics.secretScanning}**`,
+              `- Secret-scanning alerts with push-protection bypass: **${slaMetrics.secretBypassed}**`,
               '',
               '## Age-based SLA breaches',
-              `- Code scanning aged 7+ days: **${codeAged7}**`,
-              `- Code scanning aged 14+ days: **${codeAged14}**`,
-              `- Code scanning aged 30+ days: **${codeAged30}**`,
-              `- High-severity code scanning alerts aged 14+ days: **${highSeverityCodeAged}**`,
-              `- Dependabot alerts aged 7+ days: **${dependabotAged7}**`,
-              `- Dependabot alerts aged 14+ days: **${dependabotAged14}**`,
-              `- Dependabot alerts aged 30+ days: **${dependabotAged30}**`,
-              `- High/critical Dependabot alerts aged 14+ days: **${criticalDependabotAged}**`,
-              `- Secret scanning alerts aged 7+ days: **${secretAged7}**`,
-              `- Secret scanning alerts aged 14+ days: **${secretAged14}**`,
-              `- Secret scanning alerts aged 30+ days: **${secretAged30}**`,
-              `- Push-protection bypassed secret alerts aged 7+ days: **${secretBypassedAged}**`,
+              `- Code scanning aged 7+ days: **${slaMetrics.codeAged7}**`,
+              `- Code scanning aged 14+ days: **${slaMetrics.codeAged14}**`,
+              `- Code scanning aged 30+ days: **${slaMetrics.codeAged30}**`,
+              `- High-severity code scanning alerts aged 14+ days: **${slaMetrics.highSeverityCodeAged}**`,
+              `- Dependabot alerts aged 7+ days: **${slaMetrics.dependabotAged7}**`,
+              `- Dependabot alerts aged 14+ days: **${slaMetrics.dependabotAged14}**`,
+              `- Dependabot alerts aged 30+ days: **${slaMetrics.dependabotAged30}**`,
+              `- High/critical Dependabot alerts aged 14+ days: **${slaMetrics.criticalDependabotAged}**`,
+              `- Secret scanning alerts aged 7+ days: **${slaMetrics.secretAged7}**`,
+              `- Secret scanning alerts aged 14+ days: **${slaMetrics.secretAged14}**`,
+              `- Secret scanning alerts aged 30+ days: **${slaMetrics.secretAged30}**`,
+              `- Push-protection bypassed secret alerts aged 7+ days: **${slaMetrics.secretBypassedAged}**`,
               '',
               '## Severity slices',
               ...(codeSeverity === 'unknown' ? ['- Code scanning severity: unknown'] : mapLines(codeSeverity, 'Code scanning severity', severityOrder)),

--- a/.github/workflows/ghas-alert-sla-bot.yml
+++ b/.github/workflows/ghas-alert-sla-bot.yml
@@ -33,7 +33,6 @@ jobs:
               unavailableAlerts,
               metricOrUnknown,
               countOrUnknown,
-              formatMetric,
             } = require(`${process.env.GITHUB_WORKSPACE}/scripts/ghas_tracker_state.js`);
             const weekOf = new Date().toISOString().slice(0, 10);
             const labels = [
@@ -127,6 +126,28 @@ jobs:
             const dependabotAlerts = await fetchAlerts('/repos/{owner}/{repo}/dependabot/alerts', 'Dependabot alerts');
             const secretAlerts = await fetchAlerts('/repos/{owner}/{repo}/secret-scanning/alerts', 'Secret scanning alerts');
 
+            const codeAlertCount = countOrUnknown(codeAlerts);
+            const dependabotAlertCount = countOrUnknown(dependabotAlerts);
+            const secretAlertCount = countOrUnknown(secretAlerts);
+            const codeAged7 = metricOrUnknown(codeAlerts, (alerts) => countAtLeast(alerts, 7));
+            const codeAged14 = metricOrUnknown(codeAlerts, (alerts) => countAtLeast(alerts, 14));
+            const codeAged30 = metricOrUnknown(codeAlerts, (alerts) => countAtLeast(alerts, 30));
+            const dependabotAged7 = metricOrUnknown(
+              dependabotAlerts,
+              (alerts) => countAtLeast(alerts, 7)
+            );
+            const dependabotAged14 = metricOrUnknown(
+              dependabotAlerts,
+              (alerts) => countAtLeast(alerts, 14)
+            );
+            const dependabotAged30 = metricOrUnknown(
+              dependabotAlerts,
+              (alerts) => countAtLeast(alerts, 30)
+            );
+            const secretAged7 = metricOrUnknown(secretAlerts, (alerts) => countAtLeast(alerts, 7));
+            const secretAged14 = metricOrUnknown(secretAlerts, (alerts) => countAtLeast(alerts, 14));
+            const secretAged30 = metricOrUnknown(secretAlerts, (alerts) => countAtLeast(alerts, 30));
+
             const codeSeverity = metricOrUnknown(
               codeAlerts,
               (alerts) => summarizeSeverity(
@@ -168,23 +189,23 @@ jobs:
               'This issue is auto-generated to force older GHAS backlog slices into a time-bound remediation lane.',
               '',
               '## SLA snapshot',
-              `- Open code scanning alerts: **${codeAlerts.length}**`,
-              `- Open Dependabot alerts: **${dependabotAlerts.length}**`,
-              `- Open secret scanning alerts: **${secretAlerts.length}**`,
-              `- Secret-scanning alerts with push-protection bypass: **${secretBypassed.length}**`,
+              `- Open code scanning alerts: **${codeAlertCount}**`,
+              `- Open Dependabot alerts: **${dependabotAlertCount}**`,
+              `- Open secret scanning alerts: **${secretAlertCount}**`,
+              `- Secret-scanning alerts with push-protection bypass: **${secretBypassed}**`,
               '',
               '## Age-based SLA breaches',
-              `- Code scanning aged 7+ days: **${countAtLeast(codeAlerts, 7)}**`,
-              `- Code scanning aged 14+ days: **${countAtLeast(codeAlerts, 14)}**`,
-              `- Code scanning aged 30+ days: **${countAtLeast(codeAlerts, 30)}**`,
+              `- Code scanning aged 7+ days: **${codeAged7}**`,
+              `- Code scanning aged 14+ days: **${codeAged14}**`,
+              `- Code scanning aged 30+ days: **${codeAged30}**`,
               `- High-severity code scanning alerts aged 14+ days: **${highSeverityCodeAged}**`,
-              `- Dependabot alerts aged 7+ days: **${countAtLeast(dependabotAlerts, 7)}**`,
-              `- Dependabot alerts aged 14+ days: **${countAtLeast(dependabotAlerts, 14)}**`,
-              `- Dependabot alerts aged 30+ days: **${countAtLeast(dependabotAlerts, 30)}**`,
+              `- Dependabot alerts aged 7+ days: **${dependabotAged7}**`,
+              `- Dependabot alerts aged 14+ days: **${dependabotAged14}**`,
+              `- Dependabot alerts aged 30+ days: **${dependabotAged30}**`,
               `- High/critical Dependabot alerts aged 14+ days: **${criticalDependabotAged}**`,
-              `- Secret scanning alerts aged 7+ days: **${countAtLeast(secretAlerts, 7)}**`,
-              `- Secret scanning alerts aged 14+ days: **${countAtLeast(secretAlerts, 14)}**`,
-              `- Secret scanning alerts aged 30+ days: **${countAtLeast(secretAlerts, 30)}**`,
+              `- Secret scanning alerts aged 7+ days: **${secretAged7}**`,
+              `- Secret scanning alerts aged 14+ days: **${secretAged14}**`,
+              `- Secret scanning alerts aged 30+ days: **${secretAged30}**`,
               `- Push-protection bypassed secret alerts aged 7+ days: **${secretBypassedAged}**`,
               '',
               '## Severity slices',

--- a/scripts/ghas_tracker_state.js
+++ b/scripts/ghas_tracker_state.js
@@ -80,6 +80,54 @@ function digestAlertMetrics(codeScanning, dependabot, secretScanning) {
   };
 }
 
+function slaAlertMetrics(codeScanning, dependabot, secretScanning, ageDays) {
+  const countAtLeast = (result, days) => metricOrUnknown(
+    result,
+    (alerts) => alerts.filter((alert) => ageDays(alert) >= days).length,
+  );
+  const highSeverityCodeAged = metricOrUnknown(
+    codeScanning,
+    (alerts) => alerts.filter((alert) => {
+      const severity = alert.rule?.security_severity_level || alert.rule?.severity || 'unknown';
+      return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
+    }).length,
+  );
+  const criticalDependabotAged = metricOrUnknown(
+    dependabot,
+    (alerts) => alerts.filter((alert) => {
+      const severity = alert.security_vulnerability?.severity || alert.severity || 'unknown';
+      return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
+    }).length,
+  );
+
+  return {
+    codeScanning: countOrUnknown(codeScanning),
+    dependabot: countOrUnknown(dependabot),
+    secretScanning: countOrUnknown(secretScanning),
+    codeAged7: countAtLeast(codeScanning, 7),
+    codeAged14: countAtLeast(codeScanning, 14),
+    codeAged30: countAtLeast(codeScanning, 30),
+    highSeverityCodeAged,
+    dependabotAged7: countAtLeast(dependabot, 7),
+    dependabotAged14: countAtLeast(dependabot, 14),
+    dependabotAged30: countAtLeast(dependabot, 30),
+    criticalDependabotAged,
+    secretAged7: countAtLeast(secretScanning, 7),
+    secretAged14: countAtLeast(secretScanning, 14),
+    secretAged30: countAtLeast(secretScanning, 30),
+    secretBypassed: metricOrUnknown(
+      secretScanning,
+      (alerts) => alerts.filter((alert) => alert.push_protection_bypassed === true).length,
+    ),
+    secretBypassedAged: metricOrUnknown(
+      secretScanning,
+      (alerts) => alerts.filter(
+        (alert) => alert.push_protection_bypassed === true && ageDays(alert) >= 7,
+      ).length,
+    ),
+  };
+}
+
 module.exports = {
   collectedAlerts,
   unavailableAlerts,
@@ -88,4 +136,5 @@ module.exports = {
   countOrUnknown,
   formatMetric,
   digestAlertMetrics,
+  slaAlertMetrics,
 };

--- a/tests/test_ghas_alert_sla_state_contract.py
+++ b/tests/test_ghas_alert_sla_state_contract.py
@@ -20,66 +20,87 @@ def _node_json(source: str) -> Any:
     return json.loads(completed.stdout)
 
 
-def test_sla_metrics_preserve_collected_counts_and_unknown_state() -> None:
+def test_sla_metrics_preserve_collected_counts_and_age_buckets() -> None:
     source = f"""
 const helper = require({json.dumps(str(HELPER))});
-const summarize = (result) => ({{
-  total: helper.countOrUnknown(result),
-  aged7: helper.metricOrUnknown(
-    result,
-    (alerts) => alerts.filter((alert) => alert.ageDays >= 7).length,
-  ),
-  aged14: helper.metricOrUnknown(
-    result,
-    (alerts) => alerts.filter((alert) => alert.ageDays >= 14).length,
-  ),
-}});
-const value = {{
-  empty: summarize(helper.collectedAlerts([], 'empty')),
-  collected: summarize(helper.collectedAlerts([
-    {{ageDays: 2}},
-    {{ageDays: 8}},
-    {{ageDays: 20}},
-  ], 'collected')),
-  unavailable: summarize(helper.unavailableAlerts('unavailable', new Error('forbidden'))),
-  invalid: summarize(helper.collectedAlerts(null, 'invalid')),
-}};
+const ageDays = (alert) => alert.ageDays;
+const value = helper.slaAlertMetrics(
+  helper.collectedAlerts([
+    {{ageDays: 2, rule: {{severity: 'low'}}}},
+    {{ageDays: 8, rule: {{security_severity_level: 'high'}}}},
+    {{ageDays: 20, rule: {{security_severity_level: 'critical'}}}},
+  ], 'Code scanning'),
+  helper.collectedAlerts([
+    {{ageDays: 1, security_vulnerability: {{severity: 'medium'}}}},
+    {{ageDays: 15, security_vulnerability: {{severity: 'high'}}}},
+  ], 'Dependabot'),
+  helper.collectedAlerts([
+    {{ageDays: 3, push_protection_bypassed: true}},
+    {{ageDays: 9, push_protection_bypassed: true}},
+    {{ageDays: 20, push_protection_bypassed: false}},
+  ], 'Secret scanning'),
+  ageDays,
+);
 process.stdout.write(JSON.stringify(value));
 """
 
     assert _node_json(source) == {
-        "empty": {"total": 0, "aged7": 0, "aged14": 0},
-        "collected": {"total": 3, "aged7": 2, "aged14": 1},
-        "unavailable": {
-            "total": "unknown",
-            "aged7": "unknown",
-            "aged14": "unknown",
-        },
-        "invalid": {
-            "total": "unknown",
-            "aged7": "unknown",
-            "aged14": "unknown",
-        },
+        "codeScanning": 3,
+        "dependabot": 2,
+        "secretScanning": 3,
+        "codeAged7": 2,
+        "codeAged14": 1,
+        "codeAged30": 0,
+        "highSeverityCodeAged": 1,
+        "dependabotAged7": 1,
+        "dependabotAged14": 1,
+        "dependabotAged30": 0,
+        "criticalDependabotAged": 1,
+        "secretAged7": 2,
+        "secretAged14": 1,
+        "secretAged30": 0,
+        "secretBypassed": 2,
+        "secretBypassedAged": 1,
     }
 
 
-def test_sla_workflow_never_treats_alert_state_as_an_array() -> None:
+def test_sla_metrics_preserve_zero_and_unknown_collection_states() -> None:
+    source = f"""
+const helper = require({json.dumps(str(HELPER))});
+const ageDays = (alert) => alert.ageDays;
+const empty = helper.slaAlertMetrics(
+  helper.collectedAlerts([], 'Code scanning'),
+  helper.collectedAlerts([], 'Dependabot'),
+  helper.collectedAlerts([], 'Secret scanning'),
+  ageDays,
+);
+const unavailable = helper.slaAlertMetrics(
+  helper.unavailableAlerts('Code scanning', new Error('forbidden')),
+  helper.collectedAlerts(null, 'Dependabot'),
+  helper.unavailableAlerts('Secret scanning', new Error('forbidden')),
+  ageDays,
+);
+process.stdout.write(JSON.stringify({{empty, unavailable}}));
+"""
+    result = _node_json(source)
+
+    assert set(result["empty"].values()) == {0}
+    assert set(result["unavailable"].values()) == {"unknown"}
+
+
+def test_sla_workflow_uses_compact_normalized_metric_projection() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     expected_metrics = (
-        "const codeAlertCount = countOrUnknown(codeAlerts);",
-        "const dependabotAlertCount = countOrUnknown(dependabotAlerts);",
-        "const secretAlertCount = countOrUnknown(secretAlerts);",
-        "const codeAged7 = metricOrUnknown(codeAlerts,",
-        "const dependabotAged7 = metricOrUnknown(",
-        "const secretAged7 = metricOrUnknown(secretAlerts,",
-        "${codeAlertCount}",
-        "${dependabotAlertCount}",
-        "${secretAlertCount}",
-        "${secretBypassed}",
-        "${codeAged7}",
-        "${dependabotAged7}",
-        "${secretAged7}",
+        "slaAlertMetrics,",
+        "const slaMetrics = slaAlertMetrics(",
+        "${slaMetrics.codeScanning}",
+        "${slaMetrics.dependabot}",
+        "${slaMetrics.secretScanning}",
+        "${slaMetrics.secretBypassed}",
+        "${slaMetrics.codeAged7}",
+        "${slaMetrics.dependabotAged7}",
+        "${slaMetrics.secretAged7}",
     )
     assert all(token in text for token in expected_metrics)
 
@@ -93,6 +114,7 @@ def test_sla_workflow_never_treats_alert_state_as_an_array() -> None:
         "countAtLeast(secretAlerts,",
     )
     assert not any(token in text for token in forbidden_wrapper_array_access)
+    assert len(text.splitlines()) < 250
 
     assert "## Collection status" in text
     assert "process.env.GHAS_TOKEN || github.token" in text

--- a/tests/test_ghas_alert_sla_state_contract.py
+++ b/tests/test_ghas_alert_sla_state_contract.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts/ghas_tracker_state.js"
+WORKFLOW = ROOT / ".github/workflows/ghas-alert-sla-bot.yml"
+
+
+def _node_json(source: str) -> Any:
+    completed = subprocess.run(
+        ["node", "-e", source],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_sla_metrics_preserve_collected_counts_and_unknown_state() -> None:
+    source = f"""
+const helper = require({json.dumps(str(HELPER))});
+const summarize = (result) => ({{
+  total: helper.countOrUnknown(result),
+  aged7: helper.metricOrUnknown(
+    result,
+    (alerts) => alerts.filter((alert) => alert.ageDays >= 7).length,
+  ),
+  aged14: helper.metricOrUnknown(
+    result,
+    (alerts) => alerts.filter((alert) => alert.ageDays >= 14).length,
+  ),
+}});
+const value = {{
+  empty: summarize(helper.collectedAlerts([], 'empty')),
+  collected: summarize(helper.collectedAlerts([
+    {{ageDays: 2}},
+    {{ageDays: 8}},
+    {{ageDays: 20}},
+  ], 'collected')),
+  unavailable: summarize(helper.unavailableAlerts('unavailable', new Error('forbidden'))),
+  invalid: summarize(helper.collectedAlerts(null, 'invalid')),
+}};
+process.stdout.write(JSON.stringify(value));
+"""
+
+    assert _node_json(source) == {
+        "empty": {"total": 0, "aged7": 0, "aged14": 0},
+        "collected": {"total": 3, "aged7": 2, "aged14": 1},
+        "unavailable": {
+            "total": "unknown",
+            "aged7": "unknown",
+            "aged14": "unknown",
+        },
+        "invalid": {
+            "total": "unknown",
+            "aged7": "unknown",
+            "aged14": "unknown",
+        },
+    }
+
+
+def test_sla_workflow_never_treats_alert_state_as_an_array() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    expected_metrics = (
+        "const codeAlertCount = countOrUnknown(codeAlerts);",
+        "const dependabotAlertCount = countOrUnknown(dependabotAlerts);",
+        "const secretAlertCount = countOrUnknown(secretAlerts);",
+        "const codeAged7 = metricOrUnknown(codeAlerts,",
+        "const dependabotAged7 = metricOrUnknown(",
+        "const secretAged7 = metricOrUnknown(secretAlerts,",
+        "${codeAlertCount}",
+        "${dependabotAlertCount}",
+        "${secretAlertCount}",
+        "${secretBypassed}",
+        "${codeAged7}",
+        "${dependabotAged7}",
+        "${secretAged7}",
+    )
+    assert all(token in text for token in expected_metrics)
+
+    forbidden_wrapper_array_access = (
+        "${codeAlerts.length}",
+        "${dependabotAlerts.length}",
+        "${secretAlerts.length}",
+        "${secretBypassed.length}",
+        "countAtLeast(codeAlerts,",
+        "countAtLeast(dependabotAlerts,",
+        "countAtLeast(secretAlerts,",
+    )
+    assert not any(token in text for token in forbidden_wrapper_array_access)
+
+    assert "## Collection status" in text
+    assert "process.env.GHAS_TOKEN || github.token" in text
+    assert "dismissAlert" not in text
+    assert "updateRepositorySecurityConfiguration" not in text

--- a/tests/test_ghas_tracker_state_contract.py
+++ b/tests/test_ghas_tracker_state_contract.py
@@ -149,7 +149,7 @@ def test_workflows_use_shared_state_contract() -> None:
         assert "Collection status" in text
         assert "process.env.GHAS_TOKEN || github.token" in text
 
-    assert "countOrUnknown" in texts["sla"]
+    assert "slaAlertMetrics" in texts["sla"]
     assert "countOrUnknown" in texts["configuration"]
     assert "digestAlertMetrics" in texts["review"]
     assert "return [];" not in texts["sla"]


### PR DESCRIPTION
## Summary

I fixed the GHAS Alert SLA workflow so it no longer treats shared alert-state wrappers as raw arrays. Permission-limited or unavailable GHAS evidence now remains reportable as `unknown` instead of crashing the scheduled workflow.

Closes #2082.

## What I changed

- I derive code-scanning, Dependabot, and secret-scanning totals through `countOrUnknown()`.
- I derive every 7/14/30-day SLA bucket through `metricOrUnknown()` before rendering it.
- I render the push-protection bypass metric as the scalar returned by the shared state contract rather than dereferencing `.length`.
- I preserve severity maps, old-rule grouping, source-specific collection status, fallback notes, cadence, labels, review links, and rolling issue lifecycle.

## Regression coverage

- collected empty evidence produces authoritative numeric zeroes;
- collected non-empty evidence preserves exact totals and age buckets;
- unavailable and invalid evidence produces `unknown` for totals and derived age metrics;
- the workflow cannot render wrapper `.length` values;
- the workflow cannot pass wrapper objects directly into `countAtLeast()`;
- reporting-only security authority remains unchanged.

## Verification

```bash
python -m pytest -q \
  tests/test_ghas_alert_sla_state_contract.py \
  tests/test_ghas_tracker_state_contract.py \
  -o addopts=
python -m pre_commit run -a
```

The complete repository gate is delegated to CI, including supported Python versions, workflow governance, full coverage, strict documentation, packaging, isolated wheel installation, dependency review, security, and quality evidence publication.

## Risk

Low. The patch changes only reporting-value derivation in one scheduled workflow and adds a focused regression contract. It does not change API collection, permissions, issue ownership, security disposition, or release behavior.

## Safety boundary

- No alert dismissal or security-configuration mutation.
- No workflow rerun, remediation patch, merge authority, or semantic-equivalence claim.
- Unavailable evidence remains `unknown`; it is never converted into an empty queue.

## Rollback

Revert this pull request. No migration, secret, token, persisted-state, or workflow-permission rollback is required.