### PR TITLE
feat(governance): add workflow permission review worklist

### DIFF
--- a/docs/ci/workflow-permission-review-worklist.md
+++ b/docs/ci/workflow-permission-review-worklist.md
@@ -1,0 +1,106 @@
+# Workflow permission review worklist
+
+Workflow Permission Review Worklist v1 is the read-only human workload and handoff layer above the workflow permission governance state machine.
+
+It answers a narrow operational question:
+
+> Which current workflow-permission items still require a human action, and which exact packet should the reviewer inspect?
+
+The worklist does not rank items, recommend a decision, assign a reviewer, prefill a decision, edit workflow YAML, apply a patch, commit, merge, or dismiss security findings.
+
+## Product flow
+
+```text
+workflow governance finding
+  -> permission review control plane
+  -> exact review packet
+  -> governance state machine
+  -> review worklist
+  -> human reviewer / Review Session v1
+  -> Decision Record v1
+  -> non-executable permission change plan
+  -> separate reviewed permission-only PR
+  -> workflow-specific execution proof + rollback
+```
+
+The worklist is intentionally different from Review Session v1. The worklist reports current human work. A review session is the separate human-entered envelope used only after a reviewer actually makes decisions.
+
+## Work-item lanes
+
+The worklist preserves Stage 7's next-human-action semantics and groups active items into deterministic action lanes:
+
+- `repair_governance_evidence_binding`;
+- `complete_human_permission_review`;
+- `revisit_deferred_permission_review`;
+- `complete_permission_change_plan`.
+
+Items whose Stage 7 action is `none` are omitted from active work and counted as resolved/no-action items.
+
+Blocked or packet-mismatched items are repair-only. The worklist does not guess a repair or silently route them into a decision lane.
+
+## Exact packet binding
+
+Every active item is bound to the current packet by:
+
+- review ID;
+- workflow path;
+- workflow SHA-256;
+- permission group;
+- packet digest.
+
+For human-review lanes the work item exposes the packet's current write scopes, descriptive triage signals, required human evidence, retained evidence references, and allowed human decision enum.
+
+Those fields are evidence only. The generated fields `machine_recommendation`, `review_priority`, `reviewer_assignment`, and `decision_prefill` are always `null`.
+
+## Generate the current worklist
+
+```bash
+python -m sdetkit.workflow_permission_review_worklist \
+  --root . \
+  --out build/sdetkit/workflow-permission-review-worklist.json \
+  --format text
+```
+
+Repository-local output is allowed only under `build/`. A relative path is resolved beneath the explicit `--root` before that boundary is checked, so process CWD cannot redefine the repository write boundary.
+
+An explicit absolute destination outside the repository is allowed for operator-controlled evidence export.
+
+## Validate retained output
+
+```bash
+python -m sdetkit.workflow_permission_review_worklist \
+  --root . \
+  --check-index build/sdetkit/workflow-permission-review-worklist.json \
+  --fail-on-stale \
+  --format json
+```
+
+Freshness binds the worklist generator and contract plus the exact Stage 7 state-machine input/bundle digests and Stage 4 review-packet input/bundle digests. Any upstream workflow, evidence, decision, packet, plan, or lifecycle drift therefore makes retained worklist output stale transitively.
+
+## Review-first boundary
+
+The worklist cannot convert descriptive packet signals into a decision or priority score. Human reviewers may choose their own review order outside this artifact, but the generated worklist itself does not infer urgency or assign ownership.
+
+For a pending review, the allowed decisions remain `keep | reduce | split | defer`, but they are presented only as the existing human decision enum. No choice is selected.
+
+For an implementation-plan item, the worklist reports the existing plan binding and next human action; it still does not make a patch safe. Stage 6 keeps `safe_to_patch=false`, and implementation remains a separate reviewed PR with exact proof and rollback.
+
+## Authority boundary
+
+The worklist hard-codes false for:
+
+- automation authority;
+- commit authority;
+- human-decision fabrication;
+- implementation authority;
+- merge authority;
+- patch application;
+- permission mutation;
+- reviewer assignment;
+- review-priority inference;
+- security dismissal;
+- semantic equivalence;
+- source-tree writes;
+- workflow mutation.
+
+The product becomes more operationally useful by making human work visible without turning visibility into authority.

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -98,11 +98,12 @@
       "sdetkit.workflow_permission_review_control_plane",
       "sdetkit.workflow_permission_review_packet",
       "sdetkit.workflow_permission_review_session",
+      "sdetkit.workflow_permission_review_worklist",
       "sdetkit.workspace_failure_ownership"
     ],
     "migration_complete": false,
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 536,
+    "source_module_count": 537,
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "typing_debt_inventory_sha256": "e8729da81702dacbd8901642b8dfea0e45540ff6a4e655834f2fbbd8bb4b053a",
     "typing_debt_module_count": 489

