### PR TITLE
feat(governance): add batch workflow permission review sessions

### DIFF
--- a/docs/ci/workflow-permission-review-session.md
+++ b/docs/ci/workflow-permission-review-session.md
@@ -96,6 +96,8 @@ These are candidate review artifacts. They are not automatically copied to `docs
 
 When the output path is inside the repository, compiled candidates may only be written under `build/`.
 
+Relative `--compile-out-dir` values are resolved beneath the explicit `--root` first, so the process working directory cannot redefine the repository write boundary.
+
 The compiler refuses repository-local destinations such as:
 
 - `docs/ci/workflow-permission-decisions/`;

--- a/docs/ci/workflow-permission-review-session.md
+++ b/docs/ci/workflow-permission-review-session.md
@@ -1,0 +1,149 @@
+# Workflow permission review session
+
+Workflow Permission Review Session v1 is the batch human-review layer above the exact review packets and below Decision Record v1.
+
+It exists to make reviewing a permission queue operationally practical without letting software choose the answer.
+
+## Product flow
+
+```text
+workflow-governance-report
+  -> permission review control plane
+  -> exact review packet bundle
+  -> human review session
+  -> individually validated Decision Record v1 files
+  -> separate permission-only implementation PRs
+  -> workflow-specific execution proof + rollback
+```
+
+The session compiler never edits workflow YAML, never changes a permission, never commits a decision, never opens an implementation PR, never merges anything, and never infers `keep | reduce | split | defer`.
+
+## Generate a complete-session template
+
+```bash
+python -m sdetkit.workflow_permission_review_session \
+  --root . \
+  --template-mode complete \
+  --template-out build/sdetkit/workflow-permission-review-session.json \
+  --format text
+```
+
+A complete template contains one entry for every currently pending review packet. Immutable packet bindings are prefilled; human fields are not.
+
+At session level the reviewer must supply:
+
+- `reviewer`;
+- `reviewer_evidence` as a GitHub URL;
+- timezone-aware `decided_at`.
+
+For each reviewed packet the human must supply:
+
+- `decision`: `keep`, `reduce`, `split`, or `defer`;
+- `rationale`;
+- `proposed_change` using the Decision Record v1 rules;
+- `proof_acknowledged: true`;
+- `rollback_acknowledged: true`.
+
+The software does not default any of these fields.
+
+## Partial versus complete sessions
+
+`partial` means the reviewer intentionally submits one or more reviewed pending packets. Omitted packets remain pending.
+
+`complete` means every currently pending packet must appear exactly once. Missing or duplicate review IDs block the entire compilation.
+
+A partial session is not silently upgraded to complete, and a complete session is not silently downgraded to partial.
+
+## Exact freshness binding
+
+The session is bound to:
+
+- the packet bundle digest;
+- the packet-layer input digest;
+- each review ID;
+- each packet digest;
+- each workflow path;
+- each workflow SHA-256;
+- each permission group.
+
+If the packet bundle or any reviewed packet changes after the session was prepared, validation returns `stale` and compilation emits zero Decision Record v1 files.
+
+## Fail-closed compilation
+
+Validate and compile a completed session:
+
+```bash
+python -m sdetkit.workflow_permission_review_session \
+  --root . \
+  --session build/sdetkit/workflow-permission-review-session.json \
+  --compile-out-dir build/sdetkit/workflow-permission-decisions \
+  --fail-on-invalid \
+  --format text
+```
+
+Every candidate is reconstructed from the current packet binding plus the human-entered session fields and passed through the Decision Record v1 validator.
+
+If any session-level or entry-level requirement fails, the compiler returns `blocked` and emits zero records.
+
+For a valid current session the compiler writes only to the explicitly requested output directory and creates:
+
+- one `*.decision.json` candidate per reviewed packet;
+- `workflow-permission-review-session-compilation.json` with session digest, packet bundle digest, record SHA-256 values, and a zero-authority boundary.
+
+These are candidate review artifacts. They are not automatically copied to `docs/ci/workflow-permission-decisions/`.
+
+## Source-tree write guard
+
+When the output path is inside the repository, compiled candidates may only be written under `build/`.
+
+The compiler refuses repository-local destinations such as:
+
+- `docs/ci/workflow-permission-decisions/`;
+- `.github/workflows/`;
+- `src/`;
+- arbitrary repository folders.
+
+This prevents the batch-review tool from turning human input into an unreviewed repository mutation.
+
+## Decision Record v1 remains authoritative
+
+Review Session v1 does not replace Decision Record v1. It is a batch input and compilation envelope.
+
+Each compiled record must independently pass the existing Decision Record v1 rules, including exact workflow digest, permission group, reviewer evidence, rationale, decision-specific proposed change, proof contract, rollback contract, and zero implementation authority.
+
+## No implementation authority
+
+A valid session proves only that human decision data is current and structurally valid.
+
+It does **not** prove that a future permission reduction is correct. `reduce` and `split` still require a separate reviewed implementation PR with workflow-specific runtime proof and rollback.
+
+## Recommended review workflow
+
+1. Generate the latest Stage 4 packet bundle.
+2. Generate a fresh Stage 5 session template.
+3. Review the packet Markdown/JSON for each chosen workflow.
+4. Fill only the human fields you personally reviewed.
+5. Run validation with `--fail-on-invalid`.
+6. Compile candidates under `build/`.
+7. Inspect the compilation manifest and each Decision Record v1 candidate.
+8. Only after explicit repository review, separately retain approved decision records.
+9. Build permission-only implementation PRs from those approved decisions.
+
+## Authority boundary
+
+The session layer hard-codes false for:
+
+- automation authority;
+- commit authority;
+- decision inference;
+- human-decision fabrication;
+- implementation authority;
+- merge authority;
+- patch application;
+- permission mutation;
+- security dismissal;
+- semantic equivalence;
+- source-tree writes;
+- workflow mutation.
+
+The compiler can prepare evidence. It cannot decide or implement.

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -95,11 +95,12 @@
       "sdetkit.workflow_permission_decision_record",
       "sdetkit.workflow_permission_review_control_plane",
       "sdetkit.workflow_permission_review_packet",
+      "sdetkit.workflow_permission_review_session",
       "sdetkit.workspace_failure_ownership"
     ],
     "migration_complete": false,
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 533,
+    "source_module_count": 534,
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "typing_debt_inventory_sha256": "e8729da81702dacbd8901642b8dfea0e45540ff6a4e655834f2fbbd8bb4b053a",
     "typing_debt_module_count": 489

--- a/docs/contracts/workflow-permission-review-session.v1.json
+++ b/docs/contracts/workflow-permission-review-session.v1.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "sdetkit.workflow_permission_review_session.v1",
+  "status": "human_input_required",
+  "purpose": "Batch exact-digest human workflow-permission review decisions without inferring choices or authorizing implementation.",
+  "source_of_truth": "sdetkit.workflow_permission_review_packet",
+  "session_modes": [
+    "partial",
+    "complete"
+  ],
+  "session_binding": {
+    "packet_bundle_digest_required": true,
+    "packet_input_digest_required": true,
+    "reviewer_required": true,
+    "reviewer_github_evidence_required": true,
+    "timezone_aware_decided_at_required": true
+  },
+  "entry_binding": {
+    "review_id_required": true,
+    "packet_digest_required": true,
+    "workflow_path_required": true,
+    "workflow_sha256_required": true,
+    "permission_group_required": true,
+    "duplicate_review_ids_allowed": false,
+    "already_decided_packets_allowed": false
+  },
+  "human_decision": {
+    "allowed_values": [
+      "keep",
+      "reduce",
+      "split",
+      "defer"
+    ],
+    "rationale_required": true,
+    "proposed_change_required_by_decision_record_v1": true,
+    "proof_acknowledgement_required": true,
+    "rollback_acknowledgement_required": true,
+    "machine_inference_allowed": false,
+    "machine_default_allowed": false
+  },
+  "mode_rules": {
+    "partial": "One or more explicitly reviewed pending packets may be submitted.",
+    "complete": "Every currently pending packet must appear exactly once."
+  },
+  "compilation": {
+    "individual_decision_record_v1_validation_required": true,
+    "invalid_or_stale_session_emits_zero_records": true,
+    "output_manifest_required": true,
+    "repository_output_allowed_only_under_build": true,
+    "canonical_decision_directory_write_allowed": false,
+    "automatic_commit_allowed": false,
+    "automatic_pull_request_allowed": false,
+    "permission_implementation_allowed": false
+  },
+  "freshness": {
+    "packet_bundle_digest_bound": true,
+    "packet_input_digest_bound": true,
+    "per_packet_digest_bound": true,
+    "workflow_digest_bound": true,
+    "permission_group_bound": true,
+    "changed_packet_bundle_makes_session_stale": true
+  },
+  "authority_boundary": {
+    "automation_allowed": false,
+    "commit_allowed": false,
+    "decision_inference_allowed": false,
+    "human_decision_fabrication_allowed": false,
+    "implementation_authorized": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "permission_mutation_allowed": false,
+    "security_dismissal_allowed": false,
+    "semantic_equivalence_proven": false,
+    "source_tree_write_allowed": false,
+    "workflow_mutation_allowed": false
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ module = [
   "sdetkit.workflow_permission_decision_record",
   "sdetkit.workflow_permission_review_control_plane",
   "sdetkit.workflow_permission_review_packet",
+  "sdetkit.workflow_permission_review_session",
 ]
 ignore_errors = false
 

--- a/src/sdetkit/workflow_permission_review_session.py
+++ b/src/sdetkit/workflow_permission_review_session.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .workflow_permission_decision_record import (
+    SCHEMA_VERSION as DECISION_RECORD_SCHEMA_VERSION,
+)
+from .workflow_permission_decision_record import (
+    authority_boundary as decision_record_authority_boundary,
+)
+from .workflow_permission_decision_record import validate_decision_record
+from .workflow_permission_review_packet import build_workflow_permission_review_packet_index
+
+SCHEMA_VERSION = "sdetkit.workflow_permission_review_session.v1"
+CONTRACT_PATH = "docs/contracts/workflow-permission-review-session.v1.json"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/workflow_permission_review_session.py"
+COMPILATION_MANIFEST_NAME = "workflow-permission-review-session-compilation.json"
+ALLOWED_MODES = ("partial", "complete")
+ALLOWED_DECISIONS = ("keep", "reduce", "split", "defer")
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "commit_allowed",
+    "decision_inference_allowed",
+    "human_decision_fabrication_allowed",
+    "implementation_authorized",
+    "merge_authorized",
+    "patch_application_allowed",
+    "permission_mutation_allowed",
+    "security_dismissal_allowed",
+    "semantic_equivalence_proven",
+    "source_tree_write_allowed",
+    "workflow_mutation_allowed",
+)
+
+
+def authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def session_digest(session: dict[str, Any]) -> str:
+    return _sha256_bytes(_canonical_json_bytes(session))
+
+
+def _nonempty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _timezone_aware(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None and parsed.utcoffset() is not None
+
+
+def _pending_packets(packet_index: dict[str, Any]) -> list[dict[str, Any]]:
+    packets = packet_index.get("packets", [])
+    if not isinstance(packets, list):
+        return []
+    pending: list[dict[str, Any]] = []
+    for item in packets:
+        if not isinstance(item, dict):
+            continue
+        boundary = item.get("decision_boundary", {})
+        if not isinstance(boundary, dict) or boundary.get("human_decision_recorded") is not True:
+            pending.append(item)
+    return pending
+
+
+def _session_entry_template(packet: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "review_id": packet.get("review_id"),
+        "packet_digest": packet.get("packet_digest"),
+        "workflow": packet.get("workflow"),
+        "workflow_sha256": packet.get("workflow_sha256"),
+        "permission_group": packet.get("permission_group"),
+        "decision": None,
+        "rationale": None,
+        "proposed_change": None,
+        "proof_acknowledged": False,
+        "rollback_acknowledged": False,
+    }
+
+
+def build_review_session_template(
+    repo_root: str | Path = ".",
+    *,
+    mode: str = "complete",
+) -> dict[str, Any]:
+    if mode not in ALLOWED_MODES:
+        raise ValueError(f"unsupported session mode: {mode}")
+    packet_index = build_workflow_permission_review_packet_index(repo_root)
+    pending = _pending_packets(packet_index)
+    entries = [_session_entry_template(packet) for packet in pending] if mode == "complete" else []
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "session_mode": mode,
+        "packet_bundle_digest": packet_index.get("bundle_digest"),
+        "packet_input_digest": packet_index.get("input_provenance", {}).get("input_digest"),
+        "reviewer": None,
+        "reviewer_evidence": None,
+        "decided_at": None,
+        "entries": entries,
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def _packet_maps(packet_index: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], set[str]]:
+    pending = _pending_packets(packet_index)
+    by_review_id = {str(packet.get("review_id", "")): packet for packet in pending}
+    all_packets = packet_index.get("packets", [])
+    all_review_ids = {
+        str(packet.get("review_id", ""))
+        for packet in all_packets
+        if isinstance(packet, dict) and _nonempty_string(packet.get("review_id"))
+    }
+    return by_review_id, all_review_ids
+
+
+def _compile_entry(
+    session: dict[str, Any],
+    entry: dict[str, Any],
+    packet: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    record = {
+        "schema_version": DECISION_RECORD_SCHEMA_VERSION,
+        "review_id": packet.get("review_id"),
+        "workflow": packet.get("workflow"),
+        "workflow_sha256": packet.get("workflow_sha256"),
+        "permission_group": packet.get("permission_group"),
+        "decision": entry.get("decision"),
+        "reviewer": session.get("reviewer"),
+        "reviewer_evidence": session.get("reviewer_evidence"),
+        "decided_at": session.get("decided_at"),
+        "rationale": entry.get("rationale"),
+        "proposed_change": entry.get("proposed_change"),
+        "proof_contract": list(packet.get("proof_contract", [])),
+        "rollback_contract": packet.get("rollback_contract"),
+        "authority_boundary": decision_record_authority_boundary(),
+    }
+    review_entry = {
+        "review_id": packet.get("review_id"),
+        "workflow": packet.get("workflow"),
+        "workflow_sha256": packet.get("workflow_sha256"),
+        "permission_group": packet.get("permission_group"),
+    }
+    return record, validate_decision_record(record, review_entry)
+
+
+def validate_review_session(
+    repo_root: str | Path,
+    session: dict[str, Any],
+) -> dict[str, Any]:
+    packet_index = build_workflow_permission_review_packet_index(repo_root)
+    pending_by_review_id, all_review_ids = _packet_maps(packet_index)
+    stale_reasons: list[str] = []
+    invalid_reasons: list[str] = []
+
+    if session.get("schema_version") != SCHEMA_VERSION:
+        invalid_reasons.append("schema_version_mismatch")
+    mode = session.get("session_mode")
+    if mode not in ALLOWED_MODES:
+        invalid_reasons.append("session_mode_invalid")
+    if session.get("packet_bundle_digest") != packet_index.get("bundle_digest"):
+        stale_reasons.append("packet_bundle_digest_mismatch")
+    if session.get("packet_input_digest") != packet_index.get("input_provenance", {}).get(
+        "input_digest"
+    ):
+        stale_reasons.append("packet_input_digest_mismatch")
+    if pending_by_review_id and not _nonempty_string(session.get("reviewer")):
+        invalid_reasons.append("reviewer_missing")
+    reviewer_evidence = session.get("reviewer_evidence")
+    if pending_by_review_id and not _nonempty_string(reviewer_evidence):
+        invalid_reasons.append("reviewer_evidence_missing")
+    elif pending_by_review_id and not str(reviewer_evidence).startswith("https://github.com/"):
+        invalid_reasons.append("reviewer_evidence_must_be_github_url")
+    if pending_by_review_id and not _timezone_aware(session.get("decided_at")):
+        invalid_reasons.append("decided_at_invalid")
+    if session.get("authority_boundary") != authority_boundary():
+        invalid_reasons.append("authority_boundary_mismatch")
+
+    entries = session.get("entries")
+    if not isinstance(entries, list):
+        invalid_reasons.append("entries_missing")
+        entries = []
+    if not entries and pending_by_review_id:
+        invalid_reasons.append("session_has_no_review_entries")
+
+    seen_review_ids: set[str] = set()
+    compiled_candidates: list[dict[str, Any]] = []
+    for offset, item in enumerate(entries):
+        prefix = f"entry[{offset}]"
+        if not isinstance(item, dict):
+            invalid_reasons.append(f"{prefix}:entry_must_be_object")
+            continue
+        review_id = item.get("review_id")
+        if not _nonempty_string(review_id):
+            invalid_reasons.append(f"{prefix}:review_id_missing")
+            continue
+        review_id_text = str(review_id)
+        if review_id_text in seen_review_ids:
+            invalid_reasons.append(f"duplicate_review_id:{review_id_text}")
+            continue
+        seen_review_ids.add(review_id_text)
+
+        packet = pending_by_review_id.get(review_id_text)
+        if packet is None:
+            if review_id_text in all_review_ids:
+                invalid_reasons.append(f"review_already_decided:{review_id_text}")
+            else:
+                invalid_reasons.append(f"unknown_review_id:{review_id_text}")
+            continue
+
+        if item.get("packet_digest") != packet.get("packet_digest"):
+            stale_reasons.append(f"packet_digest_mismatch:{review_id_text}")
+        if item.get("workflow") != packet.get("workflow"):
+            stale_reasons.append(f"workflow_mismatch:{review_id_text}")
+        if item.get("workflow_sha256") != packet.get("workflow_sha256"):
+            stale_reasons.append(f"workflow_digest_mismatch:{review_id_text}")
+        if item.get("permission_group") != packet.get("permission_group"):
+            stale_reasons.append(f"permission_group_mismatch:{review_id_text}")
+        if item.get("proof_acknowledged") is not True:
+            invalid_reasons.append(f"proof_not_acknowledged:{review_id_text}")
+        if item.get("rollback_acknowledged") is not True:
+            invalid_reasons.append(f"rollback_not_acknowledged:{review_id_text}")
+        if item.get("decision") not in ALLOWED_DECISIONS:
+            invalid_reasons.append(f"decision_invalid:{review_id_text}")
+
+        record, record_validation = _compile_entry(session, item, packet)
+        record_reasons = record_validation.get("reasons", [])
+        if isinstance(record_reasons, list):
+            for reason in record_reasons:
+                invalid_reasons.append(f"decision_record_invalid:{review_id_text}:{reason}")
+        compiled_candidates.append(
+            {
+                "review_id": review_id_text,
+                "packet_digest": packet.get("packet_digest"),
+                "record": record,
+                "record_validation": record_validation,
+            }
+        )
+
+    pending_ids = set(pending_by_review_id)
+    missing_review_ids = sorted(pending_ids - seen_review_ids)
+    if mode == "complete" and missing_review_ids:
+        invalid_reasons.extend(
+            f"complete_session_missing:{review_id}" for review_id in missing_review_ids
+        )
+
+    stale_reasons = sorted(set(stale_reasons))
+    invalid_reasons = sorted(set(invalid_reasons))
+    if invalid_reasons:
+        status = "invalid"
+    elif stale_reasons:
+        status = "stale"
+    else:
+        status = "not_required" if not pending_by_review_id else "current"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "valid_current": status == "current",
+        "stale": status == "stale",
+        "session_digest": session_digest(session),
+        "session_mode": mode,
+        "packet_bundle_digest": packet_index.get("bundle_digest"),
+        "pending_packet_count": len(pending_by_review_id),
+        "submitted_entry_count": len(entries),
+        "validated_entry_count": len(compiled_candidates),
+        "missing_review_ids": missing_review_ids,
+        "stale_reasons": stale_reasons,
+        "invalid_reasons": invalid_reasons,
+        "compiled_candidates": compiled_candidates if status == "current" else [],
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def compile_review_session(
+    repo_root: str | Path,
+    session: dict[str, Any],
+) -> dict[str, Any]:
+    validation = validate_review_session(repo_root, session)
+    if validation.get("valid_current") is not True:
+        return {
+            "status": ("not_required" if validation.get("status") == "not_required" else "blocked"),
+            "validation": validation,
+            "compiled_record_count": 0,
+            "records": [],
+            "manifest": None,
+            "authority_boundary": authority_boundary(),
+        }
+
+    candidates = validation.get("compiled_candidates", [])
+    records: list[dict[str, Any]] = []
+    manifest_records: list[dict[str, Any]] = []
+    if isinstance(candidates, list):
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            record = candidate.get("record")
+            if not isinstance(record, dict):
+                continue
+            review_id = str(candidate.get("review_id", "unknown"))
+            filename = f"{review_id}.decision.json"
+            record_sha256 = _sha256_bytes(_canonical_json_bytes(record))
+            records.append(
+                {
+                    "review_id": review_id,
+                    "filename": filename,
+                    "record_sha256": record_sha256,
+                    "record": record,
+                }
+            )
+            manifest_records.append(
+                {
+                    "review_id": review_id,
+                    "filename": filename,
+                    "record_sha256": record_sha256,
+                    "packet_digest": candidate.get("packet_digest"),
+                }
+            )
+    records.sort(key=lambda item: str(item.get("review_id", "")))
+    manifest_records.sort(key=lambda item: str(item.get("review_id", "")))
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "session_digest": validation.get("session_digest"),
+        "session_mode": validation.get("session_mode"),
+        "packet_bundle_digest": validation.get("packet_bundle_digest"),
+        "compiled_record_count": len(records),
+        "records": manifest_records,
+        "source_tree_write_allowed": False,
+        "canonical_decision_directory_write_allowed": False,
+        "implementation_authorized": False,
+        "authority_boundary": authority_boundary(),
+    }
+    return {
+        "status": "compiled",
+        "validation": validation,
+        "compiled_record_count": len(records),
+        "records": records,
+        "manifest": manifest,
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def _safe_output_directory(repo_root: Path, out_dir: Path) -> Path:
+    output = (repo_root / out_dir).resolve() if not out_dir.is_absolute() else out_dir.resolve()
+    if output.is_relative_to(repo_root):
+        relative = output.relative_to(repo_root)
+        if not relative.parts or relative.parts[0] != "build":
+            raise ValueError(
+                "compiled decision records may only be written under build/ inside the repository"
+            )
+    return output
+
+
+def write_compiled_decision_records(
+    repo_root: str | Path,
+    out_dir: str | Path,
+    compilation: dict[str, Any],
+) -> dict[str, Any]:
+    if compilation.get("status") != "compiled":
+        raise ValueError("cannot write blocked review-session compilation")
+    root = Path(repo_root).resolve()
+    output = _safe_output_directory(root, Path(out_dir))
+    output.mkdir(parents=True, exist_ok=True)
+
+    written: list[str] = []
+    records = compilation.get("records", [])
+    if isinstance(records, list):
+        for item in records:
+            if not isinstance(item, dict):
+                continue
+            record = item.get("record")
+            filename = item.get("filename")
+            if not isinstance(record, dict) or not isinstance(filename, str):
+                continue
+            path = output / filename
+            path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            written.append(path.as_posix())
+
+    manifest = compilation.get("manifest")
+    if not isinstance(manifest, dict):
+        raise ValueError("compiled review session is missing a manifest")
+    manifest_path = output / COMPILATION_MANIFEST_NAME
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return {
+        "written_record_count": len(written),
+        "written_records": written,
+        "manifest_path": manifest_path.as_posix(),
+        "source_tree_write_allowed": False,
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def render_validation_text(validation: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"status={validation.get('status', 'unknown')}",
+            f"session_digest={validation.get('session_digest', '')}",
+            f"session_mode={validation.get('session_mode', '')}",
+            f"pending_packet_count={validation.get('pending_packet_count', 0)}",
+            f"submitted_entry_count={validation.get('submitted_entry_count', 0)}",
+            "stale_reasons=" + json.dumps(validation.get("stale_reasons", []), sort_keys=True),
+            "invalid_reasons=" + json.dumps(validation.get("invalid_reasons", []), sort_keys=True),
+            "decision_inference_allowed=false",
+            "permission_mutation_allowed=false",
+            "commit_allowed=false",
+        ]
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("review session must be a JSON object")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.workflow_permission_review_session",
+        description="Validate and compile exact-digest batch human workflow-permission review sessions.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--template-out")
+    parser.add_argument("--template-mode", choices=ALLOWED_MODES, default="complete")
+    parser.add_argument("--session")
+    parser.add_argument("--compile-out-dir")
+    parser.add_argument("--fail-on-invalid", action="store_true")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    root = Path(ns.root).resolve()
+    result: dict[str, Any] = {"authority_boundary": authority_boundary()}
+    exit_code = 0
+
+    if ns.template_out:
+        template = build_review_session_template(root, mode=ns.template_mode)
+        template_path = Path(ns.template_out)
+        if not template_path.is_absolute():
+            template_path = root / template_path
+        _write_json(template_path, template)
+        result["template_path"] = template_path.as_posix()
+        result["template"] = template
+
+    if ns.session:
+        session_path = Path(ns.session)
+        if not session_path.is_absolute():
+            session_path = root / session_path
+        session = _load_json(session_path)
+        compilation = compile_review_session(root, session)
+        result["compilation"] = compilation
+        validation = compilation.get("validation", {})
+        if ns.compile_out_dir and compilation.get("status") == "compiled":
+            result["write_result"] = write_compiled_decision_records(
+                root,
+                ns.compile_out_dir,
+                compilation,
+            )
+        if ns.fail_on_invalid and (
+            not isinstance(validation, dict) or validation.get("valid_current") is not True
+        ):
+            exit_code = 1
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    else:
+        compilation_value = result.get("compilation")
+        if isinstance(compilation_value, dict):
+            validation_value = compilation_value.get("validation")
+            if isinstance(validation_value, dict):
+                sys.stdout.write(render_validation_text(validation_value) + "\n")
+            sys.stdout.write(
+                f"compiled_record_count={compilation_value.get('compiled_record_count', 0)}\n"
+            )
+        elif "template" in result:
+            template = result["template"]
+            if isinstance(template, dict):
+                entries = template.get("entries", [])
+                count = len(entries) if isinstance(entries, list) else 0
+                sys.stdout.write(f"template_mode={template.get('session_mode', '')}\n")
+                sys.stdout.write(f"template_entry_count={count}\n")
+                sys.stdout.write("decision_inference_allowed=false\n")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,10 +24,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 533
+    assert payload["observed"]["source_module_count"] == 534
     assert payload["observed"]["typing_debt_module_count"] == 489
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 44
+    assert len(checked) == 45
     assert "sdetkit._formatter_policy_proposal_observation_records" in checked
     assert "sdetkit._formatter_policy_proposal_observation_schema" in checked
     assert "sdetkit.adoption_product_kpi_freshness" in checked
@@ -52,6 +52,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.workflow_permission_decision_record" in checked
     assert "sdetkit.workflow_permission_review_control_plane" in checked
     assert "sdetkit.workflow_permission_review_packet" in checked
+    assert "sdetkit.workflow_permission_review_session" in checked
     assert "sdetkit.workspace_failure_ownership" in checked
     inventory = payload["typing_debt_inventory"]
     assert inventory["module_count"] == 489
@@ -81,6 +82,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.workflow_permission_decision_record" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_control_plane" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_packet" not in inventory["modules"]
+    assert "sdetkit.workflow_permission_review_session" not in inventory["modules"]
     assert "sdetkit.workspace_failure_ownership" not in inventory["modules"]
 
 
@@ -99,7 +101,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 533,
+            "actual": 534,
         }
     ]
 

--- a/tests/test_workflow_permission_review_session.py
+++ b/tests/test_workflow_permission_review_session.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import workflow_permission_decision_record as decision_record
+from sdetkit import workflow_permission_review_packet as review_packet
+from sdetkit import workflow_permission_review_session as review_session
+
+
+def _packet(
+    workflow: str,
+    *,
+    digest: str,
+    decided: bool = False,
+) -> dict[str, object]:
+    review_id = decision_record.review_id_for_workflow(workflow)
+    workflow_sha256 = ("a" if "one" in workflow else "b") * 64
+    return {
+        "schema_version": review_packet.SCHEMA_VERSION,
+        "packet_id": f"packet-{review_id}",
+        "review_id": review_id,
+        "workflow": workflow,
+        "workflow_sha256": workflow_sha256,
+        "permission_group": "repository_mutation",
+        "review_state": "human_decision_recorded" if decided else "pending_human_review",
+        "packet_digest": digest,
+        "decision_boundary": {
+            "human_decision_recorded": decided,
+            "current_human_decision": "keep" if decided else None,
+        },
+        "proof_contract": ["exact-head CI", "workflow-specific execution proof"],
+        "rollback_contract": {
+            "strategy": "restore_exact_workflow_bytes",
+            "workflow_sha256": workflow_sha256,
+        },
+    }
+
+
+def _packet_index(*, second_decided: bool = False) -> dict[str, object]:
+    packets = [
+        _packet(".github/workflows/one.yml", digest="packet-one"),
+        _packet(".github/workflows/two.yml", digest="packet-two", decided=second_decided),
+    ]
+    return {
+        "schema_version": review_packet.SCHEMA_VERSION,
+        "bundle_digest": "bundle-current",
+        "input_provenance": {"input_digest": "input-current"},
+        "packets": packets,
+    }
+
+
+def _session_entry(packet: dict[str, object], *, decision: str = "keep") -> dict[str, object]:
+    proposed_change: dict[str, object]
+    if decision in {"keep", "defer"}:
+        proposed_change = {"kind": "none"}
+    else:
+        proposed_change = {
+            "kind": "permission_only",
+            "summary": "Use the reviewed narrower job-local write scope.",
+            "evidence_ref": "https://github.com/sherif69-sa/DevS69-sdetkit/issues/2181",
+        }
+    return {
+        "review_id": packet["review_id"],
+        "packet_digest": packet["packet_digest"],
+        "workflow": packet["workflow"],
+        "workflow_sha256": packet["workflow_sha256"],
+        "permission_group": packet["permission_group"],
+        "decision": decision,
+        "rationale": "I reviewed the exact workflow evidence and made this decision.",
+        "proposed_change": proposed_change,
+        "proof_acknowledged": True,
+        "rollback_acknowledged": True,
+    }
+
+
+def _session(
+    packet_index: dict[str, object],
+    *,
+    mode: str = "partial",
+    entries: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    packets = packet_index["packets"]
+    assert isinstance(packets, list)
+    if entries is None:
+        first = packets[0]
+        assert isinstance(first, dict)
+        entries = [_session_entry(first)]
+    return {
+        "schema_version": review_session.SCHEMA_VERSION,
+        "session_mode": mode,
+        "packet_bundle_digest": packet_index["bundle_digest"],
+        "packet_input_digest": packet_index["input_provenance"]["input_digest"],
+        "reviewer": "repository-owner",
+        "reviewer_evidence": "https://github.com/sherif69-sa/DevS69-sdetkit/issues/2181#issuecomment-1",
+        "decided_at": "2026-08-08T15:00:00+00:00",
+        "entries": entries,
+        "authority_boundary": review_session.authority_boundary(),
+    }
+
+
+def _install_packet_index(monkeypatch, packet_index: dict[str, object]) -> None:
+    monkeypatch.setattr(
+        review_session,
+        "build_workflow_permission_review_packet_index",
+        lambda _root: packet_index,
+    )
+
+
+def test_live_complete_template_binds_every_pending_packet_without_deciding() -> None:
+    packet_index = review_packet.build_workflow_permission_review_packet_index(".")
+    template = review_session.build_review_session_template(".", mode="complete")
+    pending = [
+        packet
+        for packet in packet_index["packets"]
+        if packet["decision_boundary"]["human_decision_recorded"] is False
+    ]
+
+    assert template["packet_bundle_digest"] == packet_index["bundle_digest"]
+    assert template["packet_input_digest"] == packet_index["input_provenance"]["input_digest"]
+    assert len(template["entries"]) == len(pending)
+    assert template["reviewer"] is None
+    assert template["reviewer_evidence"] is None
+    assert template["decided_at"] is None
+    assert not any(template["authority_boundary"].values())
+    for entry in template["entries"]:
+        assert entry["decision"] is None
+        assert entry["rationale"] is None
+        assert entry["proposed_change"] is None
+        assert entry["proof_acknowledged"] is False
+        assert entry["rollback_acknowledged"] is False
+
+
+def test_blank_generated_template_is_intentionally_invalid() -> None:
+    template = review_session.build_review_session_template(".", mode="complete")
+    validation = review_session.validate_review_session(".", template)
+
+    assert validation["valid_current"] is False
+    assert validation["status"] == "invalid"
+    assert "reviewer_missing" in validation["invalid_reasons"]
+    assert "reviewer_evidence_missing" in validation["invalid_reasons"]
+    assert "decided_at_invalid" in validation["invalid_reasons"]
+    assert validation["compiled_candidates"] == []
+
+
+def test_valid_partial_session_compiles_only_explicit_human_entry(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "compiled"
+    assert compilation["compiled_record_count"] == 1
+    assert len(compilation["records"]) == 1
+    record = compilation["records"][0]["record"]
+    assert record["decision"] == "keep"
+    assert record["reviewer"] == session["reviewer"]
+    assert record["rationale"] == session["entries"][0]["rationale"]
+    assert not any(record["authority_boundary"].values())
+    assert not any(compilation["authority_boundary"].values())
+
+
+def test_valid_reduce_session_is_revalidated_by_decision_record_v1(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    packets = packet_index["packets"]
+    assert isinstance(packets, list)
+    first = packets[0]
+    assert isinstance(first, dict)
+    session = _session(packet_index, entries=[_session_entry(first, decision="reduce")])
+
+    compilation = review_session.compile_review_session(".", session)
+    record = compilation["records"][0]["record"]
+    review_entry = {
+        "review_id": first["review_id"],
+        "workflow": first["workflow"],
+        "workflow_sha256": first["workflow_sha256"],
+        "permission_group": first["permission_group"],
+    }
+    validation = decision_record.validate_decision_record(record, review_entry)
+
+    assert validation["valid_current"] is True
+    assert validation["reasons"] == []
+    assert record["proposed_change"]["kind"] == "permission_only"
+
+
+def test_complete_session_requires_every_pending_packet(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index, mode="complete")
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["compiled_record_count"] == 0
+    assert compilation["records"] == []
+    missing = compilation["validation"]["missing_review_ids"]
+    assert len(missing) == 1
+    assert f"complete_session_missing:{missing[0]}" in compilation["validation"]["invalid_reasons"]
+
+
+def test_complete_session_compiles_all_pending_packets_when_explicit(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    packets = packet_index["packets"]
+    assert isinstance(packets, list)
+    entries = [_session_entry(packet) for packet in packets if isinstance(packet, dict)]
+    session = _session(packet_index, mode="complete", entries=entries)
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "compiled"
+    assert compilation["compiled_record_count"] == 2
+    assert compilation["validation"]["missing_review_ids"] == []
+
+
+def test_stale_bundle_blocks_all_records(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+    session["packet_bundle_digest"] = "old-bundle"
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["records"] == []
+    assert compilation["validation"]["status"] == "stale"
+    assert compilation["validation"]["stale_reasons"] == ["packet_bundle_digest_mismatch"]
+
+
+def test_stale_packet_binding_blocks_all_records(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+    session["entries"][0]["packet_digest"] = "old-packet"
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["records"] == []
+    reasons = compilation["validation"]["stale_reasons"]
+    assert any(reason.startswith("packet_digest_mismatch:") for reason in reasons)
+
+
+def test_duplicate_review_id_is_conflict_not_latest_wins(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    packets = packet_index["packets"]
+    assert isinstance(packets, list)
+    first = packets[0]
+    assert isinstance(first, dict)
+    entry = _session_entry(first)
+    session = _session(packet_index, entries=[entry, copy.deepcopy(entry)])
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["records"] == []
+    assert any(
+        reason.startswith("duplicate_review_id:")
+        for reason in compilation["validation"]["invalid_reasons"]
+    )
+
+
+def test_already_decided_packet_cannot_be_reviewed_again(monkeypatch) -> None:
+    packet_index = _packet_index(second_decided=True)
+    _install_packet_index(monkeypatch, packet_index)
+    packets = packet_index["packets"]
+    assert isinstance(packets, list)
+    second = packets[1]
+    assert isinstance(second, dict)
+    session = _session(packet_index, entries=[_session_entry(second)])
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["records"] == []
+    assert (
+        f"review_already_decided:{second['review_id']}"
+        in compilation["validation"]["invalid_reasons"]
+    )
+
+
+def test_missing_proof_or_rollback_acknowledgement_blocks_session(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+    session["entries"][0]["proof_acknowledged"] = False
+    session["entries"][0]["rollback_acknowledged"] = False
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["records"] == []
+    reasons = compilation["validation"]["invalid_reasons"]
+    assert any(reason.startswith("proof_not_acknowledged:") for reason in reasons)
+    assert any(reason.startswith("rollback_not_acknowledged:") for reason in reasons)
+
+
+def test_invalid_decision_record_fields_block_entire_session(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+    session["entries"][0]["rationale"] = ""
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["records"] == []
+    assert any(
+        reason.endswith(":rationale_missing")
+        for reason in compilation["validation"]["invalid_reasons"]
+    )
+
+
+def test_session_digest_is_deterministic_and_changes_with_human_input(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+
+    first = review_session.session_digest(session)
+    second = review_session.session_digest(copy.deepcopy(session))
+    changed = copy.deepcopy(session)
+    changed["entries"][0]["rationale"] = "Different reviewed rationale."
+
+    assert first == second
+    assert first != review_session.session_digest(changed)
+
+
+def test_compilation_manifest_binds_session_and_record_hashes(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+
+    compilation = review_session.compile_review_session(".", session)
+    manifest = compilation["manifest"]
+    record_item = compilation["records"][0]
+
+    assert manifest["session_digest"] == review_session.session_digest(session)
+    assert manifest["packet_bundle_digest"] == packet_index["bundle_digest"]
+    assert manifest["compiled_record_count"] == 1
+    assert manifest["records"][0]["record_sha256"] == record_item["record_sha256"]
+    assert manifest["canonical_decision_directory_write_allowed"] is False
+    assert manifest["source_tree_write_allowed"] is False
+    assert manifest["implementation_authorized"] is False
+    assert not any(manifest["authority_boundary"].values())
+
+
+def test_writer_allows_external_output_but_never_grants_source_write(
+    monkeypatch, tmp_path: Path
+) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    compilation = review_session.compile_review_session(".", _session(packet_index))
+
+    result = review_session.write_compiled_decision_records(".", tmp_path, compilation)
+
+    assert result["written_record_count"] == 1
+    assert Path(result["manifest_path"]).is_file()
+    record_path = Path(result["written_records"][0])
+    assert record_path.is_file()
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["decision"] == "keep"
+    assert result["source_tree_write_allowed"] is False
+    assert not any(result["authority_boundary"].values())
+
+
+def test_writer_refuses_canonical_decision_directory(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    compilation = review_session.compile_review_session(".", _session(packet_index))
+
+    with pytest.raises(ValueError, match="only be written under build"):
+        review_session.write_compiled_decision_records(
+            ".",
+            "docs/ci/workflow-permission-decisions",
+            compilation,
+        )
+
+
+def test_authority_escalation_blocks_session(monkeypatch) -> None:
+    packet_index = _packet_index()
+    _install_packet_index(monkeypatch, packet_index)
+    session = _session(packet_index)
+    session["authority_boundary"]["permission_mutation_allowed"] = True
+
+    compilation = review_session.compile_review_session(".", session)
+
+    assert compilation["status"] == "blocked"
+    assert compilation["records"] == []
+    assert "authority_boundary_mismatch" in compilation["validation"]["invalid_reasons"]
+
+
+def test_zero_pending_packets_are_not_required(monkeypatch) -> None:
+    packet_index = _packet_index(second_decided=True)
+    packets = packet_index["packets"]
+    assert isinstance(packets, list)
+    first = packets[0]
+    assert isinstance(first, dict)
+    first["decision_boundary"]["human_decision_recorded"] = True
+    _install_packet_index(monkeypatch, packet_index)
+
+    template = review_session.build_review_session_template(".", mode="complete")
+    validation = review_session.validate_review_session(".", template)
+    compilation = review_session.compile_review_session(".", template)
+
+    assert template["entries"] == []
+    assert validation["status"] == "not_required"
+    assert validation["valid_current"] is False
+    assert validation["pending_packet_count"] == 0
+    assert validation["invalid_reasons"] == []
+    assert validation["stale_reasons"] == []
+    assert compilation["status"] == "not_required"
+    assert compilation["compiled_record_count"] == 0
+    assert compilation["records"] == []
+    assert not any(compilation["authority_boundary"].values())

--- a/tests/test_workflow_permission_review_session_cli.py
+++ b/tests/test_workflow_permission_review_session_cli.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import workflow_permission_decision_record as decision_record
+from sdetkit import workflow_permission_review_session as review_session
+
+
+def _packet_index() -> dict[str, object]:
+    workflow = ".github/workflows/example.yml"
+    workflow_sha256 = "a" * 64
+    review_id = decision_record.review_id_for_workflow(workflow)
+    return {
+        "schema_version": "sdetkit.workflow_permission_review_packet.v1",
+        "bundle_digest": "bundle-current",
+        "input_provenance": {"input_digest": "input-current"},
+        "packets": [
+            {
+                "review_id": review_id,
+                "packet_digest": "packet-current",
+                "workflow": workflow,
+                "workflow_sha256": workflow_sha256,
+                "permission_group": "repository_mutation",
+                "decision_boundary": {"human_decision_recorded": False},
+                "proof_contract": ["exact-head CI"],
+                "rollback_contract": {
+                    "strategy": "restore_exact_workflow_bytes",
+                    "workflow_sha256": workflow_sha256,
+                },
+            }
+        ],
+    }
+
+
+def _install_packet_index(monkeypatch) -> dict[str, object]:
+    payload = _packet_index()
+    monkeypatch.setattr(
+        review_session,
+        "build_workflow_permission_review_packet_index",
+        lambda _root: payload,
+    )
+    return payload
+
+
+def _completed_session(monkeypatch, root: Path) -> Path:
+    _install_packet_index(monkeypatch)
+    session = review_session.build_review_session_template(root, mode="complete")
+    session["reviewer"] = "repository-owner"
+    session["reviewer_evidence"] = (
+        "https://github.com/sherif69-sa/DevS69-sdetkit/issues/2181#issuecomment-1"
+    )
+    session["decided_at"] = "2026-08-08T15:00:00+00:00"
+    entry = session["entries"][0]
+    entry["decision"] = "keep"
+    entry["rationale"] = "I reviewed the exact workflow and chose to retain its permissions."
+    entry["proposed_change"] = {"kind": "none"}
+    entry["proof_acknowledged"] = True
+    entry["rollback_acknowledged"] = True
+    path = root / "session.json"
+    path.write_text(json.dumps(session, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_main_writes_complete_template_and_json_output(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    packet_index = _install_packet_index(monkeypatch)
+
+    result = review_session.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--template-mode",
+            "complete",
+            "--template-out",
+            "build/review-session.json",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert result == 0
+    template_path = tmp_path / "build" / "review-session.json"
+    assert template_path.is_file()
+    template = json.loads(template_path.read_text(encoding="utf-8"))
+    assert template["packet_bundle_digest"] == packet_index["bundle_digest"]
+    assert len(template["entries"]) == 1
+    assert template["reviewer"] is None
+    output = json.loads(capsys.readouterr().out)
+    assert output["template_path"] == template_path.as_posix()
+    assert output["template"]["entries"][0]["decision"] is None
+    assert not any(output["authority_boundary"].values())
+
+
+def test_main_compiles_valid_session_to_build_and_renders_text(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    session_path = _completed_session(monkeypatch, tmp_path)
+
+    result = review_session.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--session",
+            session_path.name,
+            "--compile-out-dir",
+            "build/compiled-decisions",
+            "--fail-on-invalid",
+            "--format",
+            "text",
+        ]
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "status=current" in output
+    assert "compiled_record_count=1" in output
+    assert "decision_inference_allowed=false" in output
+    assert "permission_mutation_allowed=false" in output
+    compiled_dir = tmp_path / "build" / "compiled-decisions"
+    manifest = compiled_dir / review_session.COMPILATION_MANIFEST_NAME
+    assert manifest.is_file()
+    decision_files = sorted(compiled_dir.glob("*.decision.json"))
+    assert len(decision_files) == 1
+    decision = json.loads(decision_files[0].read_text(encoding="utf-8"))
+    assert decision["decision"] == "keep"
+    assert decision["reviewer"] == "repository-owner"
+
+
+def test_main_invalid_session_fails_closed_without_output_records(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    session_path = _completed_session(monkeypatch, tmp_path)
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    session["packet_bundle_digest"] = "stale-bundle"
+    session_path.write_text(json.dumps(session, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    result = review_session.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--session",
+            session_path.name,
+            "--compile-out-dir",
+            "build/blocked-decisions",
+            "--fail-on-invalid",
+            "--format",
+            "text",
+        ]
+    )
+
+    assert result == 1
+    output = capsys.readouterr().out
+    assert "status=stale" in output
+    assert "packet_bundle_digest_mismatch" in output
+    assert "compiled_record_count=0" in output
+    assert not (tmp_path / "build" / "blocked-decisions").exists()
+
+
+def test_main_template_text_reports_blank_human_boundary(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _install_packet_index(monkeypatch)
+
+    result = review_session.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--template-out",
+            "build/review-session.json",
+            "--format",
+            "text",
+        ]
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "template_mode=complete" in output
+    assert "template_entry_count=1" in output
+    assert "decision_inference_allowed=false" in output
+
+
+def test_load_json_rejects_non_object_session(tmp_path: Path) -> None:
+    path = tmp_path / "session.json"
+    path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="review session must be a JSON object"):
+        review_session._load_json(path)
+
+
+def test_safe_output_directory_resolves_relative_path_beneath_explicit_root(
+    tmp_path: Path,
+) -> None:
+    output = review_session._safe_output_directory(
+        tmp_path,
+        Path("build/compiled-decisions"),
+    )
+
+    assert output == (tmp_path / "build" / "compiled-decisions").resolve()
+
+    with pytest.raises(ValueError, match="only be written under build"):
+        review_session._safe_output_directory(
+            tmp_path,
+            Path("docs/ci/workflow-permission-decisions"),
+        )


### PR DESCRIPTION
Advances #2181. #2202 is now merged into `main`; this PR has been restacked directly on that squash commit and is being re-proven on the exact current head.

## Why

Workflow Permission Review Packet v1 prepares exact reviewer evidence. This PR adds Workflow Permission Review Session v1 so a human can review multiple pending permission packets in one exact-digest batch without software choosing any answer.

## What this adds

- `sdetkit.workflow_permission_review_session` validator/compiler + CLI;
- versioned `workflow-permission-review-session.v1` contract;
- partial and complete review-session modes;
- exact packet-bundle and per-packet bindings;
- explicit human reviewer/evidence/time, decision, rationale, proposed change, proof acknowledgement, and rollback acknowledgement;
- duplicate/already-decided/stale/mixed-invalid sessions fail closed with zero candidate records;
- every candidate independently revalidated through Decision Record v1;
- deterministic session digest and compilation manifest;
- repository-local compilation output restricted to `build/`;
- canonical decision storage and workflow/source-tree writes refused;
- zero-pending terminal state returns `not_required` without fabricating a reviewer.

## Root-relative write-boundary repair

The initial Quality work added real CLI operator-path coverage rather than lowering the reviewed 87.89% whole-package floor. Those tests exposed a real bug: relative `--compile-out-dir build/...` values were resolved against process CWD rather than explicit `--root`.

The implementation now resolves relative compilation destinations beneath `--root` first, then enforces the existing `build/` restriction. The operator documentation explicitly records that process CWD cannot redefine the repository write boundary.

Regression coverage pins both outcomes:

- `build/compiled-decisions` resolves beneath explicit root;
- `docs/ci/workflow-permission-decisions` remains rejected.

## Authority boundary

Generated session templates contain no default reviewer or decisions. Decision inference, human-decision fabrication, source-tree write, workflow mutation, patch application, permission mutation, implementation, security dismissal, semantic equivalence and merge authority all remain false.

## Quality truth

The exact Stage 5 product tree previously measured:

- whole-package coverage: **87.89946860300401%**, above the unchanged 87.89 floor;
- source modules: **534**;
- typing-debt modules: **489**;
- explicitly typed modules: **45**;
- quality-truth mismatches: **0**.

Fresh exact-head Quality/CI is running again because the squash-restack changed ancestry.

## Current exact scope

Base `main`: `f91d25019f9d3dc3ad40063a776f8ac17b001354`

Current exact head: `66a1feb9424e185015122e28f1b4fdf7b69f9acf`

Exactly 8 files are in product scope:

1. `docs/ci/workflow-permission-review-session.md`
2. `docs/contracts/quality-truth-baseline.v1.json`
3. `docs/contracts/workflow-permission-review-session.v1.json`
4. `pyproject.toml`
5. `src/sdetkit/workflow_permission_review_session.py`
6. `tests/test_quality_truth_baseline.py`
7. `tests/test_workflow_permission_review_session.py`
8. `tests/test_workflow_permission_review_session_cli.py`

No `.github/workflows/*` file is in scope.

This PR does not retain decisions automatically and does not authorize any workflow permission change.