### PR TITLE
release: establish the complete 1.2.0 candidate truth

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -234,7 +234,7 @@ jobs:
           done
           builder="$(find "$RUNNER_TEMP/release-candidate-qualifications" -name build_release_candidate_qualification.py -print -quit)"
           test -n "$builder"
-          # Next action: verify external publishing settings before creating v1.1.0.
+          # Next action: verify external publishing settings before creating the resolved candidate tag.
           python "$builder" verdict \
             "${record_args[@]}" \
             --candidate-tag "$CANDIDATE_TAG" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 ## Unreleased
 
-No changes after the release-candidate freeze.
+Release qualification, external publishing configuration, and public verification remain pending.
 
-## [1.1.0]
+## [1.2.0]
 
-Release candidate frozen: 2026-06-30
+Full-product release candidate scope established: 2026-07-18. Not yet tagged or published.
+
+- Added exact first-failure extraction, shared FailureVector evidence, review-first SafetyGate decisions, protected verification, trajectory records, and repository memory.
+- Added deterministic release-readiness, merge-readiness, PR Quality, workflow-governance, package, provenance, and operator-reporting contracts.
+- Added read-only adoption and saved-failure diagnosis across Python, JavaScript/TypeScript, Go, Rust, Java, .NET, and C++ repositories.
+- Added conservative CI-provider evidence for GitHub Actions, GitLab CI, Jenkins, and CircleCI.
+- Added complete fixture-backed C++ and mixed-language monorepo adoption-to-diagnosis operator proofs.
+- Added multi-workspace ownership, quality/security evidence, anti-cheat boundaries, and review-first unknown handling.
+- Updated dependency, documentation, security, packaging, exact-wheel qualification, and release supply-chain gates.
+
+## [1.1.0] — Unpublished superseded candidate
+
+Release candidate frozen: 2026-06-30. It was never tagged or published and was superseded after the full product scope advanced.
 
 - Added structured diagnosis and review-first verification evidence.
 - Added read-only JavaScript, TypeScript, and Go adapters.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Start with [`docs/first-failure-triage.md`](docs/first-failure-triage.md) and [`
 
 See the [committed public launch proof](docs/public-launch-proof.md) for a realistic saved pytest failure reduced to its first failing node, affected file, focused proof command, and review-first decision. The same proof includes a fixture-based Python, JavaScript/TypeScript, and Go adoption profile generated without installing target dependencies, executing target code, mutating the target, or authorizing a merge.
 
-The proof is tied to an immutable source commit and is explicitly marked **main-only until the qualified 1.1.0 release**.
+The proof is tied to an immutable source commit and is explicitly marked **main-only until the qualified 1.2.0 release**.
 
 ## Decision contract
 
@@ -102,7 +102,7 @@ For this repository, `make first-proof` emits `FIRST_PROOF_DECISION=SHIP|NO-SHIP
 
 ## Release channel
 
-The install command above uses the latest published package, `sdetkit==1.0.3`. The repository `main` branch contains additional diagnostic, verification, benchmark, trajectory, and adoption capabilities that remain **main-only** until the next qualified release. See the [current product delta](docs/current-product-delta.md) before treating repository documentation as installed-wheel proof.
+The install command above uses the latest published package, `sdetkit==1.0.3`. The repository `main` branch contains additional diagnostic, verification, benchmark, trajectory, multi-ecosystem, CI-provider, and mixed-workspace capabilities that remain **main-only** until the qualified 1.2.0 release. See the [current product delta](docs/current-product-delta.md) before treating repository documentation as installed-wheel proof.
 
 ## Documentation map
 

--- a/docs/contracts/current-product-delta.v1.json
+++ b/docs/contracts/current-product-delta.v1.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "sdetkit.current_product_delta.v1",
-  "generated_on": "2026-06-30",
+  "generated_on": "2026-07-18",
   "released_version": "1.0.3",
   "released_on": "2026-04-18",
-  "project_version": "1.1.0",
-  "release_candidate_version": "1.1.0",
-  "release_status": "release_candidate_frozen_not_published",
+  "project_version": "1.2.0",
+  "release_candidate_version": "1.2.0",
+  "release_status": "release_candidate_scope_established_not_qualified",
   "canonical_first_path": [
     "python -m sdetkit gate fast",
     "python -m sdetkit gate release",
@@ -18,8 +18,8 @@
     "documentation_must_not_imply_release_candidate_capabilities_are_published": true
   },
   "release_candidate_contract": {
-    "version": "1.1.0",
-    "scope": "repository_release_candidate",
+    "version": "1.2.0",
+    "scope": "repository_full_product_candidate",
     "publication_claimed": false,
     "tag_created": false,
     "public_install_verified": false
@@ -28,28 +28,34 @@
     {
       "id": "diagnostic_failure_model",
       "stability": "advanced_supported",
-      "capabilities": ["diagnostic contracts and read-only ecosystem adapters"]
+      "capabilities": ["exact first-failure extraction and shared cross-ecosystem FailureVector evidence"]
     },
     {
       "id": "verification_and_benchmarking",
-      "stability": "experimental_incubator",
-      "capabilities": ["isolated proof, protected verification, and anti-cheat evidence"]
+      "stability": "advanced_supported",
+      "capabilities": ["SafetyGate, protected verification, proof-chain integrity, and anti-cheat evidence"]
     },
     {
       "id": "trajectory_and_memory",
-      "stability": "experimental_incubator",
-      "capabilities": ["trajectory storage and repository memory"]
+      "stability": "advanced_supported",
+      "capabilities": ["trajectory storage, repository memory, and reviewed outcome evidence"]
     },
     {
       "id": "external_adoption_intelligence",
       "stability": "advanced_supported",
-      "capabilities": ["read-only adoption intelligence and SHA-bound canonical replay"]
+      "capabilities": ["read-only adoption intelligence across Python, JavaScript/TypeScript, Go, Rust, Java, .NET, and C++"]
+    },
+    {
+      "id": "ci_provider_and_workspace_intelligence",
+      "stability": "advanced_supported",
+      "capabilities": ["GitHub Actions, GitLab CI, Jenkins, CircleCI, C++ operator proof, and mixed-monorepo composition"]
     }
   ],
   "release_blockers": [
+    "merge release-truth candidate metadata",
+    "freeze and qualify the exact 1.2.0 candidate SHA",
     "verify the protected pypi environment and Trusted Publisher",
-    "merge exact-head candidate evidence",
-    "create the signed v1.1.0 tag",
+    "create the immutable signed v1.2.0 tag",
     "publish and verify the exact distributions",
     "record post-release public evidence"
   ],

--- a/docs/current-product-delta.md
+++ b/docs/current-product-delta.md
@@ -7,15 +7,18 @@ Contract: [`docs/contracts/current-product-delta.v1.json`](contracts/current-pro
 | Surface | Current truth |
 |---|---|
 | Published package | `sdetkit==1.0.3` |
-| Repository package metadata | `1.1.0` |
-| Candidate state | frozen, not published |
-| Public 1.1.0 installation | not yet verified |
+| Repository package metadata | `1.2.0` candidate |
+| Previous candidate | `1.1.0` was frozen but never tagged or published and is superseded |
+| Candidate state | full-product scope established; exact-head qualification pending |
+| Public 1.2.0 installation | not yet verified |
 
-The README intentionally remains pinned to `sdetkit==1.0.3` until 1.1.0 is published and independently verified.
+The README intentionally remains pinned to `sdetkit==1.0.3` until 1.2.0 is published and independently verified.
 
 ## Candidate scope
 
-The 1.1.0 candidate contains structured diagnosis, review-first safety decisions, read-only JavaScript/TypeScript and Go adapters, isolated proof, protected proof-chain integrity, trajectory evidence, and adoption intelligence.
+The 1.2.0 candidate represents the complete integrated product on `main`: exact failure extraction, shared FailureVector diagnosis, review-first SafetyGate decisions, protected verification, trajectory and RepoMemory evidence, deterministic operator reporting, release and merge readiness, and read-only adoption-to-diagnosis support across Python, JavaScript/TypeScript, Go, Rust, Java, .NET, and C++.
+
+It also includes conservative CI-provider evidence for GitHub Actions, GitLab CI, Jenkins, and CircleCI, plus complete C++ and mixed-language monorepo operator proofs.
 
 The stable first path remains:
 
@@ -27,15 +30,16 @@ python -m sdetkit doctor
 
 ## Exact-head evidence
 
-A commit cannot contain its own final SHA. The canonical adoption workflow therefore retains the replay under its stable artifact contract, while GitHub Actions metadata binds that artifact to the workflow run's exact `head_sha`. The tag-driven release workflow separately builds once and qualifies the exact wheel on Python 3.10, 3.11, and 3.12.
+A commit cannot contain its own final SHA. The candidate workflow therefore binds generated artifacts to the workflow run's exact `head_sha`. The tag-driven release workflow separately builds once and qualifies the exact wheel on Python 3.10, 3.11, and 3.12.
 
 ## Remaining release gates
 
-1. Verify the protected GitHub `pypi` environment and matching PyPI Trusted Publisher.
-2. Merge the exact-head candidate PR.
-3. Create a signed `v1.1.0` tag.
-4. Complete public publication, digest verification, and clean installation.
-5. Record the completed release in a post-release evidence PR.
+1. Merge the release-truth candidate metadata PR.
+2. Freeze and qualify the exact 1.2.0 candidate SHA.
+3. Verify the protected GitHub `pypi` environment and matching PyPI Trusted Publisher.
+4. Create the immutable signed `v1.2.0` tag.
+5. Complete public publication, digest verification, and clean installation.
+6. Record the completed release in a post-release evidence PR and only then update README installation guidance.
 
 ## Authority boundary
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Use [First failure triage](first-failure-triage.md) for the shortest operator pa
 
 The [public launch proof](public-launch-proof.md) shows a realistic saved pytest failure reduced to its first failing node, owning file, focused proof command, and review-first decision. It also profiles a fixture-based Python, JavaScript/TypeScript, and Go repository without dependency installation, target-code execution, target mutation, or merge authorization.
 
-The artifacts are reproducible, tied to an immutable source SHA, accessible as text, and marked **main-only until the qualified 1.1.0 release**.
+The artifacts are reproducible, tied to an immutable source SHA, accessible as text, and marked **main-only until the qualified 1.2.0 release**.
 
 ## Fast start
 

--- a/docs/project/release-candidate-qualification.md
+++ b/docs/project/release-candidate-qualification.md
@@ -52,7 +52,7 @@ release-candidate-verdict
 
 ## Promotion boundary
 
-A green qualification run is repository evidence, not publication proof. Before creating `v1.1.0`, a maintainer must independently verify:
+A green qualification run is repository evidence, not publication proof. Before creating `v1.2.0`, a maintainer must independently verify:
 
 1. the protected GitHub environment is named `pypi` and has the intended reviewers and deployment rules;
 2. the PyPI Trusted Publisher is bound to owner `sherif69-sa`, repository `DevS69-sdetkit`, workflow `release.yml`, and environment `pypi`.

--- a/docs/public-launch-proof.md
+++ b/docs/public-launch-proof.md
@@ -6,7 +6,7 @@ This page demonstrates two current repository capabilities:
 2. profile an external-repository fixture without installing dependencies, executing target code, mutating the target, or authorizing a merge.
 
 !!! note "Published package versus main"
-    This proof records repository `main` behavior at source commit `f367b25b003efebb75dcaa72fd229979be59b8c2`. These capabilities remain **main-only until the qualified 1.1.0 release**. The published `1.0.3` wheel is not proof of these surfaces.
+    This proof records repository `main` behavior at source commit `f367b25b003efebb75dcaa72fd229979be59b8c2`. These capabilities remain **main-only until the qualified 1.2.0 release**. The published `1.0.3` wheel is not proof of these surfaces.
 
 ## Reproduce the proof
 
@@ -97,8 +97,8 @@ This is a text-first static walkthrough. It shows a pytest failure log, the firs
 
 > Deterministic release confidence for CI: first-failure diagnosis, ship/no-ship evidence, and review-first proof commands.
 
-## 1.1.0 proof-led announcement draft
+## 1.2.0 proof-led announcement draft
 
-> SDETKit 1.1.0 turns saved CI evidence into a first meaningful failure, affected file, focused proof command, and explicit review-first decision. Its adoption profiler identifies Python, JavaScript/TypeScript, Go, CI, and security surfaces without installing target dependencies, executing target code, changing the target repository, or authorizing a merge.
+> SDETKit 1.2.0 connects saved CI evidence to the first meaningful failure, affected file, exact proof command, review-first safety decision, protected verification, and retained trajectory evidence. Its adoption intelligence covers Python, JavaScript/TypeScript, Go, Rust, Java, .NET, C++, supported CI-provider evidence, and mixed workspaces without silently executing or mutating target repositories.
 
-This remains a draft until the qualified `1.1.0` release workflow succeeds and the public package is verified.
+This remains a draft until the qualified `1.2.0` release workflow succeeds and the public package is independently verified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sdetkit"
-version = "1.1.0"
+version = "1.2.0"
 requires-python = ">=3.10"
 readme = "README.md"
 description = "Operator-grade release confidence and test intelligence platform: deterministic gates, evidence, integration assurance, and failure forensics."

--- a/scripts/build_release_candidate_qualification.py
+++ b/scripts/build_release_candidate_qualification.py
@@ -205,7 +205,7 @@ def build_verdict(
             "GitHub environment pypi protection",
             "PyPI Trusted Publisher binding",
         ],
-        "next_action": "verify external publishing settings before creating v1.1.0",
+        "next_action": f"verify external publishing settings before creating {candidate_tag}",
     }
 
 

--- a/src/sdetkit/data/current_product_delta.v1.json
+++ b/src/sdetkit/data/current_product_delta.v1.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "sdetkit.current_product_delta.v1",
-  "generated_on": "2026-06-30",
+  "generated_on": "2026-07-18",
   "released_version": "1.0.3",
   "released_on": "2026-04-18",
-  "project_version": "1.1.0",
-  "release_candidate_version": "1.1.0",
-  "release_status": "release_candidate_frozen_not_published",
+  "project_version": "1.2.0",
+  "release_candidate_version": "1.2.0",
+  "release_status": "release_candidate_scope_established_not_qualified",
   "canonical_first_path": [
     "python -m sdetkit gate fast",
     "python -m sdetkit gate release",
@@ -18,8 +18,8 @@
     "documentation_must_not_imply_release_candidate_capabilities_are_published": true
   },
   "release_candidate_contract": {
-    "version": "1.1.0",
-    "scope": "repository_release_candidate",
+    "version": "1.2.0",
+    "scope": "repository_full_product_candidate",
     "publication_claimed": false,
     "tag_created": false,
     "public_install_verified": false
@@ -28,51 +28,36 @@
     {
       "id": "diagnostic_failure_model",
       "stability": "advanced_supported",
-      "capabilities": [
-        "FailureVector extraction and normalized failure contracts",
-        "review-first SafetyGate decisions",
-        "DiagnosticJob and execution-plan handoffs",
-        "read-only JavaScript/TypeScript and Go failure adapters"
-      ]
+      "capabilities": ["exact first-failure extraction and shared cross-ecosystem FailureVector evidence"]
     },
     {
       "id": "verification_and_benchmarking",
-      "stability": "experimental_incubator",
-      "capabilities": [
-        "isolated proof execution",
-        "protected verifier decisions",
-        "protected proof-chain integrity",
-        "patch scoring and anti-cheat checks",
-        "replayable remediation benchmark scorecards"
-      ]
+      "stability": "advanced_supported",
+      "capabilities": ["SafetyGate, protected verification, proof-chain integrity, and anti-cheat evidence"]
     },
     {
       "id": "trajectory_and_memory",
-      "stability": "experimental_incubator",
-      "capabilities": [
-        "trajectory storage",
-        "repository memory",
-        "diagnostic learning and pattern insights"
-      ]
+      "stability": "advanced_supported",
+      "capabilities": ["trajectory storage, repository memory, and reviewed outcome evidence"]
     },
     {
       "id": "external_adoption_intelligence",
       "stability": "advanced_supported",
-      "capabilities": [
-        "read-only repository surface discovery",
-        "proof recommendation generation",
-        "external integration evidence bundles",
-        "public repository trial-matrix reporting",
-        "SHA-bound release-candidate external acceptance artifacts"
-      ]
+      "capabilities": ["read-only adoption intelligence across Python, JavaScript/TypeScript, Go, Rust, Java, .NET, and C++"]
+    },
+    {
+      "id": "ci_provider_and_workspace_intelligence",
+      "stability": "advanced_supported",
+      "capabilities": ["GitHub Actions, GitLab CI, Jenkins, CircleCI, C++ operator proof, and mixed-monorepo composition"]
     }
   ],
   "release_blockers": [
-    "verify protected GitHub pypi environment and matching PyPI Trusted Publisher",
-    "merge release-candidate metadata and exact-head acceptance evidence",
-    "create signed v1.1.0 tag",
-    "qualify and publish exact artifacts through the release workflow",
-    "record post-release public verification evidence"
+    "merge release-truth candidate metadata",
+    "freeze and qualify the exact 1.2.0 candidate SHA",
+    "verify the protected pypi environment and Trusted Publisher",
+    "create the immutable signed v1.2.0 tag",
+    "publish and verify the exact distributions",
+    "record post-release public evidence"
   ],
   "authority_boundary": {
     "automation_allowed": false,

--- a/tests/test_current_product_delta_contract.py
+++ b/tests/test_current_product_delta_contract.py
@@ -34,10 +34,10 @@ def test_current_product_delta_separates_candidate_from_published_version() -> N
     published = delta["published_package_contract"]
     candidate = delta["release_candidate_contract"]
 
-    assert delta["project_version"] == project["version"] == "1.1.0"
+    assert delta["project_version"] == project["version"] == "1.2.0"
     assert delta["release_candidate_version"] == project["version"]
     assert delta["released_version"] == published["version"] == "1.0.3"
-    assert delta["release_status"] == "release_candidate_frozen_not_published"
+    assert delta["release_status"] == "release_candidate_scope_established_not_qualified"
     assert candidate["publication_claimed"] is False
     assert candidate["tag_created"] is False
     assert candidate["public_install_verified"] is False
@@ -63,10 +63,11 @@ def test_current_product_delta_declares_candidate_groups_and_release_blockers() 
         "verification_and_benchmarking",
         "trajectory_and_memory",
         "external_adoption_intelligence",
+        "ci_provider_and_workspace_intelligence",
     }
     assert all(group["capabilities"] for group in groups)
     assert isinstance(blockers, list)
-    assert len(blockers) >= 5
+    assert len(blockers) >= 6
 
 
 def test_docs_and_packaged_delta_match_governing_fields() -> None:
@@ -93,4 +94,4 @@ def test_readme_remains_pinned_to_published_package_until_release() -> None:
     assert "docs/current-product-delta.md" in readme
     assert "main-only" in readme
     assert "sdetkit==1.0.3" in readme
-    assert "sdetkit==1.1.0" not in readme
+    assert "sdetkit==1.2.0" not in readme

--- a/tests/test_release_candidate_qualification_contract.py
+++ b/tests/test_release_candidate_qualification_contract.py
@@ -81,5 +81,6 @@ def test_candidate_evidence_keeps_external_authority_unverified() -> None:
     assert '"publish_authorized": False' in text
     assert "GitHub environment pypi protection" in text
     assert "PyPI Trusted Publisher binding" in text
-    assert "verify external publishing settings before creating v1.1.0" in text
+    assert "verify external publishing settings before creating the resolved candidate tag" in text
+    assert "before creating v1.1.0" not in text
     assert "Record qualification verdict" in text

--- a/tests/test_release_candidate_qualification_evidence.py
+++ b/tests/test_release_candidate_qualification_evidence.py
@@ -22,16 +22,16 @@ def _manifest() -> dict[str, object]:
     return {
         "schema_version": "sdetkit.release_distribution_manifest.v1",
         "source_sha": "a" * 40,
-        "tag": "v1.1.0",
-        "version": "1.1.0",
+        "tag": "v1.2.0",
+        "version": "1.2.0",
         "files": [
             {
-                "name": "sdetkit-1.1.0-py3-none-any.whl",
+                "name": "sdetkit-1.2.0-py3-none-any.whl",
                 "size_bytes": 1234,
                 "sha256": "b" * 64,
             },
             {
-                "name": "sdetkit-1.1.0.tar.gz",
+                "name": "sdetkit-1.2.0.tar.gz",
                 "size_bytes": 2345,
                 "sha256": "c" * 64,
             },
@@ -67,7 +67,7 @@ def test_python_record_binds_exact_wheel_and_evidence(tmp_path: Path) -> None:
     assert record["source_sha"] == "a" * 40
     assert record["python_version"] == "3.12"
     assert record["wheel"] == {
-        "name": "sdetkit-1.1.0-py3-none-any.whl",
+        "name": "sdetkit-1.2.0-py3-none-any.whl",
         "sha256": "b" * 64,
         "size_bytes": 1234,
     }
@@ -86,8 +86,8 @@ def test_verdict_requires_exact_python_set_and_same_wheel(tmp_path: Path) -> Non
 
     verdict = module.build_verdict(
         records=records,
-        candidate_tag="v1.1.0",
-        version="1.1.0",
+        candidate_tag="v1.2.0",
+        version="1.2.0",
         source_sha="a" * 40,
     )
 
@@ -98,6 +98,7 @@ def test_verdict_requires_exact_python_set_and_same_wheel(tmp_path: Path) -> Non
     assert verdict["exact_wheel"]["sha256"] == "b" * 64
     assert verdict["external_settings_verified"] is False
     assert verdict["publish_authorized"] is False
+    assert verdict["next_action"] == "verify external publishing settings before creating v1.2.0"
 
 
 def test_verdict_rejects_missing_python_record(tmp_path: Path) -> None:
@@ -107,8 +108,8 @@ def test_verdict_rejects_missing_python_record(tmp_path: Path) -> None:
     try:
         module.build_verdict(
             records=records,
-            candidate_tag="v1.1.0",
-            version="1.1.0",
+            candidate_tag="v1.2.0",
+            version="1.2.0",
             source_sha="a" * 40,
         )
     except ValueError as exc:
@@ -128,8 +129,8 @@ def test_verdict_rejects_wheel_digest_drift(tmp_path: Path) -> None:
     try:
         module.build_verdict(
             records=records,
-            candidate_tag="v1.1.0",
-            version="1.1.0",
+            candidate_tag="v1.2.0",
+            version="1.2.0",
             source_sha="a" * 40,
         )
     except ValueError as exc:
@@ -146,8 +147,8 @@ def test_verdict_rejects_publication_authority_claim(tmp_path: Path) -> None:
     try:
         module.build_verdict(
             records=records,
-            candidate_tag="v1.1.0",
-            version="1.1.0",
+            candidate_tag="v1.2.0",
+            version="1.2.0",
             source_sha="a" * 40,
         )
     except ValueError as exc:


### PR DESCRIPTION
## Summary

Establishes `1.2.0` as the review-first full-product release candidate after the post-`1.1.0` Rust, Java, .NET, C++, CI-provider, mixed-monorepo, diagnostic, verification, and release-readiness work merged.

- advances repository package metadata from `1.1.0` to `1.2.0`;
- records the complete integrated capability scope in `CHANGELOG.md`;
- preserves `1.1.0` as an unpublished, superseded historical candidate;
- synchronizes docs and packaged current-product-delta contracts;
- keeps public installation guidance pinned to the verified PyPI release `1.0.3`;
- updates public launch wording to the qualified `1.2.0` release;
- makes release-candidate verdict next-action text derive from the resolved candidate tag instead of hard-coding `v1.1.0`;
- updates focused release and product-delta regression tests;
- preserves all review-first and no-publication authority boundaries.

Closes the first release-truth slice of #2112.

## Why

The earlier `1.1.0` candidate was frozen before major product capabilities merged. Current `main` could not truthfully be tagged as `v1.1.0` while its changelog claimed no post-freeze changes. This PR makes the repository candidate metadata match the complete integrated product before exact-head qualification begins.

## Verification

CI must prove this exact head. Required lanes include:

- `python -m pytest -q tests/test_current_product_delta_contract.py tests/test_version_alignment_docs.py -o addopts=`
- `python -m pytest -q tests/test_release_candidate_qualification_contract.py tests/test_release_candidate_qualification_evidence.py tests/test_release_distribution_scripts.py -o addopts=`
- `python -m pre_commit run -a`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- full quality and coverage gates;
- package build, Twine, wheel-content, and installed-wheel smoke;
- Release Candidate Qualification exact-wheel matrix on Python 3.10, 3.11, and 3.12.

Local proof was not run in this session because the WSL checkout is not mounted and the execution container cannot resolve GitHub. GitHub Actions is the current verifier for this draft.

## Risk

- **Risk:** medium/high release metadata and workflow-contract change.
- **Compatibility:** public package remains `sdetkit==1.0.3`; no public CLI or schema removal.
- **Rollback:** revert this PR before tagging.

## Hard boundaries

```text
tag_created=false
publication_attempted=false
publish_authorized=false
automation_allowed=false
patch_application_allowed=false
merge_authorized=false
semantic_equivalence_proven=false
```

Do not mark ready or merge until all required CI and release-candidate qualification lanes are green on the exact PR head.