### PR TITLE
feat(failure-vector): preserve mixed workspace ownership

### DIFF
--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -35,7 +35,7 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 514,
+    "source_module_count": 515,
     "typing_debt_module_count": 487,
     "typing_debt_inventory_sha256": "19c733747317a3bf1e439ff1bb27b6539e1224d1bdc5ff7df39de4a62f100707",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
@@ -66,7 +66,8 @@
       "sdetkit.pr_quality_required_terminal",
       "sdetkit.protected_proof_chain",
       "sdetkit.safety_gate",
-      "sdetkit.trajectory_store"
+      "sdetkit.trajectory_store",
+      "sdetkit.workspace_failure_ownership"
     ],
     "migration_complete": false
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,10 @@ module = [
 ignore_errors = false
 
 [[tool.mypy.overrides]]
+module = "sdetkit.workspace_failure_ownership"
+ignore_errors = false
+
+[[tool.mypy.overrides]]
 module = "sdetkit.cpp_operator_proof"
 ignore_errors = false
 

--- a/src/sdetkit/workspace_failure_ownership.py
+++ b/src/sdetkit/workspace_failure_ownership.py
@@ -147,10 +147,7 @@ def normalize_saved_workspace_failure(
         reasons = (
             ("workspace_not_identified",)
             if not candidates
-            else (
-                "multiple_workspace_candidates:"
-                + ",".join(item.path for item in candidates),
-            )
+            else ("multiple_workspace_candidates:" + ",".join(item.path for item in candidates),)
         )
         adapter = _ambiguous_adapter_result(
             log_text,

--- a/src/sdetkit/workspace_failure_ownership.py
+++ b/src/sdetkit/workspace_failure_ownership.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from sdetkit.failure_vector import BUNDLE_SCHEMA_VERSION, FailureVector
+from sdetkit.failure_vector_adapters import (
+    FailureVectorAdapterResult,
+    extract_ecosystem_failure_vector,
+)
+from sdetkit.protected_verifier import verify_patch
+from sdetkit.safety_gate import SafetyGateDecision, evaluate_failure_vector
+
+SCHEMA_VERSION = "sdetkit.workspace_failure_ownership.v1"
+DEFAULT_ENVIRONMENT = "github_actions"
+
+JsonObject = dict[str, Any]
+
+_AUTHORITY_BOUNDARY: JsonObject = {
+    "target_code_execution": False,
+    "automation_allowed": False,
+    "patch_application_allowed": False,
+    "security_dismissal_allowed": False,
+    "publication_authorized": False,
+    "merge_authorized": False,
+    "semantic_equivalence_proven": False,
+}
+
+
+@dataclass(frozen=True, order=True)
+class WorkspaceDefinition:
+    path: str
+    ecosystem: str
+    manifest: str
+
+    def normalized(self) -> WorkspaceDefinition:
+        path = _normalize_workspace_path(self.path)
+        manifest = _normalize_evidence_path(self.manifest)
+        if not path or path == ".":
+            raise ValueError("workspace path must identify a nested repository-owned workspace")
+        if not self.ecosystem.strip():
+            raise ValueError("workspace ecosystem must be non-empty")
+        if not manifest:
+            raise ValueError("workspace manifest must be non-empty")
+        return WorkspaceDefinition(path, self.ecosystem.strip(), manifest)
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self.normalized())
+
+
+@dataclass(frozen=True)
+class WorkspaceFailureResult:
+    workspace: WorkspaceDefinition | None
+    candidate_workspaces: tuple[WorkspaceDefinition, ...]
+    evidence_source: str
+    ownership_confidence: str
+    adapter: FailureVectorAdapterResult
+    safety_gate: SafetyGateDecision
+    protected_verifier: Mapping[str, Any]
+    uncertainty: tuple[str, ...]
+
+    def to_dict(self) -> JsonObject:
+        workspace_payload = (
+            self.workspace.to_dict() if self.workspace is not None else _unknown_workspace()
+        )
+        vector_payload = self.adapter.to_dict()
+        vector_payload.update(
+            {
+                "workspace_identity": workspace_payload,
+                "evidence_source": self.evidence_source,
+                "ownership_confidence": self.ownership_confidence,
+                "identity_key": _identity_key(workspace_payload, self.evidence_source),
+            }
+        )
+        safety_payload = self.safety_gate.to_dict()
+        safety_payload.update(
+            {
+                "workspace_identity": workspace_payload,
+                "evidence_source": self.evidence_source,
+            }
+        )
+        protected_payload = dict(self.protected_verifier)
+        protected_payload.update(
+            {
+                "workspace_identity": workspace_payload,
+                "evidence_source": self.evidence_source,
+                "synthetic_patch_created": False,
+            }
+        )
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "review_required",
+            "workspace_identity": workspace_payload,
+            "candidate_workspaces": [item.to_dict() for item in self.candidate_workspaces],
+            "evidence_source": self.evidence_source,
+            "identity_key": _identity_key(workspace_payload, self.evidence_source),
+            "ownership_confidence": self.ownership_confidence,
+            "uncertainty": list(self.uncertainty),
+            "failure_vector": vector_payload,
+            "safety_gate": safety_payload,
+            "protected_verifier": protected_payload,
+            "review_first": self.safety_gate.review_first
+            and _protected_review_first(protected_payload),
+            "target_code_execution": False,
+            "synthetic_patch_created": False,
+            "authority_boundary": dict(_AUTHORITY_BOUNDARY),
+        }
+
+
+def normalize_saved_workspace_failure(
+    log_text: str,
+    *,
+    workspaces: Sequence[WorkspaceDefinition],
+    evidence_source: str,
+    check: str,
+    environment: str = DEFAULT_ENVIRONMENT,
+) -> WorkspaceFailureResult:
+    """Normalize saved evidence while preserving or denying workspace ownership explicitly."""
+
+    normalized_workspaces = _normalized_workspaces(workspaces)
+    source = _normalize_evidence_path(evidence_source)
+    if not source:
+        raise ValueError("evidence_source must be non-empty")
+    candidates = tuple(
+        workspace
+        for workspace in normalized_workspaces
+        if _mentions_workspace(log_text, workspace.path)
+    )
+
+    if len(candidates) == 1:
+        workspace = candidates[0]
+        adapter = extract_ecosystem_failure_vector(
+            log_text,
+            ecosystem=workspace.ecosystem,
+            check=check,
+            log_url=source,
+            environment=environment,
+        )
+        uncertainty = tuple(adapter.uncertainty)
+        confidence = "high" if adapter.confidence != "low" else "low"
+    else:
+        workspace = None
+        reasons = (
+            ("workspace_not_identified",)
+            if not candidates
+            else (
+                "multiple_workspace_candidates:"
+                + ",".join(item.path for item in candidates),
+            )
+        )
+        adapter = _ambiguous_adapter_result(
+            log_text,
+            check=check,
+            log_url=source,
+            environment=environment,
+            uncertainty=reasons,
+        )
+        uncertainty = reasons
+        confidence = "low"
+
+    safety_gate = evaluate_failure_vector(adapter.vector)
+    failure_bundle = _failure_bundle(
+        adapter,
+        workspace=workspace,
+        candidate_workspaces=candidates,
+        evidence_source=source,
+        environment=environment,
+        safety_gate=safety_gate,
+    )
+    protected_verifier = verify_patch(
+        patch_score={},
+        failure_bundle=failure_bundle,
+    )
+    return WorkspaceFailureResult(
+        workspace=workspace,
+        candidate_workspaces=candidates,
+        evidence_source=source,
+        ownership_confidence=confidence,
+        adapter=adapter,
+        safety_gate=safety_gate,
+        protected_verifier=protected_verifier,
+        uncertainty=uncertainty,
+    )
+
+
+def build_workspace_failure_bundle(
+    log_paths: Sequence[str | Path],
+    *,
+    workspaces: Sequence[WorkspaceDefinition],
+    evidence_root: str | Path | None = None,
+    environment: str = DEFAULT_ENVIRONMENT,
+) -> JsonObject:
+    """Build deterministic workspace-scoped FailureVector evidence from saved log files."""
+
+    root = Path(evidence_root).resolve() if evidence_root is not None else None
+    entries: list[JsonObject] = []
+    for path in sorted((Path(item) for item in log_paths), key=lambda item: item.as_posix()):
+        if not path.is_file():
+            raise ValueError(f"saved failure log does not exist: {path}")
+        source = _relative_evidence_source(path, root)
+        result = normalize_saved_workspace_failure(
+            path.read_text(encoding="utf-8", errors="ignore"),
+            workspaces=workspaces,
+            evidence_source=source,
+            check=path.stem,
+            environment=environment,
+        )
+        entries.append(result.to_dict())
+
+    entries.sort(key=lambda item: str(item["identity_key"]))
+    identity_keys = [str(item["identity_key"]) for item in entries]
+    if len(identity_keys) != len(set(identity_keys)):
+        raise RuntimeError("workspace failure identity collision detected")
+
+    by_workspace = Counter(str(item["workspace_identity"]["path"]) for item in entries)
+    by_ecosystem = Counter(str(item["workspace_identity"]["ecosystem"]) for item in entries)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "vector_bundle_schema_version": BUNDLE_SCHEMA_VERSION,
+        "status": "review_required",
+        "environment": environment,
+        "failure_vector_count": len(entries),
+        "summary": {
+            "by_workspace": dict(sorted(by_workspace.items())),
+            "by_ecosystem": dict(sorted(by_ecosystem.items())),
+            "high_confidence_ownership_count": sum(
+                1 for item in entries if item["ownership_confidence"] == "high"
+            ),
+            "low_confidence_ownership_count": sum(
+                1 for item in entries if item["ownership_confidence"] == "low"
+            ),
+            "review_first_count": sum(1 for item in entries if item["review_first"] is True),
+        },
+        "workspace_failures": entries,
+        "target_code_execution": False,
+        "synthetic_patch_created": False,
+        "authority_boundary": dict(_AUTHORITY_BOUNDARY),
+    }
+
+
+def _normalized_workspaces(
+    workspaces: Sequence[WorkspaceDefinition],
+) -> tuple[WorkspaceDefinition, ...]:
+    normalized = tuple(sorted({item.normalized() for item in workspaces}))
+    if not normalized:
+        raise ValueError("at least one workspace definition is required")
+    paths = [item.path for item in normalized]
+    if len(paths) != len(set(paths)):
+        raise ValueError("workspace paths must be unique")
+    return normalized
+
+
+def _normalize_workspace_path(path: str) -> str:
+    normalized = _normalize_evidence_path(path).strip("/")
+    return normalized or "."
+
+
+def _normalize_evidence_path(path: str) -> str:
+    return path.replace("\\", "/").strip()
+
+
+def _mentions_workspace(log_text: str, workspace: str) -> bool:
+    normalized = log_text.replace("\\", "/")
+    return f"{workspace.rstrip('/')}/" in normalized
+
+
+def _relative_evidence_source(path: Path, root: Path | None) -> str:
+    resolved = path.resolve()
+    if root is None:
+        return path.as_posix()
+    try:
+        return resolved.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"saved failure log is outside evidence_root: {path}") from exc
+
+
+def _ambiguous_adapter_result(
+    log_text: str,
+    *,
+    check: str,
+    log_url: str,
+    environment: str,
+    uncertainty: tuple[str, ...],
+) -> FailureVectorAdapterResult:
+    first_line = next(
+        (line.strip() for line in log_text.splitlines() if line.strip()),
+        "unknown",
+    )
+    vector = FailureVector(
+        check=check,
+        command="unknown",
+        exit_code=None,
+        failure_class="unknown",
+        risk="high",
+        scope="unknown",
+        reproducible_locally="not_run",
+        safe_fix_candidate=False,
+        first_failing_line=first_line,
+        affected_files=(),
+        log_url=log_url,
+        local_repro_command=None,
+        environment=environment,
+        headline_signal=f"{check}: ambiguous_workspace",
+        actual_failure=first_line,
+        failure_type="unknown",
+        failing_command="unknown",
+        failing_test_or_check=check,
+        owner_hint="unknown",
+        safe_fix_allowed=False,
+    )
+    return FailureVectorAdapterResult(
+        vector=vector,
+        ecosystem="unknown",
+        tool="unknown",
+        confidence="low",
+        uncertainty=uncertainty,
+    )
+
+
+def _failure_bundle(
+    adapter: FailureVectorAdapterResult,
+    *,
+    workspace: WorkspaceDefinition | None,
+    candidate_workspaces: Sequence[WorkspaceDefinition],
+    evidence_source: str,
+    environment: str,
+    safety_gate: SafetyGateDecision,
+) -> JsonObject:
+    workspace_payload = workspace.to_dict() if workspace is not None else _unknown_workspace()
+    vector_payload = adapter.to_dict()
+    vector_payload.update(
+        {
+            "workspace_identity": workspace_payload,
+            "evidence_source": evidence_source,
+        }
+    )
+    return {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "status": "review_required",
+        "environment": environment,
+        "failure_vector_count": 1,
+        "workspace_identity": workspace_payload,
+        "candidate_workspaces": [item.to_dict() for item in candidate_workspaces],
+        "evidence_source": evidence_source,
+        "failure_vectors": [vector_payload],
+        "safety_gate": {
+            **safety_gate.to_dict(),
+            "workspace_identity": workspace_payload,
+            "evidence_source": evidence_source,
+        },
+        "target_code_execution": False,
+        "synthetic_patch_created": False,
+        "decision_boundary": dict(_AUTHORITY_BOUNDARY),
+    }
+
+
+def _unknown_workspace() -> dict[str, str]:
+    return {"path": "unknown", "ecosystem": "unknown", "manifest": "unknown"}
+
+
+def _identity_key(workspace: Mapping[str, Any], evidence_source: str) -> str:
+    return "|".join(
+        (
+            str(workspace.get("path", "unknown")),
+            str(workspace.get("ecosystem", "unknown")),
+            evidence_source,
+        )
+    )
+
+
+def _protected_review_first(payload: Mapping[str, Any]) -> bool:
+    decision = payload.get("decision")
+    return isinstance(decision, Mapping) and decision.get("review_first") is True
+
+
+def render_workspace_failure_bundle(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"

--- a/tests/fixtures/ci_failures/mixed_monorepo/admin/shared_test.log
+++ b/tests/fixtures/ci_failures/mixed_monorepo/admin/shared_test.log
@@ -1,0 +1,8 @@
+Run npm test
+
+FAIL apps/admin/tests/shared.test.ts
+  SharedView
+    ✕ renders shared view
+
+AssertionError: expected true to be false
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/mixed_monorepo/ambiguous/mixed_shared_test.log
+++ b/tests/fixtures/ci_failures/mixed_monorepo/ambiguous/mixed_shared_test.log
@@ -1,0 +1,9 @@
+Run npm test
+FAIL apps/admin/tests/shared.test.ts
+AssertionError: expected true to be false
+
+Run cargo test
+test shared::renders_shared_view ... FAILED
+thread 'shared::renders_shared_view' panicked at crates/native/src/lib.rs:14:5:
+assertion failed: left == right
+Process completed with exit code 1

--- a/tests/fixtures/ci_failures/mixed_monorepo/native/shared_test.log
+++ b/tests/fixtures/ci_failures/mixed_monorepo/native/shared_test.log
@@ -1,0 +1,8 @@
+Run cargo test
+
+running 1 test
+test shared::renders_shared_view ... FAILED
+thread 'shared::renders_shared_view' panicked at crates/native/src/lib.rs:14:5:
+assertion failed: left == right
+test result: FAILED. 0 passed; 1 failed
+Process completed with exit code 101

--- a/tests/fixtures/ci_failures/mixed_monorepo/web/shared_test.log
+++ b/tests/fixtures/ci_failures/mixed_monorepo/web/shared_test.log
@@ -1,0 +1,8 @@
+Run npm test
+
+FAIL apps/web/tests/shared.test.ts
+  SharedView
+    ✕ renders shared view
+
+AssertionError: expected true to be false
+Process completed with exit code 1

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,10 +24,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 514
+    assert payload["observed"]["source_module_count"] == 515
     assert payload["observed"]["typing_debt_module_count"] == 487
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 27
+    assert len(checked) == 28
     assert "sdetkit.adoption_surface.cpp" in checked
     assert "sdetkit.adoption_surface.cpp_quality_security" in checked
     assert "sdetkit.adoption_surface.java_security" in checked
@@ -36,6 +36,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.cpp_operator_proof" in checked
     assert "sdetkit.failure_vector_cpp" in checked
     assert "sdetkit.merge_readiness" in checked
+    assert "sdetkit.workspace_failure_ownership" in checked
     inventory = payload["typing_debt_inventory"]
     assert inventory["module_count"] == 487
     assert len(inventory["modules"]) == 487
@@ -47,6 +48,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.cpp_operator_proof" not in inventory["modules"]
     assert "sdetkit.failure_vector_cpp" not in inventory["modules"]
     assert "sdetkit.merge_readiness" not in inventory["modules"]
+    assert "sdetkit.workspace_failure_ownership" not in inventory["modules"]
 
 
 def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Path) -> None:
