### PR TITLE
fix(adoption): preserve deterministic mixed workspace identity

### DIFF
--- a/src/sdetkit/adoption_surface/__init__.py
+++ b/src/sdetkit/adoption_surface/__init__.py
@@ -21,6 +21,26 @@ from sdetkit.adoption_surface.javascript_security import (
     extend_javascript_package_security,
 )
 
+_core.IGNORED_PARTS.update(
+    {
+        ".nox",
+        "build",
+        "cmake-build-debug",
+        "cmake-build-release",
+        "dependencies",
+        "deps",
+        "dist",
+        "external",
+        "out",
+        "target",
+        "third-party",
+        "third_party",
+        "vendor",
+        "vendors",
+        "venv",
+    }
+)
+
 REQUIRED_FALSE_FIELDS = _base.REQUIRED_FALSE_FIELDS
 REQUIRED_LIST_FIELDS = _base.REQUIRED_LIST_FIELDS
 REQUIRED_OBJECT_FIELDS = _base.REQUIRED_OBJECT_FIELDS
@@ -59,7 +79,6 @@ def _refine_python_src_evidence(payload: dict[str, Any], root: Path) -> None:
     languages = payload.get("detected_languages")
     if not isinstance(languages, list):
         return
-
     for index, item in enumerate(languages):
         if not isinstance(item, dict) or item.get("name") != "python":
             continue

--- a/tests/test_adoption_surface_nested_workspaces.py
+++ b/tests/test_adoption_surface_nested_workspaces.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from sdetkit.adoption_proof_recommendations import (
@@ -50,6 +51,11 @@ def _workspace_source(workspace: str) -> dict[str, str]:
 
 def _scope_text(workspace: str) -> str:
     return f"working_directory={workspace}"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
 
 
 def test_nested_mixed_workspaces_emit_scoped_manual_proof() -> None:
@@ -130,3 +136,98 @@ def test_unproven_nested_workspaces_remain_review_first(tmp_path: Path) -> None:
     assert payload["automation_allowed"] is False
     assert payload["patch_application_allowed"] is False
     assert payload["merge_authorized"] is False
+
+
+def test_mixed_workspace_identity_excludes_generated_and_vendored_manifests(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "services" / "api" / "pyproject.toml",
+        '[project]\nname = "api"\nversion = "0.1.0"\n'
+        '[project.optional-dependencies]\ntest = ["pytest"]\n',
+    )
+    _write(
+        tmp_path / "apps" / "admin" / "package.json",
+        '{"name":"admin","scripts":{"test":"node --test"}}\n',
+    )
+    _write(
+        tmp_path / "apps" / "web" / "package.json",
+        '{"name":"web","scripts":{"test":"node --test"}}\n',
+    )
+    _write(
+        tmp_path / "crates" / "native" / "Cargo.toml",
+        '[package]\nname = "native"\nversion = "0.1.0"\nedition = "2021"\n',
+    )
+
+    _write(
+        tmp_path / "services" / "api" / "build" / "generated" / "pyproject.toml",
+        '[project]\nname = "generated"\nversion = "0.1.0"\ndependencies = ["pytest"]\n',
+    )
+    _write(
+        tmp_path / "apps" / "admin" / "node_modules" / "generated" / "package.json",
+        '{"name":"generated","scripts":{"test":"node --test"}}\n',
+    )
+    _write(
+        tmp_path / "crates" / "native" / "target" / "dependency" / "Cargo.toml",
+        '[package]\nname = "dependency"\nversion = "0.1.0"\nedition = "2021"\n',
+    )
+    _write(
+        tmp_path / "vendor" / "portal" / "package.json",
+        '{"name":"vendor-portal","scripts":{"test":"node --test"}}\n',
+    )
+
+    payload = discover_adoption_surface(tmp_path)
+    scoped = _workspace_commands(payload)
+
+    expected = {
+        Path("apps", "admin").as_posix(),
+        Path("apps", "web").as_posix(),
+        Path("crates", "native").as_posix(),
+        Path("services", "api").as_posix(),
+    }
+    assert set(scoped) == expected
+    assert scoped[Path("crates", "native").as_posix()]["command"] == "cargo test"
+    assert payload["review_first_unknowns"] == []
+    assert all(item["auto_run_allowed"] is False for item in scoped.values())
+
+    npm_owners = sorted(
+        workspace for workspace, item in scoped.items() if item["command"] == "npm test"
+    )
+    assert npm_owners == [Path("apps", "admin").as_posix(), Path("apps", "web").as_posix()]
+
+
+def test_mixed_workspace_identity_is_serialization_deterministic(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "apps" / "web" / "package.json",
+        '{"name":"web","scripts":{"test":"node --test"}}\n',
+    )
+    _write(
+        tmp_path / "services" / "api" / "pyproject.toml",
+        '[project]\nname = "api"\nversion = "0.1.0"\ndependencies = ["pytest"]\n',
+    )
+    _write(
+        tmp_path / "crates" / "native" / "Cargo.toml",
+        '[package]\nname = "native"\nversion = "0.1.0"\nedition = "2021"\n',
+    )
+
+    first = discover_adoption_surface(tmp_path)
+    second = discover_adoption_surface(tmp_path)
+
+    assert json.dumps(first, sort_keys=True, separators=(",", ":")) == json.dumps(
+        second,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    first_commands = first["recommended_proof_commands"]
+    assert isinstance(first_commands, list)
+    identities = [
+        (
+            str(item["surface"]),
+            str(item["command"]),
+            str(item["source"]["working_directory"]),
+            str(item["source"]["file"]),
+        )
+        for item in first_commands
+        if isinstance(item, dict) and isinstance(item.get("source"), dict)
+    ]
+    assert identities == sorted(identities)


### PR DESCRIPTION
## Summary

PR 1 of #2107. Harden nested mixed-language workspace identity by extending the shared recursive scanner’s ignored path inventory for generated, dependency, vendor, build-output, and local-environment trees.

The two-file change preserves identical commands in separate workspaces through surface, working directory, and source-file context. Tests cover Python, two JavaScript/TypeScript workspaces sharing `npm test`, a Rust workspace, rejection of `build`, `node_modules`, `target`, and `vendor`, deterministic serialization, and `auto_run_allowed=false`.

## Exact scope

```text
base=868835f446f1ef6c49267619894db0b6c3a8dcff
head=737f9b5eb1818b0cc9aed34a8eaf4500592b10cb
files=2
commits=2
additions=121
deletions=1
workflow_changed=false
target_code_execution=false
automation_allowed=false
patch_application_allowed=false
security_dismissal_allowed=false
publication_authorized=false
merge_authorized=false
semantic_equivalence_proven=false
```

## Exact-head proof

Green on `737f9b5eb1818b0cc9aed34a8eaf4500592b10cb`:

- Fast CI Python 3.11/3.12 and Full CI;
- complete coverage gate, pre-commit, and strict docs;
- First Proof Python 3.10–3.13;
- Ubuntu/macOS Python 3.11–3.13;
- Quality, Security, OSV, dependency, Premium, Enterprise, audit, packaging, wheel, and governance gates;
- required `maintenance-autopilot` and `ci` contexts;
- PR Quality reports required checks, security, runtime proof, and artifact integrity clear;
- reported coverage: 96.69%;
- no failure artifact and no review threads.

## Boundary

This is read-only discovery. It does not execute target commands, assign saved failures to workspaces, change FailureVector/SafetyGate/ProtectedVerifier, apply patches, publish, or authorize merge.

Advances #2107; it does not close the epic.