### PR TITLE
feat(governance): prepare non-executable workflow permission change plans

### DIFF
--- a/docs/ci/workflow-permission-change-plan.md
+++ b/docs/ci/workflow-permission-change-plan.md
@@ -1,0 +1,147 @@
+# Workflow permission change plan
+
+Workflow Permission Change Plan v1 is the non-executable implementation-planning layer after a valid retained human permission decision.
+
+It does not decide whether a workflow should change. It does not infer target permissions. It does not generate a YAML patch. It does not edit a workflow. It does not authorize implementation.
+
+## Product flow
+
+```text
+workflow-governance-report
+  -> permission review control plane
+  -> exact review packets
+  -> human review session
+  -> retained Decision Record v1
+  -> permission change plan v1
+  -> separate reviewed permission-only PR
+  -> workflow-specific execution proof + rollback
+```
+
+## Eligibility
+
+A plan may exist only when the current control plane contains exactly one valid current human Decision Record v1 with decision `reduce` or `split`.
+
+The following never create an implementation plan:
+
+- a pending review;
+- a generated review packet;
+- Markdown review evidence;
+- a recommendation;
+- `keep`;
+- `defer`;
+- a stale or conflicting decision record.
+
+If a `reduce` or `split` decision is reported but its exact retained decision-record file cannot be opened and hashed, plan generation fails closed.
+
+## Generate the live plan index
+
+```bash
+python -m sdetkit.workflow_permission_change_plan \
+  --root . \
+  --out build/sdetkit/workflow-permission-change-plans.json \
+  --format text
+```
+
+With no current `reduce` or `split` decisions, the expected live state is:
+
+```text
+status=not_required
+change_plan_count=0
+implementation_authorized=false
+permission_mutation_allowed=false
+```
+
+That is the correct state for the repository today. The generator must not convert the existing review recommendations into change plans.
+
+## Exact decision binding
+
+Every plan template is bound to:
+
+- review ID;
+- workflow path;
+- exact workflow SHA-256;
+- permission group;
+- human decision (`reduce` or `split`);
+- retained Decision Record v1 path;
+- exact Decision Record file SHA-256;
+- the human-approved `proposed_change` intent;
+- current write-scope snapshot;
+- proof contract;
+- rollback contract;
+- plan digest.
+
+The plan-layer input digest is also bound to the current permission-review control-plane input digest, so workflow, evidence, contract, or decision-record changes stale retained planning output transitively.
+
+## Human implementation fields
+
+The generated template deliberately leaves the concrete implementation empty:
+
+```json
+{
+  "implementation_scope": "permissions_only",
+  "top_level_permissions": null,
+  "job_permissions": null,
+  "implementation_rationale": null,
+  "proof_execution_refs": [],
+  "rollback_execution_ref": null,
+  "human_completion_required": true
+}
+```
+
+A human engineer must describe the proposed top-level/job permission maps and rationale. Software does not infer them from workflow steps or from the human decision summary.
+
+## Structural validation
+
+The validator accepts permission levels `read`, `write`, and `none` and checks:
+
+- exact current plan binding;
+- permissions-only scope;
+- a target permission map is present;
+- implementation rationale is present;
+- no requested `write` scope is new relative to the reviewed current write-scope snapshot;
+- proof/rollback reference fields have valid shapes;
+- `ready_for_patch=false`;
+- `safe_to_patch=false`;
+- separate reviewed PR remains required;
+- all authority bits remain false.
+
+A structurally valid plan returns `structurally_ready_for_separate_pr`. This wording is intentional: it means the plan may be used as evidence for a future reviewed permission-only PR. It does **not** authorize a patch.
+
+## No write-scope escalation
+
+If the reviewed workflow currently grants:
+
+```text
+contents: write
+issues: write
+```
+
+then a plan may redistribute those write scope classes between workflow/job permission maps, or reduce them to `read`/`none`, but it cannot introduce `packages: write` or another previously absent write scope.
+
+This is a structural anti-escalation rule. It is not a proof that the narrower/split permission layout will preserve workflow behavior.
+
+## Semantic proof remains separate
+
+The plan validator cannot prove semantic equivalence. A future implementation PR must still execute the workflow-specific proof contract, compare outcomes, retain rollback evidence, and pass normal exact-head repository CI.
+
+Therefore these remain false even for a structurally valid plan:
+
+- `implementation_authorized`;
+- `safe_to_patch`;
+- `patch_application_allowed`;
+- `permission_mutation_allowed`;
+- `semantic_equivalence_proven`;
+- `merge_authorized`.
+
+## Why this layer is useful
+
+Decision Record v1 captures *what the human decided*. Change Plan v1 captures *what an engineer proposes to implement* without conflating the two. That gives reviewers a deterministic audit trail:
+
+```text
+human decision bytes
+  -> implementation-plan bytes
+  -> future patch bytes
+  -> execution proof
+```
+
+Each boundary can become stale independently and none grants the next boundary automatic authority.

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -92,6 +92,7 @@
       "sdetkit.protected_proof_chain",
       "sdetkit.safety_gate",
       "sdetkit.trajectory_store",
+      "sdetkit.workflow_permission_change_plan",
       "sdetkit.workflow_permission_decision_record",
       "sdetkit.workflow_permission_review_control_plane",
       "sdetkit.workflow_permission_review_packet",
@@ -100,7 +101,7 @@
     ],
     "migration_complete": false,
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 534,
+    "source_module_count": 535,
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "typing_debt_inventory_sha256": "e8729da81702dacbd8901642b8dfea0e45540ff6a4e655834f2fbbd8bb4b053a",
     "typing_debt_module_count": 489