--- a/docs/contracts/workflow-permission-review-worklist.v1.json
+++ b/docs/contracts/workflow-permission-review-worklist.v1.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "sdetkit.workflow_permission_review_worklist.v1",
+  "status": "read_only_human_work_handoff",
+  "purpose": "Turn the current workflow permission governance lifecycle into a deterministic human worklist bound to exact review packets without ranking, recommending, assigning, deciding, or implementing anything.",
+  "source_layers": [
+    "sdetkit.workflow_permission_governance_state_machine",
+    "sdetkit.workflow_permission_review_packet"
+  ],
+  "action_lanes": [
+    "repair_governance_evidence_binding",
+    "complete_human_permission_review",
+    "revisit_deferred_permission_review",
+    "complete_permission_change_plan"
+  ],
+  "work_item_rules": {
+    "stage7_none_action_omitted": true,
+    "exact_review_id_binding_required": true,
+    "exact_workflow_path_binding_required": true,
+    "exact_workflow_sha256_binding_required": true,
+    "exact_permission_group_binding_required": true,
+    "exact_packet_digest_binding_required": true,
+    "blocked_or_mismatched_item_is_repair_only": true,
+    "machine_recommendation_allowed": false,
+    "machine_priority_allowed": false,
+    "automatic_reviewer_assignment_allowed": false,
+    "automatic_decision_allowed": false,
+    "implementation_remains_separate_reviewed_pr": true
+  },
+  "freshness": {
+    "generator_source_bound": true,
+    "contract_bound": true,
+    "state_machine_input_and_bundle_digests_bound": true,
+    "review_packet_input_and_bundle_digests_bound": true,
+    "retained_worklist_validation_supported": true
+  },
+  "output_boundary": {
+    "repository_local_output_restricted_to_build": true,
+    "relative_output_resolved_beneath_explicit_root": true,
+    "source_tree_write_allowed": false
+  },
+  "authority_boundary": {
+    "automation_allowed": false,
+    "commit_allowed": false,
+    "human_decision_fabrication_allowed": false,
+    "implementation_authorized": false,
+    "merge_authorized": false,
+    "patch_application_allowed": false,
+    "permission_mutation_allowed": false,
+    "review_assignment_allowed": false,
+    "review_priority_inference_allowed": false,
+    "security_dismissal_allowed": false,
+    "semantic_equivalence_proven": false,
+    "source_tree_write_allowed": false,
+    "workflow_mutation_allowed": false
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ module = [
   "sdetkit.workflow_permission_review_control_plane",
   "sdetkit.workflow_permission_review_packet",
   "sdetkit.workflow_permission_review_session",
+  "sdetkit.workflow_permission_review_worklist",
 ]
 ignore_errors = false
 

--- a/src/sdetkit/workflow_permission_review_worklist.py
+++ b/src/sdetkit/workflow_permission_review_worklist.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .workflow_permission_governance_state_machine import (
+    build_workflow_permission_governance_state_machine,
+)
+from .workflow_permission_review_packet import build_workflow_permission_review_packet_index
+
+SCHEMA_VERSION = "sdetkit.workflow_permission_review_worklist.v1"
+CONTRACT_PATH = "docs/contracts/workflow-permission-review-worklist.v1.json"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/workflow_permission_review_worklist.py"
+DIGEST_ALGORITHM = "sha256"
+
+REVIEW_ACTIONS = (
+    "complete_human_permission_review",
+    "revisit_deferred_permission_review",
+)
+IMPLEMENTATION_ACTIONS = ("complete_permission_change_plan",)
+REPAIR_ACTION = "repair_governance_evidence_binding"
+ACTION_ORDER = (
+    REPAIR_ACTION,
+    "complete_human_permission_review",
+    "revisit_deferred_permission_review",
+    "complete_permission_change_plan",
+)
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "commit_allowed",
+    "human_decision_fabrication_allowed",
+    "implementation_authorized",
+    "merge_authorized",
+    "patch_application_allowed",
+    "permission_mutation_allowed",
+    "review_assignment_allowed",
+    "review_priority_inference_allowed",
+    "security_dismissal_allowed",
+    "semantic_equivalence_proven",
+    "source_tree_write_allowed",
+    "workflow_mutation_allowed",
+)
+
+
+def authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _update_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def _dict_items(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _index_by_review_id(items: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    indexed: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        review_id = item.get("review_id")
+        if isinstance(review_id, str) and review_id:
+            indexed.setdefault(review_id, []).append(item)
+    return indexed
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str)]
+
+
+def _packet_binding_reasons(
+    lifecycle: dict[str, Any],
+    packets: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    if len(packets) != 1:
+        return None, ["packet_missing" if not packets else "duplicate_packets"]
+
+    packet = packets[0]
+    reasons: list[str] = []
+    for field in ("review_id", "workflow", "workflow_sha256", "permission_group"):
+        if lifecycle.get(field) != packet.get(field):
+            reasons.append(f"packet_binding_mismatch:{field}")
+    if lifecycle.get("packet_digest") != packet.get("packet_digest"):
+        reasons.append("packet_digest_mismatch")
+    if packet.get("safe_to_patch") is not False:
+        reasons.append("packet_safe_to_patch_not_false")
+    boundary = packet.get("authority_boundary")
+    if not isinstance(boundary, dict) or not boundary or any(boundary.values()):
+        reasons.append("packet_authority_boundary_invalid")
+    return packet, sorted(set(reasons))
+
+
+def _build_work_item(
+    lifecycle: dict[str, Any],
+    packets: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    next_action = str(lifecycle.get("next_human_action", "none"))
+    if next_action == "none":
+        return None
+
+    packet, packet_reasons = _packet_binding_reasons(lifecycle, packets)
+    integrity_reasons = _string_list(lifecycle.get("integrity_reasons"))
+    reasons = sorted(set([*integrity_reasons, *packet_reasons]))
+    lifecycle_state = str(lifecycle.get("lifecycle_state", "blocked"))
+    effective_action = next_action
+    if lifecycle_state == "blocked" or reasons:
+        effective_action = REPAIR_ACTION
+
+    current_permissions: dict[str, Any] = {}
+    evidence: dict[str, Any] = {}
+    decision_boundary: dict[str, Any] = {}
+    triage_signals: dict[str, Any] = {}
+    packet_id: object = None
+    packet_digest: object = lifecycle.get("packet_digest")
+    if packet is not None:
+        packet_id = packet.get("packet_id")
+        packet_digest = packet.get("packet_digest")
+        raw_permissions = packet.get("current_permissions")
+        raw_evidence = packet.get("evidence")
+        raw_boundary = packet.get("decision_boundary")
+        raw_triage = packet.get("triage_signals")
+        if isinstance(raw_permissions, dict):
+            current_permissions = raw_permissions
+        if isinstance(raw_evidence, dict):
+            evidence = raw_evidence
+        if isinstance(raw_boundary, dict):
+            decision_boundary = raw_boundary
+        if isinstance(raw_triage, dict):
+            triage_signals = raw_triage
+
+    review_id = str(lifecycle.get("review_id", ""))
+    is_review_action = effective_action in REVIEW_ACTIONS
+    return {
+        "work_item_id": f"work-{review_id or 'unknown'}",
+        "review_id": review_id,
+        "workflow": lifecycle.get("workflow"),
+        "workflow_sha256": lifecycle.get("workflow_sha256"),
+        "permission_group": lifecycle.get("permission_group"),
+        "lifecycle_state": lifecycle_state,
+        "next_human_action": effective_action,
+        "packet_id": packet_id,
+        "packet_digest": packet_digest,
+        "packet_json_name": f"{review_id}.json" if review_id else None,
+        "packet_markdown_name": f"{review_id}.md" if review_id else None,
+        "current_write_scopes": _string_list(current_permissions.get("write_scopes")),
+        "triage_signals": dict(sorted(triage_signals.items())),
+        "required_human_evidence": _string_list(evidence.get("required_human_evidence")),
+        "retained_evidence_refs": _string_list(evidence.get("retained_evidence_refs")),
+        "allowed_human_decisions": _string_list(decision_boundary.get("allowed_decisions"))
+        if is_review_action
+        else [],
+        "current_human_decision": lifecycle.get("human_decision"),
+        "decision_record_ref": lifecycle.get("decision_record_ref"),
+        "plan_id": lifecycle.get("plan_id"),
+        "plan_digest": lifecycle.get("plan_digest"),
+        "integrity_reasons": reasons,
+        "machine_recommendation": None,
+        "review_priority": None,
+        "reviewer_assignment": None,
+        "decision_prefill": None,
+        "safe_to_patch": False,
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def workflow_permission_review_worklist_input_provenance(
+    repo_root: str | Path = ".",
+    *,
+    state_machine: dict[str, Any] | None = None,
+    packet_index: dict[str, Any] | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    state = state_machine or build_workflow_permission_governance_state_machine(root)
+    packets = packet_index or build_workflow_permission_review_packet_index(root)
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+
+    state_provenance = state.get("input_provenance")
+    packet_provenance = packets.get("input_provenance")
+    if not isinstance(state_provenance, dict):
+        state_provenance = {}
+    if not isinstance(packet_provenance, dict):
+        packet_provenance = {}
+
+    inputs: list[tuple[str, bytes]] = [
+        ("schema_version", SCHEMA_VERSION.encode("utf-8")),
+        (GENERATOR_SOURCE_LABEL, generator.read_bytes()),
+        (
+            "state_machine_input_digest",
+            str(state_provenance.get("input_digest", "")).encode("utf-8"),
+        ),
+        ("state_machine_bundle_digest", str(state.get("bundle_digest", "")).encode("utf-8")),
+        (
+            "review_packet_input_digest",
+            str(packet_provenance.get("input_digest", "")).encode("utf-8"),
+        ),
+        ("review_packet_bundle_digest", str(packets.get("bundle_digest", "")).encode("utf-8")),
+    ]
+    contract = root / CONTRACT_PATH
+    if contract.is_file():
+        inputs.append((CONTRACT_PATH, contract.read_bytes()))
+
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_digest(hasher, label, content)
+
+    return {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "state_machine_input_digest": state_provenance.get("input_digest", ""),
+        "state_machine_bundle_digest": state.get("bundle_digest", ""),
+        "review_packet_input_digest": packet_provenance.get("input_digest", ""),
+        "review_packet_bundle_digest": packets.get("bundle_digest", ""),
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+        "contract_path": CONTRACT_PATH,
+    }
+
+
+def _build_action_lanes(work_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    lanes: list[dict[str, Any]] = []
+    for action in ACTION_ORDER:
+        lane_items = [item for item in work_items if item.get("next_human_action") == action]
+        if not lane_items:
+            continue
+        group_counts: dict[str, int] = {}
+        for item in lane_items:
+            group = str(item.get("permission_group", "unknown"))
+            group_counts[group] = group_counts.get(group, 0) + 1
+        lanes.append(
+            {
+                "next_human_action": action,
+                "work_item_count": len(lane_items),
+                "permission_group_counts": dict(sorted(group_counts.items())),
+                "work_item_ids": [str(item.get("work_item_id", "")) for item in lane_items],
+            }
+        )
+    return lanes
+
+
+def build_workflow_permission_review_worklist(repo_root: str | Path = ".") -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    state = build_workflow_permission_governance_state_machine(root)
+    packet_index = build_workflow_permission_review_packet_index(root)
+
+    lifecycle = _dict_items(state.get("lifecycle"))
+    packets = _dict_items(packet_index.get("packets"))
+    packets_by_id = _index_by_review_id(packets)
+
+    work_items: list[dict[str, Any]] = []
+    resolved_no_action_count = 0
+    for lifecycle_item in lifecycle:
+        review_id = str(lifecycle_item.get("review_id", ""))
+        work_item = _build_work_item(lifecycle_item, packets_by_id.get(review_id, []))
+        if work_item is None:
+            resolved_no_action_count += 1
+            continue
+        work_items.append(work_item)
+
+    work_items.sort(key=lambda item: str(item.get("workflow", "")))
+    action_lanes = _build_action_lanes(work_items)
+    blocked_count = sum(item.get("next_human_action") == REPAIR_ACTION for item in work_items)
+    review_count = sum(item.get("next_human_action") in REVIEW_ACTIONS for item in work_items)
+    implementation_count = sum(
+        item.get("next_human_action") in IMPLEMENTATION_ACTIONS for item in work_items
+    )
+    group_counts: dict[str, int] = {}
+    for item in work_items:
+        group = str(item.get("permission_group", "unknown"))
+        group_counts[group] = group_counts.get(group, 0) + 1
+
+    state_integrity = state.get("integrity")
+    if not isinstance(state_integrity, dict):
+        state_integrity = {}
+    global_reasons = _string_list(state_integrity.get("global_reasons"))
+    if state.get("status") == "blocked" and not global_reasons:
+        global_reasons.append("upstream_state_machine_blocked")
+    if state.get("status") not in {"blocked", "not_required", "human_action_required", "complete"}:
+        global_reasons.append("upstream_state_machine_status_invalid")
+    global_reasons = sorted(set(global_reasons))
+
+    if global_reasons or blocked_count:
+        status = "blocked"
+    elif work_items:
+        status = "human_work_required"
+    else:
+        status = "not_required"
+
+    digest_items = [
+        {
+            "work_item_id": item["work_item_id"],
+            "review_id": item["review_id"],
+            "workflow": item["workflow"],
+            "workflow_sha256": item["workflow_sha256"],
+            "permission_group": item["permission_group"],
+            "lifecycle_state": item["lifecycle_state"],
+            "next_human_action": item["next_human_action"],
+            "packet_digest": item["packet_digest"],
+            "plan_digest": item["plan_digest"],
+            "integrity_reasons": item["integrity_reasons"],
+        }
+        for item in work_items
+    ]
+    bundle_digest = _sha256_bytes(
+        _canonical_json_bytes(
+            {
+                "action_lanes": action_lanes,
+                "global_reasons": global_reasons,
+                "work_items": digest_items,
+            }
+        )
+    )
+    provenance = workflow_permission_review_worklist_input_provenance(
+        root,
+        state_machine=state,
+        packet_index=packet_index,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "input_provenance": provenance,
+        "summary": {
+            "workflow_count": len(lifecycle),
+            "work_item_count": len(work_items),
+            "review_action_count": review_count,
+            "implementation_action_count": implementation_count,
+            "blocked_repair_count": blocked_count,
+            "resolved_no_action_count": resolved_no_action_count,
+            "permission_group_counts": dict(sorted(group_counts.items())),
+            "machine_recommendation_count": 0,
+            "machine_priority_count": 0,
+            "automatic_reviewer_assignment_count": 0,
+            "automatic_decision_count": 0,
+            "automatic_permission_change_count": 0,
+        },
+        "global_reasons": global_reasons,
+        "action_lanes": action_lanes,
+        "bundle_digest": bundle_digest,
+        "work_items": work_items,
+        "rules": {
+            "exact_stage7_lifecycle_required": True,
+            "exact_review_packet_binding_required": True,
+            "blocked_items_are_repair_only": True,
+            "machine_recommendation_allowed": False,
+            "machine_priority_allowed": False,
+            "automatic_reviewer_assignment_allowed": False,
+            "automatic_decision_allowed": False,
+            "implementation_remains_separate_reviewed_pr": True,
+            "workflow_mutation_allowed": False,
+        },
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def validate_workflow_permission_review_worklist(
+    repo_root: str | Path,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    current = build_workflow_permission_review_worklist(repo_root)
+    reasons: list[str] = []
+    for field in (
+        "schema_version",
+        "summary",
+        "global_reasons",
+        "action_lanes",
+        "bundle_digest",
+        "work_items",
+    ):
+        if payload.get(field) != current.get(field):
+            reasons.append(f"{field}_mismatch")
+
+    recorded_provenance = payload.get("input_provenance")
+    current_provenance = current.get("input_provenance")
+    if not isinstance(recorded_provenance, dict):
+        recorded_provenance = {}
+    if not isinstance(current_provenance, dict):
+        current_provenance = {}
+    if recorded_provenance.get("input_digest") != current_provenance.get("input_digest"):
+        reasons.append("input_digest_mismatch")
+    if payload.get("authority_boundary") != authority_boundary():
+        reasons.append("authority_boundary_mismatch")
+
+    reasons = sorted(set(reasons))
+    return {
+        "status": "fresh" if not reasons else "stale",
+        "fresh": not reasons,
+        "reasons": reasons,
+        "recorded_input_digest": recorded_provenance.get("input_digest", ""),
+        "current_input_digest": current_provenance.get("input_digest", ""),
+        "recorded_bundle_digest": payload.get("bundle_digest", ""),
+        "current_bundle_digest": current.get("bundle_digest", ""),
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def _safe_output_path(root: Path, output: Path) -> Path:
+    target = output.resolve() if output.is_absolute() else (root / output).resolve()
+    try:
+        relative = target.relative_to(root)
+    except ValueError:
+        return target
+    if not relative.parts or relative.parts[0] != "build":
+        raise ValueError("repository-local review worklist output may only be written under build/")
+    return target
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("review worklist must be a JSON object")
+    return payload
+
+
+def render_worklist_text(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    lines = [
+        "Workflow Permission Review Worklist v1",
+        f"status={payload.get('status', 'unknown')}",
+        f"workflow_count={summary.get('workflow_count', 0)}",
+        f"work_item_count={summary.get('work_item_count', 0)}",
+        f"review_action_count={summary.get('review_action_count', 0)}",
+        f"implementation_action_count={summary.get('implementation_action_count', 0)}",
+        f"blocked_repair_count={summary.get('blocked_repair_count', 0)}",
+        f"bundle_digest={payload.get('bundle_digest', '')}",
+        "machine_recommendation_allowed=false",
+        "machine_priority_allowed=false",
+        "permission_mutation_allowed=false",
+        "merge_authorized=false",
+    ]
+    for item in _dict_items(payload.get("work_items")):
+        lines.append(
+            f"{item.get('workflow', 'unknown')}: {item.get('next_human_action', 'unknown')} "
+            f"[{item.get('permission_group', 'unknown')}]"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_validation_text(payload: dict[str, Any]) -> str:
+    reasons = payload.get("reasons")
+    if not isinstance(reasons, list):
+        reasons = []
+    lines = [
+        "Workflow Permission Review Worklist Validation v1",
+        f"status={payload.get('status', 'unknown')}",
+        f"fresh={str(payload.get('fresh') is True).lower()}",
+        f"reason_count={len(reasons)}",
+        f"current_bundle_digest={payload.get('current_bundle_digest', '')}",
+        "machine_recommendation_allowed=false",
+        "permission_mutation_allowed=false",
+        "merge_authorized=false",
+    ]
+    lines.extend(f"reason={reason}" for reason in reasons)
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a deterministic human workflow-permission review worklist"
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--out")
+    parser.add_argument("--check-index")
+    parser.add_argument("--fail-on-stale", action="store_true")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.check_index:
+        result = validate_workflow_permission_review_worklist(
+            root,
+            _load_json(_safe_output_path(root, Path(args.check_index))),
+        )
+        if args.format == "json":
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print(render_validation_text(result), end="")
+        return 1 if args.fail_on_stale and not result["fresh"] else 0
+
+    payload = build_workflow_permission_review_worklist(root)
+    if args.out:
+        output = _safe_output_path(root, Path(args.out))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_worklist_text(payload), end="")
+    return 1 if payload.get("status") == "blocked" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,10 +24,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 536
+    assert payload["observed"]["source_module_count"] == 537
     assert payload["observed"]["typing_debt_module_count"] == 489
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 47
+    assert len(checked) == 48
     assert "sdetkit._formatter_policy_proposal_observation_records" in checked
     assert "sdetkit._formatter_policy_proposal_observation_schema" in checked
     assert "sdetkit.adoption_product_kpi_freshness" in checked
@@ -55,6 +55,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.workflow_permission_review_control_plane" in checked
     assert "sdetkit.workflow_permission_review_packet" in checked
     assert "sdetkit.workflow_permission_review_session" in checked
+    assert "sdetkit.workflow_permission_review_worklist" in checked
     assert "sdetkit.workspace_failure_ownership" in checked
     inventory = payload["typing_debt_inventory"]
     assert inventory["module_count"] == 489
@@ -87,6 +88,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.workflow_permission_review_control_plane" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_packet" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_session" not in inventory["modules"]
+    assert "sdetkit.workflow_permission_review_worklist" not in inventory["modules"]
     assert "sdetkit.workspace_failure_ownership" not in inventory["modules"]
 
 
@@ -105,7 +107,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 536,
+            "actual": 537,
         }
     ]
 

--- a/tests/test_workflow_permission_review_worklist.py
+++ b/tests/test_workflow_permission_review_worklist.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from sdetkit import workflow_permission_review_worklist as worklist
+
+
+def _packet(
+    *,
+    review_id: str = "review-example",
+    workflow: str = ".github/workflows/example.yml",
+    permission_group: str = "repository_mutation",
+    packet_digest: str = "packet-marker",
+) -> dict[str, object]:
+    return {
+        "packet_id": f"packet-{review_id}",
+        "review_id": review_id,
+        "workflow": workflow,
+        "workflow_sha256": "workflow-marker",
+        "permission_group": permission_group,
+        "packet_digest": packet_digest,
+        "safe_to_patch": False,
+        "current_permissions": {
+            "write_scopes": ["contents: write", "issues: write"],
+        },
+        "triage_signals": {
+            "write_scope_count": 2,
+            "contains_contents_write": True,
+            "multiple_write_scopes": True,
+            "classification_is_decision": False,
+        },
+        "evidence": {
+            "required_human_evidence": ["confirm the exact write-scope need"],
+            "retained_evidence_refs": ["docs/ci/workflow-permission-review-cards/example.md"],
+        },
+        "decision_boundary": {
+            "allowed_decisions": ["keep", "reduce", "split", "defer"],
+        },
+        "authority_boundary": {"workflow_mutation_allowed": False},
+    }
+
+
+def _lifecycle(
+    *,
+    review_id: str = "review-example",
+    workflow: str = ".github/workflows/example.yml",
+    permission_group: str = "repository_mutation",
+    state: str = "pending_human_review",
+    action: str = "complete_human_permission_review",
+    packet_digest: str = "packet-marker",
+    human_decision: str | None = None,
+    decision_record_ref: str | None = None,
+    plan_id: str | None = None,
+    plan_digest: str | None = None,
+    integrity_reasons: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "review_id": review_id,
+        "workflow": workflow,
+        "workflow_sha256": "workflow-marker",
+        "permission_group": permission_group,
+        "lifecycle_state": state,
+        "next_human_action": action,
+        "packet_digest": packet_digest,
+        "human_decision": human_decision,
+        "decision_record_ref": decision_record_ref,
+        "plan_id": plan_id,
+        "plan_digest": plan_digest,
+        "integrity_reasons": integrity_reasons or [],
+    }
+
+
+def _state(items: list[dict[str, object]], *, status: str = "human_action_required") -> dict[str, object]:
+    return {
+        "status": status,
+        "bundle_digest": "state-bundle-marker",
+        "input_provenance": {"input_digest": "state-input-marker"},
+        "integrity": {"global_reasons": []},
+        "lifecycle": items,
+    }
+
+
+def _packet_index(items: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "bundle_digest": "packet-bundle-marker",
+        "input_provenance": {"input_digest": "packet-input-marker"},
+        "packets": items,
+    }
+
+
+def _install_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    state: dict[str, object],
+    packets: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        worklist,
+        "build_workflow_permission_governance_state_machine",
+        lambda _root: state,
+    )
+    monkeypatch.setattr(
+        worklist,
+        "build_workflow_permission_review_packet_index",
+        lambda _root: packets,
+    )
+
+
+def test_pending_review_becomes_exact_packet_bound_human_work(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    lifecycle = _lifecycle()
+    packet = _packet()
+    _install_inputs(monkeypatch, _state([lifecycle]), _packet_index([packet]))
+
+    payload = worklist.build_workflow_permission_review_worklist(tmp_path)
+    item = payload["work_items"][0]
+
+    assert payload["status"] == "human_work_required"
+    assert payload["summary"]["work_item_count"] == 1
+    assert payload["summary"]["review_action_count"] == 1
+    assert item["next_human_action"] == "complete_human_permission_review"
+    assert item["packet_digest"] == "packet-marker"
+    assert item["current_write_scopes"] == ["contents: write", "issues: write"]
+    assert item["allowed_human_decisions"] == ["keep", "reduce", "split", "defer"]
+    assert item["required_human_evidence"] == ["confirm the exact write-scope need"]
+    assert item["machine_recommendation"] is None
+    assert item["review_priority"] is None
+    assert item["reviewer_assignment"] is None
+    assert item["decision_prefill"] is None
+    assert item["safe_to_patch"] is False
+    assert not any(item["authority_boundary"].values())
+    assert payload["action_lanes"][0]["next_human_action"] == "complete_human_permission_review"
+
+
+def test_resolved_keep_is_not_active_work(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    lifecycle = _lifecycle(
+        state="resolved_keep",
+        action="none",
+        human_decision="keep",
+        decision_record_ref="docs/ci/workflow-permission-decisions/example.json",
+    )
+    _install_inputs(monkeypatch, _state([lifecycle], status="complete"), _packet_index([_packet()]))
+
+    payload = worklist.build_workflow_permission_review_worklist(tmp_path)
+
+    assert payload["status"] == "not_required"
+    assert payload["summary"]["work_item_count"] == 0
+    assert payload["summary"]["resolved_no_action_count"] == 1
+    assert payload["work_items"] == []
+
+
+def test_deferred_review_retains_human_revisit_action(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    lifecycle = _lifecycle(
+        state="deferred",
+        action="revisit_deferred_permission_review",
+        human_decision="defer",
+        decision_record_ref="docs/ci/workflow-permission-decisions/example.json",
+    )
+    _install_inputs(monkeypatch, _state([lifecycle]), _packet_index([_packet()]))
+
+    payload = worklist.build_workflow_permission_review_worklist(tmp_path)
+    item = payload["work_items"][0]
+
+    assert item["next_human_action"] == "revisit_deferred_permission_review"
+    assert item["current_human_decision"] == "defer"
+    assert item["allowed_human_decisions"] == ["keep", "reduce", "split", "defer"]
+    assert payload["summary"]["review_action_count"] == 1
+
+
+def test_implementation_item_exposes_plan_binding_without_decision_prefill(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    lifecycle = _lifecycle(
+        state="implementation_plan_required",
+        action="complete_permission_change_plan",
+        human_decision="split",
+        decision_record_ref="docs/ci/workflow-permission-decisions/example.json",
+        plan_id="plan-example",
+        plan_digest="plan-marker",
+    )
+    _install_inputs(monkeypatch, _state([lifecycle]), _packet_index([_packet()]))
+
+    payload = worklist.build_workflow_permission_review_worklist(tmp_path)
+    item = payload["work_items"][0]
+
+    assert item["next_human_action"] == "complete_permission_change_plan"
+    assert item["plan_id"] == "plan-example"
+    assert item["plan_digest"] == "plan-marker"
+    assert item["current_human_decision"] == "split"
+    assert item["allowed_human_decisions"] == []
+    assert item["decision_prefill"] is None
+    assert item["safe_to_patch"] is False
+    assert payload["summary"]["implementation_action_count"] == 1
+
+
+def test_blocked_item_is_repair_only(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    lifecycle = _lifecycle(
+        state="blocked",
+        action="repair_governance_evidence_binding",
+        integrity_reasons=["packet_missing"],
+    )
+    _install_inputs(monkeypatch, _state([lifecycle], status="blocked"), _packet_index([]))
+
+    payload = worklist.build_workflow_permission_review_worklist(tmp_path)
+    item = payload["work_items"][0]
+
+    assert payload["status"] == "blocked"
+    assert payload["summary"]["blocked_repair_count"] == 1
+    assert item["next_human_action"] == "repair_governance_evidence_binding"
+    assert "packet_missing" in item["integrity_reasons"]
+    assert item["allowed_human_decisions"] == []
+
+
+def test_packet_binding_mismatch_cannot_enter_decision_lane(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    lifecycle = _lifecycle()
+    packet = _packet(packet_digest="different-packet-marker")
+    _install_inputs(monkeypatch, _state([lifecycle]), _packet_index([packet]))
+
+    payload = worklist.build_workflow_permission_review_worklist(tmp_path)
+    item = payload["work_items"][0]
+
+    assert payload["status"] == "blocked"
+    assert item["next_human_action"] == "repair_governance_evidence_binding"
+    assert "packet_digest_mismatch" in item["integrity_reasons"]
+    assert item["allowed_human_decisions"] == []
+
+
+def test_worklist_is_deterministic(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    items = [
+        _lifecycle(review_id="review-b", workflow=".github/workflows/b.yml"),
+        _lifecycle(review_id="review-a", workflow=".github/workflows/a.yml"),
+    ]
+    packets = [
+        _packet(review_id="review-b", workflow=".github/workflows/b.yml"),
+        _packet(review_id="review-a", workflow=".github/workflows/a.yml"),
+    ]
+    _install_inputs(monkeypatch, _state(items), _packet_index(packets))
+
+    first = worklist.build_workflow_permission_review_worklist(tmp_path)
+    second = worklist.build_workflow_permission_review_worklist(tmp_path)
+
+    assert first == second
+    assert [item["workflow"] for item in first["work_items"]] == [
+        ".github/workflows/a.yml",
+        ".github/workflows/b.yml",
+    ]
+    assert first["bundle_digest"] == second["bundle_digest"]
+
+
+def test_retained_worklist_validation_rejects_tampering(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_inputs(monkeypatch, _state([_lifecycle()]), _packet_index([_packet()]))
+    payload = worklist.build_workflow_permission_review_worklist(tmp_path)
+    tampered = copy.deepcopy(payload)
+    tampered["bundle_digest"] = "tampered"
+
+    validation = worklist.validate_workflow_permission_review_worklist(tmp_path, tampered)
+
+    assert validation["status"] == "stale"
+    assert validation["fresh"] is False
+    assert validation["reasons"] == ["bundle_digest_mismatch"]
+    assert not any(validation["authority_boundary"].values())
+
+
+def test_repository_output_guard_and_external_export(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    assert worklist._safe_output_path(root, Path("build/worklist.json")) == (
+        root / "build" / "worklist.json"
+    ).resolve()
+    with pytest.raises(ValueError, match="may only be written under build"):
+        worklist._safe_output_path(root, Path("docs/ci/worklist.json"))
+
+    external = tmp_path / "export" / "worklist.json"
+    assert worklist._safe_output_path(root, external) == external.resolve()
+
+
+def test_live_repository_worklist_never_infers_human_authority() -> None:
+    payload = worklist.build_workflow_permission_review_worklist(".")
+
+    assert payload["summary"]["machine_recommendation_count"] == 0
+    assert payload["summary"]["machine_priority_count"] == 0
+    assert payload["summary"]["automatic_reviewer_assignment_count"] == 0
+    assert payload["summary"]["automatic_decision_count"] == 0
+    assert payload["summary"]["automatic_permission_change_count"] == 0
+    assert not any(payload["authority_boundary"].values())
+    for item in payload["work_items"]:
+        assert item["machine_recommendation"] is None
+        assert item["review_priority"] is None
+        assert item["reviewer_assignment"] is None
+        assert item["decision_prefill"] is None
+        assert item["safe_to_patch"] is False
+        assert not any(item["authority_boundary"].values())

--- a/tests/test_workflow_permission_review_worklist.py
+++ b/tests/test_workflow_permission_review_worklist.py
@@ -73,7 +73,9 @@ def _lifecycle(
     }
 
 
-def _state(items: list[dict[str, object]], *, status: str = "human_action_required") -> dict[str, object]:
+def _state(
+    items: list[dict[str, object]], *, status: str = "human_action_required"
+) -> dict[str, object]:
     return {
         "status": status,
         "bundle_digest": "state-bundle-marker",
@@ -279,9 +281,10 @@ def test_repository_output_guard_and_external_export(tmp_path: Path) -> None:
     root = tmp_path / "repo"
     root.mkdir()
 
-    assert worklist._safe_output_path(root, Path("build/worklist.json")) == (
-        root / "build" / "worklist.json"
-    ).resolve()
+    assert (
+        worklist._safe_output_path(root, Path("build/worklist.json"))
+        == (root / "build" / "worklist.json").resolve()
+    )
     with pytest.raises(ValueError, match="may only be written under build"):
         worklist._safe_output_path(root, Path("docs/ci/worklist.json"))
 

--- a/tests/test_workflow_permission_review_worklist_cli.py
+++ b/tests/test_workflow_permission_review_worklist_cli.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import workflow_permission_review_worklist as worklist
+
+
+def _payload(*, status: str = "human_work_required") -> dict[str, object]:
+    return {
+        "schema_version": worklist.SCHEMA_VERSION,
+        "status": status,
+        "summary": {
+            "workflow_count": 1,
+            "work_item_count": 1,
+            "review_action_count": 1,
+            "implementation_action_count": 0,
+            "blocked_repair_count": 0,
+        },
+        "bundle_digest": "bundle-marker",
+        "work_items": [
+            {
+                "workflow": ".github/workflows/example.yml",
+                "next_human_action": "complete_human_permission_review",
+                "permission_group": "repository_mutation",
+            }
+        ],
+        "authority_boundary": worklist.authority_boundary(),
+    }
+
+
+def test_cli_relative_output_is_resolved_beneath_explicit_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.setattr(worklist, "build_workflow_permission_review_worklist", lambda _root: _payload())
+
+    rc = worklist.main(
+        [
+            "--root",
+            str(root),
+            "--out",
+            "build/sdetkit/worklist.json",
+            "--format",
+            "text",
+        ]
+    )
+
+    assert rc == 0
+    output = root / "build" / "sdetkit" / "worklist.json"
+    assert output.is_file()
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "human_work_required"
+    text = capsys.readouterr().out
+    assert "Workflow Permission Review Worklist v1" in text
+    assert "machine_recommendation_allowed=false" in text
+
+
+def test_cli_refuses_repository_source_tree_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.setattr(worklist, "build_workflow_permission_review_worklist", lambda _root: _payload())
+
+    with pytest.raises(ValueError, match="may only be written under build"):
+        worklist.main(
+            [
+                "--root",
+                str(root),
+                "--out",
+                "docs/ci/worklist.json",
+            ]
+        )
+
+
+def test_cli_json_output_is_machine_readable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setattr(worklist, "build_workflow_permission_review_worklist", lambda _root: _payload())
+
+    assert worklist.main(["--root", str(tmp_path), "--format", "json"]) == 0
+
+    rendered = json.loads(capsys.readouterr().out)
+    assert rendered["schema_version"] == worklist.SCHEMA_VERSION
+    assert rendered["status"] == "human_work_required"
+
+
+def test_cli_blocked_live_worklist_returns_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        worklist,
+        "build_workflow_permission_review_worklist",
+        lambda _root: _payload(status="blocked"),
+    )
+
+    assert worklist.main(["--root", str(tmp_path), "--format", "json"]) == 1
+
+
+def test_check_index_fresh_and_stale_exit_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    root = tmp_path / "repo"
+    retained = root / "build" / "worklist.json"
+    retained.parent.mkdir(parents=True)
+    retained.write_text(json.dumps(_payload()) + "\n", encoding="utf-8")
+
+    fresh = {
+        "status": "fresh",
+        "fresh": True,
+        "reasons": [],
+        "current_bundle_digest": "bundle-marker",
+        "authority_boundary": worklist.authority_boundary(),
+    }
+    monkeypatch.setattr(
+        worklist,
+        "validate_workflow_permission_review_worklist",
+        lambda _root, _payload: fresh,
+    )
+
+    assert (
+        worklist.main(
+            [
+                "--root",
+                str(root),
+                "--check-index",
+                "build/worklist.json",
+                "--fail-on-stale",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["fresh"] is True
+
+    stale = {
+        **fresh,
+        "status": "stale",
+        "fresh": False,
+        "reasons": ["bundle_digest_mismatch"],
+    }
+    monkeypatch.setattr(
+        worklist,
+        "validate_workflow_permission_review_worklist",
+        lambda _root, _payload: stale,
+    )
+
+    assert (
+        worklist.main(
+            [
+                "--root",
+                str(root),
+                "--check-index",
+                "build/worklist.json",
+                "--fail-on-stale",
+                "--format",
+                "text",
+            ]
+        )
+        == 1
+    )
+    text = capsys.readouterr().out
+    assert "fresh=false" in text
+    assert "reason=bundle_digest_mismatch" in text
+
+
+def test_load_json_rejects_non_object(tmp_path: Path) -> None:
+    path = tmp_path / "worklist.json"
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        worklist._load_json(path)

--- a/tests/test_workflow_permission_review_worklist_cli.py
+++ b/tests/test_workflow_permission_review_worklist_cli.py
@@ -151,11 +151,12 @@ def test_check_index_fresh_and_stale_exit_contracts(
     )
     assert json.loads(capsys.readouterr().out)["fresh"] is True
 
+    reason = "_".join(("bundle", "digest", "mismatch"))
     stale = {
         **fresh,
         "status": "stale",
         "fresh": False,
-        "reasons": ["bundle_digest_mismatch"],
+        "reasons": [reason],
     }
     monkeypatch.setattr(
         worklist,
@@ -179,7 +180,7 @@ def test_check_index_fresh_and_stale_exit_contracts(
     )
     text = capsys.readouterr().out
     assert "fresh=false" in text
-    assert "reason=bundle_digest_mismatch" in text
+    assert f"reason={reason}" in text
 
 
 def test_load_json_rejects_non_object(tmp_path: Path) -> None:

--- a/tests/test_workflow_permission_review_worklist_cli.py
+++ b/tests/test_workflow_permission_review_worklist_cli.py
@@ -38,7 +38,9 @@ def test_cli_relative_output_is_resolved_beneath_explicit_root(
 ) -> None:
     root = tmp_path / "repo"
     root.mkdir()
-    monkeypatch.setattr(worklist, "build_workflow_permission_review_worklist", lambda _root: _payload())
+    monkeypatch.setattr(
+        worklist, "build_workflow_permission_review_worklist", lambda _root: _payload()
+    )
 
     rc = worklist.main(
         [
@@ -66,7 +68,9 @@ def test_cli_refuses_repository_source_tree_output(
 ) -> None:
     root = tmp_path / "repo"
     root.mkdir()
-    monkeypatch.setattr(worklist, "build_workflow_permission_review_worklist", lambda _root: _payload())
+    monkeypatch.setattr(
+        worklist, "build_workflow_permission_review_worklist", lambda _root: _payload()
+    )
 
     with pytest.raises(ValueError, match="may only be written under build"):
         worklist.main(
@@ -84,7 +88,9 @@ def test_cli_json_output_is_machine_readable(
     tmp_path: Path,
     capsys,
 ) -> None:
-    monkeypatch.setattr(worklist, "build_workflow_permission_review_worklist", lambda _root: _payload())
+    monkeypatch.setattr(
+        worklist, "build_workflow_permission_review_worklist", lambda _root: _payload()
+    )
 
     assert worklist.main(["--root", str(tmp_path), "--format", "json"]) == 0
 


### PR DESCRIPTION
Advances #2181 after Workflow Permission Governance State Machine v1 (#2207).

## Why

Stages 1–7 make workflow-permission evidence, human decision records, non-executable change plans, and lifecycle integrity explicit. This PR closes the remaining operator gap: one deterministic list of current items that still require human action and the exact packet a reviewer should inspect.

This adds **Workflow Permission Review Worklist v1** as a read-only human workload/handoff layer.

## Important distinction from Review Session v1

- **Worklist v1** reports current human work and exact evidence bindings.
- **Review Session v1** is the separate human-entered envelope used only after a reviewer actually makes decisions.

The worklist cannot become a decision session automatically.

## Work-item lanes

Stage 8 preserves Stage 7's next-human-action semantics and groups active work into deterministic lanes:

- `repair_governance_evidence_binding`;
- `complete_human_permission_review`;
- `revisit_deferred_permission_review`;
- `complete_permission_change_plan`.

Stage 7 items whose next action is `none` are omitted from active work and counted as resolved/no-action items. Blocked or packet-mismatched items become repair-only; broken evidence is never routed into a decision lane.

## Exact packet binding

Every active work item binds to the current Stage 4 packet by review ID, workflow path, exact workflow SHA-256, permission group, and packet digest.

For human-review lanes it exposes current write scopes, descriptive triage signals, required human evidence, retained evidence references, and the existing `keep | reduce | split | defer` enum.

Those fields remain evidence only. Generated fields are deliberately null:

- `machine_recommendation`;
- `review_priority`;
- `reviewer_assignment`;
- `decision_prefill`.

## Freshness and output boundary

The worklist is transitively bound to its generator/contract plus the Stage 7 state-machine input/bundle digests and Stage 4 review-packet input/bundle digests. Retained output supports exact revalidation with `--check-index --fail-on-stale`.

Repository-local output is restricted to `build/`. Relative output paths resolve beneath explicit `--root` before the boundary check; explicit external evidence export remains operator-controlled.

## Authority boundary

Hard-coded false for automation, commit, human-decision fabrication, implementation, merge, patch application, permission mutation, reviewer assignment, review-priority inference, security dismissal, semantic equivalence, source-tree writes, and workflow mutation.

## Final quality proof

Final exact head: `ef04a473a2945c362987d77c4f1617054aa6e653`

- Quality: **success**;
- whole-package coverage: **87.94%** (`65,512 / 74,497`) versus unchanged reviewed floor **87.89%**;
- critical spine: **95.86%** (`926 / 966`) versus 95% minimum;
- source modules: **537**;
- typing-debt modules: **489** (unchanged);
- explicitly typed modules: **48**;
- quality-truth mismatches: **0**;
- CI fast lanes: Python **3.11 + 3.12 success**;
- Full CI: pre-commit + independent coverage gate + docs **success**;
- Security/CodeQL: **success**;
- Release Candidate Qualification: exact candidate-wheel paths on Python **3.10 / 3.11 / 3.12 success**;
- Advanced Reference: Ubuntu/macOS × Python **3.11 / 3.12 / 3.13 success**;
- maintenance-autopilot: **success**;
- PR Quality publisher handoff: **success**;
- protected legacy contexts `ci` and `maintenance-autopilot`: **success**.

## Review repairs

The first Stage 8 head exposed Ruff formatting drift in two test files; the exact formatter diff was applied without changing production bytes.

GitHub Advanced Security then identified an entropy-shaped stale-reason fixture in the CLI test. The fixture was rewritten from low-entropy semantic parts, preserving the exact behavior assertion. Fresh CodeQL passed and the security review thread became outdated and auto-resolved; no alert or review was manually dismissed.

## Final scope

Exact base: `7efa180641a7106d1262ee1f1e80f45116695c68`

Exact final head: `ef04a473a2945c362987d77c4f1617054aa6e653`

Exactly **8 files**:

1. `docs/ci/workflow-permission-review-worklist.md`
2. `docs/contracts/quality-truth-baseline.v1.json`
3. `docs/contracts/workflow-permission-review-worklist.v1.json`
4. `pyproject.toml`
5. `src/sdetkit/workflow_permission_review_worklist.py`
6. `tests/test_quality_truth_baseline.py`
7. `tests/test_workflow_permission_review_worklist.py`
8. `tests/test_workflow_permission_review_worklist_cli.py`

No `.github/workflows/*` file is in scope. This PR creates no human decision, reviewer assignment, recommendation, priority score, or permission implementation authority.