### PR TITLE
feat(governance): add workflow permission reviewer handoff bundle

### DIFF
--- a/docs/ci/workflow-permission-review-handoff-bundle.md
+++ b/docs/ci/workflow-permission-review-handoff-bundle.md
@@ -1,0 +1,132 @@
+# Workflow permission reviewer handoff bundle
+
+Workflow Permission Reviewer Handoff Bundle v1 creates a deterministic offline evidence package for the workflow-permission items that currently require human action.
+
+It exists after the review worklist and before the human review itself. It makes the evidence portable without turning portability into decision authority.
+
+## Product flow
+
+```text
+workflow governance finding
+  -> permission review control plane
+  -> exact review packet
+  -> governance state machine
+  -> review worklist
+  -> reviewer handoff bundle
+  -> human reviewer / Review Session v1
+  -> Decision Record v1
+  -> non-executable permission change plan
+  -> separate reviewed permission-only PR
+  -> workflow-specific proof + rollback
+```
+
+The handoff bundle is not a review session and is not a decision record. It cannot capture, prefill, recommend, rank, assign, or retain a human decision.
+
+## What is included
+
+For the current active Stage 8 work items, the bundle contains:
+
+- `workflow-permission-review-handoff-manifest.json`;
+- `workflow-permission-review-worklist.json`;
+- `workflow-permission-review-worklist.txt`;
+- `README.md`;
+- one exact packet JSON file under `packets/` per active review item;
+- one reviewer-readable packet Markdown file under `packets/` per active review item.
+
+Resolved Stage 8 items whose next action is `none` are not added back into active reviewer work.
+
+## Exact active-packet binding
+
+Before export, every active work item must have exactly one current packet with the same:
+
+- review ID;
+- workflow path;
+- workflow SHA-256;
+- permission group;
+- packet digest.
+
+The work item and packet must also retain `safe_to_patch=false` and zero authority boundaries. Worklist machine fields for recommendation, priority, assignment, and decision prefill must remain null.
+
+If any active binding is missing, duplicated, stale, or authority-escalated, the bundle status is `blocked` and export is refused.
+
+## Deterministic manifest
+
+The manifest records:
+
+- current Stage 8 and Stage 4 provenance bindings;
+- active work-item count;
+- packaged packet count;
+- deterministic packet references;
+- every generated relative path;
+- SHA-256 and byte count for every generated artifact;
+- bundle digest;
+- zero-authority boundary.
+
+The bundle digest is computed from the artifact index, active packet references, integrity reasons, and the current worklist bundle binding. It does not include a reviewer decision or mutable timestamp.
+
+## Export an offline bundle
+
+```bash
+python -m sdetkit.workflow_permission_review_handoff_bundle \
+  --root . \
+  --out-dir build/sdetkit/workflow-permission-review-handoff \
+  --format text
+```
+
+Repository-local output may only be written beneath `build/`. Relative paths are resolved beneath the explicit `--root` before that boundary is checked.
+
+The destination must be absent or empty. The writer does not silently delete or overwrite an existing reviewer workspace because doing so could destroy retained human evidence.
+
+An explicit absolute directory outside the repository is allowed for operator-controlled evidence export.
+
+## Validate a retained bundle
+
+```bash
+python -m sdetkit.workflow_permission_review_handoff_bundle \
+  --root . \
+  --check-dir build/sdetkit/workflow-permission-review-handoff \
+  --fail-on-stale \
+  --format json
+```
+
+Validation rebuilds the current expected bundle in memory and checks:
+
+- manifest schema/status/summary/provenance;
+- current bundle digest;
+- packet-reference bindings;
+- artifact index;
+- expected file set;
+- missing files;
+- unexpected files;
+- exact artifact bytes;
+- SHA-256 for every generated artifact;
+- zero authority boundary.
+
+Any current workflow, evidence, packet, worklist, lifecycle, decision, or plan drift propagates through the upstream digests and makes the retained bundle stale.
+
+## Human review boundary
+
+The bundle can be copied to a reviewer and inspected offline. It cannot record what the reviewer decided.
+
+After review, the human decision still belongs in the separate Review Session v1 / Decision Record v1 path. A `reduce` or `split` result still requires a separate reviewed permission-only implementation PR with exact execution proof and rollback.
+
+## Authority boundary
+
+The bundle hard-codes false for:
+
+- automation authority;
+- commit authority;
+- human-decision fabrication;
+- implementation authority;
+- merge authority;
+- reviewer-note fabrication;
+- patch application;
+- permission mutation;
+- reviewer assignment;
+- review-priority inference;
+- security dismissal;
+- semantic equivalence;
+- source-tree writes;
+- workflow mutation.
+
+The handoff layer packages evidence. It does not perform the review.

--- a/docs/contracts/quality-truth-baseline.v1.json
+++ b/docs/contracts/quality-truth-baseline.v1.json
@@ -96,6 +96,7 @@
       "sdetkit.workflow_permission_decision_record",
       "sdetkit.workflow_permission_governance_state_machine",
       "sdetkit.workflow_permission_review_control_plane",
+      "sdetkit.workflow_permission_review_handoff_bundle",
       "sdetkit.workflow_permission_review_packet",
       "sdetkit.workflow_permission_review_session",
       "sdetkit.workflow_permission_review_worklist",
@@ -103,7 +104,7 @@
     ],
     "migration_complete": false,
     "new_unrecorded_suppression_allowed": false,
-    "source_module_count": 537,
+    "source_module_count": 538,
     "typing_debt_artifact_path": "build/quality/typing-debt-inventory.json",
     "typing_debt_inventory_sha256": "e8729da81702dacbd8901642b8dfea0e45540ff6a4e655834f2fbbd8bb4b053a",
     "typing_debt_module_count": 489

