### PR TITLE
feat(governance): generate exact workflow permission review packets

### DIFF
--- a/docs/ci/workflow-permission-review-packet.md
+++ b/docs/ci/workflow-permission-review-packet.md
@@ -1,0 +1,141 @@
+# Workflow permission review packet
+
+`python -m sdetkit.workflow_permission_review_packet` turns the workflow permission review control plane into a deterministic reviewer bundle.
+
+The bundle is evidence-only. It does not create a human decision, recommend `keep | reduce | split | defer`, edit workflow YAML, authorize a permission change, authorize a patch, authorize merge, dismiss security findings, or claim semantic equivalence.
+
+## Why this layer exists
+
+The control plane identifies what needs human review. Decision Record V1 defines how a real human decision is recorded. The review-packet layer fills the operational gap between those two stages by preparing the evidence a reviewer needs without crossing the human-decision boundary.
+
+The intended flow is:
+
+```text
+workflow-governance-report
+  -> workflow permission review control plane
+  -> workflow permission review packet
+  -> human reviewer
+  -> exact decision record v1
+  -> separate permission-only implementation PR
+  -> workflow-specific proof + rollback
+```
+
+## Generate the complete bundle
+
+```bash
+python -m sdetkit.workflow_permission_review_packet \
+  --root . \
+  --out-dir build/sdetkit/workflow-permission-review-packets \
+  --format text
+```
+
+The output directory contains:
+
+- `workflow-permission-review-packet-index.json`;
+- `workflow-permission-review-packet-index.md`;
+- one exact-digest JSON packet per review item;
+- one reviewer-readable Markdown packet per review item.
+
+The packet filenames use the stable review ID, not a mutable display title.
+
+## What every packet contains
+
+Each generated packet retains:
+
+- review ID;
+- workflow path;
+- exact workflow SHA-256;
+- permission group;
+- current write scopes;
+- inferred permission reasons from the governance report;
+- human evidence still required;
+- retained review-card and decision-evidence references when present;
+- transparent triage signals derived from the current write scopes;
+- allowed human decision enum;
+- proof contract;
+- rollback contract;
+- a blank Decision Record V1 template;
+- a zero-authority boundary.
+
+The packet digest is computed over canonical JSON for the complete packet except the digest field itself.
+
+## Triage signals are not recommendations
+
+The generator records transparent signals such as whether a workflow contains `contents: write`, `security-events: write`, `id-token: write`, or more than one write scope.
+
+Those signals are descriptive only. They do not produce a risk verdict, recommendation, decision, or permission change. The generated field `machine_recommendation` is always `null`.
+
+## Blank decision template
+
+For a queue item that does not yet have a valid current human decision, the packet contains a template with the exact immutable binding fields pre-populated:
+
+- `review_id`;
+- `workflow`;
+- `workflow_sha256`;
+- `permission_group`;
+- proof contract;
+- rollback contract;
+- zero-authority boundary.
+
+The human fields remain empty:
+
+- `decision`;
+- `reviewer`;
+- `reviewer_evidence`;
+- `decided_at`;
+- `rationale`;
+- `proposed_change`.
+
+The template is intentionally not a valid decision record until a human reviewer completes it and records the evidence required by Decision Record V1.
+
+## Freshness validation
+
+After retaining an index, validate it against the current repository:
+
+```bash
+python -m sdetkit.workflow_permission_review_packet \
+  --root . \
+  --check-index build/sdetkit/workflow-permission-review-packets/workflow-permission-review-packet-index.json \
+  --fail-on-stale \
+  --format text
+```
+
+Freshness is bound to:
+
+- the packet-generator source;
+- `docs/contracts/workflow-permission-review-packet.v1.json`;
+- the exact control-plane input digest.
+
+The control-plane digest already transitively binds workflow bytes, review evidence, decision evidence, Decision Record V1, and its own generator/contract inputs. Therefore workflow/evidence/decision changes make retained packet output stale.
+
+## Existing review cards
+
+Human-authored review cards remain evidence, not generated truth. The packet generator maps a retained card to a workflow when the card names the workflow or its permission group. It does not parse prose into a decision.
+
+This preserves scoped documents such as the Pages review card and the PR/issue-interaction card without treating their text as automatic permission authority.
+
+## Proof before merge
+
+For changes to this product surface, run at minimum:
+
+```bash
+python -m ruff check \
+  src/sdetkit/workflow_permission_review_packet.py \
+  tests/test_workflow_permission_review_packet.py
+python -m mypy \
+  src/sdetkit/workflow_permission_decision_record.py \
+  src/sdetkit/workflow_permission_review_control_plane.py \
+  src/sdetkit/workflow_permission_review_packet.py
+python -m pytest -q \
+  tests/test_workflow_permission_decision_record.py \
+  tests/test_workflow_permission_review_control_plane.py \
+  tests/test_workflow_permission_review_packet.py \
+  tests/test_quality_truth_baseline.py \
+  -o addopts=
+```
+
+Then require the repository's normal exact-head Quality, CI, Security/CodeQL, cross-platform, release-qualification, and PR-quality gates.
+
+## Authority boundary
+
+A review packet cannot make a future permission-only PR safe by itself. Even after a human decision is recorded, implementation remains a separate reviewed change with workflow-specific execution proof and rollback.

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -94,11 +94,12 @@
       "sdetkit.trajectory_store",
       "sdetkit.workflow_permission_decision_record",
       "sdetkit.workflow_permission_review_control_plane",
