### PR TITLE
feat(product): evaluate reviewed KPI evidence

### DIFF
--- a/docs/adoption-product-kpi-evidence.md
+++ b/docs/adoption-product-kpi-evidence.md
@@ -6,7 +6,7 @@ Contract: [`docs/contracts/adoption-product-kpi-evidence.v1.json`](contracts/ado
 
 This lane measures how well SDETKit discovers, diagnoses, scopes, and explains real repository evidence. It replaces anecdotal maturity claims with reviewed observations and explicit denominators.
 
-The contract is intentionally report-only. It does not authorize target-repository execution, mutation, patch application, merge, publication, security dismissal, or semantic-equivalence claims.
+The evaluator is intentionally report-only. It does not authorize target-repository execution, mutation, patch application, merge, publication, security dismissal, or semantic-equivalence claims.
 
 ## Required reviewed metrics
 
@@ -48,21 +48,101 @@ unsupported
 not_applicable
 ```
 
-Unavailable, malformed, and unsupported evidence remains visible. The reporter must not convert a collection failure into an authoritative zero, infer a missing review result, or silently remove difficult observations from the denominator.
+Unavailable, malformed, and unsupported evidence remains visible. The evaluator does not convert a collection failure into an authoritative zero, infer a missing review result, or silently remove difficult observations from the report.
+
+## Observation input
+
+The evaluator accepts one JSON object using schema `sdetkit.adoption_product_kpi_observations.v1`:
+
+```json
+{
+  "schema_version": "sdetkit.adoption_product_kpi_observations.v1",
+  "observations": [
+    {
+      "observation_id": "repo-001",
+      "repository_name": "example-repo",
+      "repository_url": "https://example.invalid/example-repo",
+      "source_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "evidence_path": "evidence/repo-001.json",
+      "evidence_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "reviewer_id": "reviewer-1",
+      "reviewed_at": "2026-07-18T12:00:00Z",
+      "metric_outcomes": {
+        "discovery_precision": "pass",
+        "first_failure_extraction_precision": "pass",
+        "workspace_ownership_precision": "pass",
+        "proof_command_actionability": "pass",
+        "authority_boundary_preservation": "pass",
+        "unsafe_authority_rejection": "pass",
+        "operator_actionability": "pass"
+      },
+      "review_notes": "Reviewed against retained source evidence."
+    }
+  ]
+}
+```
+
+Every contracted metric is required for every observation. Reviewer timestamps must include a timezone, source commits must be hexadecimal, and retained evidence must carry its SHA-256 digest.
+
+## Generate the report
+
+```bash
+python -m sdetkit.adoption_product_kpi_report \
+  --observations-json build/sdetkit/reviewed-kpi-observations.json \
+  --out build/sdetkit/adoption-product-kpi-report.json \
+  --format text
+```
+
+The command writes both:
+
+```text
+build/sdetkit/adoption-product-kpi-report.json
+build/sdetkit/adoption-product-kpi-report.md
+```
+
+The JSON artifact contains the reviewed observation count, metric totals, complete outcome counts, source relationships, input digest, current Git head, review provenance index, rules, and denied authority.
 
 ## Denominator rule
 
-Each KPI reports its reviewed pass count and reviewed applicable denominator together with the complete outcome totals. A percentage without the source count, review state, and provenance is not product proof.
+For each metric:
 
-## What this contract proves
+```text
+numerator = pass
+denominator = pass + fail
+```
 
-The contract proves the expected shape and safety boundary for a future deterministic KPI evaluator. It does not yet prove real-repository product performance. That proof requires reviewed observation records, source provenance, a generated report, freshness validation, and repository CI.
+Unavailable, malformed, unsupported, and not-applicable outcomes remain visible beside the denominator. When `pass + fail` is zero, precision is `null` and status is `unavailable`; the evaluator never reports a fabricated `0%`.
 
-## Planned implementation sequence
+## Freshness validation
 
-1. Versioned contract and tests.
-2. Deterministic JSON and Markdown evaluator.
-3. Reviewed real-repository observation set with explicit denominators.
-4. Capability-matrix, maturity-radar, roadmap, and operator-report integration.
+```bash
+python -m sdetkit.adoption_product_kpi_report \
+  --observations-json build/sdetkit/reviewed-kpi-observations.json \
+  --out build/sdetkit/adoption-product-kpi-report.json \
+  --check-freshness \
+  --format text
+```
 
-The sequence remains local-first and review-first. No hosted service or patch execution is required for this lane.
+Freshness binds the report to:
+
+- the exact observation bytes;
+- the exact KPI contract bytes;
+- the evaluator source;
+- the accepted schema versions;
+- the current repository head;
+- the complete metric and authority payload.
+
+A changed observation, contract, generator, head, metric count, authority value, or report body makes the artifact stale.
+
+## What the evaluator proves
+
+The evaluator proves that a report is a deterministic aggregation of the supplied reviewed records and that its source and authority boundaries have not drifted. It does not prove that the supplied human reviews are correct, that a target repository endorses SDETKit, or that a prediction is equivalent to retained evidence.
+
+## Implementation sequence
+
+1. Versioned contract and tests — complete.
+2. Deterministic JSON and Markdown evaluator — implemented in this slice.
+3. Reviewed real-repository observation set with explicit denominators — next.
+4. Capability-matrix, maturity-radar, roadmap, and operator-report integration — after real evidence exists.
+
+The sequence remains local-first and review-first. No hosted service or target-repository execution is required for this lane.

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "sdetkit.quality_truth_baseline.v1",
-  "generated_on": "2026-07-17",
+  "generated_on": "2026-07-18",
   "status": "staged_migration_visible",
   "coverage": {
     "critical_spine": {
@@ -35,7 +35,7 @@
     "blanket_package_suppression_present": true,
     "blanket_module_pattern": "sdetkit.*",
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 516,
+    "source_module_count": 520,
     "typing_debt_module_count": 487,
     "typing_debt_inventory_sha256": "19c733747317a3bf1e439ff1bb27b6539e1224d1bdc5ff7df39de4a62f100707",
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
@@ -47,6 +47,10 @@
       "sdetkit.adoption_evidence_bundle",
       "sdetkit.adoption_external_integration",
       "sdetkit.adoption_learning",
+      "sdetkit.adoption_product_kpi_freshness",
+      "sdetkit.adoption_product_kpi_model",
+      "sdetkit.adoption_product_kpi_render",
+      "sdetkit.adoption_product_kpi_report",
       "sdetkit.adoption_proof_recommendations",
       "sdetkit.adoption_public_repo_trial_matrix_report",
       "sdetkit.adoption_repo_topology",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,15 @@ module = [
 ]
 ignore_errors = false
 
+[[tool.mypy.overrides]]
+module = [
+  "sdetkit.adoption_product_kpi_freshness",
+  "sdetkit.adoption_product_kpi_model",
+  "sdetkit.adoption_product_kpi_render",
+  "sdetkit.adoption_product_kpi_report",
+]
+ignore_errors = false
+
 [tool.mutmut]
 paths_to_mutate = ["src/sdetkit"]
 tests_dir = ["tests"]

--- a/src/sdetkit/adoption_product_kpi_freshness.py
+++ b/src/sdetkit/adoption_product_kpi_freshness.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .adoption_product_kpi_model import (
+    AUTHORITY_FIELDS,
+    DEFAULT_CONTRACT,
+    REPORT_SCHEMA,
+    authority_boundary,
+    build_report,
+    load_object,
+)
+
+
+def _stale(reason: str) -> dict[str, Any]:
+    return {
+        "status": "stale",
+        "fresh": False,
+        "schema_valid": False,
+        "source_schema_valid": False,
+        "current_head_valid": False,
+        "authority_valid": False,
+        "reasons": [reason],
+        "recorded_input_digest": "",
+        "current_input_digest": "",
+        "recorded_head_sha": "",
+        "current_head_sha": "",
+        "reporting_only": True,
+        **authority_boundary(),
+    }
+
+
+def validate_freshness(
+    payload: dict[str, Any],
+    *,
+    observations_json: str | Path,
+    contract_json: str | Path = DEFAULT_CONTRACT,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    expected = build_report(
+        observations_json,
+        contract_json=contract_json,
+        root=root,
+        current_head_sha=current_head_sha,
+    )
+    reasons: list[str] = []
+    compared_fields = (
+        "schema_version",
+        "report_status",
+        "input_provenance",
+        "source_relationships",
+        "reviewed_observation_count",
+        "metric_count",
+        "metrics",
+        "metrics_without_applicable_denominator",
+        "outcome_totals",
+        "reviewed_observation_index",
+        "rules",
+        "authority_boundary",
+    )
+    for field in compared_fields:
+        if payload.get(field) != expected.get(field):
+            reasons.append(f"{field}_mismatch")
+    for field in AUTHORITY_FIELDS:
+        if payload.get(field) is not False:
+            reasons.append(f"{field}_mismatch")
+
+    recorded = payload.get("input_provenance")
+    if not isinstance(recorded, dict):
+        recorded = {}
+    current = expected["input_provenance"]
+    relationships = expected["source_relationships"]
+    fresh = not reasons
+    return {
+        "status": "fresh" if fresh else "stale",
+        "fresh": fresh,
+        "schema_valid": payload.get("schema_version") == REPORT_SCHEMA,
+        "source_schema_valid": bool(
+            relationships["contract_schema_accepted"]
+            and relationships["observations_schema_accepted"]
+        ),
+        "current_head_valid": bool(
+            current["current_head_available"]
+            and recorded.get("current_head_sha") == current["current_head_sha"]
+        ),
+        "authority_valid": all(payload.get(field) is False for field in AUTHORITY_FIELDS)
+        and payload.get("authority_boundary") == authority_boundary(),
+        "reasons": sorted(set(reasons)),
+        "recorded_input_digest": recorded.get("input_digest", ""),
+        "current_input_digest": current["input_digest"],
+        "recorded_head_sha": recorded.get("current_head_sha", ""),
+        "current_head_sha": current["current_head_sha"],
+        "reporting_only": True,
+        **authority_boundary(),
+    }
+
+
+def check_freshness(
+    *,
+    report_path: str | Path,
+    observations_json: str | Path,
+    contract_json: str | Path = DEFAULT_CONTRACT,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    path = Path(report_path)
+    if not path.is_file():
+        return _stale("report_missing")
+    try:
+        payload = load_object(path)
+        return validate_freshness(
+            payload,
+            observations_json=observations_json,
+            contract_json=contract_json,
+            root=root,
+            current_head_sha=current_head_sha,
+        )
+    except ValueError as exc:
+        return _stale(f"source_or_report_invalid:{exc}")
+
+
+def render_freshness_text(payload: dict[str, Any]) -> str:
+    raw_reasons = payload.get("reasons")
+    reasons = raw_reasons if isinstance(raw_reasons, list) else []
+    return "\n".join(
+        [
+            f"freshness_status={payload.get('status', 'stale')}",
+            f"fresh={str(bool(payload.get('fresh', False))).lower()}",
+            f"schema_valid={str(bool(payload.get('schema_valid', False))).lower()}",
+            f"source_schema_valid={str(bool(payload.get('source_schema_valid', False))).lower()}",
+            f"current_head_valid={str(bool(payload.get('current_head_valid', False))).lower()}",
+            f"authority_valid={str(bool(payload.get('authority_valid', False))).lower()}",
+            f"freshness_reasons={','.join(str(item) for item in reasons) or 'none'}",
+            f"recorded_input_digest={payload.get('recorded_input_digest', '')}",
+            f"current_input_digest={payload.get('current_input_digest', '')}",
+            f"recorded_head_sha={payload.get('recorded_head_sha', '')}",
+            f"current_head_sha={payload.get('current_head_sha', '')}",
+        ]
+    )

--- a/src/sdetkit/adoption_product_kpi_freshness.py
+++ b/src/sdetkit/adoption_product_kpi_freshness.py
@@ -72,6 +72,8 @@ def validate_freshness(
         recorded = {}
     current = expected["input_provenance"]
     relationships = expected["source_relationships"]
+    if not current["current_head_available"]:
+        reasons.append("current_head_unavailable")
     fresh = not reasons
     return {
         "status": "fresh" if fresh else "stale",

--- a/src/sdetkit/adoption_product_kpi_model.py
+++ b/src/sdetkit/adoption_product_kpi_model.py
@@ -96,16 +96,12 @@ def input_provenance(
     repo_root = Path(root).resolve()
     observations_path = Path(observations_json).resolve()
     contract_path = Path(contract_json).resolve()
-    generator = (
-        Path(generator_path).resolve() if generator_path else Path(__file__).resolve()
-    )
+    generator = Path(generator_path).resolve() if generator_path else Path(__file__).resolve()
     head_sha = _head(repo_root) if current_head_sha is None else current_head_sha
     observations_bytes = (
         observations_path.read_bytes() if observations_path.is_file() else b"<missing>"
     )
-    contract_bytes = (
-        contract_path.read_bytes() if contract_path.is_file() else b"<missing>"
-    )
+    contract_bytes = contract_path.read_bytes() if contract_path.is_file() else b"<missing>"
     generator_bytes = generator.read_bytes() if generator.is_file() else b"<missing>"
     parts = [
         ("contract_schema", CONTRACT_SCHEMA.encode()),
@@ -174,13 +170,9 @@ def _reviewed_at(value: str, observation_id: str) -> None:
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
-        raise ValueError(
-            f"observation {observation_id} reviewed_at must be RFC3339"
-        ) from exc
+        raise ValueError(f"observation {observation_id} reviewed_at must be RFC3339") from exc
     if parsed.tzinfo is None:
-        raise ValueError(
-            f"observation {observation_id} reviewed_at must include timezone"
-        )
+        raise ValueError(f"observation {observation_id} reviewed_at must include timezone")
 
 
 def reviewed_observations(
@@ -188,12 +180,8 @@ def reviewed_observations(
 ) -> list[dict[str, Any]]:
     if source.get("schema_version") != OBSERVATIONS_SCHEMA:
         raise ValueError(f"observations schema_version must be {OBSERVATIONS_SCHEMA}")
-    required = _string_list(
-        contract.get("required_observation_fields"), "required fields"
-    )
-    allowed = set(
-        _string_list(contract.get("allowed_observation_outcomes"), "outcomes")
-    )
+    required = _string_list(contract.get("required_observation_fields"), "required fields")
+    allowed = set(_string_list(contract.get("allowed_observation_outcomes"), "outcomes"))
     raw_items = source.get("observations")
     if not isinstance(raw_items, list):
         raise ValueError("observations must be a list")
@@ -224,31 +212,21 @@ def reviewed_observations(
         for field in text_fields:
             value = raw.get(field)
             if not isinstance(value, str) or not value.strip():
-                raise ValueError(
-                    f"observation {observation_id} field {field} must be non-empty"
-                )
+                raise ValueError(f"observation {observation_id} field {field} must be non-empty")
             normalized[field] = value.strip()
         if re.fullmatch(r"[0-9a-fA-F]{7,64}", normalized["source_commit_sha"]) is None:
-            raise ValueError(
-                f"observation {observation_id} source_commit_sha must be hexadecimal"
-            )
+            raise ValueError(f"observation {observation_id} source_commit_sha must be hexadecimal")
         if re.fullmatch(r"[0-9a-fA-F]{64}", normalized["evidence_sha256"]) is None:
-            raise ValueError(
-                f"observation {observation_id} evidence_sha256 must be sha256"
-            )
+            raise ValueError(f"observation {observation_id} evidence_sha256 must be sha256")
         _reviewed_at(normalized["reviewed_at"], observation_id)
         outcomes = raw.get("metric_outcomes")
         if not isinstance(outcomes, dict) or set(outcomes) != expected_metrics:
-            raise ValueError(
-                f"observation {observation_id} must contain every contracted metric"
-            )
+            raise ValueError(f"observation {observation_id} must contain every contracted metric")
         normalized_outcomes: dict[str, str] = {}
         for metric_id in metric_ids:
             outcome = str(outcomes[metric_id]).strip()
             if outcome not in allowed:
-                raise ValueError(
-                    f"observation {observation_id} has invalid outcome {outcome!r}"
-                )
+                raise ValueError(f"observation {observation_id} has invalid outcome {outcome!r}")
             normalized_outcomes[metric_id] = outcome
         normalized["metric_outcomes"] = normalized_outcomes
         result.append(normalized)
@@ -313,8 +291,7 @@ def build_report(
         "report_status": status,
         "input_provenance": provenance,
         "source_relationships": {
-            "contract_schema_accepted": provenance["contract_schema_version"]
-            == CONTRACT_SCHEMA,
+            "contract_schema_accepted": provenance["contract_schema_version"] == CONTRACT_SCHEMA,
             "observations_schema_accepted": provenance["observations_schema_version"]
             == OBSERVATIONS_SCHEMA,
             "current_head_bound": bool(provenance["current_head_available"]),

--- a/src/sdetkit/adoption_product_kpi_model.py
+++ b/src/sdetkit/adoption_product_kpi_model.py
@@ -96,10 +96,16 @@ def input_provenance(
     repo_root = Path(root).resolve()
     observations_path = Path(observations_json).resolve()
     contract_path = Path(contract_json).resolve()
-    generator = Path(generator_path).resolve() if generator_path else Path(__file__).resolve()
+    generator = (
+        Path(generator_path).resolve() if generator_path else Path(__file__).resolve()
+    )
     head_sha = _head(repo_root) if current_head_sha is None else current_head_sha
-    observations_bytes = observations_path.read_bytes() if observations_path.is_file() else b"<missing>"
-    contract_bytes = contract_path.read_bytes() if contract_path.is_file() else b"<missing>"
+    observations_bytes = (
+        observations_path.read_bytes() if observations_path.is_file() else b"<missing>"
+    )
+    contract_bytes = (
+        contract_path.read_bytes() if contract_path.is_file() else b"<missing>"
+    )
     generator_bytes = generator.read_bytes() if generator.is_file() else b"<missing>"
     parts = [
         ("contract_schema", CONTRACT_SCHEMA.encode()),
@@ -168,9 +174,13 @@ def _reviewed_at(value: str, observation_id: str) -> None:
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
-        raise ValueError(f"observation {observation_id} reviewed_at must be RFC3339") from exc
+        raise ValueError(
+            f"observation {observation_id} reviewed_at must be RFC3339"
+        ) from exc
     if parsed.tzinfo is None:
-        raise ValueError(f"observation {observation_id} reviewed_at must include timezone")
+        raise ValueError(
+            f"observation {observation_id} reviewed_at must include timezone"
+        )
 
 
 def reviewed_observations(
@@ -178,8 +188,12 @@ def reviewed_observations(
 ) -> list[dict[str, Any]]:
     if source.get("schema_version") != OBSERVATIONS_SCHEMA:
         raise ValueError(f"observations schema_version must be {OBSERVATIONS_SCHEMA}")
-    required = _string_list(contract.get("required_observation_fields"), "required fields")
-    allowed = set(_string_list(contract.get("allowed_observation_outcomes"), "outcomes"))
+    required = _string_list(
+        contract.get("required_observation_fields"), "required fields"
+    )
+    allowed = set(
+        _string_list(contract.get("allowed_observation_outcomes"), "outcomes")
+    )
     raw_items = source.get("observations")
     if not isinstance(raw_items, list):
         raise ValueError("observations must be a list")
@@ -210,21 +224,31 @@ def reviewed_observations(
         for field in text_fields:
             value = raw.get(field)
             if not isinstance(value, str) or not value.strip():
-                raise ValueError(f"observation {observation_id} field {field} must be non-empty")
+                raise ValueError(
+                    f"observation {observation_id} field {field} must be non-empty"
+                )
             normalized[field] = value.strip()
         if re.fullmatch(r"[0-9a-fA-F]{7,64}", normalized["source_commit_sha"]) is None:
-            raise ValueError(f"observation {observation_id} source_commit_sha must be hexadecimal")
+            raise ValueError(
+                f"observation {observation_id} source_commit_sha must be hexadecimal"
+            )
         if re.fullmatch(r"[0-9a-fA-F]{64}", normalized["evidence_sha256"]) is None:
-            raise ValueError(f"observation {observation_id} evidence_sha256 must be sha256")
+            raise ValueError(
+                f"observation {observation_id} evidence_sha256 must be sha256"
+            )
         _reviewed_at(normalized["reviewed_at"], observation_id)
         outcomes = raw.get("metric_outcomes")
         if not isinstance(outcomes, dict) or set(outcomes) != expected_metrics:
-            raise ValueError(f"observation {observation_id} must contain every contracted metric")
+            raise ValueError(
+                f"observation {observation_id} must contain every contracted metric"
+            )
         normalized_outcomes: dict[str, str] = {}
         for metric_id in metric_ids:
             outcome = str(outcomes[metric_id]).strip()
             if outcome not in allowed:
-                raise ValueError(f"observation {observation_id} has invalid outcome {outcome!r}")
+                raise ValueError(
+                    f"observation {observation_id} has invalid outcome {outcome!r}"
+                )
             normalized_outcomes[metric_id] = outcome
         normalized["metric_outcomes"] = normalized_outcomes
         result.append(normalized)
@@ -279,13 +303,18 @@ def build_report(
             }
         )
     boundary = authority_boundary()
-    status = "reviewed_evidence_available" if observations and not unavailable_metrics else "review_required"
+    status = (
+        "reviewed_evidence_available"
+        if observations and not unavailable_metrics
+        else "review_required"
+    )
     return {
         "schema_version": REPORT_SCHEMA,
         "report_status": status,
         "input_provenance": provenance,
         "source_relationships": {
-            "contract_schema_accepted": provenance["contract_schema_version"] == CONTRACT_SCHEMA,
+            "contract_schema_accepted": provenance["contract_schema_version"]
+            == CONTRACT_SCHEMA,
             "observations_schema_accepted": provenance["observations_schema_version"]
             == OBSERVATIONS_SCHEMA,
             "current_head_bound": bool(provenance["current_head_available"]),
@@ -296,16 +325,19 @@ def build_report(
         "metrics_without_applicable_denominator": unavailable_metrics,
         "outcome_totals": {outcome: totals[outcome] for outcome in outcomes},
         "reviewed_observation_index": [
-            {field: observation[field] for field in (
-                "observation_id",
-                "repository_name",
-                "repository_url",
-                "source_commit_sha",
-                "evidence_path",
-                "evidence_sha256",
-                "reviewer_id",
-                "reviewed_at",
-            )}
+            {
+                field: observation[field]
+                for field in (
+                    "observation_id",
+                    "repository_name",
+                    "repository_url",
+                    "source_commit_sha",
+                    "evidence_path",
+                    "evidence_sha256",
+                    "reviewer_id",
+                    "reviewed_at",
+                )
+            }
             for observation in observations
         ],
         "rules": dict(REPORT_RULES),

--- a/src/sdetkit/adoption_product_kpi_model.py
+++ b/src/sdetkit/adoption_product_kpi_model.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+REPORT_SCHEMA = "sdetkit.adoption_product_kpi_report.v1"
+CONTRACT_SCHEMA = "sdetkit.adoption_product_kpi_evidence.v1"
+OBSERVATIONS_SCHEMA = "sdetkit.adoption_product_kpi_observations.v1"
+DEFAULT_CONTRACT = "docs/contracts/adoption-product-kpi-evidence.v1.json"
+GENERATOR_SOURCE = "src/sdetkit/adoption_product_kpi_model.py"
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "patch_application_allowed",
+    "merge_authorized",
+    "publication_authorized",
+    "security_dismissal_allowed",
+    "semantic_equivalence_proven",
+)
+REPORT_RULES = {
+    "authoritative_zero_after_collection_failure": False,
+    "explicit_denominators_required": True,
+    "missing_outcomes_inferred": False,
+    "predictions_are_proof": False,
+    "reviewed_observations_only": True,
+    "source_provenance_required": True,
+    "target_repo_mutation": False,
+    "target_tests_executed_by_reporter": False,
+    "unavailable_malformed_unsupported_retained": True,
+}
+
+
+def authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def load_object(path: str | Path) -> dict[str, Any]:
+    resolved = Path(path)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"invalid JSON object: {resolved}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {resolved}")
+    return payload
+
+
+def _head(root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _schema(path: Path) -> str:
+    try:
+        return str(load_object(path).get("schema_version", "")).strip()
+    except ValueError:
+        return ""
+
+
+def _display(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _digest_parts(parts: list[tuple[str, bytes]]) -> str:
+    hasher = hashlib.sha256()
+    for label, content in sorted(parts):
+        label_bytes = label.encode("utf-8")
+        hasher.update(len(label_bytes).to_bytes(8, "big"))
+        hasher.update(label_bytes)
+        hasher.update(len(content).to_bytes(8, "big"))
+        hasher.update(content)
+    return hasher.hexdigest()
+
+
+def input_provenance(
+    observations_json: str | Path,
+    *,
+    contract_json: str | Path = DEFAULT_CONTRACT,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    repo_root = Path(root).resolve()
+    observations_path = Path(observations_json).resolve()
+    contract_path = Path(contract_json).resolve()
+    generator = Path(generator_path).resolve() if generator_path else Path(__file__).resolve()
+    head_sha = _head(repo_root) if current_head_sha is None else current_head_sha
+    observations_bytes = observations_path.read_bytes() if observations_path.is_file() else b"<missing>"
+    contract_bytes = contract_path.read_bytes() if contract_path.is_file() else b"<missing>"
+    generator_bytes = generator.read_bytes() if generator.is_file() else b"<missing>"
+    parts = [
+        ("contract_schema", CONTRACT_SCHEMA.encode()),
+        ("observations_schema", OBSERVATIONS_SCHEMA.encode()),
+        ("current_head_sha", head_sha.encode()),
+        ("report_schema", REPORT_SCHEMA.encode()),
+        (GENERATOR_SOURCE, generator_bytes),
+        ("contract_json", contract_bytes),
+        ("observations_json", observations_bytes),
+    ]
+    return {
+        "digest_algorithm": "sha256",
+        "input_digest": _digest_parts(parts),
+        "input_count": len(parts),
+        "generator_schema_version": REPORT_SCHEMA,
+        "generator_source": GENERATOR_SOURCE,
+        "contract_path": _display(repo_root, contract_path),
+        "contract_sha256": hashlib.sha256(contract_bytes).hexdigest(),
+        "contract_schema_version": _schema(contract_path),
+        "observations_path": _display(repo_root, observations_path),
+        "observations_sha256": hashlib.sha256(observations_bytes).hexdigest(),
+        "observations_schema_version": _schema(observations_path),
+        "accepted_contract_schema": CONTRACT_SCHEMA,
+        "accepted_observations_schema": OBSERVATIONS_SCHEMA,
+        "current_head_sha": head_sha,
+        "current_head_available": bool(head_sha),
+    }
+
+
+def _string_list(value: object, field: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field} must be a list of strings")
+    return [item.strip() for item in value if item.strip()]
+
+
+def metric_definitions(contract: dict[str, Any]) -> list[dict[str, str]]:
+    raw = contract.get("metric_definitions")
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("metric_definitions must be a non-empty list")
+    result: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("metric definitions must be objects")
+        metric_id = str(item.get("metric_id", "")).strip()
+        description = str(item.get("description", "")).strip()
+        if not metric_id or metric_id in seen or not description:
+            raise ValueError("metric definitions require unique ids and descriptions")
+        if item.get("numerator") != "reviewed_pass_observations":
+            raise ValueError(f"unsupported numerator for {metric_id}")
+        if item.get("denominator") != "reviewed_applicable_observations":
+            raise ValueError(f"unsupported denominator for {metric_id}")
+        seen.add(metric_id)
+        result.append(
+            {
+                "metric_id": metric_id,
+                "description": description,
+                "numerator": "reviewed_pass_observations",
+                "denominator": "reviewed_applicable_observations",
+            }
+        )
+    return result
+
+
+def _reviewed_at(value: str, observation_id: str) -> None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"observation {observation_id} reviewed_at must be RFC3339") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"observation {observation_id} reviewed_at must include timezone")
+
+
+def reviewed_observations(
+    source: dict[str, Any], contract: dict[str, Any], metric_ids: list[str]
+) -> list[dict[str, Any]]:
+    if source.get("schema_version") != OBSERVATIONS_SCHEMA:
+        raise ValueError(f"observations schema_version must be {OBSERVATIONS_SCHEMA}")
+    required = _string_list(contract.get("required_observation_fields"), "required fields")
+    allowed = set(_string_list(contract.get("allowed_observation_outcomes"), "outcomes"))
+    raw_items = source.get("observations")
+    if not isinstance(raw_items, list):
+        raise ValueError("observations must be a list")
+    expected_metrics = set(metric_ids)
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    text_fields = (
+        "repository_name",
+        "repository_url",
+        "source_commit_sha",
+        "evidence_path",
+        "evidence_sha256",
+        "reviewer_id",
+        "reviewed_at",
+        "review_notes",
+    )
+    for index, raw in enumerate(raw_items, 1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"observation {index} must be an object")
+        missing = [field for field in required if field not in raw]
+        if missing:
+            raise ValueError(f"observation {index} missing: {','.join(missing)}")
+        observation_id = str(raw.get("observation_id", "")).strip()
+        if not observation_id or observation_id in seen:
+            raise ValueError(f"observation {index} has invalid observation_id")
+        seen.add(observation_id)
+        normalized: dict[str, Any] = {"observation_id": observation_id}
+        for field in text_fields:
+            value = raw.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"observation {observation_id} field {field} must be non-empty")
+            normalized[field] = value.strip()
+        if re.fullmatch(r"[0-9a-fA-F]{7,64}", normalized["source_commit_sha"]) is None:
+            raise ValueError(f"observation {observation_id} source_commit_sha must be hexadecimal")
+        if re.fullmatch(r"[0-9a-fA-F]{64}", normalized["evidence_sha256"]) is None:
+            raise ValueError(f"observation {observation_id} evidence_sha256 must be sha256")
+        _reviewed_at(normalized["reviewed_at"], observation_id)
+        outcomes = raw.get("metric_outcomes")
+        if not isinstance(outcomes, dict) or set(outcomes) != expected_metrics:
+            raise ValueError(f"observation {observation_id} must contain every contracted metric")
+        normalized_outcomes: dict[str, str] = {}
+        for metric_id in metric_ids:
+            outcome = str(outcomes[metric_id]).strip()
+            if outcome not in allowed:
+                raise ValueError(f"observation {observation_id} has invalid outcome {outcome!r}")
+            normalized_outcomes[metric_id] = outcome
+        normalized["metric_outcomes"] = normalized_outcomes
+        result.append(normalized)
+    return sorted(result, key=lambda item: item["observation_id"])
+
+
+def build_report(
+    observations_json: str | Path,
+    *,
+    contract_json: str | Path = DEFAULT_CONTRACT,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    contract = load_object(contract_json)
+    source = load_object(observations_json)
+    if contract.get("schema_version") != CONTRACT_SCHEMA:
+        raise ValueError(f"contract schema_version must be {CONTRACT_SCHEMA}")
+    definitions = metric_definitions(contract)
+    metric_ids = [item["metric_id"] for item in definitions]
+    observations = reviewed_observations(source, contract, metric_ids)
+    outcomes = _string_list(contract.get("allowed_observation_outcomes"), "outcomes")
+    provenance = input_provenance(
+        observations_json,
+        contract_json=contract_json,
+        root=root,
+        current_head_sha=current_head_sha,
+        generator_path=generator_path,
+    )
+    metrics: list[dict[str, Any]] = []
+    totals: Counter[str] = Counter({outcome: 0 for outcome in outcomes})
+    unavailable_metrics: list[str] = []
+    for definition in definitions:
+        metric_id = definition["metric_id"]
+        counts: Counter[str] = Counter({outcome: 0 for outcome in outcomes})
+        for observation in observations:
+            outcome = observation["metric_outcomes"][metric_id]
+            counts[outcome] += 1
+            totals[outcome] += 1
+        numerator = counts["pass"]
+        denominator = counts["pass"] + counts["fail"]
+        if denominator == 0:
+            unavailable_metrics.append(metric_id)
+        metrics.append(
+            {
+                **definition,
+                "status": "measured" if denominator else "unavailable",
+                "reviewed_pass_observations": numerator,
+                "reviewed_applicable_observations": denominator,
+                "precision": round(numerator / denominator, 6) if denominator else None,
+                "outcome_counts": {outcome: counts[outcome] for outcome in outcomes},
+            }
+        )
+    boundary = authority_boundary()
+    status = "reviewed_evidence_available" if observations and not unavailable_metrics else "review_required"
+    return {
+        "schema_version": REPORT_SCHEMA,
+        "report_status": status,
+        "input_provenance": provenance,
+        "source_relationships": {
+            "contract_schema_accepted": provenance["contract_schema_version"] == CONTRACT_SCHEMA,
+            "observations_schema_accepted": provenance["observations_schema_version"]
+            == OBSERVATIONS_SCHEMA,
+            "current_head_bound": bool(provenance["current_head_available"]),
+        },
+        "reviewed_observation_count": len(observations),
+        "metric_count": len(metrics),
+        "metrics": metrics,
+        "metrics_without_applicable_denominator": unavailable_metrics,
+        "outcome_totals": {outcome: totals[outcome] for outcome in outcomes},
+        "reviewed_observation_index": [
+            {field: observation[field] for field in (
+                "observation_id",
+                "repository_name",
+                "repository_url",
+                "source_commit_sha",
+                "evidence_path",
+                "evidence_sha256",
+                "reviewer_id",
+                "reviewed_at",
+            )}
+            for observation in observations
+        ],
+        "rules": dict(REPORT_RULES),
+        "authority_boundary": boundary,
+        **boundary,
+    }

--- a/src/sdetkit/adoption_product_kpi_render.py
+++ b/src/sdetkit/adoption_product_kpi_render.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    return "# SDETKit reviewed product KPI report\n"

--- a/src/sdetkit/adoption_product_kpi_render.py
+++ b/src/sdetkit/adoption_product_kpi_render.py
@@ -4,4 +4,73 @@ from typing import Any
 
 
 def render_markdown(payload: dict[str, Any]) -> str:
-    return "# SDETKit reviewed product KPI report\n"
+    provenance = payload.get("input_provenance")
+    if not isinstance(provenance, dict):
+        provenance = {}
+    lines = [
+        "# SDETKit reviewed product KPI report",
+        "",
+        f"- report_status: {payload.get('report_status', 'review_required')}",
+        f"- reviewed_observation_count: {payload.get('reviewed_observation_count', 0)}",
+        f"- metric_count: {payload.get('metric_count', 0)}",
+        f"- input_digest: `{provenance.get('input_digest', '')}`",
+        f"- current_head_sha: `{provenance.get('current_head_sha', '')}`",
+        "- reporting_only: true",
+        "- review_first: true",
+        "",
+        "## Metrics",
+        "",
+        "| Metric | Status | Pass | Fail | Applicable | Precision | Unavailable | Malformed | Unsupported | N/A |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    raw_metrics = payload.get("metrics")
+    metrics = raw_metrics if isinstance(raw_metrics, list) else []
+    for metric in metrics:
+        if not isinstance(metric, dict):
+            continue
+        raw_counts = metric.get("outcome_counts")
+        counts = raw_counts if isinstance(raw_counts, dict) else {}
+        precision = metric.get("precision")
+        precision_text = "unavailable" if precision is None else f"{float(precision) * 100:.2f}%"
+        lines.append(
+            "| {metric_id} | {status} | {passed} | {failed} | {denominator} | {precision} | "
+            "{unavailable} | {malformed} | {unsupported} | {not_applicable} |".format(
+                metric_id=metric.get("metric_id", "unknown"),
+                status=metric.get("status", "unavailable"),
+                passed=counts.get("pass", 0),
+                failed=counts.get("fail", 0),
+                denominator=metric.get("reviewed_applicable_observations", 0),
+                precision=precision_text,
+                unavailable=counts.get("unavailable", 0),
+                malformed=counts.get("malformed", 0),
+                unsupported=counts.get("unsupported", 0),
+                not_applicable=counts.get("not_applicable", 0),
+            )
+        )
+
+    lines.extend(["", "## Reviewed observation provenance", ""])
+    raw_observations = payload.get("reviewed_observation_index")
+    observations = raw_observations if isinstance(raw_observations, list) else []
+    if not observations:
+        lines.append("- none")
+    for observation in observations:
+        if not isinstance(observation, dict):
+            continue
+        lines.append(
+            "- `{observation_id}` — {repository_name} @ `{source_commit_sha}`; "
+            "reviewer `{reviewer_id}`; evidence `{evidence_sha256}`".format(
+                observation_id=observation.get("observation_id", ""),
+                repository_name=observation.get("repository_name", ""),
+                source_commit_sha=observation.get("source_commit_sha", ""),
+                reviewer_id=observation.get("reviewer_id", ""),
+                evidence_sha256=observation.get("evidence_sha256", ""),
+            )
+        )
+
+    lines.extend(["", "## Authority boundary", ""])
+    raw_boundary = payload.get("authority_boundary")
+    boundary = raw_boundary if isinstance(raw_boundary, dict) else {}
+    for field, value in sorted(boundary.items()):
+        lines.append(f"- {field}: {str(bool(value)).lower()}")
+    lines.append("")
+    return "\n".join(lines)

--- a/src/sdetkit/adoption_product_kpi_report.py
+++ b/src/sdetkit/adoption_product_kpi_report.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .adoption_product_kpi_freshness import check_freshness, render_freshness_text
+from .adoption_product_kpi_model import DEFAULT_CONTRACT, build_report
+from .adoption_product_kpi_render import render_markdown
+
+DEFAULT_REPORT = "build/sdetkit/adoption-product-kpi-report.json"
+
+
+def write_artifacts(
+    *,
+    observations_json: str | Path,
+    out: str | Path = DEFAULT_REPORT,
+    markdown_out: str | Path | None = None,
+    contract_json: str | Path = DEFAULT_CONTRACT,
+    root: str | Path = ".",
+    current_head_sha: str | None = None,
+) -> dict[str, Any]:
+    payload = build_report(
+        observations_json,
+        contract_json=contract_json,
+        root=root,
+        current_head_sha=current_head_sha,
+    )
+    out_path = Path(out)
+    markdown_path = Path(markdown_out) if markdown_out else out_path.with_suffix(".md")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(payload) + "\n", encoding="utf-8")
+    return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit adoption-product-kpi-report",
+        description="Build a deterministic report from reviewed real-repository KPI observations.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--observations-json", required=True)
+    parser.add_argument("--contract-json", default=DEFAULT_CONTRACT)
+    parser.add_argument("--out", default=DEFAULT_REPORT)
+    parser.add_argument("--markdown-out", default="")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    parser.add_argument("--check-freshness", action="store_true")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    if ns.check_freshness:
+        payload = check_freshness(
+            report_path=ns.out,
+            observations_json=ns.observations_json,
+            contract_json=ns.contract_json,
+            root=ns.root,
+        )
+        output = (
+            json.dumps(payload, indent=2, sort_keys=True)
+            if ns.format == "json"
+            else render_freshness_text(payload)
+        )
+        sys.stdout.write(output + "\n")
+        return 0 if payload["fresh"] else 1
+
+    payload = write_artifacts(
+        observations_json=ns.observations_json,
+        contract_json=ns.contract_json,
+        out=ns.out,
+        markdown_out=ns.markdown_out or None,
+        root=ns.root,
+    )
+    output = (
+        json.dumps(payload, indent=2, sort_keys=True)
+        if ns.format == "json"
+        else render_markdown(payload)
+    )
+    sys.stdout.write(output + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adoption_product_kpi_model.py
+++ b/tests/test_adoption_product_kpi_model.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.adoption_product_kpi_model import (
+    OBSERVATIONS_SCHEMA,
+    REPORT_SCHEMA,
+    build_report,
+    input_provenance,
+)
+
+SOURCE_CONTRACT = Path("docs/contracts/adoption-product-kpi-evidence.v1.json")
+
+
+def _contract(tmp_path: Path) -> Path:
+    path = tmp_path / "contract.json"
+    path.write_text(SOURCE_CONTRACT.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def _metric_ids(contract: Path) -> list[str]:
+    payload = json.loads(contract.read_text(encoding="utf-8"))
+    return [item["metric_id"] for item in payload["metric_definitions"]]
+
+
+def _observation(observation_id: str, outcomes: dict[str, str]) -> dict[str, object]:
+    return {
+        "observation_id": observation_id,
+        "repository_name": f"repo-{observation_id}",
+        "repository_url": f"https://example.invalid/{observation_id}",
+        "source_commit_sha": "a" * 40,
+        "evidence_path": f"evidence/{observation_id}.json",
+        "evidence_sha256": "b" * 64,
+        "reviewer_id": "reviewer-1",
+        "reviewed_at": "2026-07-18T12:00:00Z",
+        "metric_outcomes": outcomes,
+        "review_notes": "Reviewed against the retained source artifact.",
+    }
+
+
+def _source(path: Path, observations: list[dict[str, object]]) -> Path:
+    path.write_text(
+        json.dumps({"schema_version": OBSERVATIONS_SCHEMA, "observations": observations}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_product_kpi_report_retains_outcomes_and_never_invents_zero_precision(
+    tmp_path: Path,
+) -> None:
+    contract = _contract(tmp_path)
+    metric_ids = _metric_ids(contract)
+    first = {metric_id: "pass" for metric_id in metric_ids}
+    second = {metric_id: "fail" for metric_id in metric_ids}
+    first["operator_actionability"] = "unavailable"
+    second["operator_actionability"] = "unsupported"
+    observations = _source(
+        tmp_path / "observations.json",
+        [_observation("b", second), _observation("a", first)],
+    )
+
+    payload = build_report(
+        observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="c" * 40,
+    )
+
+    assert payload["schema_version"] == REPORT_SCHEMA
+    assert payload["report_status"] == "review_required"
+    assert payload["reviewed_observation_count"] == 2
+    assert [item["observation_id"] for item in payload["reviewed_observation_index"]] == [
+        "a",
+        "b",
+    ]
+
+    metrics = {metric["metric_id"]: metric for metric in payload["metrics"]}
+    discovery = metrics["discovery_precision"]
+    assert discovery["reviewed_pass_observations"] == 1
+    assert discovery["reviewed_applicable_observations"] == 2
+    assert discovery["precision"] == 0.5
+
+    actionability = metrics["operator_actionability"]
+    assert actionability["reviewed_applicable_observations"] == 0
+    assert actionability["precision"] is None
+    assert actionability["status"] == "unavailable"
+    assert actionability["outcome_counts"]["unavailable"] == 1
+    assert actionability["outcome_counts"]["unsupported"] == 1
+    assert "operator_actionability" in payload["metrics_without_applicable_denominator"]
+    assert all(value is False for value in payload["authority_boundary"].values())
+
+
+def test_product_kpi_report_accepts_complete_reviewed_evidence(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    outcomes = {metric_id: "pass" for metric_id in _metric_ids(contract)}
+    observations = _source(tmp_path / "observations.json", [_observation("one", outcomes)])
+
+    payload = build_report(
+        observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="d" * 40,
+    )
+
+    assert payload["report_status"] == "reviewed_evidence_available"
+    assert payload["metrics_without_applicable_denominator"] == []
+    assert all(metric["precision"] == 1.0 for metric in payload["metrics"])
+    assert payload["source_relationships"] == {
+        "contract_schema_accepted": True,
+        "observations_schema_accepted": True,
+        "current_head_bound": True,
+    }
+
+
+def test_product_kpi_report_rejects_missing_or_unknown_metric_outcomes(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    metric_ids = _metric_ids(contract)
+    outcomes = {metric_id: "pass" for metric_id in metric_ids[:-1]}
+    observations = _source(tmp_path / "observations.json", [_observation("one", outcomes)])
+
+    with pytest.raises(ValueError, match="every contracted metric"):
+        build_report(
+            observations,
+            contract_json=contract,
+            root=tmp_path,
+            current_head_sha="e" * 40,
+        )
+
+
+def test_product_kpi_report_rejects_invalid_review_provenance(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    outcomes = {metric_id: "pass" for metric_id in _metric_ids(contract)}
+    observation = _observation("one", outcomes)
+    observation["evidence_sha256"] = "not-a-digest"
+    observations = _source(tmp_path / "observations.json", [observation])
+
+    with pytest.raises(ValueError, match="evidence_sha256"):
+        build_report(
+            observations,
+            contract_json=contract,
+            root=tmp_path,
+            current_head_sha="f" * 40,
+        )
+
+
+def test_product_kpi_input_digest_binds_sources_generator_and_head(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    outcomes = {metric_id: "pass" for metric_id in _metric_ids(contract)}
+    observations = _source(tmp_path / "observations.json", [_observation("one", outcomes)])
+    generator = tmp_path / "generator.py"
+    generator.write_text("generator-v1\n", encoding="utf-8")
+
+    first = input_provenance(
+        observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="1" * 40,
+        generator_path=generator,
+    )
+    second = input_provenance(
+        observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="1" * 40,
+        generator_path=generator,
+    )
+    assert first == second
+
+    generator.write_text("generator-v2\n", encoding="utf-8")
+    changed = input_provenance(
+        observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="1" * 40,
+        generator_path=generator,
+    )
+    assert changed["input_digest"] != first["input_digest"]

--- a/tests/test_adoption_product_kpi_report.py
+++ b/tests/test_adoption_product_kpi_report.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.adoption_product_kpi_freshness import check_freshness, validate_freshness
+from sdetkit.adoption_product_kpi_model import OBSERVATIONS_SCHEMA
+from sdetkit.adoption_product_kpi_report import main, write_artifacts
+
+SOURCE_CONTRACT = Path("docs/contracts/adoption-product-kpi-evidence.v1.json")
+
+
+def _contract(tmp_path: Path) -> Path:
+    path = tmp_path / "contract.json"
+    path.write_text(SOURCE_CONTRACT.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def _observations(tmp_path: Path, contract: Path) -> Path:
+    contract_payload = json.loads(contract.read_text(encoding="utf-8"))
+    outcomes = {item["metric_id"]: "pass" for item in contract_payload["metric_definitions"]}
+    payload = {
+        "schema_version": OBSERVATIONS_SCHEMA,
+        "observations": [
+            {
+                "observation_id": "review-1",
+                "repository_name": "example-repo",
+                "repository_url": "https://example.invalid/repo",
+                "source_commit_sha": "a" * 40,
+                "evidence_path": "evidence/review-1.json",
+                "evidence_sha256": "b" * 64,
+                "reviewer_id": "reviewer-1",
+                "reviewed_at": "2026-07-18T12:00:00Z",
+                "metric_outcomes": outcomes,
+                "review_notes": "Reviewed against retained source evidence.",
+            }
+        ],
+    }
+    path = tmp_path / "observations.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_product_kpi_report_writes_deterministic_json_and_markdown(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    observations = _observations(tmp_path, contract)
+    out = tmp_path / "report.json"
+
+    first = write_artifacts(
+        observations_json=observations,
+        contract_json=contract,
+        out=out,
+        root=tmp_path,
+        current_head_sha="c" * 40,
+    )
+    first_json = out.read_text(encoding="utf-8")
+    first_markdown = out.with_suffix(".md").read_text(encoding="utf-8")
+    second = write_artifacts(
+        observations_json=observations,
+        contract_json=contract,
+        out=out,
+        root=tmp_path,
+        current_head_sha="c" * 40,
+    )
+
+    assert first == second
+    assert out.read_text(encoding="utf-8") == first_json
+    assert out.with_suffix(".md").read_text(encoding="utf-8") == first_markdown
+    assert "# SDETKit reviewed product KPI report" in first_markdown
+    assert "discovery_precision" in first_markdown
+    assert "input_digest:" in first_markdown
+
+
+def test_product_kpi_freshness_detects_source_head_and_authority_drift(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    observations = _observations(tmp_path, contract)
+    out = tmp_path / "report.json"
+    payload = write_artifacts(
+        observations_json=observations,
+        contract_json=contract,
+        out=out,
+        root=tmp_path,
+        current_head_sha="d" * 40,
+    )
+
+    fresh = validate_freshness(
+        payload,
+        observations_json=observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="d" * 40,
+    )
+    assert fresh["fresh"] is True
+    assert fresh["authority_valid"] is True
+
+    head_stale = validate_freshness(
+        payload,
+        observations_json=observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="e" * 40,
+    )
+    assert head_stale["fresh"] is False
+    assert "input_provenance_mismatch" in head_stale["reasons"]
+
+    tampered = json.loads(json.dumps(payload))
+    tampered["automation_allowed"] = True
+    authority_stale = validate_freshness(
+        tampered,
+        observations_json=observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="d" * 40,
+    )
+    assert authority_stale["fresh"] is False
+    assert authority_stale["authority_valid"] is False
+    assert "automation_allowed_mismatch" in authority_stale["reasons"]
+
+    source_payload = json.loads(observations.read_text(encoding="utf-8"))
+    source_payload["observations"][0]["review_notes"] = "Changed review evidence."
+    observations.write_text(json.dumps(source_payload), encoding="utf-8")
+    source_stale = validate_freshness(
+        payload,
+        observations_json=observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="d" * 40,
+    )
+    assert source_stale["fresh"] is False
+    assert "input_provenance_mismatch" in source_stale["reasons"]
+
+
+def test_product_kpi_freshness_handles_missing_report(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    observations = _observations(tmp_path, contract)
+
+    payload = check_freshness(
+        report_path=tmp_path / "missing.json",
+        observations_json=observations,
+        contract_json=contract,
+        root=tmp_path,
+        current_head_sha="f" * 40,
+    )
+
+    assert payload["fresh"] is False
+    assert payload["reasons"] == ["report_missing"]
+
+
+def test_product_kpi_report_module_cli_generates_artifacts(tmp_path: Path, capsys) -> None:
+    contract = _contract(tmp_path)
+    observations = _observations(tmp_path, contract)
+    out = tmp_path / "report.json"
+
+    rc = main(
+        [
+            "--observations-json",
+            str(observations),
+            "--contract-json",
+            str(contract),
+            "--out",
+            str(out),
+            "--root",
+            ".",
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    assert out.is_file()
+    assert out.with_suffix(".md").is_file()
+    assert "# SDETKit reviewed product KPI report" in capsys.readouterr().out

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,10 +24,14 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 516
+    assert payload["observed"]["source_module_count"] == 520
     assert payload["observed"]["typing_debt_module_count"] == 487
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 29
+    assert len(checked) == 33
+    assert "sdetkit.adoption_product_kpi_freshness" in checked
+    assert "sdetkit.adoption_product_kpi_model" in checked
+    assert "sdetkit.adoption_product_kpi_render" in checked
+    assert "sdetkit.adoption_product_kpi_report" in checked
     assert "sdetkit.adoption_surface.cpp" in checked
     assert "sdetkit.adoption_surface.cpp_quality_security" in checked
     assert "sdetkit.adoption_surface.java_security" in checked
@@ -41,6 +45,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     inventory = payload["typing_debt_inventory"]
     assert inventory["module_count"] == 487
     assert len(inventory["modules"]) == 487
+    assert "sdetkit.adoption_product_kpi_freshness" not in inventory["modules"]
+    assert "sdetkit.adoption_product_kpi_model" not in inventory["modules"]
+    assert "sdetkit.adoption_product_kpi_render" not in inventory["modules"]
+    assert "sdetkit.adoption_product_kpi_report" not in inventory["modules"]
     assert "sdetkit.adoption_surface.cpp" not in inventory["modules"]
     assert "sdetkit.adoption_surface.cpp_quality_security" not in inventory["modules"]
     assert "sdetkit.adoption_surface.java_security" not in inventory["modules"]
@@ -68,7 +76,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 516,
+            "actual": 520,
         }
     ]
 


### PR DESCRIPTION
## Summary

Adds the deterministic evaluator for the reviewed KPI contract from #2115.

- validates reviewed observation records and provenance;
- aggregates every contracted outcome with explicit denominators;
- uses `null` when a metric has no applicable reviewed denominator;
- writes deterministic JSON and Markdown reports;
- binds freshness to source files, evaluator source, schemas, and Git head;
- preserves the existing report-only authority boundary;
- adds focused tests and operator documentation.

## Verification

```bash
python -m pytest -q tests/test_adoption_product_kpi_contract.py tests/test_adoption_product_kpi_model.py tests/test_adoption_product_kpi_report.py -o addopts=
python -m pre_commit run -a
NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
```

CI is authoritative for this connector-authored branch.

## Follow-up

The next slice is the first reviewed real-repository observation set with explicit source provenance and denominators.