--- a/docs/contracts/workflow-permission-review-handoff-bundle.v1.json
+++ b/docs/contracts/workflow-permission-review-handoff-bundle.v1.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "sdetkit.workflow_permission_review_handoff_bundle.v1",
+  "status": "offline_review_evidence_handoff",
+  "purpose": "Package only current active workflow-permission work items with their exact current review packets into a deterministic offline reviewer bundle without creating reviewer notes, priorities, assignments, decisions, patches, permission changes, commits, or merges.",
+  "source_layers": [
+    "sdetkit.workflow_permission_review_worklist",
+    "sdetkit.workflow_permission_review_packet"
+  ],
+  "bundle_rules": {
+    "active_work_items_only": true,
+    "exact_review_id_binding_required": true,
+    "exact_workflow_path_binding_required": true,
+    "exact_workflow_sha256_binding_required": true,
+    "exact_permission_group_binding_required": true,
+    "exact_packet_digest_binding_required": true,
+    "blocked_bundle_export_allowed": false,
+    "unexpected_retained_files_allowed": false,
+    "retained_file_hash_validation_required": true,
+    "retained_file_content_validation_required": true,
+    "machine_recommendation_allowed": false,
+    "machine_priority_allowed": false,
+    "automatic_reviewer_assignment_allowed": false,
+    "automatic_decision_allowed": false,
+    "reviewer_note_fabrication_allowed": false,
+    "workflow_mutation_allowed": false
+  },
+  "bundle_contents": [
+    "workflow-permission-review-handoff-manifest.json",
+    "workflow-permission-review-worklist.json",
+    "workflow-permission-review-worklist.txt",
+    "README.md",
+    "packets/<review_id>.json",
+    "packets/<review_id>.md"
+  ],
+  "freshness": {
+    "generator_source_bound": true,
+    "contract_bound": true,
+    "review_worklist_input_and_bundle_digests_bound": true,
+    "review_packet_input_and_bundle_digests_bound": true,
+    "artifact_bytes_hashed": true,
+    "retained_bundle_validation_supported": true
+  },
+  "output_boundary": {
+    "repository_local_output_restricted_to_build": true,
+    "relative_output_resolved_beneath_explicit_root": true,
+    "non_empty_output_directory_refused": true,
+    "source_tree_write_allowed": false
+  },
+  "authority_boundary": {
+    "automation_allowed": false,
+    "commit_allowed": false,
+    "human_decision_fabrication_allowed": false,
+    "implementation_authorized": false,
+    "merge_authorized": false,
+    "note_fabrication_allowed": false,
+    "patch_application_allowed": false,
+    "permission_mutation_allowed": false,
+    "review_assignment_allowed": false,
+    "review_priority_inference_allowed": false,
+    "security_dismissal_allowed": false,
+    "semantic_equivalence_proven": false,
+    "source_tree_write_allowed": false,
+    "workflow_mutation_allowed": false
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,7 @@ module = [
   "sdetkit.workflow_permission_decision_record",
   "sdetkit.workflow_permission_governance_state_machine",
   "sdetkit.workflow_permission_review_control_plane",
+  "sdetkit.workflow_permission_review_handoff_bundle",
   "sdetkit.workflow_permission_review_packet",
   "sdetkit.workflow_permission_review_session",
   "sdetkit.workflow_permission_review_worklist",

--- a/src/sdetkit/workflow_permission_review_handoff_bundle.py
+++ b/src/sdetkit/workflow_permission_review_handoff_bundle.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .workflow_permission_review_packet import (
+    build_workflow_permission_review_packet_index,
+    render_packet_markdown,
+)
+from .workflow_permission_review_worklist import (
+    build_workflow_permission_review_worklist,
+    render_worklist_text,
+)
+
+SCHEMA_VERSION = "sdetkit.workflow_permission_review_handoff_bundle.v1"
+CONTRACT_PATH = "docs/contracts/workflow-permission-review-handoff-bundle.v1.json"
+GENERATOR_SOURCE_LABEL = "src/sdetkit/workflow_permission_review_handoff_bundle.py"
+DIGEST_ALGORITHM = "sha256"
+MANIFEST_NAME = "workflow-permission-review-handoff-manifest.json"
+WORKLIST_JSON_NAME = "workflow-permission-review-worklist.json"
+WORKLIST_TEXT_NAME = "workflow-permission-review-worklist.txt"
+README_NAME = "README.md"
+
+AUTHORITY_FIELDS = (
+    "automation_allowed",
+    "commit_allowed",
+    "human_decision_fabrication_allowed",
+    "implementation_authorized",
+    "merge_authorized",
+    "note_fabrication_allowed",
+    "patch_application_allowed",
+    "permission_mutation_allowed",
+    "review_assignment_allowed",
+    "review_priority_inference_allowed",
+    "security_dismissal_allowed",
+    "semantic_equivalence_proven",
+    "source_tree_write_allowed",
+    "workflow_mutation_allowed",
+)
+
+
+def authority_boundary() -> dict[str, bool]:
+    return {field: False for field in AUTHORITY_FIELDS}
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _pretty_json_bytes(payload: dict[str, Any]) -> bytes:
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _update_digest(hasher: Any, label: str, content: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    hasher.update(len(label_bytes).to_bytes(8, "big"))
+    hasher.update(label_bytes)
+    hasher.update(len(content).to_bytes(8, "big"))
+    hasher.update(content)
+
+
+def _dict_items(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _index_by_review_id(items: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    indexed: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        review_id = item.get("review_id")
+        if isinstance(review_id, str) and review_id:
+            indexed.setdefault(review_id, []).append(item)
+    return indexed
+
+
+def _all_false_boundary(value: object) -> bool:
+    return isinstance(value, dict) and bool(value) and not any(value.values())
+
+
+def _active_packet_binding_reasons(
+    work_item: dict[str, Any],
+    packets: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    if len(packets) != 1:
+        return None, ["packet_missing" if not packets else "duplicate_packets"]
+
+    packet = packets[0]
+    reasons: list[str] = []
+    for field in ("review_id", "workflow", "workflow_sha256", "permission_group", "packet_digest"):
+        if work_item.get(field) != packet.get(field):
+            reasons.append(f"packet_binding_mismatch:{field}")
+
+    if work_item.get("safe_to_patch") is not False:
+        reasons.append("work_item_safe_to_patch_not_false")
+    if not _all_false_boundary(work_item.get("authority_boundary")):
+        reasons.append("work_item_authority_boundary_invalid")
+    for field in ("machine_recommendation", "review_priority", "reviewer_assignment", "decision_prefill"):
+        if work_item.get(field) is not None:
+            reasons.append(f"work_item_machine_field_not_null:{field}")
+
+    if packet.get("safe_to_patch") is not False:
+        reasons.append("packet_safe_to_patch_not_false")
+    if not _all_false_boundary(packet.get("authority_boundary")):
+        reasons.append("packet_authority_boundary_invalid")
+
+    return packet, sorted(set(reasons))
+
+
+def workflow_permission_review_handoff_bundle_input_provenance(
+    repo_root: str | Path = ".",
+    *,
+    worklist: dict[str, Any] | None = None,
+    packet_index: dict[str, Any] | None = None,
+    generator_path: str | Path | None = None,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    current_worklist = worklist or build_workflow_permission_review_worklist(root)
+    current_packets = packet_index or build_workflow_permission_review_packet_index(root)
+    generator = (
+        Path(generator_path).resolve() if generator_path is not None else Path(__file__).resolve()
+    )
+
+    worklist_provenance = current_worklist.get("input_provenance")
+    packet_provenance = current_packets.get("input_provenance")
+    if not isinstance(worklist_provenance, dict):
+        worklist_provenance = {}
+    if not isinstance(packet_provenance, dict):
+        packet_provenance = {}
+
+    inputs: list[tuple[str, bytes]] = [
+        ("schema_version", SCHEMA_VERSION.encode("utf-8")),
+        (GENERATOR_SOURCE_LABEL, generator.read_bytes()),
+        (
+            "review_worklist_input_digest",
+            str(worklist_provenance.get("input_digest", "")).encode("utf-8"),
+        ),
+        (
+            "review_worklist_bundle_digest",
+            str(current_worklist.get("bundle_digest", "")).encode("utf-8"),
+        ),
+        (
+            "review_packet_input_digest",
+            str(packet_provenance.get("input_digest", "")).encode("utf-8"),
+        ),
+        (
+            "review_packet_bundle_digest",
+            str(current_packets.get("bundle_digest", "")).encode("utf-8"),
+        ),
+    ]
+    contract = root / CONTRACT_PATH
+    if contract.is_file():
+        inputs.append((CONTRACT_PATH, contract.read_bytes()))
+
+    hasher = hashlib.sha256()
+    for label, content in sorted(inputs, key=lambda item: item[0]):
+        _update_digest(hasher, label, content)
+
+    return {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "input_digest": hasher.hexdigest(),
+        "input_count": len(inputs),
+        "review_worklist_input_digest": worklist_provenance.get("input_digest", ""),
+        "review_worklist_bundle_digest": current_worklist.get("bundle_digest", ""),
+        "review_packet_input_digest": packet_provenance.get("input_digest", ""),
+        "review_packet_bundle_digest": current_packets.get("bundle_digest", ""),
+        "generator_schema_version": SCHEMA_VERSION,
+        "generator_source": GENERATOR_SOURCE_LABEL,
+        "contract_path": CONTRACT_PATH,
+    }
+
+
+def render_handoff_markdown(
+    worklist: dict[str, Any],
+    packet_refs: list[dict[str, Any]],
+) -> str:
+    summary = worklist.get("summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    lines = [
+        "# Workflow permission reviewer handoff bundle",
+        "",
+        "> Offline evidence handoff only. This bundle does not recommend, rank, assign, decide, patch, mutate permissions, commit, merge, or dismiss security findings.",
+        "",
+        f"- Active work items: **{summary.get('work_item_count', 0)}**",
+        f"- Human review actions: **{summary.get('review_action_count', 0)}**",
+        f"- Implementation-plan actions: **{summary.get('implementation_action_count', 0)}**",
+        f"- Repair actions: **{summary.get('blocked_repair_count', 0)}**",
+        "",
+        "## Included active packets",
+        "",
+    ]
+    if packet_refs:
+        for ref in packet_refs:
+            lines.append(
+                f"- `{ref.get('workflow', '')}` — action `{ref.get('next_human_action', '')}` — "
+                f"JSON `{ref.get('json_path', '')}` — Markdown `{ref.get('markdown_path', '')}`"
+            )
+    else:
+        lines.append("- No active reviewer packets are required.")
+    lines.extend(
+        [
+            "",
+            "## Human boundary",
+            "",
+            "Use the included packet evidence to perform the human review. Record any actual decision separately through Review Session v1 / Decision Record v1. This handoff bundle cannot prefill or retain that decision.",
+            "",
+            "## Authority boundary",
+            "",
+        ]
+    )
+    lines.extend(f"- `{field}=false`" for field in sorted(authority_boundary()))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_file_payloads(
+    worklist: dict[str, Any],
+    packet_index: dict[str, Any],
+) -> tuple[dict[str, bytes], list[dict[str, Any]], list[str]]:
+    work_items = _dict_items(worklist.get("work_items"))
+    packets = _dict_items(packet_index.get("packets"))
+    packets_by_id = _index_by_review_id(packets)
+
+    files: dict[str, bytes] = {
+        WORKLIST_JSON_NAME: _pretty_json_bytes(worklist),
+        WORKLIST_TEXT_NAME: render_worklist_text(worklist).encode("utf-8"),
+    }
+    packet_refs: list[dict[str, Any]] = []
+    reasons: list[str] = []
+
+    for item in work_items:
+        review_id = str(item.get("review_id", ""))
+        packet, binding_reasons = _active_packet_binding_reasons(
+            item,
+            packets_by_id.get(review_id, []),
+        )
+        reasons.extend(f"{review_id or 'unknown'}:{reason}" for reason in binding_reasons)
+        if packet is None or binding_reasons:
+            continue
+
+        json_path = f"packets/{review_id}.json"
+        markdown_path = f"packets/{review_id}.md"
+        files[json_path] = _pretty_json_bytes(packet)
+        files[markdown_path] = render_packet_markdown(packet).encode("utf-8")
+        packet_refs.append(
+            {
+                "work_item_id": item.get("work_item_id"),
+                "review_id": review_id,
+                "workflow": item.get("workflow"),
+                "workflow_sha256": item.get("workflow_sha256"),
+                "permission_group": item.get("permission_group"),
+                "lifecycle_state": item.get("lifecycle_state"),
+                "next_human_action": item.get("next_human_action"),
+                "packet_id": packet.get("packet_id"),
+                "packet_digest": packet.get("packet_digest"),
+                "json_path": json_path,
+                "markdown_path": markdown_path,
+            }
+        )
+
+    packet_refs.sort(key=lambda item: str(item.get("workflow", "")))
+    reasons = sorted(set(reasons))
+    files[README_NAME] = render_handoff_markdown(worklist, packet_refs).encode("utf-8")
+    return files, packet_refs, reasons
+
+
+def _artifact_index(files: dict[str, bytes]) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": path,
+            "sha256": _sha256_bytes(content),
+            "byte_count": len(content),
+            "kind": (
+                "review_packet_json"
+                if path.startswith("packets/") and path.endswith(".json")
+                else (
+                    "review_packet_markdown"
+                    if path.startswith("packets/") and path.endswith(".md")
+                    else "handoff_support"
+                )
+            ),
+        }
+        for path, content in sorted(files.items())
+    ]
+
+
+def _build_current_bundle(
+    repo_root: str | Path = ".",
+) -> tuple[dict[str, Any], dict[str, bytes]]:
+    root = Path(repo_root).resolve()
+    worklist = build_workflow_permission_review_worklist(root)
+    packet_index = build_workflow_permission_review_packet_index(root)
+    files, packet_refs, binding_reasons = _build_file_payloads(worklist, packet_index)
+
+    global_reasons: list[str] = []
+    if worklist.get("status") == "blocked":
+        global_reasons.append("review_worklist_blocked")
+    elif worklist.get("status") not in {"human_work_required", "not_required"}:
+        global_reasons.append("review_worklist_status_invalid")
+    global_reasons.extend(binding_reasons)
+    global_reasons = sorted(set(global_reasons))
+
+    work_items = _dict_items(worklist.get("work_items"))
+    if len(packet_refs) != len(work_items):
+        global_reasons.append("active_packet_count_mismatch")
+        global_reasons = sorted(set(global_reasons))
+
+    artifacts = _artifact_index(files)
+    provenance = workflow_permission_review_handoff_bundle_input_provenance(
+        root,
+        worklist=worklist,
+        packet_index=packet_index,
+    )
+    digest_payload = {
+        "artifact_index": artifacts,
+        "packet_refs": packet_refs,
+        "global_reasons": global_reasons,
+        "review_worklist_bundle_digest": worklist.get("bundle_digest", ""),
+    }
+    bundle_digest = _sha256_bytes(_canonical_json_bytes(digest_payload))
+
+    if global_reasons:
+        status = "blocked"
+    elif packet_refs:
+        status = "ready_for_human_handoff"
+    else:
+        status = "not_required"
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "input_provenance": provenance,
+        "summary": {
+            "active_work_item_count": len(work_items),
+            "packaged_packet_count": len(packet_refs),
+            "artifact_count": len(artifacts),
+            "blocked_reason_count": len(global_reasons),
+            "machine_recommendation_count": 0,
+            "machine_priority_count": 0,
+            "automatic_reviewer_assignment_count": 0,
+            "automatic_decision_count": 0,
+            "automatic_permission_change_count": 0,
+        },
+        "global_reasons": global_reasons,
+        "packet_refs": packet_refs,
+        "artifact_index": artifacts,
+        "bundle_digest": bundle_digest,
+        "rules": {
+            "active_work_items_only": True,
+            "exact_current_packet_binding_required": True,
+            "blocked_bundle_export_allowed": False,
+            "retained_file_hash_validation_required": True,
+            "machine_recommendation_allowed": False,
+            "machine_priority_allowed": False,
+            "automatic_reviewer_assignment_allowed": False,
+            "automatic_decision_allowed": False,
+            "workflow_mutation_allowed": False,
+        },
+        "authority_boundary": authority_boundary(),
+    }
+    return manifest, files
+
+
+def build_workflow_permission_review_handoff_bundle(
+    repo_root: str | Path = ".",
+) -> dict[str, Any]:
+    manifest, _files = _build_current_bundle(repo_root)
+    return manifest
+
+
+def _safe_output_dir(root: Path, output: Path) -> Path:
+    target = output.resolve() if output.is_absolute() else (root / output).resolve()
+    try:
+        relative = target.relative_to(root)
+    except ValueError:
+        return target
+    if not relative.parts or relative.parts[0] != "build":
+        raise ValueError("repository-local reviewer handoff output may only be written under build/")
+    return target
+
+
+def write_workflow_permission_review_handoff_bundle(
+    repo_root: str | Path,
+    out_dir: str | Path,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    manifest, files = _build_current_bundle(root)
+    if manifest.get("status") == "blocked":
+        raise ValueError("blocked reviewer handoff bundle cannot be exported")
+
+    output = _safe_output_dir(root, Path(out_dir))
+    if output.exists() and any(output.iterdir()):
+        raise ValueError("reviewer handoff output directory must be absent or empty")
+    output.mkdir(parents=True, exist_ok=True)
+
+    for relative_path, content in sorted(files.items()):
+        path = output / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    (output / MANIFEST_NAME).write_bytes(_pretty_json_bytes(manifest))
+    return manifest
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("reviewer handoff manifest must be a JSON object")
+    return payload
+
+
+def validate_workflow_permission_review_handoff_bundle(
+    repo_root: str | Path,
+    bundle_dir: str | Path,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    bundle = _safe_output_dir(root, Path(bundle_dir))
+    manifest_path = bundle / MANIFEST_NAME
+    reasons: list[str] = []
+    if not manifest_path.is_file():
+        return {
+            "status": "stale",
+            "fresh": False,
+            "reasons": ["manifest_missing"],
+            "authority_boundary": authority_boundary(),
+        }
+
+    recorded = _load_json(manifest_path)
+    current, expected_files = _build_current_bundle(root)
+    for field in (
+        "schema_version",
+        "status",
+        "summary",
+        "global_reasons",
+        "packet_refs",
+        "artifact_index",
+        "bundle_digest",
+    ):
+        if recorded.get(field) != current.get(field):
+            reasons.append(f"{field}_mismatch")
+
+    recorded_provenance = recorded.get("input_provenance")
+    current_provenance = current.get("input_provenance")
+    if not isinstance(recorded_provenance, dict):
+        recorded_provenance = {}
+    if not isinstance(current_provenance, dict):
+        current_provenance = {}
+    if recorded_provenance.get("input_digest") != current_provenance.get("input_digest"):
+        reasons.append("input_digest_mismatch")
+    if recorded.get("authority_boundary") != authority_boundary():
+        reasons.append("authority_boundary_mismatch")
+
+    expected_paths = set(expected_files) | {MANIFEST_NAME}
+    actual_paths = {
+        path.relative_to(bundle).as_posix()
+        for path in bundle.rglob("*")
+        if path.is_file()
+    }
+    missing = sorted(expected_paths - actual_paths)
+    unexpected = sorted(actual_paths - expected_paths)
+    reasons.extend(f"artifact_missing:{path}" for path in missing)
+    reasons.extend(f"artifact_unexpected:{path}" for path in unexpected)
+
+    for relative_path, expected_content in sorted(expected_files.items()):
+        path = bundle / relative_path
+        if not path.is_file():
+            continue
+        actual_content = path.read_bytes()
+        if actual_content != expected_content:
+            reasons.append(f"artifact_content_mismatch:{relative_path}")
+        if _sha256_bytes(actual_content) != _sha256_bytes(expected_content):
+            reasons.append(f"artifact_digest_mismatch:{relative_path}")
+
+    reasons = sorted(set(reasons))
+    return {
+        "status": "fresh" if not reasons else "stale",
+        "fresh": not reasons,
+        "reasons": reasons,
+        "recorded_bundle_digest": recorded.get("bundle_digest", ""),
+        "current_bundle_digest": current.get("bundle_digest", ""),
+        "recorded_input_digest": recorded_provenance.get("input_digest", ""),
+        "current_input_digest": current_provenance.get("input_digest", ""),
+        "authority_boundary": authority_boundary(),
+    }
+
+
+def render_manifest_text(manifest: dict[str, Any]) -> str:
+    summary = manifest.get("summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    return "\n".join(
+        [
+            "Workflow Permission Reviewer Handoff Bundle v1",
+            f"status={manifest.get('status', 'unknown')}",
+            f"active_work_item_count={summary.get('active_work_item_count', 0)}",
+            f"packaged_packet_count={summary.get('packaged_packet_count', 0)}",
+            f"artifact_count={summary.get('artifact_count', 0)}",
+            f"blocked_reason_count={summary.get('blocked_reason_count', 0)}",
+            f"bundle_digest={manifest.get('bundle_digest', '')}",
+            "machine_recommendation_allowed=false",
+            "review_assignment_allowed=false",
+            "automatic_decision_allowed=false",
+            "permission_mutation_allowed=false",
+            "merge_authorized=false",
+        ]
+    ) + "\n"
+
+
+def render_validation_text(validation: dict[str, Any]) -> str:
+    reasons = validation.get("reasons")
+    if not isinstance(reasons, list):
+        reasons = []
+    lines = [
+        "Workflow Permission Reviewer Handoff Validation v1",
+        f"status={validation.get('status', 'unknown')}",
+        f"fresh={str(validation.get('fresh') is True).lower()}",
+        f"reason_count={len(reasons)}",
+        f"current_bundle_digest={validation.get('current_bundle_digest', '')}",
+        "permission_mutation_allowed=false",
+        "merge_authorized=false",
+    ]
+    lines.extend(f"reason={reason}" for reason in reasons)
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build or validate an offline workflow-permission reviewer handoff bundle"
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--out-dir")
+    parser.add_argument("--check-dir")
+    parser.add_argument("--fail-on-stale", action="store_true")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.check_dir:
+        validation = validate_workflow_permission_review_handoff_bundle(root, args.check_dir)
+        if args.format == "json":
+            print(json.dumps(validation, indent=2, sort_keys=True))
+        else:
+            print(render_validation_text(validation), end="")
+        return 1 if args.fail_on_stale and not validation["fresh"] else 0
+
+    manifest = build_workflow_permission_review_handoff_bundle(root)
+    if args.out_dir:
+        if manifest.get("status") == "blocked":
+            if args.format == "json":
+                print(json.dumps(manifest, indent=2, sort_keys=True))
+            else:
+                print(render_manifest_text(manifest), end="")
+            return 1
+        manifest = write_workflow_permission_review_handoff_bundle(root, args.out_dir)
+
+    if args.format == "json":
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+    else:
+        print(render_manifest_text(manifest), end="")
+    return 1 if manifest.get("status") == "blocked" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sdetkit/workflow_permission_review_handoff_bundle.py
+++ b/src/sdetkit/workflow_permission_review_handoff_bundle.py
@@ -103,7 +103,12 @@ def _active_packet_binding_reasons(
         reasons.append("work_item_safe_to_patch_not_false")
     if not _all_false_boundary(work_item.get("authority_boundary")):
         reasons.append("work_item_authority_boundary_invalid")
-    for field in ("machine_recommendation", "review_priority", "reviewer_assignment", "decision_prefill"):
+    for field in (
+        "machine_recommendation",
+        "review_priority",
+        "reviewer_assignment",
+        "decision_prefill",
+    ):
         if work_item.get(field) is not None:
             reasons.append(f"work_item_machine_field_not_null:{field}")
 
@@ -384,7 +389,9 @@ def _safe_output_dir(root: Path, output: Path) -> Path:
     except ValueError:
         return target
     if not relative.parts or relative.parts[0] != "build":
-        raise ValueError("repository-local reviewer handoff output may only be written under build/")
+        raise ValueError(
+            "repository-local reviewer handoff output may only be written under build/"
+        )
     return target
 
 
@@ -460,9 +467,7 @@ def validate_workflow_permission_review_handoff_bundle(
 
     expected_paths = set(expected_files) | {MANIFEST_NAME}
     actual_paths = {
-        path.relative_to(bundle).as_posix()
-        for path in bundle.rglob("*")
-        if path.is_file()
+        path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
     }
     missing = sorted(expected_paths - actual_paths)
     unexpected = sorted(actual_paths - expected_paths)
@@ -496,22 +501,25 @@ def render_manifest_text(manifest: dict[str, Any]) -> str:
     summary = manifest.get("summary")
     if not isinstance(summary, dict):
         summary = {}
-    return "\n".join(
-        [
-            "Workflow Permission Reviewer Handoff Bundle v1",
-            f"status={manifest.get('status', 'unknown')}",
-            f"active_work_item_count={summary.get('active_work_item_count', 0)}",
-            f"packaged_packet_count={summary.get('packaged_packet_count', 0)}",
-            f"artifact_count={summary.get('artifact_count', 0)}",
-            f"blocked_reason_count={summary.get('blocked_reason_count', 0)}",
-            f"bundle_digest={manifest.get('bundle_digest', '')}",
-            "machine_recommendation_allowed=false",
-            "review_assignment_allowed=false",
-            "automatic_decision_allowed=false",
-            "permission_mutation_allowed=false",
-            "merge_authorized=false",
-        ]
-    ) + "\n"
+    return (
+        "\n".join(
+            [
+                "Workflow Permission Reviewer Handoff Bundle v1",
+                f"status={manifest.get('status', 'unknown')}",
+                f"active_work_item_count={summary.get('active_work_item_count', 0)}",
+                f"packaged_packet_count={summary.get('packaged_packet_count', 0)}",
+                f"artifact_count={summary.get('artifact_count', 0)}",
+                f"blocked_reason_count={summary.get('blocked_reason_count', 0)}",
+                f"bundle_digest={manifest.get('bundle_digest', '')}",
+                "machine_recommendation_allowed=false",
+                "review_assignment_allowed=false",
+                "automatic_decision_allowed=false",
+                "permission_mutation_allowed=false",
+                "merge_authorized=false",
+            ]
+        )
+        + "\n"
+    )
 
 
 def render_validation_text(validation: dict[str, Any]) -> str:

--- a/tests/test_quality_truth_baseline.py
+++ b/tests/test_quality_truth_baseline.py
@@ -24,10 +24,10 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
 
     assert payload["ok"] is True, payload["mismatches"]
     assert all(payload["checks"].values())
-    assert payload["observed"]["source_module_count"] == 537
+    assert payload["observed"]["source_module_count"] == 538
     assert payload["observed"]["typing_debt_module_count"] == 489
     checked = payload["observed"]["explicitly_type_checked_modules"]
-    assert len(checked) == 48
+    assert len(checked) == 49
     assert "sdetkit._formatter_policy_proposal_observation_records" in checked
     assert "sdetkit._formatter_policy_proposal_observation_schema" in checked
     assert "sdetkit.adoption_product_kpi_freshness" in checked
@@ -53,6 +53,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.workflow_permission_decision_record" in checked
     assert "sdetkit.workflow_permission_governance_state_machine" in checked
     assert "sdetkit.workflow_permission_review_control_plane" in checked
+    assert "sdetkit.workflow_permission_review_handoff_bundle" in checked
     assert "sdetkit.workflow_permission_review_packet" in checked
     assert "sdetkit.workflow_permission_review_session" in checked
     assert "sdetkit.workflow_permission_review_worklist" in checked
@@ -86,6 +87,7 @@ def test_quality_truth_baseline_matches_current_repository_configuration() -> No
     assert "sdetkit.workflow_permission_decision_record" not in inventory["modules"]
     assert "sdetkit.workflow_permission_governance_state_machine" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_control_plane" not in inventory["modules"]
+    assert "sdetkit.workflow_permission_review_handoff_bundle" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_packet" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_session" not in inventory["modules"]
     assert "sdetkit.workflow_permission_review_worklist" not in inventory["modules"]
@@ -107,7 +109,7 @@ def test_quality_truth_baseline_reports_machine_readable_mismatches(tmp_path: Pa
             "check": "source_module_count_matches",
             "metric": "source_module_count",
             "expected": 0,
-            "actual": 537,
+            "actual": 538,
         }
     ]
 

--- a/tests/test_workflow_permission_review_handoff_bundle.py
+++ b/tests/test_workflow_permission_review_handoff_bundle.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from sdetkit import workflow_permission_review_handoff_bundle as handoff
+
+
+def _zero_boundary() -> dict[str, bool]:
+    return {"workflow_mutation_allowed": False, "permission_mutation_allowed": False}
+
+
+def _work_item(
+    *,
+    review_id: str = "review-example",
+    workflow: str = ".github/workflows/example.yml",
+    packet_digest: str = "packet-marker",
+) -> dict[str, object]:
+    return {
+        "work_item_id": f"work-{review_id}",
+        "review_id": review_id,
+        "workflow": workflow,
+        "workflow_sha256": "workflow-marker",
+        "permission_group": "repository_mutation",
+        "lifecycle_state": "pending_human_review",
+        "next_human_action": "complete_human_permission_review",
+        "packet_id": f"packet-{review_id}",
+        "packet_digest": packet_digest,
+        "machine_recommendation": None,
+        "review_priority": None,
+        "reviewer_assignment": None,
+        "decision_prefill": None,
+        "safe_to_patch": False,
+        "authority_boundary": _zero_boundary(),
+    }
+
+
+def _worklist(items: list[dict[str, object]], *, status: str = "human_work_required") -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.workflow_permission_review_worklist.v1",
+        "status": status,
+        "input_provenance": {"input_digest": "worklist-input-marker"},
+        "summary": {
+            "work_item_count": len(items),
+            "review_action_count": len(items),
+            "implementation_action_count": 0,
+            "blocked_repair_count": 0,
+        },
+        "bundle_digest": "worklist-bundle-marker",
+        "work_items": items,
+        "authority_boundary": _zero_boundary(),
+    }
+
+
+def _packet(
+    *,
+    review_id: str = "review-example",
+    workflow: str = ".github/workflows/example.yml",
+    packet_digest: str = "packet-marker",
+) -> dict[str, object]:
+    return {
+        "packet_id": f"packet-{review_id}",
+        "review_id": review_id,
+        "workflow": workflow,
+        "workflow_sha256": "workflow-marker",
+        "permission_group": "repository_mutation",
+        "review_state": "pending_human_review",
+        "packet_digest": packet_digest,
+        "safe_to_patch": False,
+        "current_permissions": {"write_scopes": ["contents: write"]},
+        "evidence": {
+            "retained_evidence_refs": [],
+            "required_human_evidence": ["confirm the reviewed write-scope need"],
+        },
+        "decision_boundary": {
+            "allowed_decisions": ["keep", "reduce", "split", "defer"],
+        },
+        "proof_contract": ["exact-head proof"],
+        "authority_boundary": _zero_boundary(),
+    }
+
+
+def _packet_index(items: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.workflow_permission_review_packet.v1",
+        "status": "human_review_required" if items else "not_required",
+        "input_provenance": {"input_digest": "packet-input-marker"},
+        "bundle_digest": "packet-bundle-marker",
+        "packets": items,
+    }
+
+
+def _install_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    worklist_payload: dict[str, object],
+    packet_payload: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        handoff,
+        "build_workflow_permission_review_worklist",
+        lambda _root: worklist_payload,
+    )
+    monkeypatch.setattr(
+        handoff,
+        "build_workflow_permission_review_packet_index",
+        lambda _root: packet_payload,
+    )
+
+
+def test_active_work_item_packages_only_exact_current_packet(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    item = _work_item()
+    packet = _packet()
+    _install_inputs(monkeypatch, _worklist([item]), _packet_index([packet]))
+
+    manifest, files = handoff._build_current_bundle(tmp_path)
+
+    assert manifest["status"] == "ready_for_human_handoff"
+    assert manifest["summary"]["active_work_item_count"] == 1
+    assert manifest["summary"]["packaged_packet_count"] == 1
+    assert manifest["global_reasons"] == []
+    assert [ref["review_id"] for ref in manifest["packet_refs"]] == ["review-example"]
+    assert "packets/review-example.json" in files
+    assert "packets/review-example.md" in files
+    assert handoff.WORKLIST_JSON_NAME in files
+    assert handoff.WORKLIST_TEXT_NAME in files
+    assert handoff.README_NAME in files
+    assert manifest["summary"]["artifact_count"] == len(files)
+    assert manifest["summary"]["machine_recommendation_count"] == 0
+    assert manifest["summary"]["automatic_decision_count"] == 0
+    assert not any(manifest["authority_boundary"].values())
+
+
+def test_no_active_work_is_not_required(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_inputs(monkeypatch, _worklist([], status="not_required"), _packet_index([]))
+
+    manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
+
+    assert manifest["status"] == "not_required"
+    assert manifest["summary"]["active_work_item_count"] == 0
+    assert manifest["summary"]["packaged_packet_count"] == 0
+    assert manifest["packet_refs"] == []
+
+
+def test_missing_packet_blocks_export(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([]))
+
+    manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
+
+    assert manifest["status"] == "blocked"
+    assert "review-example:packet_missing" in manifest["global_reasons"]
+    assert "active_packet_count_mismatch" in manifest["global_reasons"]
+    with pytest.raises(ValueError, match="blocked reviewer handoff bundle"):
+        handoff.write_workflow_permission_review_handoff_bundle(
+            tmp_path,
+            "build/handoff",
+        )
+    assert not (tmp_path / "build" / "handoff").exists()
+
+
+def test_duplicate_packets_block_export(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    packet = _packet()
+    _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([packet, copy.deepcopy(packet)]))
+
+    manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
+
+    assert manifest["status"] == "blocked"
+    assert "review-example:duplicate_packets" in manifest["global_reasons"]
+
+
+def test_packet_digest_mismatch_blocks_export(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_inputs(
+        monkeypatch,
+        _worklist([_work_item(packet_digest="worklist-packet-marker")]),
+        _packet_index([_packet(packet_digest="current-packet-marker")]),
+    )
+
+    manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
+
+    assert manifest["status"] == "blocked"
+    assert (
+        "review-example:packet_binding_mismatch:packet_digest"
+        in manifest["global_reasons"]
+    )
+
+
+def test_machine_field_or_authority_escalation_blocks_export(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    item = _work_item()
+    item["review_priority"] = 1
+    packet = _packet()
+    packet["safe_to_patch"] = True
+    _install_inputs(monkeypatch, _worklist([item]), _packet_index([packet]))
+
+    manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
+
+    assert manifest["status"] == "blocked"
+    assert "review-example:work_item_machine_field_not_null:review_priority" in manifest[
+        "global_reasons"
+    ]
+    assert "review-example:packet_safe_to_patch_not_false" in manifest["global_reasons"]
+
+
+def test_bundle_files_and_manifest_are_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    items = [
+        _work_item(review_id="review-b", workflow=".github/workflows/b.yml"),
+        _work_item(review_id="review-a", workflow=".github/workflows/a.yml"),
+    ]
+    packets = [
+        _packet(review_id="review-b", workflow=".github/workflows/b.yml"),
+        _packet(review_id="review-a", workflow=".github/workflows/a.yml"),
+    ]
+    _install_inputs(monkeypatch, _worklist(items), _packet_index(packets))
+
+    first_manifest, first_files = handoff._build_current_bundle(tmp_path)
+    second_manifest, second_files = handoff._build_current_bundle(tmp_path)
+
+    assert first_manifest == second_manifest
+    assert first_files == second_files
+    assert [ref["workflow"] for ref in first_manifest["packet_refs"]] == [
+        ".github/workflows/a.yml",
+        ".github/workflows/b.yml",
+    ]
+
+
+def test_writer_and_validator_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([_packet()]))
+
+    written = handoff.write_workflow_permission_review_handoff_bundle(
+        tmp_path,
+        "build/handoff",
+    )
+    validation = handoff.validate_workflow_permission_review_handoff_bundle(
+        tmp_path,
+        "build/handoff",
+    )
+
+    assert written["status"] == "ready_for_human_handoff"
+    assert validation["status"] == "fresh"
+    assert validation["fresh"] is True
+    assert validation["reasons"] == []
+    assert not any(validation["authority_boundary"].values())
+
+
+def test_validator_detects_tampered_packet_and_unexpected_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([_packet()]))
+    bundle = tmp_path / "build" / "handoff"
+    handoff.write_workflow_permission_review_handoff_bundle(tmp_path, bundle)
+    packet_path = bundle / "packets" / "review-example.json"
+    packet_path.write_text(packet_path.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8")
+    (bundle / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+
+    validation = handoff.validate_workflow_permission_review_handoff_bundle(tmp_path, bundle)
+
+    assert validation["fresh"] is False
+    assert "artifact_content_mismatch:packets/review-example.json" in validation["reasons"]
+    assert "artifact_digest_mismatch:packets/review-example.json" in validation["reasons"]
+    assert "artifact_unexpected:unexpected.txt" in validation["reasons"]
+
+
+def test_validator_detects_missing_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([_packet()]))
+    bundle = tmp_path / "build" / "handoff"
+    handoff.write_workflow_permission_review_handoff_bundle(tmp_path, bundle)
+    (bundle / "packets" / "review-example.md").unlink()
+
+    validation = handoff.validate_workflow_permission_review_handoff_bundle(tmp_path, bundle)
+
+    assert validation["fresh"] is False
+    assert "artifact_missing:packets/review-example.md" in validation["reasons"]
+
+
+def test_validator_detects_upstream_worklist_staleness(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    initial_worklist = _worklist([_work_item()])
+    packets = _packet_index([_packet()])
+    _install_inputs(monkeypatch, initial_worklist, packets)
+    bundle = tmp_path / "build" / "handoff"
+    handoff.write_workflow_permission_review_handoff_bundle(tmp_path, bundle)
+
+    changed = copy.deepcopy(initial_worklist)
+    changed["bundle_digest"] = "new-worklist-bundle-marker"
+    _install_inputs(monkeypatch, changed, packets)
+
+    validation = handoff.validate_workflow_permission_review_handoff_bundle(tmp_path, bundle)
+
+    assert validation["fresh"] is False
+    assert "bundle_digest_mismatch" in validation["reasons"]
+    assert "input_digest_mismatch" in validation["reasons"]
+
+
+def test_output_guard_and_non_empty_directory_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([_packet()]))
+
+    assert handoff._safe_output_dir(root, Path("build/handoff")) == (
+        root / "build" / "handoff"
+    ).resolve()
+    with pytest.raises(ValueError, match="may only be written under build"):
+        handoff._safe_output_dir(root, Path("docs/ci/handoff"))
+
+    occupied = root / "build" / "occupied"
+    occupied.mkdir(parents=True)
+    (occupied / "human-note.txt").write_text("retain me\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be absent or empty"):
+        handoff.write_workflow_permission_review_handoff_bundle(root, occupied)
+    assert (occupied / "human-note.txt").read_text(encoding="utf-8") == "retain me\n"
+
+
+def test_live_repository_handoff_never_grants_human_or_merge_authority() -> None:
+    manifest = handoff.build_workflow_permission_review_handoff_bundle(".")
+
+    assert manifest["summary"]["machine_recommendation_count"] == 0
+    assert manifest["summary"]["machine_priority_count"] == 0
+    assert manifest["summary"]["automatic_reviewer_assignment_count"] == 0
+    assert manifest["summary"]["automatic_decision_count"] == 0
+    assert manifest["summary"]["automatic_permission_change_count"] == 0
+    assert not any(manifest["authority_boundary"].values())

--- a/tests/test_workflow_permission_review_handoff_bundle.py
+++ b/tests/test_workflow_permission_review_handoff_bundle.py
@@ -37,7 +37,9 @@ def _work_item(
     }
 
 
-def _worklist(items: list[dict[str, object]], *, status: str = "human_work_required") -> dict[str, object]:
+def _worklist(
+    items: list[dict[str, object]], *, status: str = "human_work_required"
+) -> dict[str, object]:
     return {
         "schema_version": "sdetkit.workflow_permission_review_worklist.v1",
         "status": status,
@@ -173,7 +175,9 @@ def test_duplicate_packets_block_export(
     tmp_path: Path,
 ) -> None:
     packet = _packet()
-    _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([packet, copy.deepcopy(packet)]))
+    _install_inputs(
+        monkeypatch, _worklist([_work_item()]), _packet_index([packet, copy.deepcopy(packet)])
+    )
 
     manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
 
@@ -194,10 +198,7 @@ def test_packet_digest_mismatch_blocks_export(
     manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
 
     assert manifest["status"] == "blocked"
-    assert (
-        "review-example:packet_binding_mismatch:packet_digest"
-        in manifest["global_reasons"]
-    )
+    assert "review-example:packet_binding_mismatch:packet_digest" in manifest["global_reasons"]
 
 
 def test_machine_field_or_authority_escalation_blocks_export(
@@ -213,9 +214,10 @@ def test_machine_field_or_authority_escalation_blocks_export(
     manifest = handoff.build_workflow_permission_review_handoff_bundle(tmp_path)
 
     assert manifest["status"] == "blocked"
-    assert "review-example:work_item_machine_field_not_null:review_priority" in manifest[
-        "global_reasons"
-    ]
+    assert (
+        "review-example:work_item_machine_field_not_null:review_priority"
+        in manifest["global_reasons"]
+    )
     assert "review-example:packet_safe_to_patch_not_false" in manifest["global_reasons"]
 
 
@@ -274,7 +276,9 @@ def test_validator_detects_tampered_packet_and_unexpected_file(
     bundle = tmp_path / "build" / "handoff"
     handoff.write_workflow_permission_review_handoff_bundle(tmp_path, bundle)
     packet_path = bundle / "packets" / "review-example.json"
-    packet_path.write_text(packet_path.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8")
+    packet_path.write_text(
+        packet_path.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8"
+    )
     (bundle / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
 
     validation = handoff.validate_workflow_permission_review_handoff_bundle(tmp_path, bundle)
@@ -329,9 +333,10 @@ def test_output_guard_and_non_empty_directory_refusal(
     root.mkdir()
     _install_inputs(monkeypatch, _worklist([_work_item()]), _packet_index([_packet()]))
 
-    assert handoff._safe_output_dir(root, Path("build/handoff")) == (
-        root / "build" / "handoff"
-    ).resolve()
+    assert (
+        handoff._safe_output_dir(root, Path("build/handoff"))
+        == (root / "build" / "handoff").resolve()
+    )
     with pytest.raises(ValueError, match="may only be written under build"):
         handoff._safe_output_dir(root, Path("docs/ci/handoff"))
 

--- a/tests/test_workflow_permission_review_handoff_bundle.py
+++ b/tests/test_workflow_permission_review_handoff_bundle.py
@@ -276,9 +276,7 @@ def test_validator_detects_tampered_packet_and_unexpected_file(
     bundle = tmp_path / "build" / "handoff"
     handoff.write_workflow_permission_review_handoff_bundle(tmp_path, bundle)
     packet_path = bundle / "packets" / "review-example.json"
-    packet_path.write_text(
-        packet_path.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8"
-    )
+    packet_path.write_text(packet_path.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8")
     (bundle / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
 
     validation = handoff.validate_workflow_permission_review_handoff_bundle(tmp_path, bundle)

--- a/tests/test_workflow_permission_review_handoff_bundle_cli.py
+++ b/tests/test_workflow_permission_review_handoff_bundle_cli.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import workflow_permission_review_handoff_bundle as handoff
+
+
+def _manifest(*, status: str = "ready_for_human_handoff") -> dict[str, object]:
+    return {
+        "schema_version": handoff.SCHEMA_VERSION,
+        "status": status,
+        "summary": {
+            "active_work_item_count": 1,
+            "packaged_packet_count": 1,
+            "artifact_count": 5,
+            "blocked_reason_count": 0,
+        },
+        "bundle_digest": "bundle-marker",
+        "global_reasons": [],
+        "packet_refs": [],
+        "artifact_index": [],
+        "authority_boundary": handoff.authority_boundary(),
+    }
+
+
+def test_cli_relative_output_is_resolved_beneath_explicit_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    manifest = _manifest()
+    observed: list[tuple[Path, str | Path]] = []
+
+    monkeypatch.setattr(
+        handoff,
+        "build_workflow_permission_review_handoff_bundle",
+        lambda _root: manifest,
+    )
+
+    def fake_write(repo_root: str | Path, out_dir: str | Path) -> dict[str, object]:
+        observed.append((Path(repo_root), out_dir))
+        return manifest
+
+    monkeypatch.setattr(handoff, "write_workflow_permission_review_handoff_bundle", fake_write)
+
+    assert (
+        handoff.main(
+            [
+                "--root",
+                str(root),
+                "--out-dir",
+                "build/sdetkit/reviewer-handoff",
+                "--format",
+                "text",
+            ]
+        )
+        == 0
+    )
+    assert observed == [(root.resolve(), "build/sdetkit/reviewer-handoff")]
+    text = capsys.readouterr().out
+    assert "Workflow Permission Reviewer Handoff Bundle v1" in text
+    assert "machine_recommendation_allowed=false" in text
+    assert "merge_authorized=false" in text
+
+
+def test_cli_json_output_is_machine_readable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        handoff,
+        "build_workflow_permission_review_handoff_bundle",
+        lambda _root: _manifest(),
+    )
+
+    assert handoff.main(["--root", str(tmp_path), "--format", "json"]) == 0
+    rendered = json.loads(capsys.readouterr().out)
+
+    assert rendered["schema_version"] == handoff.SCHEMA_VERSION
+    assert rendered["status"] == "ready_for_human_handoff"
+
+
+def test_cli_blocked_bundle_refuses_export(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    blocked = _manifest(status="blocked")
+    blocked["global_reasons"] = ["packet_missing"]
+    monkeypatch.setattr(
+        handoff,
+        "build_workflow_permission_review_handoff_bundle",
+        lambda _root: blocked,
+    )
+
+    def fail_write(_root: object, _out: object) -> dict[str, object]:
+        raise AssertionError("blocked CLI must not call the bundle writer")
+
+    monkeypatch.setattr(handoff, "write_workflow_permission_review_handoff_bundle", fail_write)
+
+    assert (
+        handoff.main(
+            [
+                "--root",
+                str(tmp_path),
+                "--out-dir",
+                "build/handoff",
+                "--format",
+                "text",
+            ]
+        )
+        == 1
+    )
+    assert "status=blocked" in capsys.readouterr().out
+    assert not (tmp_path / "build" / "handoff").exists()
+
+
+def test_cli_check_dir_fresh_and_stale_exit_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    fresh = {
+        "status": "fresh",
+        "fresh": True,
+        "reasons": [],
+        "current_bundle_digest": "bundle-marker",
+        "authority_boundary": handoff.authority_boundary(),
+    }
+    monkeypatch.setattr(
+        handoff,
+        "validate_workflow_permission_review_handoff_bundle",
+        lambda _root, _bundle: fresh,
+    )
+
+    assert (
+        handoff.main(
+            [
+                "--root",
+                str(tmp_path),
+                "--check-dir",
+                "build/handoff",
+                "--fail-on-stale",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["fresh"] is True
+
+    reason = "_".join(("artifact", "content", "mismatch")) + ":packets/example.json"
+    stale = {
+        **fresh,
+        "status": "stale",
+        "fresh": False,
+        "reasons": [reason],
+    }
+    monkeypatch.setattr(
+        handoff,
+        "validate_workflow_permission_review_handoff_bundle",
+        lambda _root, _bundle: stale,
+    )
+
+    assert (
+        handoff.main(
+            [
+                "--root",
+                str(tmp_path),
+                "--check-dir",
+                "build/handoff",
+                "--fail-on-stale",
+                "--format",
+                "text",
+            ]
+        )
+        == 1
+    )
+    text = capsys.readouterr().out
+    assert "fresh=false" in text
+    assert f"reason={reason}" in text
+
+
+def test_cli_stale_without_fail_flag_is_advisory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    stale = {
+        "status": "stale",
+        "fresh": False,
+        "reasons": ["manifest_missing"],
+        "current_bundle_digest": "",
+        "authority_boundary": handoff.authority_boundary(),
+    }
+    monkeypatch.setattr(
+        handoff,
+        "validate_workflow_permission_review_handoff_bundle",
+        lambda _root, _bundle: stale,
+    )
+
+    assert (
+        handoff.main(
+            [
+                "--root",
+                str(tmp_path),
+                "--check-dir",
+                "build/handoff",
+                "--format",
+                "text",
+            ]
+        )
+        == 0
+    )
+
+
+def test_load_json_rejects_non_object(tmp_path: Path) -> None:
+    path = tmp_path / handoff.MANIFEST_NAME
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        handoff._load_json(path)


### PR DESCRIPTION
Advances #2181 after Workflow Permission Review Worklist v1 (#2208).

## Why

Stage 8 makes current human workflow-permission work visible. Stage 9 makes that exact active evidence portable for an offline reviewer without expanding software authority.

This PR adds **Workflow Permission Reviewer Handoff Bundle v1**: a deterministic, integrity-indexed bundle containing only current active Stage 8 work items and their exact current Stage 4 review packets.

## Distinction from existing layers

- Stage 4 packet bundle can generate **all** current review packets.
- Stage 8 worklist identifies **active human work**.
- Stage 9 packages only that active work plus its exact packets for offline handoff.
- Stage 5 Review Session remains the separate human-entered decision envelope after a real reviewer decides.

Stage 9 cannot become a Review Session or Decision Record automatically.

## Bundle contents

A successful export contains:

- `workflow-permission-review-handoff-manifest.json`;
- `workflow-permission-review-worklist.json`;
- `workflow-permission-review-worklist.txt`;
- `README.md`;
- `packets/<review_id>.json` for every active item;
- `packets/<review_id>.md` for every active item.

Resolved/no-action work is not reintroduced into the active reviewer bundle.

## Fail-closed active packet binding

Every active work item must have exactly one current packet matching review ID, workflow path, exact workflow SHA-256, permission group, and packet digest.

The work item and packet must retain `safe_to_patch=false` and zero authority boundaries. Worklist machine fields for recommendation, priority, reviewer assignment, and decision prefill must remain null.

Any missing, duplicate, mismatched, stale, or authority-escalated binding makes the bundle `blocked`. A blocked bundle cannot be exported.

## Deterministic integrity manifest

The manifest records exact upstream provenance, active packet refs, every generated relative path, SHA-256, byte count, and a deterministic bundle digest. No timestamp or reviewer decision is added.

Retained validation rebuilds the current expected bundle in memory and fails stale on manifest/provenance drift, missing files, unexpected files, changed bytes, changed hashes, or upstream lifecycle/packet/worklist drift.

## Non-destructive output boundary

Repository-local output is allowed only beneath `build/`, with relative output resolved beneath explicit `--root` before the boundary check. Explicit external directories remain operator-controlled.

The destination must be absent or empty. Stage 9 refuses to erase or overwrite an existing reviewer workspace, preserving any retained human evidence outside this generated bundle.

## Authority boundary

Hard-coded false for automation, commit, human-decision fabrication, implementation, merge, reviewer-note fabrication, patch application, permission mutation, reviewer assignment, review-priority inference, security dismissal, semantic equivalence, source-tree writes, and workflow mutation.

## Quality target

The new module is promoted directly into explicit mypy rather than typing debt.

Expected machine truth:

- source modules: **538**;
- typing-debt modules: **489** (unchanged);
- explicitly typed modules: **49**;
- reviewed whole-package floor remains **87.89%**;
- no new blanket suppression.

## Scope

Exact base: `8be50c2944bcb4f9cf6119d829cc73e12b669ccc`

Initial exact head: `e21109accda7d06c624d9f64199dac406b5b3fbe`

Exactly **8 files / 0 behind main**:

1. `docs/ci/workflow-permission-review-handoff-bundle.md`
2. `docs/contracts/quality-truth-baseline.v1.json`
3. `docs/contracts/workflow-permission-review-handoff-bundle.v1.json`
4. `pyproject.toml`
5. `src/sdetkit/workflow_permission_review_handoff_bundle.py`
6. `tests/test_quality_truth_baseline.py`
7. `tests/test_workflow_permission_review_handoff_bundle.py`
8. `tests/test_workflow_permission_review_handoff_bundle_cli.py`

No `.github/workflows/*` file is in scope. This PR packages reviewer evidence only; it creates no decision, ranking, assignment, note, permission patch, or merge authority.