+      "sdetkit.workflow_permission_review_packet",
       "sdetkit.workspace_failure_ownership"
     ],
     "migration_complete": false,
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 532,
+    "source_module_count": 533,
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "typing_debt_inventory_sha256": "e8729da81702dacbd8901642b8dfea0e45540ff6a4e655834f2fbbd8bb4b053a",
     "typing_debt_module_count": 489

--- a/docs/contracts/workflow-permission-review-packet.v1.json
+++ b/docs/contracts/workflow-permission-review-packet.v1.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "sdetkit.workflow_permission_review_packet.v1",
+  "status": "review_evidence_only",
+  "purpose": "Generate deterministic, exact-workflow reviewer packets for workflow permission review without creating or implying a human decision.",
+  "source_of_truth": "sdetkit.workflow_permission_review_control_plane",
+  "packet_binding": {
+    "review_id_required": true,
+    "workflow_path_required": true,
+    "workflow_sha256_required": true,
+    "permission_group_required": true,
+    "packet_digest_required": true
+  },
+  "decision_boundary": {
+    "allowed_human_decisions": [
+      "keep",
+      "reduce",
+      "split",
+      "defer"
+    ],
+    "generated_packet_may_choose_decision": false,
+    "generated_packet_may_recommend_decision": false,
+    "generated_packet_may_fabricate_reviewer": false,
+    "blank_decision_template_allowed": true,
+    "valid_current_decision_record_required_to_advance_state": true,
+    "implementation_remains_separate_reviewed_pr": true
+  },
+  "freshness": {
+    "generator_source_bound": true,
+    "contract_bound": true,
+    "control_plane_input_digest_bound": true,
+    "workflow_byte_changes_must_stale_packet": true,
+    "decision_record_changes_must_stale_packet": true,
+    "review_evidence_changes_must_stale_packet": true
+  },
+  "required_packet_sections": [
+    "exact_binding",
+    "current_permissions",
+    "evidence",
+    "triage_signals",
+    "decision_boundary",
+    "proof_contract",
+    "rollback_contract",
+    "authority_boundary"
+  ],
+  "authority_boundary": {
+    "automation_allowed": false,
+    "human_decision_fabrication_allowed": false,
+    "implementation_authorized": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "permission_mutation_allowed": false,
+    "security_dismissal_allowed": false,
+    "semantic_equivalence_proven": false,
+    "workflow_mutation_allowed": false
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,7 @@ ignore_errors = false
 module = [
   "sdetkit.workflow_permission_decision_record",
   "sdetkit.workflow_permission_review_control_plane",
+  "sdetkit.workflow_permission_review_packet",
 ]
 ignore_errors = false
 

--- a/src/sdetkit/workflow_permission_review_packet.py
+++ b/src/sdetkit/workflow_permission_review_packet.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .workflow_permission_decision_record import authority_boundary as decision_authority_boundary
+from .workflow_permission_review_control_plane import build_workflow_permission_review_control_plane
+
+SCHEMA_VERSION = "sdetkit.workflow_permission_review_packet.v1"
+CONTRACT_PATH = "docs/contracts/workflow-permission-review-packet.v1.json"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/workflow_permission_review_packet.py"
+REVIEW_CARD_DIR = "docs/ci/workflow-permission-review-cards"
+DEFAULT_INDEX_NAME = "workflow-permission-review-packet-index.json"
+DEFAULT_MARKDOWN_INDEX_NAME = "workflow-permission-review-packet-index.md"
+DIGEST_ALGORITHM = "sha256"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "human_decision_fabrication_allowed",
+    "implementation_authorized",
+    "merge_authorized",
+    "patch_application_allowed",
+    "permission_mutation_allowed",
+    "security_dismissal_allowed",
+    "semantic_equivalence_proven",
+    "workflow_mutation_allowed",
+)
+
+
+def authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _update_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def _review_card_refs(root: Path, workflow: str, permission_group: str) -> list[str]:
+    directory = root / REVIEW_CARD_DIR
+    if not directory.is_dir():
+        return []
+
+    refs: list[str] = []
+    for path in sorted(directory.glob("*.md")):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if workflow in text or permission_group in text:
+            refs.append(path.relative_to(root).as_posix())
+    return refs
+
+
+def _triage_signals(write_scopes: Sequence[str]) -> dict[str, Any]:
+    scopes = sorted(set(write_scopes))
+    return {
+        "write_scope_count": len(scopes),
+        "contains_contents_write": "contents: write" in scopes,
+        "contains_id_token_write": "id-token: write" in scopes,
+        "contains_issues_write": "issues: write" in scopes,
+        "contains_packages_write": "packages: write" in scopes,
+        "contains_pages_write": "pages: write" in scopes,
+        "contains_pull_requests_write": "pull-requests: write" in scopes,
+        "contains_security_events_write": "security-events: write" in scopes,
+        "multiple_write_scopes": len(scopes) > 1,
+        "classification_is_decision": False,
+        "classification_authorizes_change": False,
+    }
+
+
+def _decision_template(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "template_only": True,
+        "human_completion_required": True,
+        "schema_version": "sdetkit.workflow_permission_decision_record.v1",
+        "review_id": entry.get("review_id"),
+        "workflow": entry.get("workflow"),
+        "workflow_sha256": entry.get("workflow_sha256"),
+        "permission_group": entry.get("permission_group"),
+        "decision": None,
+        "reviewer": None,
+        "reviewer_evidence": None,
+        "decided_at": None,
+        "rationale": None,
+        "proposed_change": None,
+        "proof_contract": list(entry.get("proof_contract", [])),
+        "rollback_contract": entry.get("rollback_contract"),
+        "authority_boundary": decision_authority_boundary(),
+    }
+
+
+def _packet_digest(packet: dict[str, Any]) -> str:
+    digest_input = dict(packet)
+    digest_input.pop("packet_digest", None)
+    return _sha256_bytes(_canonical_json_bytes(digest_input))
+
+
+def _build_packet(root: Path, entry: dict[str, Any]) -> dict[str, Any]:
+    workflow = str(entry.get("workflow", ""))
+    permission_group = str(entry.get("permission_group", "unknown"))
+    write_scopes = [str(scope) for scope in entry.get("granted_write_scopes", [])]
+    review_card_refs = _review_card_refs(root, workflow, permission_group)
+    decision_evidence_refs = [str(ref) for ref in entry.get("decision_evidence_refs", [])]
+    evidence_refs = sorted(set([*review_card_refs, *decision_evidence_refs]))
+    human_decision_recorded = entry.get("human_decision_recorded") is True
+
+    packet: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "packet_id": f"packet-{entry.get('review_id', 'unknown')}",
+        "review_id": entry.get("review_id"),
+        "workflow": workflow,
+        "workflow_sha256": entry.get("workflow_sha256"),
+        "permission_group": permission_group,
+        "review_state": entry.get("review_state"),
+        "current_permissions": {
+            "write_scopes": sorted(set(write_scopes)),
+            "scope_count": len(set(write_scopes)),
+        },
+        "evidence": {
+            "inferred_permission_reasons": list(entry.get("inferred_permission_reasons", [])),
+            "required_human_evidence": list(entry.get("required_human_evidence", [])),
+            "review_card_refs": review_card_refs,
+            "decision_evidence_refs": decision_evidence_refs,
+            "retained_evidence_refs": evidence_refs,
+            "retained_evidence_present": bool(evidence_refs),
+            "generated_packet_is_human_evidence": False,
+        },
+        "triage_signals": _triage_signals(write_scopes),
+        "decision_boundary": {
+            "allowed_decisions": list(entry.get("allowed_decisions", [])),
+            "human_decision_recorded": human_decision_recorded,
+            "current_human_decision": entry.get("human_decision"),
+            "decision_record_ref": entry.get("decision_record_ref"),
+            "decision_record_refs": list(entry.get("decision_record_refs", [])),
+            "machine_recommendation": None,
+            "generated_packet_may_choose_decision": False,
+            "decision_record_template": None
+            if human_decision_recorded
+            else _decision_template(entry),
+        },
+        "proof_contract": list(entry.get("proof_contract", [])),
+        "rollback_contract": entry.get("rollback_contract"),
+        "requires_human_review": entry.get("requires_human_review") is True,
+        "safe_to_patch": False,
+        "next_allowed_action": entry.get("next_allowed_action"),
+        "authority_boundary": authority_boundary(),
+    }
+    packet["packet_digest"] = _packet_digest(packet)
+    return packet
+
+
+def workflow_permission_review_packet_input_provenance(
+    repo_root: str | Path = ".",
+    *,
+    control_plane: dict[str, Any] | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    plane = control_plane or build_workflow_permission_review_control_plane(root)
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+
+    inputs: list[tuple[str, bytes]] = [
+        ("schema_version", SCHEMA_VERSION.encode("utf-8")),
+        (GENERATOR_SOURCE_LABEL, generator.read_bytes()),
+        (
+            "control_plane_input_digest",
+            str(plane.get("input_provenance", {}).get("input_digest", "")).encode("utf-8"),
+        ),
+    ]
+    contract = root / CONTRACT_PATH
+    if contract.is_file():
+        inputs.append((CONTRACT_PATH, contract.read_bytes()))
+
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_digest(hasher, label, content)
+
+    return {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "control_plane_input_digest": plane.get("input_provenance", {}).get("input_digest", ""),
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+        "contract_path": CONTRACT_PATH,
+    }
+
+
+def build_workflow_permission_review_packet_index(
+    repo_root: str | Path = ".",
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    control_plane = build_workflow_permission_review_control_plane(root)
+    queue = control_plane.get("review_queue", [])
+    if not isinstance(queue, list):
+        queue = []
+
+    packets = [_build_packet(root, entry) for entry in queue if isinstance(entry, dict)]
+    packets.sort(key=lambda item: str(item.get("workflow", "")))
+
+    group_counts: dict[str, int] = {}
+    pending_count = 0
+    decided_count = 0
+    retained_evidence_count = 0
+    for packet in packets:
+        group = str(packet.get("permission_group", "unknown"))
+        group_counts[group] = group_counts.get(group, 0) + 1
+        decision_boundary = packet.get("decision_boundary", {})
+        if (
+            isinstance(decision_boundary, dict)
+            and decision_boundary.get("human_decision_recorded") is True
+        ):
+            decided_count += 1
+        else:
+            pending_count += 1
+        evidence = packet.get("evidence", {})
+        if isinstance(evidence, dict) and evidence.get("retained_evidence_present") is True:
+            retained_evidence_count += 1
+
+    packet_refs = [
+        {
+            "packet_id": packet["packet_id"],
+            "review_id": packet["review_id"],
+            "workflow": packet["workflow"],
+            "workflow_sha256": packet["workflow_sha256"],
+            "permission_group": packet["permission_group"],
+            "review_state": packet["review_state"],
+            "packet_digest": packet["packet_digest"],
+            "json_path": f"{packet['review_id']}.json",
+            "markdown_path": f"{packet['review_id']}.md",
+        }
+        for packet in packets
+    ]
+    bundle_digest = _sha256_bytes(_canonical_json_bytes({"packets": packet_refs}))
+    provenance = workflow_permission_review_packet_input_provenance(
+        root,
+        control_plane=control_plane,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "not_required"
+            if not packets
+            else ("human_review_required" if pending_count else "human_decisions_recorded")
+        ),
+        "input_provenance": provenance,
+        "summary": {
+            "packet_count": len(packets),
+            "permission_group_count": len(group_counts),
+            "group_counts": dict(sorted(group_counts.items())),
+            "pending_human_review_count": pending_count,
+            "human_decision_recorded_count": decided_count,
+            "retained_evidence_packet_count": retained_evidence_count,
+            "machine_recommendation_count": 0,
+            "decision_template_count": pending_count,
+            "automatic_permission_change_allowed": False,
+        },
+        "bundle_digest": bundle_digest,
+        "packet_index": packet_refs,
+        "packets": packets,
+        "rules": {
+            "review_first": True,
+            "packet_is_evidence_not_decision": True,
+            "packet_may_not_prefill_decision": True,
+            "packet_may_not_fabricate_reviewer": True,
+            "exact_workflow_digest_required": True,
+            "valid_decision_record_required_to_advance_state": True,
+            "implementation_remains_separate_reviewed_pr": True,
+            "workflow_mutation_allowed": False,
+        },
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def validate_workflow_permission_review_packet_index(
+    repo_root: str | Path,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    current = build_workflow_permission_review_packet_index(repo_root)
+    reasons: list[str] = []
+
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        reasons.append("schema_version_mismatch")
+    if payload.get("input_provenance", {}).get("input_digest") != current.get(
+        "input_provenance", {}
+    ).get("input_digest"):
+        reasons.append("input_digest_mismatch")
+    if payload.get("bundle_digest") != current.get("bundle_digest"):
+        reasons.append("bundle_digest_mismatch")
+    if payload.get("summary") != current.get("summary"):
+        reasons.append("summary_mismatch")
+    if payload.get("packet_index") != current.get("packet_index"):
+        reasons.append("packet_index_mismatch")
+    if payload.get("authority_boundary") != authority_boundary():
+        reasons.append("authority_boundary_mismatch")
+
+    recorded_packets = payload.get("packets", [])
+    current_packets = current.get("packets", [])
+    if not isinstance(recorded_packets, list):
+        recorded_packets = []
+        reasons.append("packets_missing")
+    if recorded_packets != current_packets:
+        reasons.append("packets_mismatch")
+
+    reasons = sorted(set(reasons))
+    return {
+        "status": "fresh" if not reasons else "stale",
+        "fresh": not reasons,
+        "reasons": reasons,
+        "recorded_input_digest": payload.get("input_provenance", {}).get("input_digest", ""),
+        "current_input_digest": current.get("input_provenance", {}).get("input_digest", ""),
+        "recorded_bundle_digest": payload.get("bundle_digest", ""),
+        "current_bundle_digest": current.get("bundle_digest", ""),
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def render_packet_markdown(packet: dict[str, Any]) -> str:
+    permissions = packet.get("current_permissions", {})
+    write_scopes = permissions.get("write_scopes", []) if isinstance(permissions, dict) else []
+    evidence = packet.get("evidence", {})
+    evidence_refs = evidence.get("retained_evidence_refs", []) if isinstance(evidence, dict) else []
+    required_evidence = (
+        evidence.get("required_human_evidence", []) if isinstance(evidence, dict) else []
+    )
+    decision_boundary = packet.get("decision_boundary", {})
+    allowed_decisions = (
+        decision_boundary.get("allowed_decisions", [])
+        if isinstance(decision_boundary, dict)
+        else []
+    )
+
+    lines = [
+        f"# Workflow permission review packet: {packet.get('workflow', '')}",
+        "",
+        "> Generated evidence only. This packet is not a human decision and grants no permission-change, patch, merge, or workflow-mutation authority.",
+        "",
+        "## Exact binding",
+        "",
+        f"- Review ID: `{packet.get('review_id', '')}`",
+        f"- Workflow: `{packet.get('workflow', '')}`",
+        f"- Workflow SHA-256: `{packet.get('workflow_sha256', '')}`",
+        f"- Permission group: `{packet.get('permission_group', '')}`",
+        f"- Packet digest: `{packet.get('packet_digest', '')}`",
+        "",
+        "## Current write scopes",
+        "",
+    ]
+    lines.extend([f"- `{scope}`" for scope in write_scopes] or ["- None detected."])
+    lines.extend(["", "## Retained evidence references", ""])
+    lines.extend(
+        [f"- `{ref}`" for ref in evidence_refs] or ["- No retained card/decision evidence mapped."]
+    )
+    lines.extend(["", "## Human evidence still required", ""])
+    lines.extend(
+        [f"- {item}" for item in required_evidence]
+        or ["- Follow the control-plane proof contract."]
+    )
+    lines.extend(["", "## Decision boundary", ""])
+    lines.append("Allowed human decisions: " + ", ".join(f"`{item}`" for item in allowed_decisions))
+    lines.extend(
+        [
+            "",
+            "The generated packet does **not** choose or recommend a decision. A human reviewer must create a valid current decision record bound to these exact workflow bytes.",
+            "",
+            "## Proof contract",
+            "",
+        ]
+    )
+    lines.extend([f"- `{item}`" for item in packet.get("proof_contract", [])])
+    lines.extend(["", "## Authority boundary", ""])
+    lines.extend([f"- `{key}=false`" for key in sorted(authority_boundary())])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_index_markdown(index: dict[str, Any]) -> str:
+    summary = index.get("summary", {})
+    packet_index = index.get("packet_index", [])
+    lines = [
+        "# Workflow permission review packet index",
+        "",
+        "> Generated review evidence. No packet is a human decision or permission-change authorization.",
+        "",
+        f"- Packets: **{summary.get('packet_count', 0)}**",
+        f"- Pending human review: **{summary.get('pending_human_review_count', 0)}**",
+        f"- Human decisions recorded: **{summary.get('human_decision_recorded_count', 0)}**",
+        f"- Machine recommendations: **{summary.get('machine_recommendation_count', 0)}**",
+        f"- Bundle digest: `{index.get('bundle_digest', '')}`",
+        "",
+        "## Packets",
+        "",
+    ]
+    if isinstance(packet_index, list):
+        for item in packet_index:
+            if not isinstance(item, dict):
+                continue
+            lines.append(
+                f"- `{item.get('workflow', '')}` — `{item.get('review_id', '')}` — `{item.get('packet_digest', '')}`"
+            )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_workflow_permission_review_packet_bundle(
+    repo_root: str | Path,
+    out_dir: str | Path,
+    *,
+    index: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    root = Path(repo_root).resolve()
+    output = Path(out_dir)
+    if not output.is_absolute():
+        output = root / output
+    output.mkdir(parents=True, exist_ok=True)
+
+    payload = index or build_workflow_permission_review_packet_index(root)
+    packets = payload.get("packets", [])
+    if not isinstance(packets, list):
+        packets = []
+
+    for packet in packets:
+        if not isinstance(packet, dict):
+            continue
+        review_id = str(packet.get("review_id", "unknown"))
+        (output / f"{review_id}.json").write_text(
+            json.dumps(packet, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (output / f"{review_id}.md").write_text(render_packet_markdown(packet), encoding="utf-8")
+
+    index_path = output / DEFAULT_INDEX_NAME
+    markdown_index_path = output / DEFAULT_MARKDOWN_INDEX_NAME
+    index_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_index_path.write_text(render_index_markdown(payload), encoding="utf-8")
+    return {
+        "index_path": index_path.relative_to(root).as_posix()
+        if index_path.is_relative_to(root)
+        else index_path.as_posix(),
+        "markdown_index_path": markdown_index_path.relative_to(root).as_posix()
+        if markdown_index_path.is_relative_to(root)
+        else markdown_index_path.as_posix(),
+    }
+
+
+def render_index_text(index: dict[str, Any]) -> str:
+    summary = index.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
+    return "\n".join(
+        [
+            f"packet_count={summary.get('packet_count', 0)}",
+            f"pending_human_review_count={summary.get('pending_human_review_count', 0)}",
+            f"human_decision_recorded_count={summary.get('human_decision_recorded_count', 0)}",
+            f"machine_recommendation_count={summary.get('machine_recommendation_count', 0)}",
+            f"bundle_digest={index.get('bundle_digest', '')}",
+            "permission_mutation_allowed=false",
+            "human_decision_fabrication_allowed=false",
+            "merge_authorized=false",
+        ]
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("review packet index must be a JSON object")
+    return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.workflow_permission_review_packet",
+        description="Generate exact-digest workflow permission human-review packets.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--out-dir")
+    parser.add_argument("--check-index")
+    parser.add_argument("--fail-on-stale", action="store_true")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    index = build_workflow_permission_review_packet_index(ns.root)
+    if ns.out_dir:
+        write_workflow_permission_review_packet_bundle(ns.root, ns.out_dir, index=index)
+
+    validation: dict[str, Any] | None = None
+    if ns.check_index:
+        root = Path(ns.root).resolve()
+        check_path = Path(ns.check_index)
+        if not check_path.is_absolute():
+            check_path = root / check_path
+        validation = validate_workflow_permission_review_packet_index(root, _load_json(check_path))
+
+    output: dict[str, Any] = {"index": index}
+    if validation is not None:
+        output["freshness"] = validation
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_index_text(index) + "\n")
+        if validation is not None:
+            sys.stdout.write(f"freshness_status={validation.get('status', 'unknown')}\n")
+            reasons = validation.get("reasons", [])
+            if isinstance(reasons, list):
+                sys.stdout.write("freshness_reasons=" + json.dumps(reasons, sort_keys=True) + "\n")
+
+    if ns.fail_on_stale and validation is not None and validation.get("fresh") is not True:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,10 +24,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 532
+    assert payload["observed"]["source_module_count"] == 533
     assert payload["observed"]["typing_debt_module_count"] == 489
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 43
+    assert len(checked) == 44
     assert "sdetkit._formatter_policy_proposal_observation_records" in checked
     assert "sdetkit._formatter_policy_proposal_observation_schema" in checked
     assert "sdetkit.adoption_product_kpi_freshness" in checked
@@ -51,6 +51,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.product_maturity_radar_portfolio" in checked
     assert "sdetkit.workflow_permission_decision_record" in checked
     assert "sdetkit.workflow_permission_review_control_plane" in checked
+    assert "sdetkit.workflow_permission_review_packet" in checked
     assert "sdetkit.workspace_failure_ownership" in checked
     inventory = payload["typing_debt_inventory"]
     assert inventory["module_count"] == 489
@@ -79,6 +80,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.product_maturity_radar_portfolio" not in inventory["modules"]
     assert "sdetkit.workflow_permission_decision_record" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_control_plane" not in inventory["modules"]
+    assert "sdetkit.workflow_permission_review_packet" not in inventory["modules"]
     assert "sdetkit.workspace_failure_ownership" not in inventory["modules"]
 
 
@@ -97,7 +99,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 532,
+            "actual": 533,
         }
     ]
 

--- a/tests/test_workflow_permission_review_packet.py
+++ b/tests/test_workflow_permission_review_packet.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+from sdetkit import workflow_permission_decision_record as decision_record
+from sdetkit import workflow_permission_review_control_plane as control_plane
+from sdetkit import workflow_permission_review_packet as review_packet
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _packet_by_workflow(payload: dict[str, object], workflow: str) -> dict[str, object]:
+    packets = payload["packets"]
+    assert isinstance(packets, list)
+    for item in packets:
+        if isinstance(item, dict) and item.get("workflow") == workflow:
+            return item
+    raise AssertionError(f"packet not found for {workflow}")
+
+
+def test_live_packet_index_mirrors_control_plane_without_machine_decisions() -> None:
+    plane = control_plane.build_workflow_permission_review_control_plane(".")
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+
+    assert payload["summary"]["packet_count"] == plane["summary"]["permission_review_count"]
+    assert (
+        payload["summary"]["pending_human_review_count"]
+        == plane["summary"]["pending_human_review_count"]
+    )
+    assert (
+        payload["summary"]["human_decision_recorded_count"]
+        == plane["summary"]["human_decision_recorded_count"]
+    )
+    assert payload["summary"]["machine_recommendation_count"] == 0
+    assert payload["summary"]["automatic_permission_change_allowed"] is False
+    assert not any(payload["authority_boundary"].values())
+
+    packet_workflows = {item["workflow"] for item in payload["packet_index"]}
+    plane_workflows = {item["workflow"] for item in plane["review_queue"]}
+    assert packet_workflows == plane_workflows
+
+
+def test_every_live_packet_is_bound_to_exact_workflow_bytes() -> None:
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+
+    for packet in payload["packets"]:
+        workflow = Path(packet["workflow"])
+        assert workflow.is_file()
+        assert packet["workflow_sha256"] == _sha256(workflow)
+        assert packet["packet_digest"] == review_packet._packet_digest(packet)
+        assert packet["safe_to_patch"] is False
+        assert not any(packet["authority_boundary"].values())
+
+
+def test_pending_packet_template_never_prefills_human_decision() -> None:
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+
+    pending_packets = [
+        packet
+        for packet in payload["packets"]
+        if packet["decision_boundary"]["human_decision_recorded"] is False
+    ]
+    assert pending_packets
+    for packet in pending_packets:
+        boundary = packet["decision_boundary"]
+        assert boundary["machine_recommendation"] is None
+        assert boundary["generated_packet_may_choose_decision"] is False
+        template = boundary["decision_record_template"]
+        assert template["template_only"] is True
+        assert template["human_completion_required"] is True
+        assert template["decision"] is None
+        assert template["reviewer"] is None
+        assert template["reviewer_evidence"] is None
+        assert template["decided_at"] is None
+        assert template["rationale"] is None
+        assert template["proposed_change"] is None
+        assert not any(template["authority_boundary"].values())
+
+
+def test_blank_packet_template_is_not_a_valid_human_decision_record() -> None:
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+    packet = next(
+        item
+        for item in payload["packets"]
+        if item["decision_boundary"]["human_decision_recorded"] is False
+    )
+    template = packet["decision_boundary"]["decision_record_template"]
+    review_entry = {
+        "review_id": packet["review_id"],
+        "workflow": packet["workflow"],
+        "workflow_sha256": packet["workflow_sha256"],
+        "permission_group": packet["permission_group"],
+    }
+
+    validation = decision_record.validate_decision_record(template, review_entry)
+
+    assert validation["valid_current"] is False
+    assert validation["status"] == "invalid"
+    assert "decision_invalid" in validation["reasons"]
+    assert "reviewer_missing" in validation["reasons"]
+    assert "reviewer_evidence_missing" in validation["reasons"]
+    assert "rationale_missing" in validation["reasons"]
+
+
+def test_existing_review_cards_are_retained_as_evidence_not_decisions() -> None:
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+
+    pages = _packet_by_workflow(payload, ".github/workflows/pages.yml")
+    pages_refs = pages["evidence"]["review_card_refs"]
+    assert "docs/ci/workflow-permission-review-cards/deployment-oidc-pages.md" in pages_refs
+    assert pages["decision_boundary"]["machine_recommendation"] is None
+
+    contributor = _packet_by_workflow(
+        payload,
+        ".github/workflows/contributor-onboarding-bot.yml",
+    )
+    contributor_refs = contributor["evidence"]["review_card_refs"]
+    assert "docs/ci/workflow-permission-review-cards/pr-issue-interaction.md" in contributor_refs
+    assert contributor["evidence"]["generated_packet_is_human_evidence"] is False
+
+
+def test_packet_generation_is_deterministic() -> None:
+    first = review_packet.build_workflow_permission_review_packet_index(".")
+    second = review_packet.build_workflow_permission_review_packet_index(".")
+
+    assert first == second
+    assert first["bundle_digest"] == second["bundle_digest"]
+
+
+def test_bundle_writer_round_trips_through_freshness_validator(tmp_path: Path) -> None:
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+    paths = review_packet.write_workflow_permission_review_packet_bundle(
+        ".",
+        tmp_path,
+        index=payload,
+    )
+    index_path = tmp_path / review_packet.DEFAULT_INDEX_NAME
+    retained = json.loads(index_path.read_text(encoding="utf-8"))
+
+    validation = review_packet.validate_workflow_permission_review_packet_index(".", retained)
+
+    assert validation["fresh"] is True
+    assert validation["reasons"] == []
+    assert paths["index_path"] == index_path.as_posix()
+    assert (tmp_path / review_packet.DEFAULT_MARKDOWN_INDEX_NAME).is_file()
+    for item in payload["packet_index"]:
+        assert (tmp_path / item["json_path"]).is_file()
+        assert (tmp_path / item["markdown_path"]).is_file()
+
+
+def test_freshness_rejects_packet_or_bundle_tampering() -> None:
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+    tampered = copy.deepcopy(payload)
+    tampered["bundle_digest"] = "tampered"
+    tampered["packets"][0]["safe_to_patch"] = True
+
+    validation = review_packet.validate_workflow_permission_review_packet_index(".", tampered)
+
+    assert validation["fresh"] is False
+    assert validation["status"] == "stale"
+    assert "bundle_digest_mismatch" in validation["reasons"]
+    assert "packets_mismatch" in validation["reasons"]
+
+
+def test_current_human_decision_is_reported_without_generating_new_template(monkeypatch) -> None:
+    workflow = ".github/workflows/example.yml"
+    entry = {
+        "review_id": decision_record.review_id_for_workflow(workflow),
+        "workflow": workflow,
+        "workflow_sha256": "a" * 64,
+        "permission_group": "repository_mutation",
+        "granted_write_scopes": ["contents: write"],
+        "inferred_permission_reasons": ["reviewed reason"],
+        "required_human_evidence": ["reviewed proof"],
+        "review_state": "human_decision_recorded",
+        "human_decision_recorded": True,
+        "human_decision": "keep",
+        "allowed_decisions": ["keep", "reduce", "split", "defer"],
+        "decision_evidence_refs": [],
+        "decision_record_ref": "docs/ci/workflow-permission-decisions/example.decision.json",
+        "decision_record_refs": ["docs/ci/workflow-permission-decisions/example.decision.json"],
+        "proof_contract": ["exact-head CI"],
+        "rollback_contract": {
+            "strategy": "restore_exact_workflow_bytes",
+            "workflow_sha256": "a" * 64,
+        },
+        "requires_human_review": True,
+        "next_allowed_action": "retain_current_permissions",
+    }
+    fake_plane = {
+        "input_provenance": {"input_digest": "fake-control-plane-digest"},
+        "review_queue": [entry],
+    }
+    monkeypatch.setattr(
+        review_packet,
+        "build_workflow_permission_review_control_plane",
+        lambda _root: fake_plane,
+    )
+
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+    packet = payload["packets"][0]
+
+    assert payload["summary"]["human_decision_recorded_count"] == 1
+    assert payload["summary"]["pending_human_review_count"] == 0
+    assert packet["decision_boundary"]["current_human_decision"] == "keep"
+    assert packet["decision_boundary"]["decision_record_template"] is None
+    assert packet["safe_to_patch"] is False
+    assert not any(packet["authority_boundary"].values())
+
+
+def test_empty_review_queue_is_not_required(monkeypatch) -> None:
+    fake_plane = {
+        "input_provenance": {"input_digest": "empty-control-plane-digest"},
+        "review_queue": [],
+    }
+    monkeypatch.setattr(
+        review_packet,
+        "build_workflow_permission_review_control_plane",
+        lambda _root: fake_plane,
+    )
+
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+
+    assert payload["status"] == "not_required"
+    assert payload["summary"]["packet_count"] == 0
+    assert payload["summary"]["decision_template_count"] == 0
+    assert payload["packets"] == []
+    assert payload["packet_index"] == []
+
+
+def test_markdown_keeps_review_first_boundary_visible() -> None:
+    payload = review_packet.build_workflow_permission_review_packet_index(".")
+    packet = payload["packets"][0]
+    markdown = review_packet.render_packet_markdown(packet)
+    index_markdown = review_packet.render_index_markdown(payload)
+
+    assert "Generated evidence only" in markdown
+    assert "does **not** choose or recommend a decision" in markdown
+    assert "permission_mutation_allowed=false" in markdown
+    assert "No packet is a human decision" in index_markdown
+    assert f"`{payload['bundle_digest']}`" in index_markdown


### PR DESCRIPTION
Advances #2181. #2201 has now been merged into `main`; this PR was cleanly restacked on that squash commit so its review scope is again exactly the Stage 4 delta.

## Why

The permission-review control plane and Decision Record v1 establish *what needs review* and *how an exact human decision is recorded*. This PR fills the operational gap between them with deterministic reviewer packets for every current permission-review item.

## What this adds

- `sdetkit.workflow_permission_review_packet` generator and CLI;
- versioned `workflow-permission-review-packet.v1` contract;
- one exact-digest JSON + Markdown packet per live review item;
- exact binding to review ID, workflow path, workflow SHA-256, permission group, packet digest, and bundle digest;
- retained human-authored review cards and decision evidence referenced as evidence only;
- transparent current write-scope signals;
- blank Decision Record v1 templates with immutable binding fields populated and every human decision field left empty;
- freshness validation transitively bound through the control-plane digest;
- adversarial tests for tampering, stale packets, deterministic output, blank-template invalidity, current-decision behavior, empty queues, and zero authority.

## Human decision boundary

Generated packets never choose or recommend `keep | reduce | split | defer`.

For pending reviews:

- `machine_recommendation = null`;
- `decision = null`;
- `reviewer = null`;
- `reviewer_evidence = null`;
- `decided_at = null`;
- `rationale = null`;
- `proposed_change = null`;
- `safe_to_patch = false`.

A generated packet is evidence, not a human decision and not permission-change authority.

## Quality truth

The packet module is explicitly type checked rather than added to blanket typing debt.

Measured contract for this stage:

- source modules: **533**
- typing-debt modules: **489**
- explicitly typed modules: **44**
- quality-truth mismatches: **0**

The pre-restack exact product tree already passed Quality, Full CI, Security/CodeQL, the Ubuntu/macOS Python 3.11/3.12/3.13 matrix, release qualification, and trusted PR Quality publication. Fresh exact-head CI is running again after the ancestry-only restack.

## Post-#2201 squash restack

#2201 was squash-merged into `main`, so this branch was rebuilt as a single direct child of the new main commit using the same already-proven Stage 4 blobs. No Stage 4 product bytes changed during the restack.

Current exact base: `9ebb9ec66706dda0919ef2d1250cae705b5f834c`

Current exact head: `6fdc8f43ffbd534e2780a1a7657a000b79687566`

Current scope: **1 commit / 7 files / 0 behind main**.

Exactly these 7 files change:

1. `docs/ci/workflow-permission-review-packet.md`
2. `docs/contracts/quality-truth-baseline.v1.json`
3. `docs/contracts/workflow-permission-review-packet.v1.json`
4. `pyproject.toml`
5. `src/sdetkit/workflow_permission_review_packet.py`
6. `tests/test_quality_truth_baseline.py`
7. `tests/test_workflow_permission_review_packet.py`

No `.github/workflows/*` file is in the final diff.

## Authority boundary

This PR does not create a human decision, mutate workflow permissions, authorize a patch, authorize merge, dismiss security findings, or claim semantic equivalence. A later `reduce`/`split` implementation still requires a valid current human decision and a separate reviewed permission-only PR with workflow-specific proof and rollback.