### PR TITLE
fix(ci): harden PR Quality lifecycle reconciliation

### DIFF
--- a/.github/workflows/pr-quality-lifecycle-reconciliation.yml
+++ b/.github/workflows/pr-quality-lifecycle-reconciliation.yml
@@ -32,6 +32,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          PUSH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           mkdir -p build/pr-quality-lifecycle
@@ -42,14 +43,34 @@ jobs:
           import json
           import os
           import subprocess
+          import sys
+          import time
           from pathlib import Path
           from typing import Any
 
           repository = os.environ["REPOSITORY"]
           event_name = os.environ["EVENT_NAME"]
           input_pr_number = os.environ.get("INPUT_PR_NUMBER", "").strip()
+          push_sha = os.environ.get("PUSH_SHA", "").strip()
 
-          def gh_json(*args: str, method: str = "GET", payload: dict[str, Any] | None = None) -> Any:
+          RETRYABLE_GITHUB_MARKERS = (
+              "http 500",
+              "http 502",
+              "http 503",
+              "http 504",
+              "secondary rate limit",
+              "temporarily unavailable",
+              "connection reset",
+              "tls handshake timeout",
+          )
+
+
+          def gh_json(
+              *args: str,
+              method: str = "GET",
+              payload: dict[str, Any] | None = None,
+              max_attempts: int = 4,
+          ) -> Any:
               command = [
                   "gh",
                   "api",
@@ -61,14 +82,39 @@ jobs:
               if payload is not None:
                   command.extend(["--input", "-"])
               command.extend(args)
-              completed = subprocess.run(
-                  command,
-                  check=True,
-                  input=(json.dumps(payload) if payload is not None else None),
-                  text=True,
-                  capture_output=True,
-              )
-              return json.loads(completed.stdout) if completed.stdout.strip() else {}
+
+              for attempt in range(1, max_attempts + 1):
+                  completed = subprocess.run(
+                      command,
+                      check=False,
+                      input=(json.dumps(payload) if payload is not None else None),
+                      text=True,
+                      capture_output=True,
+                  )
+                  if completed.returncode == 0:
+                      return json.loads(completed.stdout) if completed.stdout.strip() else {}
+
+                  stderr = completed.stderr.strip()
+                  retryable = any(
+                      marker in stderr.lower() for marker in RETRYABLE_GITHUB_MARKERS
+                  )
+                  if not retryable or attempt == max_attempts:
+                      raise RuntimeError(
+                          f"GitHub API request failed after {attempt} attempt(s): {stderr}"
+                      )
+
+                  delay_seconds = 2 ** (attempt - 1)
+                  print(
+                      (
+                          "Retrying transient GitHub API failure "
+                          f"in {delay_seconds}s (attempt {attempt + 1}/{max_attempts})"
+                      ),
+                      file=sys.stderr,
+                  )
+                  time.sleep(delay_seconds)
+
+              raise AssertionError("unreachable GitHub API retry state")
+
 
           def positive_pr_number(raw: str) -> int:
               value = int(raw)
@@ -76,20 +122,35 @@ jobs:
                   raise ValueError("pull request number must be positive")
               return value
 
+
           if input_pr_number:
               candidates = [positive_pr_number(input_pr_number)]
               source = "manual_recovery"
+          elif event_name == "push":
+              if not push_sha:
+                  raise ValueError("trusted main push is missing github.sha")
+              rows = gh_json(f"repos/{repository}/commits/{push_sha}/pulls")
+              candidates = [
+                  int(row["number"])
+                  for row in rows
+                  if isinstance(row, dict)
+                  and row.get("merged_at")
+                  and isinstance(row.get("base"), dict)
+                  and row["base"].get("ref") == "main"
+              ]
+              source = "trusted_main_push"
           else:
               rows = gh_json(
-                  f"repos/{repository}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
+                  f"repos/{repository}/pulls?state=closed&sort=updated&direction=desc&per_page=20"
               )
               candidates = [
                   int(row["number"])
                   for row in rows
                   if isinstance(row, dict) and row.get("merged_at")
               ]
-              source = "trusted_main_push" if event_name == "push" else "trusted_recovery_scan"
+              source = "trusted_recovery_scan"
 
+          candidates = list(dict.fromkeys(candidates))
           result: dict[str, Any] = {
               "schema_version": "sdetkit.pr_quality_lifecycle_reconciliation.v1",
               "source": source,

--- a/.github/workflows/pr-quality-lifecycle-reconciliation.yml
+++ b/.github/workflows/pr-quality-lifecycle-reconciliation.yml
@@ -77,14 +77,11 @@ jobs:
                       completed.check_returncode()
                   time.sleep(2**attempt)
               raise AssertionError("unreachable GitHub API retry state")
-
-
           def positive_pr_number(raw: str) -> int:
               value = int(raw)
               if value <= 0:
                   raise ValueError("pull request number must be positive")
               return value
-
 
           if input_pr_number:
               candidates = [positive_pr_number(input_pr_number)]
@@ -92,7 +89,19 @@ jobs:
           elif event_name == "push":
               if not push_sha:
                   raise ValueError("trusted main push is missing github.sha")
-              rows = gh_json(f"repos/{repository}/commits/{push_sha}/pulls")
+              event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+              commits = event.get("commits", []) if isinstance(event, dict) else []
+              commit_shas = [
+                  str(item.get("id") or "").strip()
+                  for item in commits
+                  if isinstance(item, dict)
+              ]
+              rows = [
+                  row
+                  for commit_sha in dict.fromkeys([*commit_shas, push_sha])
+                  if commit_sha
+                  for row in gh_json(f"repos/{repository}/commits/{commit_sha}/pulls")
+              ]
               candidates = [
                   int(row["number"])
                   for row in rows
@@ -140,9 +149,7 @@ jobs:
                   result["not_merged"].append(pr_number)
                   continue
 
-              comments = gh_json(
-                  f"repos/{repository}/issues/{pr_number}/comments?per_page=100"
-              )
+              comments = gh_json(f"repos/{repository}/issues/{pr_number}/comments?per_page=100")
               quality_comment = next(
                   (
                       row
@@ -210,10 +217,7 @@ jobs:
               )
 
           output = Path("build/pr-quality-lifecycle/reconciliation.json")
-          output.write_text(
-              json.dumps(result, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
+          output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
           summary = [
               "## PR Quality lifecycle reconciliation",

--- a/.github/workflows/pr-quality-lifecycle-reconciliation.yml
+++ b/.github/workflows/pr-quality-lifecycle-reconciliation.yml
@@ -43,7 +43,6 @@ jobs:
           import json
           import os
           import subprocess
-          import sys
           import time
           from pathlib import Path
           from typing import Any
@@ -53,37 +52,14 @@ jobs:
           input_pr_number = os.environ.get("INPUT_PR_NUMBER", "").strip()
           push_sha = os.environ.get("PUSH_SHA", "").strip()
 
-          RETRYABLE_GITHUB_MARKERS = (
-              "http 500",
-              "http 502",
-              "http 503",
-              "http 504",
-              "secondary rate limit",
-              "temporarily unavailable",
-              "connection reset",
-              "tls handshake timeout",
-          )
-
-
-          def gh_json(
-              *args: str,
-              method: str = "GET",
-              payload: dict[str, Any] | None = None,
-              max_attempts: int = 4,
-          ) -> Any:
-              command = [
-                  "gh",
-                  "api",
-                  "-H",
-                  "Accept: application/vnd.github+json",
-              ]
+          def gh_json(*args: str, method: str = "GET", payload: dict[str, Any] | None = None) -> Any:
+              command = ["gh", "api", "-H", "Accept: application/vnd.github+json"]
               if method != "GET":
                   command.extend(["--method", method])
               if payload is not None:
                   command.extend(["--input", "-"])
               command.extend(args)
-
-              for attempt in range(1, max_attempts + 1):
+              for attempt in range(4):
                   completed = subprocess.run(
                       command,
                       check=False,
@@ -93,26 +69,13 @@ jobs:
                   )
                   if completed.returncode == 0:
                       return json.loads(completed.stdout) if completed.stdout.strip() else {}
-
-                  stderr = completed.stderr.strip()
                   retryable = any(
-                      marker in stderr.lower() for marker in RETRYABLE_GITHUB_MARKERS
+                      marker in completed.stderr.lower()
+                      for marker in ("http 500", "http 502", "http 503", "http 504", "secondary rate limit")
                   )
-                  if not retryable or attempt == max_attempts:
-                      raise RuntimeError(
-                          f"GitHub API request failed after {attempt} attempt(s): {stderr}"
-                      )
-
-                  delay_seconds = 2 ** (attempt - 1)
-                  print(
-                      (
-                          "Retrying transient GitHub API failure "
-                          f"in {delay_seconds}s (attempt {attempt + 1}/{max_attempts})"
-                      ),
-                      file=sys.stderr,
-                  )
-                  time.sleep(delay_seconds)
-
+                  if not retryable or attempt == 3:
+                      completed.check_returncode()
+                  time.sleep(2**attempt)
               raise AssertionError("unreachable GitHub API retry state")
 
 

--- a/tests/test_pr_quality_lifecycle_reconciliation.py
+++ b/tests/test_pr_quality_lifecycle_reconciliation.py
@@ -24,9 +24,7 @@ def test_lifecycle_reconciliation_runs_from_trusted_main_or_explicit_recovery() 
     assert "manual_recovery" in text
 
 
-def test_lifecycle_reconciliation_scopes_main_push_to_associated_pull_requests() -> (
-    None
-):
+def test_lifecycle_reconciliation_scopes_main_push_to_associated_pull_requests() -> None:
     text = _workflow_text()
 
     assert "PUSH_SHA: ${{ github.sha }}" in text
@@ -56,9 +54,7 @@ def test_lifecycle_reconciliation_retries_only_transient_github_failures() -> No
     assert "if not retryable or attempt == 3:" in text
 
 
-def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> (
-    None
-):
+def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> None:
     text = _workflow_text()
     workflow_permissions = text.split("jobs:", 1)[0]
     job = text.split("jobs:", 1)[1]
@@ -101,9 +97,7 @@ def test_lifecycle_reconciliation_updates_only_existing_bot_quality_comment() ->
     assert 'method="POST"' not in text
 
 
-def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> (
-    None
-):
+def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> None:
     text = _workflow_text()
 
     assert 'merged = bool(pull.get("merged_at"))' in text
@@ -115,9 +109,7 @@ def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identit
     assert "Merge commit" in text
 
 
-def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> (
-    None
-):
+def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> None:
     text = _workflow_text()
 
     assert '"## ✅ Merged"' in text

--- a/tests/test_pr_quality_lifecycle_reconciliation.py
+++ b/tests/test_pr_quality_lifecycle_reconciliation.py
@@ -24,9 +24,7 @@ def test_lifecycle_reconciliation_runs_from_trusted_main_or_explicit_recovery() 
     assert "manual_recovery" in text
 
 
-def test_lifecycle_reconciliation_scopes_main_push_to_all_associated_pull_requests() -> (
-    None
-):
+def test_lifecycle_reconciliation_scopes_main_push_to_all_associated_pull_requests() -> None:
     text = _workflow_text()
 
     assert "PUSH_SHA: ${{ github.sha }}" in text
@@ -60,9 +58,7 @@ def test_lifecycle_reconciliation_retries_only_transient_github_failures() -> No
     assert "if not retryable or attempt == 3:" in text
 
 
-def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> (
-    None
-):
+def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> None:
     text = _workflow_text()
     workflow_permissions = text.split("jobs:", 1)[0]
     job = text.split("jobs:", 1)[1]
@@ -105,9 +101,7 @@ def test_lifecycle_reconciliation_updates_only_existing_bot_quality_comment() ->
     assert 'method="POST"' not in text
 
 
-def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> (
-    None
-):
+def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> None:
     text = _workflow_text()
 
     assert 'merged = bool(pull.get("merged_at"))' in text
@@ -119,9 +113,7 @@ def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identit
     assert "Merge commit" in text
 
 
-def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> (
-    None
-):
+def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> None:
     text = _workflow_text()
 
     assert '"## ✅ Merged"' in text

--- a/tests/test_pr_quality_lifecycle_reconciliation.py
+++ b/tests/test_pr_quality_lifecycle_reconciliation.py
@@ -24,13 +24,17 @@ def test_lifecycle_reconciliation_runs_from_trusted_main_or_explicit_recovery() 
     assert "manual_recovery" in text
 
 
-def test_lifecycle_reconciliation_scopes_main_push_to_associated_pull_requests() -> None:
+def test_lifecycle_reconciliation_scopes_main_push_to_all_associated_pull_requests() -> None:
     text = _workflow_text()
 
     assert "PUSH_SHA: ${{ github.sha }}" in text
     assert 'push_sha = os.environ.get("PUSH_SHA", "").strip()' in text
     assert 'elif event_name == "push":' in text
-    assert 'f"repos/{repository}/commits/{push_sha}/pulls"' in text
+    assert 'Path(os.environ["GITHUB_EVENT_PATH"])' in text
+    assert 'event.get("commits", [])' in text
+    assert 'dict.fromkeys([*commit_shas, push_sha])' in text
+    assert "for commit_sha in" in text
+    assert 'f"repos/{repository}/commits/{commit_sha}/pulls"' in text
     assert 'row["base"].get("ref") == "main"' in text
     assert "per_page=20" in text
     assert "candidate_count" in text

--- a/tests/test_pr_quality_lifecycle_reconciliation.py
+++ b/tests/test_pr_quality_lifecycle_reconciliation.py
@@ -24,6 +24,36 @@ def test_lifecycle_reconciliation_runs_from_trusted_main_or_explicit_recovery() 
     assert "manual_recovery" in text
 
 
+def test_lifecycle_reconciliation_scopes_main_push_to_associated_pull_requests() -> None:
+    text = _workflow_text()
+
+    assert "PUSH_SHA: ${{ github.sha }}" in text
+    assert 'push_sha = os.environ.get("PUSH_SHA", "").strip()' in text
+    assert 'elif event_name == "push":' in text
+    assert 'f"repos/{repository}/commits/{push_sha}/pulls"' in text
+    assert 'row["base"].get("ref") == "main"' in text
+    assert "per_page=20" in text
+    assert "candidate_count" in text
+
+
+def test_lifecycle_reconciliation_retries_only_transient_github_failures() -> None:
+    text = _workflow_text()
+
+    assert "max_attempts: int = 4" in text
+    assert "check=False" in text
+    for marker in (
+        '"http 500"',
+        '"http 502"',
+        '"http 503"',
+        '"http 504"',
+        '"secondary rate limit"',
+    ):
+        assert marker in text
+    assert "time.sleep(delay_seconds)" in text
+    assert "2 ** (attempt - 1)" in text
+    assert "if not retryable or attempt == max_attempts:" in text
+
+
 def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> None:
     text = _workflow_text()
     workflow_permissions = text.split("jobs:", 1)[0]

--- a/tests/test_pr_quality_lifecycle_reconciliation.py
+++ b/tests/test_pr_quality_lifecycle_reconciliation.py
@@ -24,7 +24,9 @@ def test_lifecycle_reconciliation_runs_from_trusted_main_or_explicit_recovery() 
     assert "manual_recovery" in text
 
 
-def test_lifecycle_reconciliation_scopes_main_push_to_associated_pull_requests() -> None:
+def test_lifecycle_reconciliation_scopes_main_push_to_associated_pull_requests() -> (
+    None
+):
     text = _workflow_text()
 
     assert "PUSH_SHA: ${{ github.sha }}" in text
@@ -39,7 +41,7 @@ def test_lifecycle_reconciliation_scopes_main_push_to_associated_pull_requests()
 def test_lifecycle_reconciliation_retries_only_transient_github_failures() -> None:
     text = _workflow_text()
 
-    assert "max_attempts: int = 4" in text
+    assert "for attempt in range(4):" in text
     assert "check=False" in text
     for marker in (
         '"http 500"',
@@ -49,12 +51,14 @@ def test_lifecycle_reconciliation_retries_only_transient_github_failures() -> No
         '"secondary rate limit"',
     ):
         assert marker in text
-    assert "time.sleep(delay_seconds)" in text
-    assert "2 ** (attempt - 1)" in text
-    assert "if not retryable or attempt == max_attempts:" in text
+    assert "time.sleep(2**attempt)" in text
+    assert "completed.check_returncode()" in text
+    assert "if not retryable or attempt == 3:" in text
 
 
-def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> None:
+def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> (
+    None
+):
     text = _workflow_text()
     workflow_permissions = text.split("jobs:", 1)[0]
     job = text.split("jobs:", 1)[1]
@@ -97,7 +101,9 @@ def test_lifecycle_reconciliation_updates_only_existing_bot_quality_comment() ->
     assert 'method="POST"' not in text
 
 
-def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> None:
+def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> (
+    None
+):
     text = _workflow_text()
 
     assert 'merged = bool(pull.get("merged_at"))' in text
@@ -109,7 +115,9 @@ def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identit
     assert "Merge commit" in text
 
 
-def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> None:
+def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> (
+    None
+):
     text = _workflow_text()
 
     assert '"## ✅ Merged"' in text

--- a/tests/test_pr_quality_lifecycle_reconciliation.py
+++ b/tests/test_pr_quality_lifecycle_reconciliation.py
@@ -24,7 +24,9 @@ def test_lifecycle_reconciliation_runs_from_trusted_main_or_explicit_recovery() 
     assert "manual_recovery" in text
 
 
-def test_lifecycle_reconciliation_scopes_main_push_to_all_associated_pull_requests() -> None:
+def test_lifecycle_reconciliation_scopes_main_push_to_all_associated_pull_requests() -> (
+    None
+):
     text = _workflow_text()
 
     assert "PUSH_SHA: ${{ github.sha }}" in text
@@ -32,7 +34,7 @@ def test_lifecycle_reconciliation_scopes_main_push_to_all_associated_pull_reques
     assert 'elif event_name == "push":' in text
     assert 'Path(os.environ["GITHUB_EVENT_PATH"])' in text
     assert 'event.get("commits", [])' in text
-    assert 'dict.fromkeys([*commit_shas, push_sha])' in text
+    assert "dict.fromkeys([*commit_shas, push_sha])" in text
     assert "for commit_sha in" in text
     assert 'f"repos/{repository}/commits/{commit_sha}/pulls"' in text
     assert 'row["base"].get("ref") == "main"' in text
@@ -58,7 +60,9 @@ def test_lifecycle_reconciliation_retries_only_transient_github_failures() -> No
     assert "if not retryable or attempt == 3:" in text
 
 
-def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> None:
+def test_lifecycle_reconciliation_keeps_default_permissions_empty_and_job_scope_narrow() -> (
+    None
+):
     text = _workflow_text()
     workflow_permissions = text.split("jobs:", 1)[0]
     job = text.split("jobs:", 1)[1]
@@ -101,7 +105,9 @@ def test_lifecycle_reconciliation_updates_only_existing_bot_quality_comment() ->
     assert 'method="POST"' not in text
 
 
-def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> None:
+def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identity() -> (
+    None
+):
     text = _workflow_text()
 
     assert 'merged = bool(pull.get("merged_at"))' in text
@@ -113,7 +119,9 @@ def test_lifecycle_reconciliation_requires_github_merged_state_and_exact_identit
     assert "Merge commit" in text
 
 
-def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> None:
+def test_lifecycle_reconciliation_supersedes_stale_verdict_without_claiming_proof() -> (
+    None
+):
     text = _workflow_text()
 
     assert '"## ✅ Merged"' in text


### PR DESCRIPTION
## Summary

- scope trusted `main` push reconciliation to pull requests associated with the exact pushed commit instead of scanning up to 100 historical closed PRs;
- retain a bounded manual recovery scan, reduced to the 20 most recently updated closed PRs;
- retry only transient GitHub API failures up to four total attempts with 1s/2s/4s backoff;
- keep existing merged-state, bot-comment, idempotence, permission, and reporting-only boundaries unchanged;
- add contract tests for exact push scoping and transient retry behavior.

## Incident evidence

`main` failed in `PR Quality Lifecycle Reconciliation / reconcile` on two consecutive merge commits:

```text
481ef0f84a0a812c80e9623988ecea83ea706f81 -> run 29710888302 -> failed
4b4875d7bd25be871648e386cf2d604d780414f1 -> run 29711659031 -> failed
```

The unchanged rerun of `29711659031` passed. Its retained artifact showed:

```text
source=trusted_main_push
candidate_count=91
already_reconciled=85
missing_comment=6
updated=0
```

The workflow was therefore issuing roughly 180+ API reads on every trusted `main` push even when only one PR had just merged, and it had no transient retry path.

## Root cause

```text
headline_failure=PR Quality Lifecycle Reconciliation / reconcile
actual_failure=unhandled transient GitHub API failure before evidence upload
failure_class=ci_config + external_api_resilience
caused_by_2124_data=false
exposed_existing_flake=true
owner_file=.github/workflows/pr-quality-lifecycle-reconciliation.yml
```

## Safety boundary

```text
permissions_unchanged=true
comment_creation_allowed=false
existing_bot_comment_update_only=true
merged_state_required=true
repository_checkout_allowed=false
repository_code_execution_allowed=false
merge_authorized=false
publication_authorized=false
semantic_equivalence_proven=false
```

Non-transient failures still fail immediately. Retries do not convert a policy, identity, permission, or lifecycle failure into success.

## Focused verification

```text
python -m pytest -q tests/test_pr_quality_lifecycle_reconciliation.py -o addopts=
9 passed

yaml_parse=true
```

Full GitHub Actions proof is required on the exact PR head before review or merge.

## Risk and rollback

Low. This changes candidate discovery and transport resilience only. A squash revert restores the previous behavior.