### PR TITLE
fix(governance): align workflow reproducibility measurement

### DIFF
--- a/docs/ci/workflow-local-equivalents.md
+++ b/docs/ci/workflow-local-equivalents.md
@@ -791,3 +791,27 @@ python -m pytest -q \
 The evidence workflow remains locally reproducible through the existing PR Quality commands. The
 publisher consumes only the verified handoff artifact and uses the GitHub API to update the PR
 comment.
+
+## `.github/workflows/pr-quality-lifecycle-reconciliation.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/pr-quality-publisher.yml`
+
+Local equivalent command:
+
+```bash
+python -m sdetkit workflow-governance-report --root . --format text
+```
+
+## `.github/workflows/release-candidate.yml`
+
+Local equivalent command:
+
+```bash
+make release-preflight && python -m build
+```

--- a/src/sdetkit/workflow_governance_report.py
+++ b/src/sdetkit/workflow_governance_report.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import json
 import re
+import shlex
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -25,6 +26,7 @@ FULL_SHA_RE = re.compile(r"^[a-fA-F0-9]{40}$")
 USES_RE = re.compile(r"uses:\s*([^@\s#]+)@([^\s#]+)")
 INPUT_DIGEST_ALGORITHM = "sha256"
 GENERATOR_SOURCE_LABEL = "src/sdetkit/workflow_governance_report.py"
+LOCAL_EQUIVALENTS_PATH = "docs/ci/workflow-local-equivalents.md"
 
 
 def _update_input_digest(hasher: Any, label: str, content: bytes) -> None:
@@ -50,6 +52,9 @@ def workflow_governance_input_provenance(
         ("schema_version", SCHEMA_VERSION.encode("utf-8")),
         (GENERATOR_SOURCE_LABEL, generator.read_bytes()),
     ]
+    local_equivalents = root / LOCAL_EQUIVALENTS_PATH
+    if local_equivalents.is_file():
+        inputs.append((LOCAL_EQUIVALENTS_PATH, local_equivalents.read_bytes()))
     inputs.extend((_rel(root, path), path.read_bytes()) for path in workflows)
 
     hasher = hashlib.sha256()
@@ -191,16 +196,86 @@ def _line_contains_any(line: str, needles: Sequence[str]) -> bool:
     return any(needle in lower for needle in needles)
 
 
+def _logical_shell_lines(text: str) -> list[str]:
+    logical_lines: list[str] = []
+    pending = ""
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            if pending:
+                logical_lines.append(pending)
+                pending = ""
+            continue
+        pending = f"{pending} {stripped}".strip() if pending else stripped
+        if pending.endswith("\\"):
+            pending = pending[:-1].rstrip()
+            continue
+        logical_lines.append(pending)
+        pending = ""
+    if pending:
+        logical_lines.append(pending)
+    return logical_lines
+
+
 def _pip_install_lines(text: str) -> list[str]:
     return [
-        line.strip()
-        for line in text.splitlines()
+        line
+        for line in _logical_shell_lines(text)
         if _line_contains_any(line, ["pip install", "python -m pip install"])
     ]
 
 
 def _uses_constraints(line: str) -> bool:
     return "-c constraints-ci.txt" in line or "--constraint constraints-ci.txt" in line
+
+
+def _is_exact_public_pypi_verification(line: str) -> bool:
+    try:
+        tokens = shlex.split(line)
+    except ValueError:
+        return False
+
+    try:
+        install_index = tokens.index("install")
+    except ValueError:
+        return False
+
+    args = tokens[install_index + 1 :]
+    requirements: list[str] = []
+    saw_no_cache = False
+    index_url = ""
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--no-cache-dir":
+            saw_no_cache = True
+            index += 1
+            continue
+        if token == "--index-url":
+            if index + 1 >= len(args):
+                return False
+            index_url = args[index + 1]
+            index += 2
+            continue
+        if token.startswith("-"):
+            return False
+        requirements.append(token)
+        index += 1
+
+    if not saw_no_cache or index_url != "https://pypi.org/simple/":
+        return False
+    if len(requirements) != 1:
+        return False
+
+    requirement = requirements[0]
+    if requirement.count("==") != 1 or "*" in requirement:
+        return False
+    name, version = requirement.split("==", 1)
+    return bool(name and version)
+
+
+def _install_is_reproducible(line: str) -> bool:
+    return _uses_constraints(line) or _is_exact_public_pypi_verification(line)
 
 
 def _permissions_least_privilege(text: str) -> bool:
@@ -219,13 +294,34 @@ def _permissions_least_privilege(text: str) -> bool:
     return not any(item in lower for item in banned)
 
 
-def _local_equivalent_documented(text: str) -> bool:
+def _inline_local_equivalent_documented(text: str) -> bool:
     lower = text.lower()
     return (
         "local equivalent" in lower
         or "local proof" in lower
         or "make proof-after-format" in lower
         or "python -m pytest" in lower
+    )
+
+
+def _catalog_local_equivalent_documented(repo_root: Path, workflow_path: Path) -> bool:
+    catalog = repo_root / LOCAL_EQUIVALENTS_PATH
+    if not catalog.is_file():
+        return False
+    relative = _rel(repo_root, workflow_path)
+    marker = f"## `{relative}`"
+    catalog_text = catalog.read_text(encoding="utf-8", errors="ignore")
+    start = catalog_text.find(marker)
+    if start < 0:
+        return False
+    next_section = catalog_text.find("\n## ", start + len(marker))
+    section = catalog_text[start:] if next_section < 0 else catalog_text[start:next_section]
+    return "local equivalent command:" in section.lower()
+
+
+def _local_equivalent_documented(repo_root: Path, workflow_path: Path, text: str) -> bool:
+    return _inline_local_equivalent_documented(text) or _catalog_local_equivalent_documented(
+        repo_root, workflow_path
     )
 
 
