### PR TITLE
test(quality): cover compatibility entrypoints

### DIFF
--- a/tests/test_continuous_upgrade_wrapper_contracts.py
+++ b/tests/test_continuous_upgrade_wrapper_contracts.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+WRAPPER_MODULES = (
+    "sdetkit.continuous_upgrade_automation",
+    "sdetkit.continuous_upgrade_baseline",
+    "sdetkit.continuous_upgrade_contracts",
+    "sdetkit.continuous_upgrade_docs",
+    "sdetkit.continuous_upgrade_foundation",
+    "sdetkit.continuous_upgrade_governance",
+    "sdetkit.continuous_upgrade_operations",
+    "sdetkit.continuous_upgrade_platform",
+    "sdetkit.continuous_upgrade_quality",
+    "sdetkit.continuous_upgrade_readiness",
+    "sdetkit.continuous_upgrade_release",
+)
+
+
+@pytest.mark.parametrize("module_name", WRAPPER_MODULES)
+def test_continuous_upgrade_wrapper_delegates_to_shared_lane(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+) -> None:
+    module: ModuleType = import_module(module_name)
+    observed: dict[str, Any] = {}
+
+    def fake_run_lane(argv: list[str] | None, config: dict[str, object]) -> int:
+        observed["argv"] = argv
+        observed["config"] = config
+        return 17
+
+    monkeypatch.setattr(module, "run_lane", fake_run_lane)
+    argv = ["--format", "json"]
+
+    assert module.main(argv) == 17
+    assert observed == {"argv": argv, "config": module._CFG}
+    assert str(module._CFG["name"]).startswith("continuous-upgrade-")

--- a/tests/test_phase_compatibility_aliases.py
+++ b/tests/test_phase_compatibility_aliases.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+PHASE_ALIASES = (
+    ("sdetkit.phases.phase1_hardening", "sdetkit.phases.baseline_hardening"),
+    ("sdetkit.phases.phase1_wrap", "sdetkit.phases.baseline_wrap"),
+    ("sdetkit.phases.phase2_hardening", "sdetkit.phases.release_readiness_hardening"),
+    ("sdetkit.phases.phase2_kickoff", "sdetkit.phases.release_readiness_kickoff"),
+    (
+        "sdetkit.phases.phase2_wrap_handoff",
+        "sdetkit.phases.release_readiness_wrap_handoff",
+    ),
+    ("sdetkit.phases.phase3_kickoff", "sdetkit.phases.platform_readiness_kickoff"),
+    ("sdetkit.phases.phase3_preplan", "sdetkit.phases.platform_readiness_preplan"),
+    (
+        "sdetkit.phases.phase3_wrap_publication",
+        "sdetkit.phases.platform_readiness_wrap_publication",
+    ),
+    ("sdetkit.phases.phase_boost", "sdetkit.phases.readiness_boost"),
+)
+
+
+@pytest.mark.parametrize(("legacy_name", "canonical_name"), PHASE_ALIASES)
+def test_legacy_phase_module_resolves_to_canonical_module(
+    legacy_name: str,
+    canonical_name: str,
+) -> None:
+    canonical = importlib.import_module(canonical_name)
+    sys.modules.pop(legacy_name, None)
+
+    legacy = importlib.import_module(legacy_name)
+
+    assert legacy is canonical
+    assert sys.modules[legacy_name] is canonical


### PR DESCRIPTION
## Summary

- exercise the eleven continuous-upgrade wrapper entrypoints that delegate to the shared lane runner;
- verify nine legacy phase-module names resolve to their canonical compatibility targets;
- restore a stable whole-package coverage buffer above the reviewed non-regression floor without lowering or editing the baseline.

## Why

The dependency PR quality runs measured 87.88% against the reviewed 87.89% floor. The first focused test covered eleven missing delegations, but normal suite variability could offset that narrow gain. This PR therefore proves an additional 45 stable compatibility-alias statements, creating a meaningful buffer rather than gaming a rounding boundary.

## Boundary

Test-only change. No runtime behavior, workflow, dependency, release, authority, security, or baseline threshold is changed.

## Verification

Required CI and the Quality workflow must prove the exact head. The two focused contracts exercise 56 previously uncovered package statements without adding production statements.

## Risk and rollback

Low test-only risk. Rollback is a squash revert.