@@ -64,7 +66,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 514,
+            "actual": 515,
         }
     ]
 

--- a/tests/test_workspace_failure_ownership.py
+++ b/tests/test_workspace_failure_ownership.py
@@ -32,10 +32,7 @@ def _logs(*relative: str) -> list[Path]:
 
 
 def _by_workspace(payload: dict) -> dict[str, dict]:
-    return {
-        str(item["workspace_identity"]["path"]): item
-        for item in payload["workspace_failures"]
-    }
+    return {str(item["workspace_identity"]["path"]): item for item in payload["workspace_failures"]}
 
 
 def test_saved_failures_keep_workspace_and_evidence_identity() -> None:
@@ -100,9 +97,7 @@ def test_ambiguous_multi_workspace_log_fails_closed() -> None:
         "crates/native",
     ]
     assert result["ownership_confidence"] == "low"
-    assert result["uncertainty"] == [
-        "multiple_workspace_candidates:apps/admin,crates/native"
-    ]
+    assert result["uncertainty"] == ["multiple_workspace_candidates:apps/admin,crates/native"]
     assert result["failure_vector"]["failure_class"] == "unknown"
     assert result["failure_vector"]["adapter"]["confidence"] == "low"
     assert result["failure_vector"]["local_repro_command"] is None

--- a/tests/test_workspace_failure_ownership.py
+++ b/tests/test_workspace_failure_ownership.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.workspace_failure_ownership import (
+    WorkspaceDefinition,
+    build_workspace_failure_bundle,
+    normalize_saved_workspace_failure,
+    render_workspace_failure_bundle,
+)
+
+FIXTURE_ROOT = Path("tests/fixtures/ci_failures/mixed_monorepo")
+WORKSPACES = (
+    WorkspaceDefinition("apps/admin", "javascript_typescript", "apps/admin/package.json"),
+    WorkspaceDefinition("apps/web", "javascript_typescript", "apps/web/package.json"),
+    WorkspaceDefinition("crates/native", "rust", "crates/native/Cargo.toml"),
+)
+AUTHORITY_FIELDS = {
+    "target_code_execution",
+    "automation_allowed",
+    "patch_application_allowed",
+    "security_dismissal_allowed",
+    "publication_authorized",
+    "merge_authorized",
+    "semantic_equivalence_proven",
+}
+
+
+def _logs(*relative: str) -> list[Path]:
+    return [FIXTURE_ROOT / item for item in relative]
+
+
+def _by_workspace(payload: dict) -> dict[str, dict]:
+    return {
+        str(item["workspace_identity"]["path"]): item
+        for item in payload["workspace_failures"]
+    }
+
+
+def test_saved_failures_keep_workspace_and_evidence_identity() -> None:
+    payload = build_workspace_failure_bundle(
+        _logs("admin/shared_test.log", "web/shared_test.log", "native/shared_test.log"),
+        workspaces=WORKSPACES,
+        evidence_root=FIXTURE_ROOT,
+    )
+
+    assert payload["failure_vector_count"] == 3
+    assert payload["summary"] == {
+        "by_workspace": {"apps/admin": 1, "apps/web": 1, "crates/native": 1},
+        "by_ecosystem": {"javascript_typescript": 2, "rust": 1},
+        "high_confidence_ownership_count": 3,
+        "low_confidence_ownership_count": 0,
+        "review_first_count": 3,
+    }
+
+    by_workspace = _by_workspace(payload)
+    admin = by_workspace["apps/admin"]
+    web = by_workspace["apps/web"]
+    native = by_workspace["crates/native"]
+
+    assert admin["evidence_source"] == "admin/shared_test.log"
+    assert web["evidence_source"] == "web/shared_test.log"
+    assert native["evidence_source"] == "native/shared_test.log"
+    assert admin["failure_vector"]["adapter"]["ecosystem"] == "javascript_typescript"
+    assert native["failure_vector"]["adapter"]["ecosystem"] == "rust"
+
+    assert admin["failure_vector"]["failing_test_or_check"] == "shared_test"
+    assert web["failure_vector"]["failing_test_or_check"] == "shared_test"
+    assert Path(admin["failure_vector"]["affected_files"][0]).name == "shared.test.ts"
+    assert Path(web["failure_vector"]["affected_files"][0]).name == "shared.test.ts"
+    assert admin["identity_key"] != web["identity_key"]
+
+    for workspace, item in by_workspace.items():
+        assert item["failure_vector"]["workspace_identity"]["path"] == workspace
+        assert item["safety_gate"]["workspace_identity"]["path"] == workspace
+        assert item["protected_verifier"]["workspace_identity"]["path"] == workspace
+        assert item["safety_gate"]["review_first"] is True
+        assert item["protected_verifier"]["decision"]["review_first"] is True
+        assert item["protected_verifier"]["synthetic_patch_created"] is False
+        assert item["review_first"] is True
+
+
+def test_ambiguous_multi_workspace_log_fails_closed() -> None:
+    path = FIXTURE_ROOT / "ambiguous/mixed_shared_test.log"
+    result = normalize_saved_workspace_failure(
+        path.read_text(encoding="utf-8"),
+        workspaces=WORKSPACES,
+        evidence_source="ambiguous/mixed_shared_test.log",
+        check="shared_test",
+    ).to_dict()
+
+    assert result["workspace_identity"] == {
+        "path": "unknown",
+        "ecosystem": "unknown",
+        "manifest": "unknown",
+    }
+    assert [item["path"] for item in result["candidate_workspaces"]] == [
+        "apps/admin",
+        "crates/native",
+    ]
+    assert result["ownership_confidence"] == "low"
+    assert result["uncertainty"] == [
+        "multiple_workspace_candidates:apps/admin,crates/native"
+    ]
+    assert result["failure_vector"]["failure_class"] == "unknown"
+    assert result["failure_vector"]["adapter"]["confidence"] == "low"
+    assert result["failure_vector"]["local_repro_command"] is None
+    assert result["safety_gate"]["review_first"] is True
+    assert result["protected_verifier"]["decision"]["review_first"] is True
+    assert result["synthetic_patch_created"] is False
+    assert result["target_code_execution"] is False
+
+
+def test_workspace_failure_bundle_is_deterministic() -> None:
+    paths = _logs("admin/shared_test.log", "web/shared_test.log", "native/shared_test.log")
+    first = build_workspace_failure_bundle(
+        paths,
+        workspaces=WORKSPACES,
+        evidence_root=FIXTURE_ROOT,
+    )
+    second = build_workspace_failure_bundle(
+        list(reversed(paths)),
+        workspaces=tuple(reversed(WORKSPACES)),
+        evidence_root=FIXTURE_ROOT,
+    )
+
+    assert render_workspace_failure_bundle(first) == render_workspace_failure_bundle(second)
+    assert json.dumps(first, sort_keys=True, separators=(",", ":")) == json.dumps(
+        second,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def test_workspace_failure_bundle_preserves_false_authority() -> None:
+    payload = build_workspace_failure_bundle(
+        _logs("admin/shared_test.log", "ambiguous/mixed_shared_test.log"),
+        workspaces=WORKSPACES,
+        evidence_root=FIXTURE_ROOT,
+    )
+
+    assert set(payload["authority_boundary"]) == AUTHORITY_FIELDS
+    assert set(payload["authority_boundary"].values()) == {False}
+    assert payload["target_code_execution"] is False
+    assert payload["synthetic_patch_created"] is False
+    for item in payload["workspace_failures"]:
+        assert set(item["authority_boundary"]) == AUTHORITY_FIELDS
+        assert set(item["authority_boundary"].values()) == {False}


### PR DESCRIPTION
## Summary

PR 2 of #2107 preserves workspace ownership from saved mixed-monorepo failures through FailureVector, SafetyGate, and ProtectedVerifier.

Known JavaScript/TypeScript and Rust evidence binds to exactly one declared workspace. Duplicate log filenames and test/check names remain distinct through workspace path, ecosystem, manifest, and evidence-source identity. Evidence mentioning multiple workspaces fails closed as low-confidence `unknown` with no local repro command and no synthetic patch.

## Exact scope

```text
base=931e1642ed0aa6e992c6d2d46745b000013bbea3
head=2f317a9af7de942da55c86c96d7f2b34db20b6e9
files=9
commits=10
additions=567
deletions=5
workflow_changed=false
target_code_execution=false
automation_allowed=false
patch_application_allowed=false
security_dismissal_allowed=false
publication_authorized=false
merge_authorized=false
semantic_equivalence_proven=false
```

## Proof

Green on the exact head:

- focused mixed-workspace ownership and ambiguity tests;
- Ruff, formatter, and explicit mypy enrollment;
- whole-package coverage and critical-spine gate;
- Fast CI Python 3.11/3.12 and independent Full CI;
- strict docs, packaging, wheel contents, and installed-wheel smoke;
- First Proof Python 3.10–3.13;
- Ubuntu/macOS Python 3.11–3.13 reference matrix;
- Security/CodeQL, OSV, dependency, Premium, Enterprise, release qualification, audit, governance, and adoption replay;
- required `maintenance-autopilot` and `ci` contexts;
- PR Quality: required checks, security, runtime proof, and artifact integrity clear;
- no review threads and no full-suite failure artifact.

## Boundary and roadmap

This reads saved evidence only. It does not execute target commands, create a repair patch, apply changes, publish, dismiss security findings, or authorize merge.

The `mixed_monorepo_vertical` gap intentionally remains open. PR3 will compose discovery/topology, workspace proof commands, scoped saved failures, Doctor/report output, trajectory/RepoMemory evidence, and the final machine-readable capability/roadmap update.

Advances #2107; does not close it.