@@ -285,7 +381,7 @@ def analyze_workflow(repo_root: str | Path, workflow_path: str | Path) -> dict[s
     pip_lines = _pip_install_lines(text)
     install_uses_constraints: bool | None
     if pip_lines:
-        install_uses_constraints = all(_uses_constraints(line) for line in pip_lines)
+        install_uses_constraints = all(_install_is_reproducible(line) for line in pip_lines)
     else:
         install_uses_constraints = None
 
@@ -323,7 +419,9 @@ def analyze_workflow(repo_root: str | Path, workflow_path: str | Path) -> dict[s
         "artifacts_have_retention": _yes_no_na(artifact_retention),
         "docs_build_strict": _yes_no_na(docs_build_strict),
         "no_secrets_in_pull_request_from_fork": "manual_review",
-        "local_equivalent_command_documented": _yes_no(_local_equivalent_documented(text)),
+        "local_equivalent_command_documented": _yes_no(
+            _local_equivalent_documented(root, path, text)
+        ),
     }
 
     findings = _workflow_findings(checklist=checklist, action_refs=action_refs)

--- a/tests/test_workflow_governance_measurement_semantics.py
+++ b/tests/test_workflow_governance_measurement_semantics.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.workflow_governance_report import (
+    analyze_workflow,
+    workflow_governance_input_provenance,
+)
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_governance_uses_canonical_local_equivalent_catalog(tmp_path: Path) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "catalog-only.yml",
+        """
+name: catalog-only
+on: [push]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+""",
+    )
+    catalog = _write(
+        tmp_path / "docs" / "ci" / "workflow-local-equivalents.md",
+        """
+# Workflow local equivalents
+
+## `.github/workflows/catalog-only.yml`
+
+Local equivalent command:
+
+```bash
+python -m pytest -q tests/test_workflow_governance_report.py
+```
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+    before = workflow_governance_input_provenance(tmp_path)
+    catalog.write_text(
+        catalog.read_text(encoding="utf-8") + "\n# changed\n",
+        encoding="utf-8",
+    )
+    after = workflow_governance_input_provenance(tmp_path)
+
+    assert payload["checklist"]["local_equivalent_command_documented"] == "yes"
+    assert "local_equivalent_command_documented" not in payload["findings"]
+    assert before["input_count"] == before["workflow_file_count"] + 3
+    assert before["input_digest"] != after["input_digest"]
+
+
+def test_governance_catalog_requires_exact_workflow_section(tmp_path: Path) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "missing.yml",
+        """
+name: missing
+on: [push]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+""",
+    )
+    _write(
+        tmp_path / "docs" / "ci" / "workflow-local-equivalents.md",
+        """
+## `.github/workflows/other.yml`
+
+Local equivalent command:
+
+```bash
+python -m pytest -q
+```
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+
+    assert payload["checklist"]["local_equivalent_command_documented"] == "no"
+    assert "local_equivalent_command_documented" in payload["findings"]
+
+
+def test_governance_accepts_exact_public_pypi_verification(tmp_path: Path) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "public-verify.yml",
+        """
+# Local equivalent: python -m pytest -q
+name: public-verify
+on: [push]
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+      - run: python -m pip install --no-cache-dir --index-url https://pypi.org/simple/ "sdetkit==1.2.0"
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+
+    assert payload["checklist"]["install_uses_constraints"] == "yes"
+    assert "install_uses_constraints" not in payload["findings"]
+
+
+def test_governance_still_flags_unpinned_public_index_install(tmp_path: Path) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "public-unpinned.yml",
+        """
+# Local equivalent: python -m pytest -q
+name: public-unpinned
+on: [push]
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+      - run: python -m pip install --no-cache-dir --index-url https://pypi.org/simple/ sdetkit
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+
+    assert payload["checklist"]["install_uses_constraints"] == "no"
+    assert "install_uses_constraints" in payload["findings"]
+
+
+def test_governance_flags_mixed_exact_and_unpinned_public_index_install(
+    tmp_path: Path,
+) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "public-mixed.yml",
+        """
+# Local equivalent: python -m pytest -q
+name: public-mixed
+on: [push]
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+      - run: python -m pip install --no-cache-dir --index-url https://pypi.org/simple/ sdetkit requests==2.34.2
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+
+    assert payload["checklist"]["install_uses_constraints"] == "no"
+    assert "install_uses_constraints" in payload["findings"]

--- a/tests/test_workflow_governance_report.py
+++ b/tests/test_workflow_governance_report.py
@@ -798,3 +798,28 @@ jobs:
     assert payload["status"] == "stale"
     assert payload["fresh"] is False
     assert out.read_text(encoding="utf-8") == original
+
+
+def test_workflow_governance_folds_multiline_constrained_installs(tmp_path: Path) -> None:
+    workflow = _write(
+        tmp_path / ".github" / "workflows" / "release.yml",
+        """
+name: release
+on: [push]
+permissions:
+  contents: read
+jobs:
+  qualify:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python -m pip install \
+            -c constraints-ci.txt --force-reinstall dist/package.whl
+      - run: python -m pytest -q tests/test_workflow_governance_report.py -o addopts=
+""",
+    )
+
+    payload = analyze_workflow(tmp_path, workflow)
+
+    assert payload["checklist"]["install_uses_constraints"] == "yes"
+    assert "install_uses_constraints" not in payload["findings"]


### PR DESCRIPTION
Advances #2181.

## Why

A fresh workflow-governance replay on current `main` found 21 findings across 18 workflows, not the stale 2-finding snapshot previously recorded on #2181:

- `permissions_least_privilege`: 16
- `local_equivalent_command_documented`: 3
- `install_uses_constraints`: 2

The 16 permission findings are intentional review-first tasks. This PR does **not** reduce workflow permissions or expand automation authority.

## What changes

- fold backslash-continued shell commands before evaluating pip-install reproducibility;
- recognize the canonical `docs/ci/workflow-local-equivalents.md` catalog when evaluating local reproducibility documentation;
- include that catalog in workflow-governance input provenance so freshness changes when the catalog changes;
- recognize the narrow public-PyPI verification exception only when `--no-cache-dir` is present, the index is exactly `https://pypi.org/simple/`, and there is exactly one non-wildcard `name==version` install target;
- reject mixed exact/unpinned public-index installs;
- add the three missing canonical local-equivalent catalog entries;
- add focused regression coverage for catalog binding, provenance freshness, multiline constrained installs, exact public-PyPI verification, and rejection of unpinned/mixed public-index installs.

## Focused proof

On the exact proposed tree:

- Ruff format/check: passed
- focused governance/release tests: **41 passed**
- workflow governance replay:
  - workflows: 58
  - review-required: 16
  - findings: 16
  - finding counts: `{ "permissions_least_privilege": 16 }`
  - provenance input count: 61

## Retained report note

`build/sdetkit/workflow-governance-report.json` is an older retained evidence snapshot and was already stale on the current base. This PR does not rewrite that historical artifact; current governance truth is produced by a fresh replay and the freshness validator remains authoritative.

## Authority boundary

- no workflow permission reduction;
- no workflow mutation authority;
- no security dismissal;
- no merge authorization;
- no semantic-equivalence claim;
- the remaining 16 permission findings stay queued for human review under the existing permission-review playbook.

Fresh exact-head repository CI is required before merge.