### PR TITLE
fix(ci): retry transient GitHub control-plane writes

### DIFF
--- a/.github/workflows/legacy-required-status-bridge.yml
+++ b/.github/workflows/legacy-required-status-bridge.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Publish pending legacy CI status for PR head
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          retries: 4
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -57,6 +58,7 @@ jobs:
       - name: Publish CI legacy required status context from CI workflow result
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          retries: 4
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/scripts/post_impact_pr_comment.py
+++ b/scripts/post_impact_pr_comment.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 MARKER = "<!-- impact-release-control -->"
 DEFAULT_HTTP_TIMEOUT_SECONDS = 30
+DEFAULT_HTTP_RETRY_ATTEMPTS = 4
+DEFAULT_HTTP_RETRY_DELAY_SECONDS = 1.0
+TRANSIENT_HTTP_STATUS_CODES = frozenset({500, 502, 503, 504})
+
+
+def _retry_delay_seconds(attempt: int) -> float:
+    return DEFAULT_HTTP_RETRY_DELAY_SECONDS * (2 ** (attempt - 1))
 
 
 def _api_request(
@@ -29,8 +37,22 @@ def _api_request(
             "User-Agent": "impact-release-control-bot",
         },
     )
-    with urllib.request.urlopen(req, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
-        return json.loads(resp.read().decode("utf-8"))
+
+    for attempt in range(1, DEFAULT_HTTP_RETRY_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            exhausted = attempt == DEFAULT_HTTP_RETRY_ATTEMPTS
+            if exc.code not in TRANSIENT_HTTP_STATUS_CODES or exhausted:
+                raise
+            time.sleep(_retry_delay_seconds(attempt))
+        except urllib.error.URLError:
+            if attempt == DEFAULT_HTTP_RETRY_ATTEMPTS:
+                raise
+            time.sleep(_retry_delay_seconds(attempt))
+
+    raise AssertionError("unreachable GitHub API retry state")
 
 
 def _compose_comment_body(comment_markdown: str) -> str:

--- a/tests/test_branch_protection_retry_contract.py
+++ b/tests/test_branch_protection_retry_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "enforce_branch_protection.py"
+SPEC = importlib.util.spec_from_file_location("enforce_branch_protection_retry", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class _Response:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+def test_request_retries_transient_github_api_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def _urlopen(*_: Any, **__: Any) -> _Response:
+        calls.append(1)
+        if len(calls) < 3:
+            raise urllib.error.HTTPError(
+                "https://api.github.test",
+                503,
+                "unavailable",
+                {},
+                io.BytesIO(b"temporarily unavailable"),
+            )
+        return _Response(b"{}")
+
+    monkeypatch.setattr(MODULE.urllib.request, "urlopen", _urlopen)
+    monkeypatch.setattr(MODULE.time, "sleep", sleeps.append)
+
+    result = MODULE._request(
+        token="token",
+        method="PUT",
+        url="https://api.github.test",
+        payload={"strict": True},
+    )
+
+    assert result == {}
+    assert len(calls) == 3
+    assert sleeps == [1.0, 2.0]
+
+
+def test_request_does_not_retry_non_transient_http_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def _urlopen(*_: Any, **__: Any) -> _Response:
+        calls.append(1)
+        raise urllib.error.HTTPError(
+            "https://api.github.test",
+            403,
+            "forbidden",
+            {},
+            io.BytesIO(b"forbidden"),
+        )
+
+    monkeypatch.setattr(MODULE.urllib.request, "urlopen", _urlopen)
+    monkeypatch.setattr(MODULE.time, "sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError, match="GitHub API error 403"):
+        MODULE._request(token="token", method="PUT", url="https://api.github.test")
+
+    assert len(calls) == 1
+    assert sleeps == []

--- a/tests/test_legacy_required_status_bridge_retry_contract.py
+++ b/tests/test_legacy_required_status_bridge_retry_contract.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(".github/workflows/legacy-required-status-bridge.yml")
+PUBLISHER_JOBS = (
+    "publish-legacy-statuses-on-pr-open",
+    "publish-legacy-statuses-from-ci-workflow",
+)
+
+
+def _workflow() -> dict:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_legacy_status_publishers_retry_transient_github_api_failures() -> None:
+    payload = _workflow()
+    jobs = payload["jobs"]
+
+    assert payload["permissions"]["statuses"] == "write"
+    for job_name in PUBLISHER_JOBS:
+        step = jobs[job_name]["steps"][0]
+        assert step["with"]["retries"] == 4
+        assert "github.rest.repos.createCommitStatus" in step["with"]["script"]
+
+
+def test_legacy_status_contexts_and_authority_remain_unchanged() -> None:
+    payload = _workflow()
+    pull_request_script = payload["jobs"][PUBLISHER_JOBS[0]]["steps"][0]["with"]["script"]
+    workflow_run_script = payload["jobs"][PUBLISHER_JOBS[1]]["steps"][0]["with"]["script"]
+
+    assert "context: 'ci'" in pull_request_script
+    assert "context: 'maintenance-autopilot'" in pull_request_script
+    assert "state: 'pending'" in pull_request_script
+    assert "state: 'success'" in pull_request_script
+    assert "context: 'ci'" in workflow_run_script
+    assert "conclusion === 'success' ? 'success' : 'failure'" in workflow_run_script

--- a/tests/test_post_impact_pr_comment.py
+++ b/tests/test_post_impact_pr_comment.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+from typing import Any
 from urllib.error import HTTPError
 
 import pytest
@@ -7,10 +9,25 @@ import pytest
 from scripts import post_impact_pr_comment
 from scripts.post_impact_pr_comment import (
     MARKER,
+    _api_request,
     _compose_comment_body,
     _find_existing_comment_id,
     upsert_comment,
 )
+
+
+class _Response:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.payload
 
 
 def test_compose_comment_body_includes_marker() -> None:
@@ -25,6 +42,59 @@ def test_find_existing_comment_id_returns_marked_comment() -> None:
         {"id": 99, "body": f"prefix\n{MARKER}\ncontent"},
     ]
     assert _find_existing_comment_id(comments) == 99
+
+
+def test_api_request_retries_transient_github_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def fake_urlopen(*_: Any, **__: Any) -> _Response:
+        calls.append(1)
+        if len(calls) < 3:
+            raise HTTPError(
+                url="https://api.github.com",
+                code=503,
+                msg="Unavailable",
+                hdrs=None,
+                fp=io.BytesIO(b"temporarily unavailable"),
+            )
+        return _Response(b"[]")
+
+    monkeypatch.setattr(post_impact_pr_comment.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(post_impact_pr_comment.time, "sleep", sleeps.append)
+
+    assert _api_request("https://api.github.com", "token") == []
+    assert len(calls) == 3
+    assert sleeps == [1.0, 2.0]
+
+
+def test_api_request_does_not_retry_non_transient_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def fake_urlopen(*_: Any, **__: Any) -> _Response:
+        calls.append(1)
+        raise HTTPError(
+            url="https://api.github.com",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,
+            fp=io.BytesIO(b"forbidden"),
+        )
+
+    monkeypatch.setattr(post_impact_pr_comment.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(post_impact_pr_comment.time, "sleep", sleeps.append)
+
+    with pytest.raises(HTTPError) as exc_info:
+        _api_request("https://api.github.com", "token")
+
+    assert exc_info.value.code == 403
+    assert len(calls) == 1
+    assert sleeps == []
 
 
 def test_upsert_comment_dry_run_short_circuits_network() -> None:

--- a/tools/enforce_branch_protection.py
+++ b/tools/enforce_branch_protection.py
@@ -2,15 +2,23 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 import urllib.error
 import urllib.request
 from typing import Any
 
 DEFAULT_HTTP_TIMEOUT_SECONDS = 30
+DEFAULT_HTTP_RETRY_ATTEMPTS = 4
+DEFAULT_HTTP_RETRY_DELAY_SECONDS = 1.0
+TRANSIENT_HTTP_STATUS_CODES = frozenset({500, 502, 503, 504})
 DEFAULT_REQUIRED_CHECKS = (
     "ci",
     "maintenance-autopilot",
 )
+
+
+def _retry_delay_seconds(attempt: int) -> float:
+    return DEFAULT_HTTP_RETRY_DELAY_SECONDS * (2 ** (attempt - 1))
 
 
 def _request(
@@ -29,15 +37,31 @@ def _request(
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
     if payload is not None:
         req.add_header("Content-Type", "application/json")
-    try:
-        with urllib.request.urlopen(req, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS) as resp:
-            text = resp.read().decode("utf-8")
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"GitHub API error {exc.code} {method} {url}: {body}") from exc
-    if not text:
-        return None
-    return json.loads(text)
+
+    for attempt in range(1, DEFAULT_HTTP_RETRY_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS) as resp:
+                text = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            exhausted = attempt == DEFAULT_HTTP_RETRY_ATTEMPTS
+            if exc.code not in TRANSIENT_HTTP_STATUS_CODES or exhausted:
+                raise RuntimeError(
+                    f"GitHub API error {exc.code} {method} {url}: {body}"
+                ) from exc
+            time.sleep(_retry_delay_seconds(attempt))
+            continue
+        except urllib.error.URLError as exc:
+            if attempt == DEFAULT_HTTP_RETRY_ATTEMPTS:
+                raise RuntimeError(f"GitHub API transport error {method} {url}: {exc}") from exc
+            time.sleep(_retry_delay_seconds(attempt))
+            continue
+
+        if not text:
+            return None
+        return json.loads(text)
+
+    raise AssertionError("unreachable GitHub API retry state")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/enforce_branch_protection.py
+++ b/tools/enforce_branch_protection.py
@@ -46,9 +46,7 @@ def _request(
             body = exc.read().decode("utf-8", errors="replace")
             exhausted = attempt == DEFAULT_HTTP_RETRY_ATTEMPTS
             if exc.code not in TRANSIENT_HTTP_STATUS_CODES or exhausted:
-                raise RuntimeError(
-                    f"GitHub API error {exc.code} {method} {url}: {body}"
-                ) from exc
+                raise RuntimeError(f"GitHub API error {exc.code} {method} {url}: {body}") from exc
             time.sleep(_retry_delay_seconds(attempt))
             continue
         except urllib.error.URLError as exc:


### PR DESCRIPTION
## Summary

- add four bounded retries to both legacy required-status publishers;
- add four-attempt exponential-backoff handling to the branch-protection and impact-comment GitHub clients;
- retry only GitHub 500/502/503/504 responses and transport failures;
- fail immediately for non-transient authorization, validation, and policy errors;
- preserve required contexts, status meanings, branch-protection payload, permissions, release decisions, and review policy;
- add focused tests for every retry boundary.

## Incident evidence

Refreshing #2124 onto current `main` exposed repeated GitHub control-plane failures while repository proof remained green:

```text
POST /statuses/9df838ee... -> 503
No server is currently available to service your request.
```

The required-status publisher failed repeatedly. The same verification window also produced failures in branch-protection enforcement and impact PR-comment publication after all local computation and policy gates had passed.

These writers previously treated a transient GitHub service response as permanent, which can block an otherwise green PR or hide its control-plane result.

## Behavior

### Required-status publishers

Both `actions/github-script` paths now use `retries: 4`. The action retries 5xx responses while keeping its non-retryable 4xx classes exempt.

### Python GitHub clients

`tools/enforce_branch_protection.py` and `scripts/post_impact_pr_comment.py` now retry HTTP 500, 502, 503, and 504 plus transport-level `URLError` failures. They use four total attempts with bounded exponential delays of 1, 2, and 4 seconds. Non-transient HTTP responses still fail immediately; the impact client retains its existing reporting-only `403 -> forbidden` behavior.

## Safety boundary

```text
required_context_names_unchanged=true
status_meanings_unchanged=true
branch_protection_payload_unchanged=true
release_decision_unchanged=true
review_policy_unchanged=true
workflow_permissions_unchanged=true
retry_attempts_bounded=4
patch_application_allowed=false
merge_authorized=false
publication_authorized=false
security_dismissal_allowed=false
```

This PR does not weaken CI, convert failed conclusions into success, change required checks, broaden permissions, alter product behavior, modify dependencies, or authorize merge.

## Verification

```bash
python -m pytest -q \
  tests/test_legacy_required_status_bridge_retry_contract.py \
  tests/test_branch_protection_retry_contract.py \
  tests/test_enforce_branch_protection.py \
  tests/test_branch_protection_workflow_alignment.py \
  tests/test_post_impact_pr_comment.py \
  -o addopts=
python -m pre_commit run -a
```

Connector-side proof with pinned Ruff `0.15.22`:

- Ruff lint: pass;
- Ruff format: pass;
- branch-protection retry tests: `2 passed`;
- impact comment tests: `6 passed`.

GitHub Actions is authoritative for exact head `62267a4f647ef37bee5d49460635b7d343528192`.

## Live exact-head proof

Already green on the exact head:

- `legacy-required-status-bridge`;
- `enforce-branch-protection`;
- `impact-release-control`;
- workflow contracts;
- repository audit;
- package build and wheel installation;
- Python 3.11 and 3.12 canonical fast gates.

Full CI and PR Quality must also finish green before this draft is promoted.

## Risk

Low. Six-file control-plane resilience patch. All retries are bounded, scoped to transient failures, and preserve original verdict and policy semantics. Rollback is a squash revert.

## Merge order

1. Merge #2126 after exact-head checks are green.
2. Refresh #2124 onto the new `main`.
3. Require exact-head full CI, PR Quality, adoption replay, and both legacy contexts.
4. Merge #2124 only after that proof.