--- a/docs/contracts/workflow-permission-change-plan.v1.json
+++ b/docs/contracts/workflow-permission-change-plan.v1.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "sdetkit.workflow_permission_change_plan.v1",
+  "status": "non_executable_implementation_planning",
+  "purpose": "Prepare exact-digest permission-only implementation-plan templates from valid current human reduce/split decisions without generating or applying workflow patches.",
+  "source_of_truth": "sdetkit.workflow_permission_review_control_plane",
+  "eligibility": {
+    "valid_current_human_decision_required": true,
+    "eligible_decisions": [
+      "reduce",
+      "split"
+    ],
+    "keep_creates_plan": false,
+    "defer_creates_plan": false,
+    "recommendation_creates_plan": false,
+    "review_packet_creates_plan": false,
+    "missing_decision_record_blocks_plan": true
+  },
+  "exact_binding": {
+    "review_id_required": true,
+    "workflow_required": true,
+    "workflow_sha256_required": true,
+    "permission_group_required": true,
+    "decision_record_ref_required": true,
+    "decision_record_sha256_required": true,
+    "plan_digest_required": true
+  },
+  "implementation_template": {
+    "scope": "permissions_only",
+    "top_level_permissions_human_completion_required": true,
+    "job_permissions_human_completion_required": true,
+    "implementation_rationale_required": true,
+    "proof_execution_refs_may_be_prepared": true,
+    "rollback_execution_ref_may_be_prepared": true,
+    "machine_may_infer_target_permissions": false,
+    "machine_may_generate_patch": false
+  },
+  "permission_safety": {
+    "allowed_levels": [
+      "read",
+      "write",
+      "none"
+    ],
+    "new_write_scope_allowed": false,
+    "current_write_scope_snapshot_required": true,
+    "structural_validation_proves_semantic_equivalence": false
+  },
+  "implementation_boundary": {
+    "structurally_valid_plan_authorizes_patch": false,
+    "separate_reviewed_permission_pr_required": true,
+    "workflow_specific_execution_proof_required": true,
+    "rollback_required": true,
+    "automatic_commit_allowed": false,
+    "automatic_pull_request_allowed": false,
+    "automatic_merge_allowed": false
+  },
+  "freshness": {
+    "generator_source_bound": true,
+    "contract_bound": true,
+    "control_plane_input_digest_bound": true,
+    "decision_record_bytes_bound": true,
+    "workflow_bytes_bound_transitively": true
+  },
+  "authority_boundary": {
+    "automation_allowed": false,
+    "commit_allowed": false,
+    "implementation_authorized": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "permission_increase_allowed": false,
+    "permission_mutation_allowed": false,
+    "security_dismissal_allowed": false,
+    "semantic_equivalence_proven": false,
+    "source_tree_write_allowed": false,
+    "workflow_mutation_allowed": false
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,7 @@ ignore_errors = false
 
 [[tool.mypy.overrides]]
 module = [
+  "sdetkit.workflow_permission_change_plan",
   "sdetkit.workflow_permission_decision_record",
   "sdetkit.workflow_permission_review_control_plane",
   "sdetkit.workflow_permission_review_packet",

--- a/src/sdetkit/workflow_permission_change_plan.py
+++ b/src/sdetkit/workflow_permission_change_plan.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .workflow_permission_review_control_plane import build_workflow_permission_review_control_plane
+
+SCHEMA_VERSION = "sdetkit.workflow_permission_change_plan.v1"
+CONTRACT_PATH = "docs/contracts/workflow-permission-change-plan.v1.json"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/workflow_permission_change_plan.py"
+PLAN_DECISIONS = ("reduce", "split")
+NON_CHANGE_DECISIONS = ("keep", "defer")
+ALLOWED_PERMISSION_LEVELS = ("read", "write", "none")
+DIGEST_ALGORITHM = "sha256"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "commit_allowed",
+    "implementation_authorized",
+    "merge_authorized",
+    "patch_application_allowed",
+    "permission_increase_allowed",
+    "permission_mutation_allowed",
+    "security_dismissal_allowed",
+    "semantic_equivalence_proven",
+    "source_tree_write_allowed",
+    "workflow_mutation_allowed",
+)
+
+
+def authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _update_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def _decision_record_sha256(root: Path, record_ref: object) -> str | None:
+    if not isinstance(record_ref, str) or not record_ref:
+        return None
+    path = root / record_ref
+    if not path.is_file():
+        return None
+    return _sha256_bytes(path.read_bytes())
+
+
+def _plan_id(review_id: object) -> str:
+    return f"wpcp-{review_id or 'unknown'}"
+
+
+def _implementation_template() -> dict[str, Any]:
+    return {
+        "implementation_scope": "permissions_only",
+        "top_level_permissions": None,
+        "job_permissions": None,
+        "implementation_rationale": None,
+        "proof_execution_refs": [],
+        "rollback_execution_ref": None,
+        "human_completion_required": True,
+    }
+
+
+def _plan_digest(plan: dict[str, Any]) -> str:
+    payload = dict(plan)
+    payload.pop("plan_digest", None)
+    return _sha256_bytes(_canonical_json_bytes(payload))
+
+
+def _build_plan(root: Path, entry: dict[str, Any]) -> dict[str, Any] | None:
+    decision = entry.get("human_decision")
+    if decision not in PLAN_DECISIONS:
+        return None
+    record_ref = entry.get("decision_record_ref")
+    record_sha256 = _decision_record_sha256(root, record_ref)
+    if record_sha256 is None:
+        return None
+
+    write_scopes = sorted({str(scope) for scope in entry.get("granted_write_scopes", [])})
+    plan: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "plan_id": _plan_id(entry.get("review_id")),
+        "review_id": entry.get("review_id"),
+        "workflow": entry.get("workflow"),
+        "workflow_sha256": entry.get("workflow_sha256"),
+        "permission_group": entry.get("permission_group"),
+        "decision_binding": {
+            "decision": decision,
+            "decision_record_ref": record_ref,
+            "decision_record_sha256": record_sha256,
+            "approved_intent": entry.get("proposed_change"),
+        },
+        "current_permission_snapshot": {
+            "granted_write_scopes": write_scopes,
+            "write_scope_count": len(write_scopes),
+        },
+        "implementation": _implementation_template(),
+        "proof_contract": list(entry.get("proof_contract", [])),
+        "rollback_contract": entry.get("rollback_contract"),
+        "ready_for_patch": False,
+        "safe_to_patch": False,
+        "requires_separate_reviewed_pr": True,
+        "authority_boundary": authority_boundary(),
+    }
+    plan["plan_digest"] = _plan_digest(plan)
+    return plan
+
+
+def workflow_permission_change_plan_input_provenance(
+    repo_root: str | Path = ".",
+    *,
+    control_plane: dict[str, Any] | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    plane = control_plane or build_workflow_permission_review_control_plane(root)
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+    inputs: list[tuple[str, bytes]] = [
+        ("schema_version", SCHEMA_VERSION.encode("utf-8")),
+        (GENERATOR_SOURCE_LABEL, generator.read_bytes()),
+        (
+            "control_plane_input_digest",
+            str(plane.get("input_provenance", {}).get("input_digest", "")).encode("utf-8"),
+        ),
+    ]
+    contract = root / CONTRACT_PATH
+    if contract.is_file():
+        inputs.append((CONTRACT_PATH, contract.read_bytes()))
+
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_digest(hasher, label, content)
+    return {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "control_plane_input_digest": plane.get("input_provenance", {}).get("input_digest", ""),
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+        "contract_path": CONTRACT_PATH,
+    }
+
+
+def build_workflow_permission_change_plan_index(
+    repo_root: str | Path = ".",
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    plane = build_workflow_permission_review_control_plane(root)
+    queue = plane.get("review_queue", [])
+    if not isinstance(queue, list):
+        queue = []
+
+    plans: list[dict[str, Any]] = []
+    non_change_decisions = 0
+    pending_reviews = 0
+    missing_record_bindings: list[str] = []
+    for entry in queue:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("human_decision_recorded") is not True:
+            pending_reviews += 1
+            continue
+        decision = entry.get("human_decision")
+        if decision in NON_CHANGE_DECISIONS:
+            non_change_decisions += 1
+            continue
+        if decision not in PLAN_DECISIONS:
+            continue
+        plan = _build_plan(root, entry)
+        if plan is None:
+            missing_record_bindings.append(str(entry.get("workflow", "unknown")))
+            continue
+        plans.append(plan)
+
+    plans.sort(key=lambda item: str(item.get("workflow", "")))
+    missing_record_bindings = sorted(set(missing_record_bindings))
+    provenance = workflow_permission_change_plan_input_provenance(root, control_plane=plane)
+    plan_refs = [
+        {
+            "plan_id": plan["plan_id"],
+            "review_id": plan["review_id"],
+            "workflow": plan["workflow"],
+            "workflow_sha256": plan["workflow_sha256"],
+            "decision": plan["decision_binding"]["decision"],
+            "decision_record_ref": plan["decision_binding"]["decision_record_ref"],
+            "decision_record_sha256": plan["decision_binding"]["decision_record_sha256"],
+            "plan_digest": plan["plan_digest"],
+        }
+        for plan in plans
+    ]
+    bundle_digest = _sha256_bytes(_canonical_json_bytes({"plans": plan_refs}))
+
+    if missing_record_bindings:
+        status = "blocked"
+    elif plans:
+        status = "human_implementation_plan_required"
+    else:
+        status = "not_required"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "input_provenance": provenance,
+        "summary": {
+            "change_plan_count": len(plans),
+            "reduce_or_split_decision_count": len(plans) + len(missing_record_bindings),
+            "non_change_decision_count": non_change_decisions,
+            "pending_human_review_count": pending_reviews,
+            "missing_decision_record_binding_count": len(missing_record_bindings),
+            "automatic_plan_completion_allowed": False,
+            "automatic_patch_generation_allowed": False,
+            "automatic_permission_change_allowed": False,
+        },
+        "missing_decision_record_bindings": missing_record_bindings,
+        "bundle_digest": bundle_digest,
+        "plan_index": plan_refs,
+        "plans": plans,
+        "rules": {
+            "valid_current_human_decision_required": True,
+            "only_reduce_or_split_create_plan": True,
+            "keep_or_defer_create_no_change_plan": False,
+            "generated_plan_may_not_infer_target_permissions": True,
+            "separate_reviewed_permission_pr_required": True,
+            "workflow_mutation_allowed": False,
+        },
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def _normalize_permissions(value: object) -> tuple[dict[str, str] | None, list[str]]:
+    if value is None:
+        return None, []
+    if not isinstance(value, Mapping):
+        return None, ["permission_map_must_be_object"]
+    normalized: dict[str, str] = {}
+    reasons: list[str] = []
+    for key, level in value.items():
+        if not isinstance(key, str) or not key.strip():
+            reasons.append("permission_scope_invalid")
+            continue
+        if level not in ALLOWED_PERMISSION_LEVELS:
+            reasons.append(f"permission_level_invalid:{key}")
+            continue
+        normalized[key.strip()] = str(level)
+    return dict(sorted(normalized.items())), reasons
+
+
+def _normalize_job_permissions(
+    value: object,
+) -> tuple[dict[str, dict[str, str]] | None, list[str]]:
+    if value is None:
+        return None, []
+    if not isinstance(value, Mapping):
+        return None, ["job_permissions_must_be_object"]
+    normalized: dict[str, dict[str, str]] = {}
+    reasons: list[str] = []
+    for job, permissions in value.items():
+        if not isinstance(job, str) or not job.strip():
+            reasons.append("job_name_invalid")
+            continue
+        mapping, mapping_reasons = _normalize_permissions(permissions)
+        reasons.extend(f"job:{job}:{reason}" for reason in mapping_reasons)
+        if mapping is not None:
+            normalized[job.strip()] = mapping
+    return dict(sorted(normalized.items())), reasons
+
+
+def _requested_write_scopes(
+    top_level: Mapping[str, str] | None,
+    jobs: Mapping[str, Mapping[str, str]] | None,
+) -> set[str]:
+    scopes: set[str] = set()
+    if top_level:
+        scopes.update(f"{scope}: write" for scope, level in top_level.items() if level == "write")
+    if jobs:
+        for permissions in jobs.values():
+            scopes.update(
+                f"{scope}: write" for scope, level in permissions.items() if level == "write"
+            )
+    return scopes
+
+
+def validate_workflow_permission_change_plan(
+    repo_root: str | Path,
+    candidate: dict[str, Any],
+) -> dict[str, Any]:
+    current_index = build_workflow_permission_change_plan_index(repo_root)
+    current_plans = current_index.get("plans", [])
+    if not isinstance(current_plans, list):
+        current_plans = []
+    by_plan_id = {
+        str(plan.get("plan_id", "")): plan for plan in current_plans if isinstance(plan, dict)
+    }
+    plan_id = candidate.get("plan_id")
+    template = by_plan_id.get(str(plan_id)) if isinstance(plan_id, str) else None
+    stale_reasons: list[str] = []
+    invalid_reasons: list[str] = []
+
+    if candidate.get("schema_version") != SCHEMA_VERSION:
+        invalid_reasons.append("schema_version_mismatch")
+    if template is None:
+        stale_reasons.append("plan_not_current")
+    else:
+        immutable_fields = (
+            "review_id",
+            "workflow",
+            "workflow_sha256",
+            "permission_group",
+            "decision_binding",
+            "current_permission_snapshot",
+            "proof_contract",
+            "rollback_contract",
+        )
+        for field in immutable_fields:
+            if candidate.get(field) != template.get(field):
+                stale_reasons.append(f"binding_mismatch:{field}")
+        if candidate.get("plan_digest") != template.get("plan_digest"):
+            stale_reasons.append("plan_digest_mismatch")
+
+    implementation = candidate.get("implementation")
+    if not isinstance(implementation, dict):
+        invalid_reasons.append("implementation_missing")
+        implementation = {}
+    if implementation.get("implementation_scope") != "permissions_only":
+        invalid_reasons.append("implementation_scope_invalid")
+
+    top_level, top_reasons = _normalize_permissions(implementation.get("top_level_permissions"))
+    jobs, job_reasons = _normalize_job_permissions(implementation.get("job_permissions"))
+    invalid_reasons.extend(top_reasons)
+    invalid_reasons.extend(job_reasons)
+    if top_level is None and jobs is None:
+        invalid_reasons.append("target_permissions_missing")
+    if (
+        not isinstance(implementation.get("implementation_rationale"), str)
+        or not str(implementation.get("implementation_rationale", "")).strip()
+    ):
+        invalid_reasons.append("implementation_rationale_missing")
+
+    existing_writes: set[str] = set()
+    if template is not None:
+        snapshot = template.get("current_permission_snapshot", {})
+        if isinstance(snapshot, dict):
+            existing_writes = {
+                str(scope)
+                for scope in snapshot.get("granted_write_scopes", [])
+                if isinstance(scope, str)
+            }
+    requested_writes = _requested_write_scopes(top_level, jobs)
+    new_writes = sorted(requested_writes - existing_writes)
+    if new_writes:
+        invalid_reasons.extend(f"new_write_scope_forbidden:{scope}" for scope in new_writes)
+
+    proof_refs = implementation.get("proof_execution_refs")
+    if not isinstance(proof_refs, list):
+        invalid_reasons.append("proof_execution_refs_must_be_list")
+    rollback_ref = implementation.get("rollback_execution_ref")
+    if rollback_ref is not None and (not isinstance(rollback_ref, str) or not rollback_ref.strip()):
+        invalid_reasons.append("rollback_execution_ref_invalid")
+
+    if candidate.get("ready_for_patch") is not False:
+        invalid_reasons.append("ready_for_patch_must_remain_false")
+    if candidate.get("safe_to_patch") is not False:
+        invalid_reasons.append("safe_to_patch_must_remain_false")
+    if candidate.get("requires_separate_reviewed_pr") is not True:
+        invalid_reasons.append("separate_reviewed_pr_boundary_missing")
+    if candidate.get("authority_boundary") != authority_boundary():
+        invalid_reasons.append("authority_boundary_mismatch")
+
+    stale_reasons = sorted(set(stale_reasons))
+    invalid_reasons = sorted(set(invalid_reasons))
+    if invalid_reasons:
+        status = "invalid"
+    elif stale_reasons:
+        status = "stale"
+    else:
+        status = "structurally_ready_for_separate_pr"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "valid_current": status == "structurally_ready_for_separate_pr",
+        "stale": status == "stale",
+        "plan_id": plan_id,
+        "stale_reasons": stale_reasons,
+        "invalid_reasons": invalid_reasons,
+        "requested_write_scopes": sorted(requested_writes),
+        "existing_write_scopes": sorted(existing_writes),
+        "new_write_scopes": new_writes,
+        "implementation_authorized": False,
+        "safe_to_patch": False,
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def validate_workflow_permission_change_plan_index(
+    repo_root: str | Path,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    current = build_workflow_permission_change_plan_index(repo_root)
+    reasons: list[str] = []
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        reasons.append("schema_version_mismatch")
+    if payload.get("input_provenance", {}).get("input_digest") != current.get(
+        "input_provenance", {}
+    ).get("input_digest"):
+        reasons.append("input_digest_mismatch")
+    if payload.get("bundle_digest") != current.get("bundle_digest"):
+        reasons.append("bundle_digest_mismatch")
+    if payload.get("summary") != current.get("summary"):
+        reasons.append("summary_mismatch")
+    if payload.get("plan_index") != current.get("plan_index"):
+        reasons.append("plan_index_mismatch")
+    if payload.get("plans") != current.get("plans"):
+        reasons.append("plans_mismatch")
+    if payload.get("authority_boundary") != authority_boundary():
+        reasons.append("authority_boundary_mismatch")
+    reasons = sorted(set(reasons))
+    return {
+        "status": "fresh" if not reasons else "stale",
+        "fresh": not reasons,
+        "reasons": reasons,
+        "current_input_digest": current.get("input_provenance", {}).get("input_digest", ""),
+        "recorded_input_digest": payload.get("input_provenance", {}).get("input_digest", ""),
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def render_index_text(index: dict[str, Any]) -> str:
+    summary = index.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
+    return "\n".join(
+        [
+            f"status={index.get('status', 'unknown')}",
+            f"change_plan_count={summary.get('change_plan_count', 0)}",
+            f"reduce_or_split_decision_count={summary.get('reduce_or_split_decision_count', 0)}",
+            f"non_change_decision_count={summary.get('non_change_decision_count', 0)}",
+            f"pending_human_review_count={summary.get('pending_human_review_count', 0)}",
+            f"bundle_digest={index.get('bundle_digest', '')}",
+            "automatic_patch_generation_allowed=false",
+            "implementation_authorized=false",
+            "permission_mutation_allowed=false",
+        ]
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.workflow_permission_change_plan",
+        description="Generate non-executable permission-only change-plan templates from current human decisions.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--out")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    index = build_workflow_permission_change_plan_index(ns.root)
+    if ns.out:
+        root = Path(ns.root).resolve()
+        out = Path(ns.out)
+        if not out.is_absolute():
+            out = root / out
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if ns.format == "json":
+        sys.stdout.write(json.dumps(index, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_index_text(index) + "\n")
+    return 1 if index.get("status") == "blocked" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,10 +24,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 534
+    assert payload["observed"]["source_module_count"] == 535
     assert payload["observed"]["typing_debt_module_count"] == 489
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 45
+    assert len(checked) == 46
     assert "sdetkit._formatter_policy_proposal_observation_records" in checked
     assert "sdetkit._formatter_policy_proposal_observation_schema" in checked
     assert "sdetkit.adoption_product_kpi_freshness" in checked
@@ -49,6 +49,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.merge_readiness" in checked
     assert "sdetkit.mixed_monorepo_operator_proof" in checked
     assert "sdetkit.product_maturity_radar_portfolio" in checked
+    assert "sdetkit.workflow_permission_change_plan" in checked
     assert "sdetkit.workflow_permission_decision_record" in checked
     assert "sdetkit.workflow_permission_review_control_plane" in checked
     assert "sdetkit.workflow_permission_review_packet" in checked
@@ -79,6 +80,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.merge_readiness" not in inventory["modules"]
     assert "sdetkit.mixed_monorepo_operator_proof" not in inventory["modules"]
     assert "sdetkit.product_maturity_radar_portfolio" not in inventory["modules"]
+    assert "sdetkit.workflow_permission_change_plan" not in inventory["modules"]
     assert "sdetkit.workflow_permission_decision_record" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_control_plane" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_packet" not in inventory["modules"]
@@ -101,7 +103,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 534,
+            "actual": 535,
         }
     ]
 

--- a/tests/test_workflow_permission_change_plan.py
+++ b/tests/test_workflow_permission_change_plan.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from sdetkit import workflow_permission_change_plan as change_plan
+
+
+def _entry(
+    root: Path,
+    *,
+    workflow: str = ".github/workflows/example.yml",
+    decision: str = "reduce",
+    record_name: str = "example.decision.json",
+    create_record: bool = True,
+) -> dict[str, object]:
+    record_ref = f"docs/ci/workflow-permission-decisions/{record_name}"
+    if create_record:
+        path = root / record_ref
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "sdetkit.workflow_permission_decision_record.v1",
+                    "review_id": "wpr-example",
+                    "workflow": workflow,
+                    "decision": decision,
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return {
+        "review_id": "wpr-example",
+        "workflow": workflow,
+        "workflow_sha256": "a" * 64,
+        "permission_group": "repository_mutation",
+        "granted_write_scopes": ["contents: write", "issues: write"],
+        "human_decision_recorded": True,
+        "human_decision": decision,
+        "decision_record_ref": record_ref,
+        "proposed_change": {
+            "kind": "permission_only",
+            "summary": "Narrow or split the reviewed write scopes.",
+            "evidence_ref": "https://github.com/sherif69-sa/DevS69-sdetkit/issues/2181",
+        },
+        "proof_contract": ["exact-head CI", "workflow-specific execution proof"],
+        "rollback_contract": {
+            "strategy": "restore_exact_workflow_bytes",
+            "workflow_sha256": "a" * 64,
+        },
+    }
+
+
+def _plane(entries: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "input_provenance": {"input_digest": "control-plane-digest"},
+        "review_queue": entries,
+    }
+
+
+def _install_plane(monkeypatch, plane: dict[str, object]) -> None:
+    monkeypatch.setattr(
+        change_plan,
+        "build_workflow_permission_review_control_plane",
+        lambda _root: plane,
+    )
+
+
+def _complete_candidate(template: dict[str, object]) -> dict[str, object]:
+    candidate = copy.deepcopy(template)
+    implementation = candidate["implementation"]
+    assert isinstance(implementation, dict)
+    implementation["top_level_permissions"] = {
+        "contents": "read",
+        "issues": "read",
+    }
+    implementation["job_permissions"] = {
+        "publisher": {
+            "contents": "write",
+        }
+    }
+    implementation["implementation_rationale"] = (
+        "Retain the reviewed contents write scope only on the job that needs it."
+    )
+    implementation["proof_execution_refs"] = []
+    implementation["rollback_execution_ref"] = None
+    return candidate
+
+
+def test_live_repository_requires_no_change_plan_without_human_reduce_or_split() -> None:
+    payload = change_plan.build_workflow_permission_change_plan_index(".")
+
+    assert payload["status"] == "not_required"
+    assert payload["summary"]["change_plan_count"] == 0
+    assert payload["summary"]["reduce_or_split_decision_count"] == 0
+    assert payload["summary"]["automatic_patch_generation_allowed"] is False
+    assert payload["summary"]["automatic_permission_change_allowed"] is False
+    assert payload["plans"] == []
+    assert not any(payload["authority_boundary"].values())
+
+
+def test_pending_review_never_creates_change_plan(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    entry["human_decision_recorded"] = False
+    entry["human_decision"] = None
+    _install_plane(monkeypatch, _plane([entry]))
+
+    payload = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+
+    assert payload["status"] == "not_required"
+    assert payload["summary"]["pending_human_review_count"] == 1
+    assert payload["plans"] == []
+
+
+def test_keep_and_defer_are_non_change_decisions(monkeypatch, tmp_path: Path) -> None:
+    keep = _entry(
+        tmp_path, workflow=".github/workflows/keep.yml", decision="keep", record_name="keep.json"
+    )
+    defer = _entry(
+        tmp_path,
+        workflow=".github/workflows/defer.yml",
+        decision="defer",
+        record_name="defer.json",
+    )
+    _install_plane(monkeypatch, _plane([keep, defer]))
+
+    payload = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+
+    assert payload["status"] == "not_required"
+    assert payload["summary"]["non_change_decision_count"] == 2
+    assert payload["summary"]["change_plan_count"] == 0
+    assert payload["plans"] == []
+
+
+def test_reduce_decision_creates_blank_non_executable_plan(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path, decision="reduce")
+    _install_plane(monkeypatch, _plane([entry]))
+
+    payload = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+    plan = payload["plans"][0]
+    implementation = plan["implementation"]
+
+    assert payload["status"] == "human_implementation_plan_required"
+    assert payload["summary"]["change_plan_count"] == 1
+    assert plan["decision_binding"]["decision"] == "reduce"
+    assert plan["decision_binding"]["decision_record_sha256"]
+    assert plan["plan_digest"] == change_plan._plan_digest(plan)
+    assert implementation["implementation_scope"] == "permissions_only"
+    assert implementation["top_level_permissions"] is None
+    assert implementation["job_permissions"] is None
+    assert implementation["implementation_rationale"] is None
+    assert implementation["human_completion_required"] is True
+    assert plan["ready_for_patch"] is False
+    assert plan["safe_to_patch"] is False
+    assert plan["requires_separate_reviewed_pr"] is True
+    assert not any(plan["authority_boundary"].values())
+
+
+def test_split_decision_creates_same_review_first_plan_boundary(
+    monkeypatch, tmp_path: Path
+) -> None:
+    entry = _entry(tmp_path, decision="split")
+    _install_plane(monkeypatch, _plane([entry]))
+
+    payload = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+    plan = payload["plans"][0]
+
+    assert plan["decision_binding"]["decision"] == "split"
+    assert plan["safe_to_patch"] is False
+    assert not any(plan["authority_boundary"].values())
+
+
+def test_missing_retained_decision_record_blocks_plan_generation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    entry = _entry(tmp_path, create_record=False)
+    _install_plane(monkeypatch, _plane([entry]))
+
+    payload = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+
+    assert payload["status"] == "blocked"
+    assert payload["summary"]["change_plan_count"] == 0
+    assert payload["summary"]["missing_decision_record_binding_count"] == 1
+    assert payload["missing_decision_record_bindings"] == [entry["workflow"]]
+
+
+def test_decision_record_bytes_are_bound_into_plan(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    first = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+    record_path = tmp_path / str(entry["decision_record_ref"])
+    record_path.write_text(record_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    second = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+
+    first_plan = first["plans"][0]
+    second_plan = second["plans"][0]
+    assert (
+        first_plan["decision_binding"]["decision_record_sha256"]
+        != second_plan["decision_binding"]["decision_record_sha256"]
+    )
+    assert first_plan["plan_digest"] != second_plan["plan_digest"]
+    assert first["bundle_digest"] != second["bundle_digest"]
+
+
+def test_structurally_valid_plan_still_does_not_authorize_patch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    template = change_plan.build_workflow_permission_change_plan_index(tmp_path)["plans"][0]
+    candidate = _complete_candidate(template)
+
+    validation = change_plan.validate_workflow_permission_change_plan(tmp_path, candidate)
+
+    assert validation["status"] == "structurally_ready_for_separate_pr"
+    assert validation["valid_current"] is True
+    assert validation["new_write_scopes"] == []
+    assert validation["implementation_authorized"] is False
+    assert validation["safe_to_patch"] is False
+    assert not any(validation["authority_boundary"].values())
+
+
+def test_new_write_scope_is_rejected(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    template = change_plan.build_workflow_permission_change_plan_index(tmp_path)["plans"][0]
+    candidate = _complete_candidate(template)
+    implementation = candidate["implementation"]
+    assert isinstance(implementation, dict)
+    jobs = implementation["job_permissions"]
+    assert isinstance(jobs, dict)
+    jobs["publisher"]["packages"] = "write"
+
+    validation = change_plan.validate_workflow_permission_change_plan(tmp_path, candidate)
+
+    assert validation["status"] == "invalid"
+    assert "packages: write" in validation["new_write_scopes"]
+    assert "new_write_scope_forbidden:packages: write" in validation["invalid_reasons"]
+
+
+def test_permission_levels_are_strict(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    template = change_plan.build_workflow_permission_change_plan_index(tmp_path)["plans"][0]
+    candidate = _complete_candidate(template)
+    implementation = candidate["implementation"]
+    assert isinstance(implementation, dict)
+    top = implementation["top_level_permissions"]
+    assert isinstance(top, dict)
+    top["contents"] = "admin"
+
+    validation = change_plan.validate_workflow_permission_change_plan(tmp_path, candidate)
+
+    assert validation["status"] == "invalid"
+    assert "permission_level_invalid:contents" in validation["invalid_reasons"]
+
+
+def test_blank_generated_plan_is_not_structurally_ready(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    template = change_plan.build_workflow_permission_change_plan_index(tmp_path)["plans"][0]
+
+    validation = change_plan.validate_workflow_permission_change_plan(tmp_path, template)
+
+    assert validation["status"] == "invalid"
+    assert "target_permissions_missing" in validation["invalid_reasons"]
+    assert "implementation_rationale_missing" in validation["invalid_reasons"]
+
+
+def test_binding_tampering_is_stale(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    template = change_plan.build_workflow_permission_change_plan_index(tmp_path)["plans"][0]
+    candidate = _complete_candidate(template)
+    candidate["workflow_sha256"] = "b" * 64
+
+    validation = change_plan.validate_workflow_permission_change_plan(tmp_path, candidate)
+
+    assert validation["status"] == "stale"
+    assert "binding_mismatch:workflow_sha256" in validation["stale_reasons"]
+
+
+def test_authority_escalation_is_invalid(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    template = change_plan.build_workflow_permission_change_plan_index(tmp_path)["plans"][0]
+    candidate = _complete_candidate(template)
+    candidate["authority_boundary"]["patch_application_allowed"] = True
+
+    validation = change_plan.validate_workflow_permission_change_plan(tmp_path, candidate)
+
+    assert validation["status"] == "invalid"
+    assert "authority_boundary_mismatch" in validation["invalid_reasons"]
+
+
+def test_retained_index_freshness_rejects_tampering(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+    payload = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+    tampered = copy.deepcopy(payload)
+    tampered["bundle_digest"] = "tampered"
+
+    validation = change_plan.validate_workflow_permission_change_plan_index(tmp_path, tampered)
+
+    assert validation["fresh"] is False
+    assert validation["status"] == "stale"
+    assert validation["reasons"] == ["bundle_digest_mismatch"]
+
+
+def test_change_plan_generation_is_deterministic(monkeypatch, tmp_path: Path) -> None:
+    entry = _entry(tmp_path)
+    _install_plane(monkeypatch, _plane([entry]))
+
+    first = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+    second = change_plan.build_workflow_permission_change_plan_index(tmp_path)
+
+    assert first == second
+    assert first["bundle_digest"] == second["bundle_digest"]

--- a/tests/test_workflow_permission_change_plan_cli.py
+++ b/tests/test_workflow_permission_change_plan_cli.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from sdetkit import workflow_permission_change_plan as change_plan
 
 
+FIXTURE_DIGEST = "fixture-digest-not-a-sha"
+
+
 def _index(*, status: str = "not_required") -> dict[str, object]:
     return {
         "schema_version": change_plan.SCHEMA_VERSION,
@@ -16,7 +19,7 @@ def _index(*, status: str = "not_required") -> dict[str, object]:
             "non_change_decision_count": 0,
             "pending_human_review_count": 16,
         },
-        "bundle_digest": "a" * 64,
+        "bundle_digest": FIXTURE_DIGEST,
         "plans": [],
         "authority_boundary": change_plan.authority_boundary(),
     }
@@ -87,7 +90,7 @@ def test_render_index_text_handles_missing_summary_shape() -> None:
         {
             "status": "not_required",
             "summary": [],
-            "bundle_digest": "b" * 64,
+            "bundle_digest": FIXTURE_DIGEST,
         }
     )
 

--- a/tests/test_workflow_permission_change_plan_cli.py
+++ b/tests/test_workflow_permission_change_plan_cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from sdetkit import workflow_permission_change_plan as change_plan
 
-
 FIXTURE_DIGEST = "fixture-digest-not-a-sha"
 
 

--- a/tests/test_workflow_permission_change_plan_cli.py
+++ b/tests/test_workflow_permission_change_plan_cli.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import workflow_permission_change_plan as change_plan
+
+
+def _index(*, status: str = "not_required") -> dict[str, object]:
+    return {
+        "schema_version": change_plan.SCHEMA_VERSION,
+        "status": status,
+        "summary": {
+            "change_plan_count": 0,
+            "reduce_or_split_decision_count": 0,
+            "non_change_decision_count": 0,
+            "pending_human_review_count": 16,
+        },
+        "bundle_digest": "a" * 64,
+        "plans": [],
+        "authority_boundary": change_plan.authority_boundary(),
+    }
+
+
+def test_main_text_reports_non_executable_live_state(monkeypatch, capsys) -> None:
+    payload = _index()
+    monkeypatch.setattr(
+        change_plan,
+        "build_workflow_permission_change_plan_index",
+        lambda _root: payload,
+    )
+
+    result = change_plan.main(["--root", ".", "--format", "text"])
+    output = capsys.readouterr().out
+
+    assert result == 0
+    assert "status=not_required" in output
+    assert "change_plan_count=0" in output
+    assert "automatic_patch_generation_allowed=false" in output
+    assert "implementation_authorized=false" in output
+    assert "permission_mutation_allowed=false" in output
+
+
+def test_main_json_writes_relative_output_beneath_explicit_root(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    payload = _index()
+    monkeypatch.setattr(
+        change_plan,
+        "build_workflow_permission_change_plan_index",
+        lambda _root: payload,
+    )
+
+    result = change_plan.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--out",
+            "build/sdetkit/workflow-permission-change-plans.json",
+            "--format",
+            "json",
+        ]
+    )
+
+    output_path = tmp_path / "build" / "sdetkit" / "workflow-permission-change-plans.json"
+    assert result == 0
+    assert json.loads(capsys.readouterr().out) == payload
+    assert json.loads(output_path.read_text(encoding="utf-8")) == payload
+
+
+def test_main_returns_nonzero_for_blocked_plan_index(monkeypatch, capsys) -> None:
+    payload = _index(status="blocked")
+    monkeypatch.setattr(
+        change_plan,
+        "build_workflow_permission_change_plan_index",
+        lambda _root: payload,
+    )
+
+    result = change_plan.main(["--format", "json"])
+
+    assert result == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+
+
+def test_render_index_text_handles_missing_summary_shape() -> None:
+    output = change_plan.render_index_text(
+        {
+            "status": "not_required",
+            "summary": [],
+            "bundle_digest": "b" * 64,
+        }
+    )
+
+    assert "change_plan_count=0" in output
+    assert "pending_human_review_count=0" in output
+    assert "implementation_authorized=false" in output


### PR DESCRIPTION
Advances #2181. #2201, #2202 and #2203 are merged into `main`. This PR is restacked directly on the Stage 5 squash commit and freshly proven on its final exact head.

## Why

The repository now has exact human Decision Record v1, deterministic review packets, and batch human review sessions. The remaining boundary before any real permission implementation is a non-executable implementation plan derived only from an exact retained human `reduce` or `split` decision.

Workflow Permission Change Plan v1 keeps human decision, engineering proposal, patch, execution proof and merge as separate authority boundaries.

## Eligibility and authority

Only a current exact human `reduce` or `split` decision backed by retained Decision Record v1 bytes may create a plan. Pending reviews, packets, recommendations, Markdown evidence, `keep`, `defer`, stale/conflicting decisions and missing records never create one.

Even a structurally valid populated plan keeps `implementation_authorized=false`, `safe_to_patch=false`, `patch_application_allowed=false`, `permission_mutation_allowed=false`, `semantic_equivalence_proven=false`, and `merge_authorized=false`. A separate reviewed permission-only PR with workflow-specific execution proof and rollback remains mandatory.

## Structural anti-escalation

The validator accepts only `read | write | none` and rejects requested `write` scopes absent from the reviewed workflow's current write-scope snapshot.

## Quality repair without moving the floor

The first Stage 6 Quality run passed pre-commit, explicit mypy and all **5,312 tests**, but whole-package coverage was **87.87%**, below the unchanged reviewed **87.89%** floor. The floor was not lowered. Dedicated operator-CLI coverage repaired the real gap.

The repaired product tree measured:

- whole-package coverage: **87.90%** (`65,025 / 73,979`), above the unchanged **87.89%** floor;
- critical-spine coverage: **95.86%** (`926 / 966`), above the **95%** minimum;
- source modules: **535**;
- typing-debt modules: **489**;
- explicitly typed modules: **46**;
- quality-truth mismatches: **0**.

## Final security-review repair

The final review-thread guard found a high-entropy alert caused by synthetic digest-shaped test literals, not product logic. The fixtures were replaced with an explicit non-SHA marker and Ruff formatting was normalized. Fresh Security/CodeQL then passed on the final head before the alert thread was resolved. The finding was repaired, not suppressed.

## Final exact-head proof

Final exact head: `e98a7d6d3c7fb0726df8df477ecbdcaff1fa29ad`

Completed successfully on that exact head:

- Quality, including the unchanged whole-package and critical-spine gates;
- Security/CodeQL;
- CI fast lanes on Python 3.11 and 3.12 plus Full CI;
- package build/Twine and installed-wheel smoke tests;
- GitHub Actions Advanced Reference: Ubuntu/macOS × Python 3.11/3.12/3.13 (**6/6**);
- Release Candidate Qualification with clean-room exact-wheel validation;
- PR Quality evidence generation and trusted handoff;
- Enterprise/Premium, branch protection, dependency review/audit, OSV, Repo Audit, operational-readiness and first-proof lanes;
- protected `ci` and `maintenance-autopilot` contexts.

## Scope

Exactly 8 files are in scope:

1. `docs/ci/workflow-permission-change-plan.md`
2. `docs/contracts/quality-truth-baseline.v1.json`
3. `docs/contracts/workflow-permission-change-plan.v1.json`
4. `pyproject.toml`
5. `src/sdetkit/workflow_permission_change_plan.py`
6. `tests/test_quality_truth_baseline.py`
7. `tests/test_workflow_permission_change_plan.py`
8. `tests/test_workflow_permission_change_plan_cli.py`

No `.github/workflows/*` file is in scope. This PR does not create a human permission decision, generate a workflow patch, mutate a permission, or grant implementation/merge authority.