### PR TITLE
fix(ci): retain maintenance failure diagnostics

### DIFF
--- a/.github/workflows/maintenance-autopilot.yml
+++ b/.github/workflows/maintenance-autopilot.yml
@@ -56,10 +56,12 @@ jobs:
           fi
 
       - name: Upload autopilot artifacts
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           retention-days: 14
           name: maintenance-autopilot
+          if-no-files-found: warn
           path: |
             build/maintenance/autopilot/autopilot-report.json
             build/maintenance/autopilot/autopilot-report.md
@@ -84,11 +86,20 @@ jobs:
             .sdetkit/maintenance/adaptive-safe-fix-memory.jsonl
 
       - name: Publish run summary
+        if: always()
         run: |
           {
             echo "## Maintenance autopilot"
             echo
-            cat build/maintenance/autopilot/autopilot-report.md
+            if [ -f build/maintenance/autopilot/autopilot-report.md ]; then
+              cat build/maintenance/autopilot/autopilot-report.md
+            elif [ -f build/maintenance/autopilot/adaptive-diagnosis.md ]; then
+              cat build/maintenance/autopilot/adaptive-diagnosis.md
+            else
+              echo "Maintenance command failed before a diagnosis report was written."
+              echo
+              echo "Inspect the failed command log and rerun the documented local equivalent."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open/update security follow-up issue when actionable findings exist

--- a/tests/test_maintenance_autopilot_failure_artifact_contract.py
+++ b/tests/test_maintenance_autopilot_failure_artifact_contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 WORKFLOW = Path(".github/workflows/maintenance-autopilot.yml")
 
 
@@ -19,15 +18,6 @@ def test_maintenance_autopilot_preserves_diagnostics_after_command_failure() -> 
     assert "if: always()" in upload_block
     assert "if-no-files-found: warn" in upload_block
     assert "if: always()" in summary_block
-    assert (
-        "if [ -f build/maintenance/autopilot/autopilot-report.md ]; then"
-        in summary_block
-    )
-    assert (
-        "elif [ -f build/maintenance/autopilot/adaptive-diagnosis.md ]; then"
-        in summary_block
-    )
-    assert (
-        "Maintenance command failed before a diagnosis report was written."
-        in summary_block
-    )
+    assert "if [ -f build/maintenance/autopilot/autopilot-report.md ]; then" in summary_block
+    assert "elif [ -f build/maintenance/autopilot/adaptive-diagnosis.md ]; then" in summary_block
+    assert "Maintenance command failed before a diagnosis report was written." in summary_block

--- a/tests/test_maintenance_autopilot_failure_artifact_contract.py
+++ b/tests/test_maintenance_autopilot_failure_artifact_contract.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/maintenance-autopilot.yml")
+
+
+def test_maintenance_autopilot_preserves_diagnostics_after_command_failure() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    upload_block = text.split("      - name: Upload autopilot artifacts", 1)[1].split(
+        "      - name: Publish run summary", 1
+    )[0]
+    summary_block = text.split("      - name: Publish run summary", 1)[1].split(
+        "      - name: Open/update security follow-up issue", 1
+    )[0]
+
+    assert "if: always()" in upload_block
+    assert "if-no-files-found: warn" in upload_block
+    assert "if: always()" in summary_block
+    assert "if [ -f build/maintenance/autopilot/autopilot-report.md ]; then" in summary_block
+    assert "elif [ -f build/maintenance/autopilot/adaptive-diagnosis.md ]; then" in summary_block
+    assert "Maintenance command failed before a diagnosis report was written." in summary_block

--- a/tests/test_maintenance_autopilot_failure_artifact_contract.py
+++ b/tests/test_maintenance_autopilot_failure_artifact_contract.py
@@ -19,6 +19,15 @@ def test_maintenance_autopilot_preserves_diagnostics_after_command_failure() -> 
     assert "if: always()" in upload_block
     assert "if-no-files-found: warn" in upload_block
     assert "if: always()" in summary_block
-    assert "if [ -f build/maintenance/autopilot/autopilot-report.md ]; then" in summary_block
-    assert "elif [ -f build/maintenance/autopilot/adaptive-diagnosis.md ]; then" in summary_block
-    assert "Maintenance command failed before a diagnosis report was written." in summary_block
+    assert (
+        "if [ -f build/maintenance/autopilot/autopilot-report.md ]; then"
+        in summary_block
+    )
+    assert (
+        "elif [ -f build/maintenance/autopilot/adaptive-diagnosis.md ]; then"
+        in summary_block
+    )
+    assert (
+        "Maintenance command failed before a diagnosis report was written."
+        in summary_block
+    )


### PR DESCRIPTION
## Summary

- run the maintenance artifact upload step with `if: always()` so failed commands do not suppress the diagnosis bundle;
- tolerate partial early-failure bundles with `if-no-files-found: warn` without changing the original failing conclusion;
- publish the normal autopilot report when present;
- fall back to the adaptive diagnosis report when the command failed before the final report was written;
- emit an explicit no-diagnosis message when neither report exists;
- add a focused workflow contract that prevents regression.

## Why

PR #2124 exposed a real observability gap. `maintenance-autopilot` failed inside `Run maintenance autopilot`, then skipped both `Upload autopilot artifacts` and `Publish run summary`. The workflow therefore hid the diagnosis artifacts that `tools/maintenance_autopilot.py` writes before raising on a failed bounded command.

This PR preserves that evidence without weakening, retrying, or converting the failed maintenance result into success.

## Safety boundary

```text
workflow_failure_still_fails=true
maintenance_decision_unchanged=true
automation_authority_unchanged=true
patch_application_allowed=false
security_dismissal_allowed=false
merge_authorized=false
```

Permissions, action pins, security follow-up conditions, remediation categories, and maintenance command arguments are unchanged.

## Verification

Expected exact-head proof:

```bash
python -m pytest -q \
  tests/test_maintenance_autopilot_workflow_artifacts.py \
  tests/test_maintenance_autopilot_failure_artifact_contract.py \
  -o addopts=
python -m pytest -q tests/test_workflow_alias_regression_guards.py -o addopts=
python -m pre_commit run -a
```

The connector runtime has no trusted local checkout, so CI must prove this exact head.

## Risk

Low. The diff is limited to one workflow and one repository-contract test. Failure conclusions remain authoritative; only diagnostic retention changes.

Rollback is a squash revert.